### PR TITLE
chore: Add lint check for Artifactory paths

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.com/

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
   - export PATH="$HOME/.yarn/bin:$PATH"
 install:
   - yarn install --production=false
+  - yarn lint
   - yarn build
   - yarn test
 jobs:

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,2 @@
 workspaces-experimental true
+--install.frozen-lockfile true

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "commit": "git-cz",
     "commitmsg": "validate-commit-msg",
     "build-storybook": "build-storybook -c .storybook -o docs",
-    "lint": "tslint --project tsconfig.json",
+    "lint": "node utils/check-lockfile-links.js && tslint --project tsconfig.json",
     "format:prettier": "prettier --config=./.prettierrc --ignore-path=./.prettierignore \"**/*.{js,jsx,json,ts,tsx,md}\" --write",
     "format:tslint": "tslint --project tsconfig.json --fix",
     "format": "yarn format:prettier && yarn format:tslint",
@@ -118,6 +118,10 @@
       ],
       "*.{js,jsx,json,md}": [
         "prettier --config=./.prettierrc --ignore-path=./.prettierignore --write",
+        "git add"
+      ],
+      "yarn.lock": [
+        "node utils/check-lockfile-links.js",
         "git add"
       ]
     }

--- a/utils/check-lockfile-links.js
+++ b/utils/check-lockfile-links.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const contents = fs.readFileSync(path.resolve(__dirname, '../yarn.lock')).toString();
+
+if (/resolved\s".*(artifactory).*\n/.test(contents)) {
+  console.error(
+    `This 'yarn.lock' file contains resolved urls that are not allowed. This usually happens if you're trying to install npm packages through a proxy like Artifactory. Make sure your npm registry is set to one that is publicly available and try running 'yarn install' again.`
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
Original PR: #11 

## Summary

* Added lint check for Artifactory paths
* Added linting to travis CI
* Added `frozen-lockfile` option to installs to prevent accidental yarn.lock file overriding
## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md
- [x] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
