### PR TITLE
fix: Added Banner to @workday/canvas-kit-react

### DIFF
--- a/modules/_canvas-kit-react/index.ts
+++ b/modules/_canvas-kit-react/index.ts
@@ -2,6 +2,7 @@ export {default as canvas} from '@workday/canvas-kit-react-core';
 export * from '@workday/canvas-kit-react-action-bar';
 export * from '@workday/canvas-kit-react-avatar';
 export * from '@workday/canvas-kit-react-button';
+export * from '@workday/canvas-kit-react-banner';
 export * from '@workday/canvas-kit-react-card';
 export * from '@workday/canvas-kit-react-checkbox';
 export * from '@workday/canvas-kit-react-color-picker';

--- a/modules/cookie-banner/react/lib/CookieBanner.tsx
+++ b/modules/cookie-banner/react/lib/CookieBanner.tsx
@@ -3,14 +3,12 @@ import styled, {css} from 'react-emotion';
 import {colors, commonColors, type, spacing} from '@workday/canvas-kit-react-core';
 import Button from '@workday/canvas-kit-react-button';
 
-export interface BannerProps {
+export interface CookieBannerProps {
   /**
    * Whether or not the banner is closed.
    */
   isClosed?: boolean;
-}
 
-export interface CookieBannerProps extends BannerProps {
   /**
    * Callback executed upon accepting cookies.
    * The function should set `isClosed` to true.
@@ -51,7 +49,8 @@ const Banner = styled('div')(
       padding: `${spacing.s} 0`,
     },
   },
-  ({isClosed}: BannerProps) => (isClosed ? {transform: 'translateY(100%)'} : null)
+  ({isClosed}: Pick<CookieBannerProps, 'isClosed'>) =>
+    isClosed ? {transform: 'translateY(100%)'} : null
 );
 
 const BannerItem = styled('div')({


### PR DESCRIPTION
Original PR: #22 

<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

`Banner` was not exported from the `canvas-kit` universal module. Adding it required removing conflicting types in `CookieBanner`.

This *could* be a breaking change if anyone relies on `BannerProps` exported by `@workday/canvas-kit-react` OR `@workday/canvas-kit-react-cookie-banner`. `BannerProps` from `@workday/canvas-kit-react` will now by pointing to `BannerProps` from `@workday/canvas-kit-banner` and `@workday/canvas-kit-react-cookie-banner` will no longer export `BannerProps`

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md
- [x] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
