### PR TITLE
build(travis): regenerate build vars

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,4 +3,5 @@ modules/canvas-kit-react-core/lib/colors.ts
 **/package.json
 .vscode
 .idea
+.travis.yml
 docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ stages:
     if: "(branch = master AND type = pull_request) OR branch != master OR branch IS NOT /release-*/"
   - name: npm publish
     if: branch =~ /^release-.*/ AND type != pull_request
+  - name: test regex
+    if: NOT branch =~ /travis-vars/
+  - name: still test regex
+    if: branch =~ /travis-v*/
 before_install:
   - npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.15.2
@@ -39,6 +43,10 @@ jobs:
     - stage: npm publish
       script:
       - "./utils/travis/getGit.sh"
+    - stage: test regex
+      script: echo test regex
+    - stage: still test regex
+      script: echo test regex again
 env:
   global:
   - secure: JZmvmwC3FY+wBnn8zuxgNTyx4suWI9NmGFyK5LQFoU0/HaZ2qvOxzckqDrsAvkljg/myt1YyHPT53BrSEwBQSDROMojC6fMyYPGx8mNYq1mEhsw+xGKPda85tsToFgJMqLF79mqF+frjPA5WU5mzFwkDZHLkRCK7srlaskAVlrxJXFKCywAPdrQy1UDksc7+2nNmVgY+HfpBh14h4v5a2Xw5NUEsIUcyQjaLt7NW2BTZ0f+DkjoSzqAumFtO1vXT3W7mfLnpiyDRkGZrG1zV34bWEFiMDAIQarTZ5KBi+vmXQ/6JNmWABYJhGt02VSwdQwjJUAVQweXI7SisOt1wQ9Sciwsk3SbVAywI45ljTSJY43A+9ZoRc6qOK4Vbz3/pVjwXqCDBdxcgKw9isk7qrTt5U5hFXH+USPldsLUXa4x9V9cfzrbstRfo25uKF9mIesFQNQSoqjPcezyZND9nxKUW9optLkFW5StDDGokuvp0P/TD8B8kmBpljw5K0N7LrQWNLdZ1i8Kn43A2BMie5TEFHnua32m6B5Brc/BaztKxgvmqETzJu7d93TBSf0p7G4dXHaoQLnjgXCy/qpktvzWot7iMDWwBYkeHBtp/4a0lyUUM3Vnmn6j3CoIvrgOhE4+zmrGHiRrL8aPUlMqwI74haDIpq97dw6kfiqt5QNw=

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,9 @@ stages:
   - name: storybook
     if: branch = master AND type != pull_request
   - name: pr-previews
-    if: "(branch = master AND type = pull_request) OR branch != master OR branch IS NOT /release-*/"
+    if: "(branch = master AND type = pull_request) OR branch != master OR NOT branch =~ /release-*/"
   - name: npm publish
     if: branch =~ /^release-.*/ AND type != pull_request
-  - name: test regex
-    if: NOT branch =~ /travis-vars/
-  - name: still test regex
-    if: branch =~ /travis-v*/
 before_install:
   - npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.15.2
@@ -43,10 +39,6 @@ jobs:
     - stage: npm publish
       script:
       - "./utils/travis/getGit.sh"
-    - stage: test regex
-      script: echo test regex
-    - stage: still test regex
-      script: echo test regex again
 env:
   global:
   - secure: JZmvmwC3FY+wBnn8zuxgNTyx4suWI9NmGFyK5LQFoU0/HaZ2qvOxzckqDrsAvkljg/myt1YyHPT53BrSEwBQSDROMojC6fMyYPGx8mNYq1mEhsw+xGKPda85tsToFgJMqLF79mqF+frjPA5WU5mzFwkDZHLkRCK7srlaskAVlrxJXFKCywAPdrQy1UDksc7+2nNmVgY+HfpBh14h4v5a2Xw5NUEsIUcyQjaLt7NW2BTZ0f+DkjoSzqAumFtO1vXT3W7mfLnpiyDRkGZrG1zV34bWEFiMDAIQarTZ5KBi+vmXQ/6JNmWABYJhGt02VSwdQwjJUAVQweXI7SisOt1wQ9Sciwsk3SbVAywI45ljTSJY43A+9ZoRc6qOK4Vbz3/pVjwXqCDBdxcgKw9isk7qrTt5U5hFXH+USPldsLUXa4x9V9cfzrbstRfo25uKF9mIesFQNQSoqjPcezyZND9nxKUW9optLkFW5StDDGokuvp0P/TD8B8kmBpljw5K0N7LrQWNLdZ1i8Kn43A2BMie5TEFHnua32m6B5Brc/BaztKxgvmqETzJu7d93TBSf0p7G4dXHaoQLnjgXCy/qpktvzWot7iMDWwBYkeHBtp/4a0lyUUM3Vnmn6j3CoIvrgOhE4+zmrGHiRrL8aPUlMqwI74haDIpq97dw6kfiqt5QNw=

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ stages:
   - name: storybook
     if: branch = master AND type != pull_request
   - name: pr-previews
-    if: "(branch = master AND type = pull_request) OR branch != master OR NOT branch =~ /release-*/"
+    if: "(branch = master AND type = pull_request) OR branch != master OR NOT branch =~ /^release-.+$/"
   - name: npm publish
-    if: branch =~ /^release-.*/ AND type != pull_request
+    if: branch =~ /^release-.+$/ AND type != pull_request
 before_install:
   - npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.15.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,40 +8,41 @@ branches:
   except:
   - gh-pages
 stages:
-  - name: storybook
-    if: branch = master AND type != pull_request
-  - name: pr-previews
-    if: "(branch = master AND type = pull_request) OR branch != master OR branch != /release-*/"
-  - name: npm publish
-    if: branch =~ /^release-.*/ AND type != pull_request
+- name: storybook
+  if: branch = master AND type != pull_request
+- name: pr-previews
+  if: "(branch = master AND type = pull_request) OR branch != master OR branch !=
+    /release-*/"
+- name: npm publish
+  if: branch =~ /^release-.*/ AND type != pull_request
 before_install:
-  - npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.15.2
-  - export PATH="$HOME/.yarn/bin:$PATH"
+- npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
+- curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.15.2
+- export PATH="$HOME/.yarn/bin:$PATH"
 install:
-  - yarn install --production=false
-  - yarn build
-  - yarn test
+- yarn install --production=false
+- yarn build
+- yarn test
 jobs:
   include:
-    - stage: storybook
-      script:
-      - yarn build-storybook
-      deploy:
-        provider: pages
-        skip_cleanup: true
-        local_dir: docs
-        github_token: "$GH_STORYBOOK_TOKEN"
-        on:
-          branch: master
-    - stage: pr previews
-      script: echo "TODO"
-    - stage: npm publish
-      script:
-      - "./utils/travis/getGit.sh"
+  - stage: storybook
+    script:
+    - yarn build-storybook
+    deploy:
+      provider: pages
+      skip_cleanup: true
+      local_dir: docs
+      github_token: "$GH_STORYBOOK_TOKEN"
+      on:
+        branch: master
+  - stage: pr previews
+    script: echo "TODO"
+  - stage: npm publish
+    script:
+    - "./utils/travis/getGit.sh"
 env:
   global:
-  - secure: VPjIkNM2XCPIwaxaAaxIn47dpGHxsQWO77xhjisBXVEbg1f5yHJG2TYPn/wWZCLfwD7QGoc/ujIAbw2ah8Cr63QurvyPLE9mO82VwAaeonihgv4lQplb346uag2UQ+7rs0E5FpZ5SGvq/GA0kgRld1h5l/TDt6DxPt4yL6+/GxXi228BRRyXnwW5CBMttlE9ufyyUJvCT9rsPpAYfKHqbutf7TYfjpGFpKFY8TTxgJes58l/FmAzj9TvfS8p1oqZw0cPUimUYSAlYzKdxxtBLcN+wkqsD4B6eRLQjMAIzN5zbaWcYKPkrta3fGWFBAbkHbKqAk2CxP5ATyjk7szgsPFU43AwEUKLgD02P5S92iDTqJVtRPLee9D5bGQUhMjYXP1p7MrCEekpR+IcuSp2L9iIat3szFue4m0uYW4FJcBLDgGFD7Bu/bEyFfsAJGlWLqc5tKcni5juvc/Ff09dnYniOzYv8pCbP8tPj2ul6ce13g0M5Fa/Ulq5Nt+3U57llzIH1zvv4re8puc9sztHK8oOmrDmG0i54eXR0u9rXGECOsNRvBD6vKR/GmT1Lc094MxrSDDXOtqC8IIG3WJYYfre7WwlnLCT5w5UnSQDiYVzmrPhllDd8lpRsuyciSxPi0jDJWv1TKmUHufrSRjzHOusaNNNwEOUq0TCN5t1sBg=
-  - secure: Z2hSVhcWQ56KO1BKprNcDgcO9vL+bKrbZEFfaY+QO+2Brs9vx7vtjmkUC5W/8LbEOGKrkm7mgOGdbaSAmz1zEOaXlqnZzA7xBOfdOHziLSDMnkges0TDkQixW/RzgxXh7BqCm7LbNYiy6cymlNxUywngPAGokHDCfDyz+8GdWJz7ASDDDvqNmwYs6WjXnf1H1v1ZPJ7zGbNacsxR+c5heEGihDA1P1V7FBzsvY94lH2CFv8zk1P3elkAsejEvkaNe1KOU1DLXGtPm+VR603OzFDKvc9xq3fa45Br/guUu9NBX6A+e4PMG/EmgGuqokOZ1ww0PQjEk8Rq1F1A6kpwIlk2r30F0Hi5hQUo33xyXcI9Jfc/KXEVD0eq1nW4yvLnytq38GOeUA9n0S9Idv88+XQhTx6h05G/CvPVxIN0Eu/v4jzzdioGO4h1JghCsxkPYldbmnFgqTHbENP46cwVTQffFx0WdHMZ+BD6Kpy8QQlswjKHesHfeLgMxA17PeIjYVd/a/4T95Ic/mWHmiQpGKn5VXVRp01Oa+y46lUHgrjzGfWd7xCpYHhATMcRG0ccdEfA3U3Tr4Kj7Ns/Qsf1bE+qXNj/JFCKnakccSYaeUq/N2imaeFXuDWjGIl+P6uE4uTKCnsloYybZtk9A742Ycqa3BfLnWeufArm7th4Smc=
-  - secure: y7IzCazmnNZG963lIYy2Lny/6Bg9bZha1ta2lCotWJY/FIlWnpQdiByvcf42ShoNQSqYVw7Jk/9fPms9aJVkXWNlBq+OPmywzNayFfUBCBevIvJH3ktwRtj1fEGI+w9E+VF04XIQF6s939QTrbSkaQmfQCHMVdtT582aMYiRwhJdJsMZthzesy3PqgcWb4vL7Woa63xVf7XtQESBSSmCzeqOqBJ3sMCLYOeDsT1HIqN9v6igNSmbqinuwY0Lyq9nq7Bxt2Ei4mUh8xSMjDVGkuo0f0Aygf5llh5U2aBzQW4ia4gBfoLtQfq7CIxREkjWCH+h9TDgbUo0ONEbtvK3OzVprzH/LxM/AO0khX0LZszHX1jd9cLFKqwqMpuFR3X5NbZkCiNTj24VEwUTt/aDWNqhtPnIpqU0Jx6AVWhlGCpjFGyaAgtbED18gH21iCt5vp+7EJeOGoIea042Rz4S7bA5rKZj6DvsLSslRRt7DH6ky8yiS9bi8VWwPbQy/HH8t/ZWP2vLf+mR5GtrpGjeFS08mOovt/My9nLrGQbbcOhEEqZqgsKRTKbfASuexo8tBxLascqb+UtyOUvyERx3iFt40RBKEfjXh9ZITP+v5PmO5tjMoT1Jc5SjCuBb6j1OIDSzfVa6ZuoKbr9wpX23NalpAShRbbnvCITSvzXTOf4=
-  - secure: gw+HFfPqBYiNKclbFR8SnP39gljyiOGeyZmN6mqBSE21PM8JWMoIwEdlFDu1nXn6tQxzPo+YRmb7+SJmHFJ2SpoTmZhNAN08NfmSzWw1UAIdeD2562sBOqJXe/WuAavYsaK/WnZunHTiAQZGJ6KXXz6JnRCsXIHJr3wngC/Px1Tw4sQqz1nmenHkK6hasN4ckq+OvYJpxyX6zjjv9cs9EADkEP1mXeytvGnAOVhRnY/tTblrNFKT9YCgjLRdNHMaXXFE6R+3ll5irW1Sa0ZyzSg1mjHomoybZxqAChJ2/cugkEX0cgKfAIg7m81GlKLlq9hs2ja7qXMZhOy8VrB/7L7QSB/AAH5GOltyQwemctUnhtF/1Chu0j1kcfBXcq3iuUTw62GbZNhHv1J37d86ok//I04vQUO77JGwmhJnWD5Pviko9tnioe+/LghGZhiOATVMZGourObw6gqYtiGGPK+Ci+Z3zKoqVq4EWz27mQXoibqFGB6g7UKrn5hIjUyWMHv9DNp8L6pwkE2BcteckSbl9PrildktjkRrKOcXDRawEcXQ/QkeT/nlEkkdkFm3Tihmi+SRMzxznxp/gDoO7FhEUHbpQAy5gH19vwTQ7xZoxceIo2DmD8ryC3mzSHDp73lODGAOcIc6NdEQynfk0wTgsvRwy+V9jhplq1y8DAo=
+  - secure: JZmvmwC3FY+wBnn8zuxgNTyx4suWI9NmGFyK5LQFoU0/HaZ2qvOxzckqDrsAvkljg/myt1YyHPT53BrSEwBQSDROMojC6fMyYPGx8mNYq1mEhsw+xGKPda85tsToFgJMqLF79mqF+frjPA5WU5mzFwkDZHLkRCK7srlaskAVlrxJXFKCywAPdrQy1UDksc7+2nNmVgY+HfpBh14h4v5a2Xw5NUEsIUcyQjaLt7NW2BTZ0f+DkjoSzqAumFtO1vXT3W7mfLnpiyDRkGZrG1zV34bWEFiMDAIQarTZ5KBi+vmXQ/6JNmWABYJhGt02VSwdQwjJUAVQweXI7SisOt1wQ9Sciwsk3SbVAywI45ljTSJY43A+9ZoRc6qOK4Vbz3/pVjwXqCDBdxcgKw9isk7qrTt5U5hFXH+USPldsLUXa4x9V9cfzrbstRfo25uKF9mIesFQNQSoqjPcezyZND9nxKUW9optLkFW5StDDGokuvp0P/TD8B8kmBpljw5K0N7LrQWNLdZ1i8Kn43A2BMie5TEFHnua32m6B5Brc/BaztKxgvmqETzJu7d93TBSf0p7G4dXHaoQLnjgXCy/qpktvzWot7iMDWwBYkeHBtp/4a0lyUUM3Vnmn6j3CoIvrgOhE4+zmrGHiRrL8aPUlMqwI74haDIpq97dw6kfiqt5QNw=
+  - secure: d9ZfQBSo1ZxNjY+tDqvP9KtFb55+pmSsKfqwtAAYmN76iL2RKVLcJuubwsEN71Kvq76Qy0onXWzfLNkWY2+YwaHvSRkBCBaMbpHBB4b1aI+zUgJX5GUDAdcbyui2jpTTsekiH39ojSVlFqoTqammwPSZp3ZTQolQ7yRAvVAGfUEJTUfy7Jy4QZN2D1kIbjhNvFC1RcFiejhQVeAf/AD8lmo9b6ScyyCrvIjfi7JcHyWteVBMeWCGHywWV/UYLg06ZQT4lJrVzRDKstMuiZQv2AztvycghnhsgPXlvzZTKpf3G4WbmyPrMsAerXD/kLsETS5BV7lN3FWCzLOidNruVgnv/5K+qx2GW709xP83IE5gHOmUcLpr2iyJi634Jt39+XaAZmM1eOaAYmWJH6g5Wl/BMxqNfMPHqOKgrcOjoEh0B7svejtx+sEGG06FB2emeJGMqHH1Or1m1SRSzBw0/ApFj9BuqYr/lSBzLAnEKdgraSTeJ3LAF+ca0z5mNRZOBt3/5gf+Fj8vGJgKGxNhmZ0J0+S8ipYJJ46pCwplj9qVYaNj4gpY/DC5pdcDQxTZInyI3mlgNFbJu5oR9n0JKRGE6BfwpZE7la9YvqGjfaM2VcUDiqNCjiglLKuSP7TPSm9wXOrC78Qm+94MKCVIHWfF/D26AvDPUHg0hqiGZmA=
+  - secure: k0sirDXLNOsjEYXfbcA7BFZbhyI4hgKaxuP5pRxbgqN0K+DwtPHfKoA6LpAf1XoI6bSDsSOhIsc85yPj5hAxDqttSamF+uR8Oc4dPiVyFA/7T6Rjr+idl8KMgE8jhkRE1Q1kiLNVkL6AfjyVVOiu7bQc8XXAAaNG7iz0/UCRsNpxWHg7Ukldycin+uS/8fr6ICNIxPzlUUHcEOGNlXg+P/wd+225Deg1vYrKs7BB8ZSpeBzeaDUSBdcA5MRuKX6iIuYzRhytsGNcgBPK54B5/qaplKMnzD+4/t5Ki6XTepXdF6RVr/x0xeLXouoOezLGGvWMYfIuXqhduJU75YxfQSHP5dq5ICqRMtZFMR+CV8OToUGMa/C+Yb/qPviR/n3jrlVU4bdNiKxotFWcDyMHXVKY104Gp3dhiYvWBBD8zkUIOwDkG1XrnLiHaFjZAAxhZ9HJ0l2oV+GXWxSslhfXevh/pxecu58/wF6kPx7+nHT3yMOvAZ3yn8ji/VUGdeYViFHnbsJ15Cbvi/GIBkUItlecydTEZIfKdcnvcT7Yk0utUV84J57n52V29GK18vYlhHi8vgeEnwXzc1JJFREHKSSTJXIhwJ4cNO/eFADRygHDof/rmmQEAmXkMRYcPGZ5OFYMuDBd/1W7/PjHdFtZkjt2cSQHCMopIC+jv5UC4ME=
+  - secure: VJl7aOS/oO/TmZpwmyuVFvKfrgaRVlqUgB2MQcbfqT1ezie5hZNY1H5YjcYps2tVG/oyQ+GW10Bwp6IYB1+rPj+PSG7uvzSfm9NVfNF5/LxLpqgkq7/wlqKiqEj7zfFuDmcCyUekQ/GTVV/QcYJvgh1Cj/QZMuXWTN6pWpTdydl6VZeEAAj/Uvdnkj/7lpZKyJ4bl4/nXmhoEvx/H3t6PoZnGLJQtGFMg7pHFklzBC3xyA4hILtpkTFjyg3DKIiIoq6AfIWN6RjL/KPXXCAwkOCbwI+QZJ+t00+TIsof79hx0dS9UuEGrjFOieIlbkOLr9ZvwhZmCVDTrn6WqGnEjfJlkqo/g53siGvGgd0TQuvyVoDCL0Q++TSDaRJ7HsIOGczowqrDBwIEnKblNhQeKake8VMajp0yPJKK1siYFc/pRcsAPy+P7dAauPSdS36xYwC1ZRztMl982ev1bn9gOEcGuVySlaDqLzu++WQD6ruYA65jAKymJC9lYmqRHnBJlcZ15QSXw7jYRPTBKEzVYIgsE2U1i9W//9OtSHzCo4IGr6XYxWnwxfV+lof8hBV1QzJBxEp+RLvAPkjumak67UwkuQb4W9tDjGgrc6DMNe9HNGEQ8mMV/KM3j01QGudJds3OXn3PYWtRejRzW6+fchsn5hE0WqeaUehxahMF7po=

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,38 +8,37 @@ branches:
   except:
   - gh-pages
 stages:
-- name: storybook
-  if: branch = master AND type != pull_request
-- name: pr-previews
-  if: "(branch = master AND type = pull_request) OR branch != master OR branch !=
-    /release-*/"
-- name: npm publish
-  if: branch =~ /^release-.*/ AND type != pull_request
+  - name: storybook
+    if: branch = master AND type != pull_request
+  - name: pr-previews
+    if: "(branch = master AND type = pull_request) OR branch != master OR branch IS NOT /release-*/"
+  - name: npm publish
+    if: branch =~ /^release-.*/ AND type != pull_request
 before_install:
-- npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
-- curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.15.2
-- export PATH="$HOME/.yarn/bin:$PATH"
+  - npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.15.2
+  - export PATH="$HOME/.yarn/bin:$PATH"
 install:
-- yarn install --production=false
-- yarn build
-- yarn test
+  - yarn install --production=false
+  - yarn build
+  - yarn test
 jobs:
   include:
-  - stage: storybook
-    script:
-    - yarn build-storybook
-    deploy:
-      provider: pages
-      skip_cleanup: true
-      local_dir: docs
-      github_token: "$GH_STORYBOOK_TOKEN"
-      on:
-        branch: master
-  - stage: pr previews
-    script: echo "TODO"
-  - stage: npm publish
-    script:
-    - "./utils/travis/getGit.sh"
+    - stage: storybook
+      script:
+      - yarn build-storybook
+      deploy:
+        provider: pages
+        skip_cleanup: true
+        local_dir: docs
+        github_token: "$GH_STORYBOOK_TOKEN"
+        on:
+          branch: master
+    - stage: pr previews
+      script: echo "TODO"
+    - stage: npm publish
+      script:
+      - "./utils/travis/getGit.sh"
 env:
   global:
   - secure: JZmvmwC3FY+wBnn8zuxgNTyx4suWI9NmGFyK5LQFoU0/HaZ2qvOxzckqDrsAvkljg/myt1YyHPT53BrSEwBQSDROMojC6fMyYPGx8mNYq1mEhsw+xGKPda85tsToFgJMqLF79mqF+frjPA5WU5mzFwkDZHLkRCK7srlaskAVlrxJXFKCywAPdrQy1UDksc7+2nNmVgY+HfpBh14h4v5a2Xw5NUEsIUcyQjaLt7NW2BTZ0f+DkjoSzqAumFtO1vXT3W7mfLnpiyDRkGZrG1zV34bWEFiMDAIQarTZ5KBi+vmXQ/6JNmWABYJhGt02VSwdQwjJUAVQweXI7SisOt1wQ9Sciwsk3SbVAywI45ljTSJY43A+9ZoRc6qOK4Vbz3/pVjwXqCDBdxcgKw9isk7qrTt5U5hFXH+USPldsLUXa4x9V9cfzrbstRfo25uKF9mIesFQNQSoqjPcezyZND9nxKUW9optLkFW5StDDGokuvp0P/TD8B8kmBpljw5K0N7LrQWNLdZ1i8Kn43A2BMie5TEFHnua32m6B5Brc/BaztKxgvmqETzJu7d93TBSf0p7G4dXHaoQLnjgXCy/qpktvzWot7iMDWwBYkeHBtp/4a0lyUUM3Vnmn6j3CoIvrgOhE4+zmrGHiRrL8aPUlMqwI74haDIpq97dw6kfiqt5QNw=


### PR DESCRIPTION
Opening the repo and moving from travis-ci.com to travis-ci.org changed the travis key for the repo. The variables used for the build had to be re-added. 

Running the command to add the variables to the travis file also changed the indentation, I'm going to leave it like this since the Travis CLI will keep changing it.