### PR TITLE
Fix fonts module export

### DIFF
--- a/modules/_canvas-kit-react/README.md
+++ b/modules/_canvas-kit-react/README.md
@@ -1,8 +1,8 @@
 # Canvas Kit React
 
-The bundle package containing all modules of the Canvas React Kit.
+The bundle package containing all modules of the Canvas Kit React.
 
 > Note: By default, no fonts are included with Canvas Kit modules. To use official Canvas Kit fonts,
 > install and import the `@workday/canvas-kit-react-fonts` module in addition to
-> `@workday/canvas-kit-react`. The fonts files are served from the Workday CDN so this allows
-> consumers to opt in to using the Workday CDN.
+> `@workday/canvas-kit-react`. By installing `@workday/canvas-kit-react-fonts` you are opting in to 
+> using the Workday CDN.

--- a/modules/_canvas-kit-react/README.md
+++ b/modules/_canvas-kit-react/README.md
@@ -1,3 +1,8 @@
-# Canvas Kit
+# Canvas Kit React
 
 The bundle package containing all modules of the Canvas React Kit.
+
+> Note: By default, no fonts are included with Canvas Kit modules. To use official Canvas Kit fonts,
+> install and import the `@workday/canvas-kit-react-fonts` module in addition to
+> `@workday/canvas-kit-react`. The fonts files are served from the Workday CDN so this allows
+> consumers to opt in to using the Workday CDN.

--- a/modules/_canvas-kit-react/index.ts
+++ b/modules/_canvas-kit-react/index.ts
@@ -8,7 +8,6 @@ export * from '@workday/canvas-kit-react-checkbox';
 export * from '@workday/canvas-kit-react-color-picker';
 export * from '@workday/canvas-kit-react-common';
 export * from '@workday/canvas-kit-react-cookie-banner';
-export * from '@workday/canvas-kit-react-fonts';
 export * from '@workday/canvas-kit-react-form-field';
 export * from '@workday/canvas-kit-react-header';
 export * from '@workday/canvas-kit-react-icon';


### PR DESCRIPTION
## Summary

The fonts module should be opt-in so consumers can choose whether or not they consume things from our CDN (it's the only module that pulls directly from that URL). Currently it's being exported by default from @workday/canvas-kit-react and it should not be.

Closes https://github.com/Workday/canvas-kit/issues/38

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md