### PR TITLE
fix: Update lodash version to fix vulnerability

### DIFF
--- a/modules/common/react/package.json
+++ b/modules/common/react/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@workday/canvas-kit-react-core": "^3.0.0-alpha.2",
     "emotion": "^9.2.12",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.14",
     "popper.js": "^1.15.0",
     "react-emotion": "^9.2.12"
   }

--- a/modules/header/react/package.json
+++ b/modules/header/react/package.json
@@ -44,7 +44,7 @@
     "@workday/canvas-system-icons-web": "^1.0.1",
     "chroma-js": "^1.4.0",
     "emotion": "^9.2.12",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.14",
     "react-emotion": "^9.2.12",
     "react-transition-group": "^2.5.0"
   },

--- a/modules/side-panel/react/package.json
+++ b/modules/side-panel/react/package.json
@@ -38,7 +38,7 @@
     "@workday/canvas-kit-react-core": "^3.0.0-alpha.2",
     "@workday/canvas-system-icons-web": "^1.0.1",
     "emotion": "^9.2.12",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.14",
     "react-emotion": "^9.2.12"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@types/enzyme": "^3.9.3",
     "@types/enzyme-adapter-react-16": "^1.0.5",
     "@types/jest-axe": "^2.2.3",
-    "@types/lodash": "^4.14.125",
+    "@types/lodash": "^4.14.136",
     "@types/node": "^8.0.58",
     "@types/react": "16.8.22",
     "@types/react-dom": "16.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2835,10 +2835,10 @@
     csstype "^2.0.0"
     indefinite-observable "^1.0.1"
 
-"@types/lodash@^4.14.125":
-  version "4.14.134"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.134.tgz#9032b440122db3a2a56200e91191996161dde5b9"
-  integrity sha512-2/O0khFUCFeDlbi7sZ7ZFRCcT812fAeOLm7Ev4KbwASkZ575TDrDcY7YyaoHdTOzKcNbfiwLYZqPmoC4wadrsw==
+"@types/lodash@^4.14.136":
+  version "4.14.136"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.136.tgz#413e85089046b865d960c9ff1d400e04c31ab60f"
+  integrity sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA==
 
 "@types/node@*", "@types/node@^12.0.8":
   version "12.0.10"
@@ -10393,6 +10393,11 @@ lodash@4.17.11, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.0.1, lodash@^4.15.0,
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+
+lodash@^4.17.14:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 log-symbols@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Versions of lodash before 4.17.12 are vulnerable to Prototype Pollution. The function defaultsDeep allows a malicious user to modify the prototype of Object via {constructor: {prototype: {...}}} causing the addition or modification of an existing property that will exist on all objects.

https://www.npmjs.com/advisories/1065