### PR TITLE
fix(Popper): Spread remainder props on wrapper div

### DIFF
--- a/modules/common/react/README.md
+++ b/modules/common/react/README.md
@@ -54,6 +54,10 @@ jest.mock('@workday/canvas-kit-react-common', () => ({
 
 ## Component Props
 
+This component extends the HTML `div` element. All additional props that are passed to this
+component that are valid HTML attributes will be rendered as part of the wrapper `div` element. This
+includes custom `data-*` attributes such as `data-test-id` to help facilitate automation testing.
+
 ### Required
 
 #### `anchorElement: Element`

--- a/modules/common/react/lib/Popper.tsx
+++ b/modules/common/react/lib/Popper.tsx
@@ -5,7 +5,7 @@ import PopperJS from 'popper.js';
 export type Placement = PopperJS.Placement;
 export type PopperOptions = PopperJS.PopperOptions;
 
-export interface PopperProps {
+export interface PopperProps extends React.HTMLAttributes<HTMLDivElement> {
   anchorElement: Element;
   children: React.ReactNode;
   containerElement?: Element;
@@ -46,7 +46,22 @@ export class Popper extends React.PureComponent<PopperProps> {
   }
 
   public renderPopper() {
-    return <div ref={this.openPopper}>{this.props.children}</div>;
+    const {
+      anchorElement,
+      children,
+      containerElement,
+      open,
+      placement,
+      popperOptions,
+      portal,
+      ...elemProps
+    } = this.props;
+
+    return (
+      <div {...elemProps} ref={this.openPopper}>
+        {this.props.children}
+      </div>
+    );
   }
 
   private openPopper = (popperNode: HTMLDivElement) => {

--- a/modules/common/react/spec/Popper.spec.tsx
+++ b/modules/common/react/spec/Popper.spec.tsx
@@ -18,9 +18,11 @@ import * as PopperJS from 'popper.js';
 import {Popper, PopperProps} from '../lib/Popper';
 
 describe('Popper', () => {
+  const dataTestId = 'TESTY_TEST';
+
   const renderPopper = (props?: Partial<PopperProps>) => {
     return mount(
-      <Popper anchorElement={document.body} {...props}>
+      <Popper anchorElement={document.body} data-test-id={dataTestId} {...props}>
         <div id="content" />
       </Popper>
     );
@@ -82,6 +84,21 @@ describe('Popper', () => {
       expect.anything(),
       expect.objectContaining(popperOptions)
     );
+    component.unmount();
+  });
+
+  test('should include className attribute', () => {
+    const className = 'classy-popper';
+    const component = renderPopper({className});
+
+    expect(component.find(`div.${className}`).length).toBe(1);
+    component.unmount();
+  });
+
+  test('should include data-* attributes', () => {
+    const component = renderPopper();
+
+    expect(component.find(`div[data-test-id="${dataTestId}"]`).length).toBe(1);
     component.unmount();
   });
 });


### PR DESCRIPTION
## Summary

A request was made to be able to support adding a z-index to the wrapping div. This was solved generically using the styled components pattern to spread remainder props on the top-level element.

## Checklist

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] code follows the
      [style guide](https://ghe.megaleo.com/UIC/wd-components/blob/master/docs/STYLEGUIDE.md)
- [x] code has been documented and, if applicable, usage described in README.md