### PR TITLE
refactor(page-header): Update PageHeader to support IconButton

### DIFF
--- a/modules/page-header/react/README.md
+++ b/modules/page-header/react/README.md
@@ -21,27 +21,17 @@ yarn add @workday/canvas-kit-react-page-header
 ```tsx
 import * as React from 'react';
 import {PageHeader} from '@workday/canvas-kit-react-page-header';
-import {SystemIcon} from '@workday/canvas-kit-react-icon';
+import {IconButton} from '@workday/canvas-kit-react-button';
 import {exportIcon, fullscreenIcon} from '@workday/canvas-system-icons-web';
 
-// No need to set the `color` or `colorHover` prop on SystemIcon here, we'll do it for you
-
 <PageHeader title="Product">
-  <a href="#">
-    <SystemIcon icon={exportIcon} />
-  </a>
-  <a href="#">
-    <SystemIcon icon={fullscreenIcon} />
-  </a>
+  <IconButton icon={exportIcon} />
+  <IconButton icon={fullscreenIcon} />
 </PageHeader>
 
 <PageHeader title="Marketing" marketing={true}>
-  <a href="#">
-    <SystemIcon icon={exportIcon} />
-  </a>
-  <a href="#">
-    <SystemIcon icon={fullscreenIcon} />
-  </a>
+  <IconButton icon={exportIcon} />
+  <IconButton icon={fullscreenIcon} />
 </PageHeader>
 ```
 

--- a/modules/page-header/react/lib/PageHeader.tsx
+++ b/modules/page-header/react/lib/PageHeader.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styled from 'react-emotion';
 import {colors, spacing, type} from '@workday/canvas-kit-react-core';
-import {SystemIcon, SystemIconProps} from '@workday/canvas-kit-react-icon';
+import {IconButton, IconButtonProps} from '@workday/canvas-kit-react-button';
 import {makeMq} from '@workday/canvas-kit-react-common';
 
 export interface PageHeaderProps {
@@ -95,22 +95,9 @@ export default class PageHeader extends React.Component<PageHeaderProps> {
         return child;
       }
 
-      // child is now guaranteed to be a valid ReactElement from the check above
-
-      type Props = {children: React.ReactNode};
-      const propsChildren = (child as React.ReactElement<Props>).props.children;
-
-      if (React.Children.count(propsChildren)) {
-        return React.cloneElement(child as React.ReactElement<Props>, {
-          children: this.renderChildren(propsChildren),
-        });
-      }
-
-      // TODO: Should be replaced with icon buttons when ready
-      if (child.type === SystemIcon) {
-        return React.cloneElement(child as React.ReactElement<SystemIconProps>, {
-          color: colors.frenchVanilla100,
-          colorHover: colors.blueberry200,
+      if (child.type === IconButton) {
+        return React.cloneElement(child as React.ReactElement<IconButtonProps>, {
+          buttonType: IconButton.Types.Inverse,
         });
       }
 

--- a/modules/page-header/react/spec/PageHeader.spec.tsx
+++ b/modules/page-header/react/spec/PageHeader.spec.tsx
@@ -3,9 +3,8 @@ import PageHeader from '../lib/PageHeader';
 import {mount} from 'enzyme';
 import {createMatchers} from 'jest-emotion';
 import * as emotion from 'emotion';
-import {SystemIcon} from '@workday/canvas-kit-react-icon';
+import {IconButton} from '@workday/canvas-kit-react-button';
 import {exportIcon, fullscreenIcon} from '@workday/canvas-system-icons-web';
-import {colors} from '@workday/canvas-kit-react-core';
 
 expect.extend(createMatchers(emotion));
 
@@ -25,49 +24,11 @@ describe('Page Header', () => {
     const component = mount(<PageHeader title="Marketing Context" marketing={true} />);
     expect(component.find('div').first()).toHaveStyleRule('max-width', '1440px');
   });
-
-  test('should set correct SystemIcon color and colorHover props', () => {
-    const testColors = {
-      color: colors.blackberry100,
-      colorHover: colors.cinnamon200,
-    };
-    const component = mount(
-      <PageHeader title="Product Context">
-        <a href="#">
-          <SystemIcon
-            className="icon1"
-            icon={exportIcon}
-            color={testColors.color}
-            colorHover={testColors.colorHover}
-          />
-        </a>
-        <a href="#">
-          <SystemIcon className="icon2" icon={fullscreenIcon} />
-        </a>
-      </PageHeader>
-    );
-    expect(
-      component
-        .find(SystemIcon)
-        .filter('.icon1')
-        .props().color
-    ).toBe(colors.frenchVanilla100);
-    expect(
-      component
-        .find(SystemIcon)
-        .filter('.icon1')
-        .props().colorHover
-    ).toBe(colors.blueberry200);
-  });
   test('should render a copy of the children', () => {
     const component = mount(
       <PageHeader title="With Children">
-        <a href="#">
-          <SystemIcon className="icon1" icon={exportIcon} />
-        </a>
-        <a href="#">
-          <SystemIcon className="icon2" icon={fullscreenIcon} />
-        </a>
+        <IconButton icon={exportIcon} />
+        <IconButton icon={fullscreenIcon} />
       </PageHeader>
     );
 
@@ -78,8 +39,8 @@ describe('Page Header', () => {
     expect(component.instance().renderChildren(null)).toEqual(null); // tests what happens when no children exist
     expect(
       // @ts-ignore
-      component.instance().renderChildren(<SystemIcon className="icon2" icon={fullscreenIcon} />)
-    ).toHaveLength(1); // tests handling of SystemIcons
+      component.instance().renderChildren(<IconButton icon={fullscreenIcon} />)
+    ).toHaveLength(1); // tests handling of IconButtons
     // @ts-ignore
     expect(component.instance().renderChildren(<PageHeader title="Page Header" />)[0].type).toBe(
       PageHeader

--- a/modules/page-header/react/stories/stories.tsx
+++ b/modules/page-header/react/stories/stories.tsx
@@ -3,9 +3,9 @@ import * as React from 'react';
 import {storiesOf} from '@storybook/react';
 import withReadme from 'storybook-readme/with-readme';
 
+import {IconButton} from '@workday/canvas-kit-react-button';
 import {exportIcon, fullscreenIcon} from '@workday/canvas-system-icons-web';
 
-import {SystemIcon} from '../../../icon/react/index';
 import PageHeader from '../index';
 import README from '../README.md';
 
@@ -14,24 +14,16 @@ storiesOf('Page Header', module)
   .add('Product Page Header', () => (
     <div className="story">
       <PageHeader title="Product Context">
-        <a href="#">
-          <SystemIcon icon={exportIcon} />
-        </a>
-        <a href="#">
-          <SystemIcon icon={fullscreenIcon} />
-        </a>
+        <IconButton icon={exportIcon} />
+        <IconButton icon={fullscreenIcon} />
       </PageHeader>
     </div>
   ))
   .add('Marketing Page Header', () => (
     <div className="story">
       <PageHeader title="Marketing Context" marketing={true}>
-        <a href="#">
-          <SystemIcon icon={exportIcon} />
-        </a>
-        <a href="#">
-          <SystemIcon icon={fullscreenIcon} />
-        </a>
+        <IconButton icon={exportIcon} />
+        <IconButton icon={fullscreenIcon} />
       </PageHeader>
     </div>
   ));


### PR DESCRIPTION
## Summary

Update `PageHeader` to use `IconButtons` instead of `SystemIcons` wrapped in links. The original implementation was a temporary solution when we didn't have `IconButtons` implemented.

References https://github.com/Workday/canvas-kit/pull/13

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [ ] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)=