### PR TITLE
Specify theme in storybook config

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -24,5 +24,11 @@ addParameters({
   },
 });
 
+addParameters({
+  readme: {
+    codeTheme: 'github',
+  },
+});
+
 configure(loadStories, module);
 injectGlobal(...fonts);


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When t he addon `storybook-readme` was updated from `5.0.2` to `5.0.5`, there was a regression where `github` was no longer the default `codeTheme` and code would not be highlighted correctly unless this was explicitly specified in Storybook's config.

An issue has been raised here: https://github.com/tuchk4/storybook-readme/issues/186

Instead of rolling back and locking `storybook-readme` at `5.0.2`, it was fairly trivial to specify a theme explicitly.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
