### PR TITLE
fix: specificity issue when you click on a primary button in the CSS …

### DIFF
--- a/modules/button/css/lib/button.scss
+++ b/modules/button/css/lib/button.scss
@@ -187,11 +187,11 @@ $_wdc-btn-caret-down-icon-hover: svg-load(
     }
 
     &.wdc-btn-active,
-    &:active {
+    &:active:not([disabled]):not(.wdc-btn-disabled) {
       background-color: $wdc-btn-bg-primary;
     }
 
-    &:focus,
+    &:focus:not([disabled]):not(.wdc-btn-disabled),
     &.wdc-btn-focus {
       background-color: $wdc-btn-bg-primary;
       box-shadow: 0 0 0 2px $wdc-btn-border-color-focus;


### PR DESCRIPTION
@lychyi hopefully submitting PR's is ok! I wanted to have a look at Canvas so sort of just diving in. Feel free to ignore and/or delete this PR if it doesn't follow proper guidelines!

Unfortunately, when I ran `yarn test` I saw many failures locally. I've ran `yarn install` so I'm not certain why but it seems like it passes CI checks here.

## Issue

If you run `yarn start` off `master` and then visit the storybook locally and view the Button --> All of the CSS section, the primary button doesn't properly reflect the active/focus states (it works in the React version however) in that you see absolutely no box-shadow.

The reason is, even though those rules come after line #179 `&:hover:not([disabled]):not(.wdc-btn-disabled)`, they do not have the _:not_'s and so have lower specificity.

As it seems there's no reason to not have these in the focus/active as well, I added thus bumping up the specificity to be equal, and so now the top down specificity that I believe was originally intended kicks in:

AFTER
![image](https://user-images.githubusercontent.com/142403/61757504-bcb0e800-ad75-11e9-8586-51e4b80882fb.png)


<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [ ] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
