### PR TITLE
feat(outside-event-listener): added utility component for handling outside events

### DIFF
--- a/modules/common/react/README.md
+++ b/modules/common/react/README.md
@@ -14,7 +14,7 @@ or
 yarn add @workday/canvas-kit-react-common
 ```
 
-# Canvas Kit Popper
+# Popper
 
 A thin wrapper component around the Popper.js positioning engine. For reference:
 https://popper.js.org/
@@ -115,3 +115,48 @@ Default: `bottom`
 > DOM hierarchy of it's parent. When true, the popper is attached to the `containerElement`.
 
 Default: `true`
+
+# OutsideEventListener
+
+Detect events that happen outside of an element. Listen for outside click events and Escape key
+presses. Works with portals.
+
+## Usage
+
+```tsx
+import * as React from 'react';
+import {OutsideEventListener, Popper} from '@workday/canvas-kit-react-common';
+import {Popup} from '@workday/canvas-kit-react-popup';
+
+<OutsideEventListener onOutsideClick={this.closePopup} onEscape={this.closePopup}>
+  <Popper placement={'bottom'} open={this.state.open} anchorElement={this.buttonRef.current}>
+    <Popup heading={'Popup Title'}>{this.props.children}</Popup>
+  </Popper>
+</OutsideEventListener>;
+```
+
+## Static Properties
+
+> None
+
+## Component Props
+
+### Required
+
+#### `children: JSX.Element`
+
+> A single JSX or React element capable of supporting an `onClick` handler.
+
+---
+
+### Optional
+
+#### `onOutsideClick: (event?: MouseEvent) => void`
+
+> This handler is called when a click event is detected outside of the child element.
+
+---
+
+#### `onEscape: (event?: KeyboardEvent) => void`
+
+> This handler is called when an Escape key press is detected.

--- a/modules/common/react/index.ts
+++ b/modules/common/react/index.ts
@@ -7,4 +7,5 @@ export * from './lib/utils/colorUtils';
 export * from './lib/parts/_brand-assets';
 export * from './lib/types';
 export * from './lib/genericStyles';
+export * from './lib/OutsideEventListener';
 export * from './lib/Popper';

--- a/modules/common/react/lib/OutsideEventListener.tsx
+++ b/modules/common/react/lib/OutsideEventListener.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+
+export interface Clickable {
+  onClick: Function;
+}
+
+export interface OutsideEventListenerProps {
+  children: JSX.Element;
+  onEscape?: (event?: KeyboardEvent) => void;
+  onOutsideClick?: (event?: MouseEvent) => void;
+}
+
+export class OutsideEventListener extends React.PureComponent<OutsideEventListenerProps> {
+  // we cannot use the DOM to detect if a click is outside when using portals,
+  // so we keep track of inside vs. outside click events
+  private insideClick = false;
+
+  public componentDidMount() {
+    document.addEventListener('click', this.onClick);
+    document.addEventListener('keydown', this.onKeyDown);
+  }
+
+  public componentWillUnmount() {
+    document.removeEventListener('click', this.onClick);
+    document.removeEventListener('keydown', this.onKeyDown);
+  }
+
+  public render() {
+    const inside = React.Children.only(this.props.children) as React.ReactElement<Clickable>;
+
+    return React.cloneElement(inside, {
+      onClick: this.onInsideClick,
+    });
+  }
+
+  private onKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Escape' && this.props.onEscape) {
+      this.props.onEscape(event);
+    }
+  };
+
+  private onClick = (event: MouseEvent) => {
+    if (this.insideClick) {
+      this.insideClick = false;
+      return;
+    }
+
+    if (this.props.onOutsideClick) {
+      this.props.onOutsideClick(event);
+    }
+  };
+
+  private onInsideClick = (event: MouseEvent) => {
+    const inside = React.Children.only(this.props.children) as React.ReactElement<Clickable>;
+
+    this.insideClick = true;
+
+    // return control to handler possibly overwritten by cloneElement
+    if (inside.props.onClick) {
+      inside.props.onClick(event);
+    }
+  };
+}

--- a/modules/common/react/package.json
+++ b/modules/common/react/package.json
@@ -36,6 +36,9 @@
   "peerDependencies": {
     "react": ">= 16.8 < 17"
   },
+  "devDependencies": {
+    "@testing-library/react": "^8.0.1"
+  },
   "dependencies": {
     "@workday/canvas-kit-react-core": "^3.0.0-alpha.2",
     "emotion": "^9.2.12",

--- a/modules/common/react/spec/OutsideEventListener.spec.tsx
+++ b/modules/common/react/spec/OutsideEventListener.spec.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import {fireEvent, render} from '@testing-library/react';
+import {OutsideEventListener, OutsideEventListenerProps} from '../lib/OutsideEventListener';
+
+describe('OutsideEventListener', () => {
+  let onInsideClick: jest.Mock;
+
+  const renderOutsideEventListener = (props?: Partial<OutsideEventListenerProps>) => {
+    return render(
+      <div id="outside">
+        <OutsideEventListener {...props}>
+          <div id="inside" onClick={onInsideClick} />
+        </OutsideEventListener>
+      </div>
+    );
+  };
+
+  describe('onOutsideClick', () => {
+    it('should be called when clicking outside', () => {
+      const onOutsideClick = jest.fn();
+      const {container, unmount} = renderOutsideEventListener({onOutsideClick});
+
+      fireEvent.click(container.querySelector('#outside')!);
+      expect(onOutsideClick).toHaveBeenCalled();
+      unmount();
+    });
+
+    it('should NOT be called when clicking inside', () => {
+      const onOutsideClick = jest.fn();
+      const {container, unmount} = renderOutsideEventListener({onOutsideClick});
+
+      fireEvent.click(container.querySelector('#inside')!);
+      expect(onOutsideClick).not.toHaveBeenCalled();
+      unmount();
+    });
+
+    it('should call original click handlers on inside clicks', () => {
+      onInsideClick = jest.fn();
+      const {container, unmount} = renderOutsideEventListener();
+
+      fireEvent.click(container.querySelector('#outside')!);
+      expect(onInsideClick).not.toHaveBeenCalled();
+
+      fireEvent.click(container.querySelector('#inside')!);
+      expect(onInsideClick).toHaveBeenCalled();
+      unmount();
+    });
+  });
+
+  describe('onEscape', () => {
+    it('should be called when Escape is pressed', () => {
+      const onEscape = jest.fn();
+      const {container, unmount} = renderOutsideEventListener({onEscape});
+
+      fireEvent.keyDown(container.querySelector('#outside')!, {key: 'Escape'});
+      expect(onEscape).toHaveBeenCalled();
+      unmount();
+    });
+
+    it('should NOT be called when a random key is pressed', () => {
+      const onEscape = jest.fn();
+      const {container, unmount} = renderOutsideEventListener({onEscape});
+
+      fireEvent.keyDown(container.querySelector('#outside')!, {key: 'Tab'});
+      expect(onEscape).not.toHaveBeenCalled();
+      unmount();
+    });
+  });
+});

--- a/modules/common/react/stories/stories.tsx
+++ b/modules/common/react/stories/stories.tsx
@@ -5,7 +5,7 @@ import withReadme from 'storybook-readme/with-readme';
 
 import {beta_Button as Button} from '../../../button/react/index';
 import {Popup} from '../../../popup/react/index';
-import {Popper} from '../index';
+import {OutsideEventListener, Popper} from '../index';
 import README from '../README.md';
 
 interface PopperPopupState {
@@ -49,10 +49,57 @@ class PopperPopup extends React.Component<{}, PopperPopupState> {
   };
 }
 
+class OutsideEventHandlerPopup extends React.Component {
+  private buttonRef: React.RefObject<HTMLButtonElement> = React.createRef();
+
+  public state: PopperPopupState = {
+    open: false,
+  };
+
+  public render() {
+    const {open} = this.state;
+
+    return (
+      <div style={{display: 'flex', justifyContent: 'center'}}>
+        <OutsideEventListener onOutsideClick={this.closePopup} onEscape={this.closePopup}>
+          <div onClick={() => console.log('I still work!')}>
+            <Button
+              buttonRef={this.buttonRef}
+              buttonType={Button.Types.Primary}
+              onClick={this.handleClick}
+            >
+              Open Popup
+            </Button>
+            <Popper placement={'bottom'} open={open} anchorElement={this.buttonRef.current!}>
+              <Popup width={400} heading={'Example'}>
+                <div>Press Escape or click outside to close.</div>
+              </Popup>
+            </Popper>
+          </div>
+        </OutsideEventListener>
+      </div>
+    );
+  }
+
+  private closePopup = () => {
+    this.setState({open: false});
+  };
+
+  private handleClick = () => {
+    this.setState({open: true});
+  };
+}
+
 storiesOf('Common', module)
   .addDecorator(withReadme(README))
   .add('Popper', () => (
     <div className="story">
       <PopperPopup />
+    </div>
+  ))
+  .add('OutsideEventHandler', () => (
+    <div className="story">
+      <h1 className="section-label">OutsideEventHandler</h1>
+      <OutsideEventHandlerPopup />
     </div>
   ));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2241,6 +2241,11 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@sheerun/mutationobserver-shim@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
+  integrity sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
+
 "@storybook/addon-actions@^5.0.11":
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-5.1.8.tgz#98d6aff42fb7fa7477b4db6cf21da3ede18ede0d"
@@ -2708,6 +2713,25 @@
     "@svgr/plugin-jsx" "^4.3.0"
     "@svgr/plugin-svgo" "^4.2.0"
     loader-utils "^1.2.3"
+
+"@testing-library/dom@^5.0.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-5.5.0.tgz#7c5024116ca8173187b52c538648884ac6b7b2f9"
+  integrity sha512-QuY/XBp9fquYXP1jklKlG0nUmFVLJXLWNYANmoFs25RDystdujLXxXSVhacVqL5oIF8ESThBzHFX1FUuV/J0kw==
+  dependencies:
+    "@babel/runtime" "^7.4.5"
+    "@sheerun/mutationobserver-shim" "^0.3.2"
+    aria-query "3.0.0"
+    pretty-format "^24.8.0"
+    wait-for-expect "^1.2.0"
+
+"@testing-library/react@^8.0.1":
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-8.0.4.tgz#6ed405ba88b625ec53d7cfa78c038a950bafc1fa"
+  integrity sha512-omm4D00Z0aMaWfPRRP4X6zIaOVb0Kf1Yc1H5VE4id9D0pQRiBcTtmjbN0kZgT8rQGxHhVAuv1NuwFwMTwKzFqg==
+  dependencies:
+    "@babel/runtime" "^7.4.5"
+    "@testing-library/dom" "^5.0.0"
 
 "@types/babel__core@^7.1.0":
   version "7.1.2"
@@ -3451,7 +3475,7 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-aria-query@^3.0.0:
+aria-query@3.0.0, aria-query@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-3.0.0.tgz#65b3fcc1ca1155a8c9ae64d6eee297f15d5133cc"
   integrity sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=
@@ -16116,6 +16140,11 @@ w3c-xmlserializer@^1.1.2:
     domexception "^1.0.1"
     webidl-conversions "^4.0.2"
     xml-name-validator "^3.0.0"
+
+wait-for-expect@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.2.0.tgz#fdab6a26e87d2039101db88bff3d8158e5c3e13f"
+  integrity sha512-EJhKpA+5UHixduMBEGhTFuLuVgQBKWxkFbefOdj2bbk2/OpA5Opsc4aUTGmF+qJ+v3kTGxDRNYwKaT4j6g5n8Q==
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
## Summary

Added a utility component to detect events outside the DOM of the child. This includes detecting outside click events and "Escape" key presses. Works with portals by leveraging the React event system. This utility will be useful for closing popover, modals and menus.

## Checklist

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md
- [x] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
