### PR TITLE
feat(menu): Menu Item can skip onClose

### DIFF
--- a/modules/menu/react/README.md
+++ b/modules/menu/react/README.md
@@ -134,7 +134,8 @@ Default: `true`
 #### `onClose: () => void`
 
 > If specified, this callback is executed when the menu should close. Called after an item is
-> selected or the escape shortcut key is used.
+> selected or the escape shortcut key is used. This will not fire if the menu item overrides 
+> the action with canSkipClose.
 
 ---
 
@@ -229,3 +230,8 @@ Default: `false`
 > Allow you to disable a menu item so it is not clickable.
 
 Default: `false`
+
+#### `canSkipClose: boolean`
+
+> Allows you to skip the onClose Menu callback that is fired at the end of
+> the onClick event.

--- a/modules/menu/react/README.md
+++ b/modules/menu/react/README.md
@@ -134,8 +134,8 @@ Default: `true`
 #### `onClose: () => void`
 
 > If specified, this callback is executed when the menu should close. Called after an item is
-> selected or the escape shortcut key is used. This will not fire if the menu item overrides 
-> the action with canSkipClose.
+> selected or the escape shortcut key is used. This will not fire if the menu item
+> sets shouldClose to false
 
 ---
 
@@ -231,7 +231,12 @@ Default: `false`
 
 Default: `false`
 
-#### `canSkipClose: boolean`
+---
 
-> Allows you to skip the onClose Menu callback that is fired at the end of
-> the onClick event.
+#### `shouldClose: boolean`
+
+> Allows the onClose Menu callback to be fired after the menu item has been clicked
+
+Default: `true`
+
+---

--- a/modules/menu/react/lib/Menu.tsx
+++ b/modules/menu/react/lib/Menu.tsx
@@ -206,7 +206,9 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
       this.props.onSelect();
     }
     if (this.props.onClose) {
-      this.props.onClose();
+      if (!menuItemProps.canSkipClose) {
+        this.props.onClose();
+      }
     }
   };
 

--- a/modules/menu/react/lib/Menu.tsx
+++ b/modules/menu/react/lib/Menu.tsx
@@ -206,7 +206,7 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
       this.props.onSelect();
     }
     if (this.props.onClose) {
-      if (!menuItemProps.canSkipClose) {
+      if (menuItemProps.shouldClose) {
         this.props.onClose();
       }
     }

--- a/modules/menu/react/lib/MenuItem.tsx
+++ b/modules/menu/react/lib/MenuItem.tsx
@@ -21,7 +21,7 @@ export interface MenuItemProps {
   hasDivider?: boolean;
   isDisabled?: boolean;
   isFocused?: boolean;
-  canSkipClose?: boolean;
+  shouldClose?: boolean;
 }
 
 const Item = styled('li')<Pick<MenuItemProps, 'isDisabled' | 'isFocused'>>(
@@ -116,6 +116,10 @@ const SecondaryStyledSystemIcon = styled(StyledSystemIcon)({
 });
 
 export default class MenuItem extends React.Component<MenuItemProps> {
+  static defaultProps = {
+    shouldClose: true,
+  };
+
   render(): React.ReactNode {
     const {
       onClick,

--- a/modules/menu/react/lib/MenuItem.tsx
+++ b/modules/menu/react/lib/MenuItem.tsx
@@ -21,6 +21,7 @@ export interface MenuItemProps {
   hasDivider?: boolean;
   isDisabled?: boolean;
   isFocused?: boolean;
+  canSkipClose?: boolean;
 }
 
 const Item = styled('li')<Pick<MenuItemProps, 'isDisabled' | 'isFocused'>>(

--- a/modules/menu/react/spec/Menu.spec.tsx
+++ b/modules/menu/react/spec/Menu.spec.tsx
@@ -44,10 +44,22 @@ describe('Menu', () => {
     component.unmount();
   });
 
-  test('should not call on close function when item is clicked with canSkipClose enabled', () => {
+  test('should call on close function when item is clicked with shouldClose enabled', () => {
     const component = mount(
       <Menu onClose={cb}>
-        <MenuItem canSkipClose={true}/>
+        <MenuItem shouldClose={false} />
+      </Menu>
+    );
+    const item = component.find('li');
+    item.simulate('click');
+    expect(cb.mock.calls.length).toBe(0);
+    component.unmount();
+  });
+
+  test('should not call on close function when item is clicked with shouldClose disabled', () => {
+    const component = mount(
+      <Menu onClose={cb}>
+        <MenuItem shouldClose={false}/>
       </Menu>
     );
     const item = component.find('li');

--- a/modules/menu/react/spec/Menu.spec.tsx
+++ b/modules/menu/react/spec/Menu.spec.tsx
@@ -44,6 +44,18 @@ describe('Menu', () => {
     component.unmount();
   });
 
+  test('should not call on close function when item is clicked with canSkipClose enabled', () => {
+    const component = mount(
+      <Menu onClose={cb}>
+        <MenuItem canSkipClose={true}/>
+      </Menu>
+    );
+    const item = component.find('li');
+    item.simulate('click');
+    expect(cb.mock.calls.length).toBe(0);
+    component.unmount();
+  });
+
   test('should not call a callback function when disabled', () => {
     const component = mount(
       <Menu>


### PR DESCRIPTION
## Summary
The menu always fires the onClose event at the end of the onClick event (if onClose is provided). 
This change gives each menu item the ability to to skip the onClose event from firing, giving the menu more flexibility.

In our use case, a menu item has the ability to replace the contents of the menu with different menu items when it is clicked. This is difficult to do, because `onClose` will always fire. We were previously handling this by maintaining state in our application to determine if the `onClose` callback was actually supposed to close the menu.

## Checklist
- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] code has been documented and, if applicable, usage described in README.md
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)
