### PR TITLE
refactor(Tooltip): Update CSS styles to match React implementation

### DIFF
--- a/modules/tooltip/css/lib/tooltip.scss
+++ b/modules/tooltip/css/lib/tooltip.scss
@@ -1,12 +1,10 @@
 .wdc-tooltip {
   @include wdc-type();
   @include wdc-type-body();
-  @include wdc-depth-3();
   display: inline-block;
   background-color: $_wdc-tooltip-bg-color;
-  padding: $wdc-spacing-s;
-  border-radius: 3px;
-  border: 1px solid $_wdc-tooltip-border-color;
+  padding: 0;
+  border-radius: $wdc-spacing-xxxs;
   position: relative;
   width: max-content;
   max-width: $_wdc-tooltip-max-width;
@@ -24,142 +22,31 @@
     min-width: $_wdc-tooltip-menu-min-width;
   }
 
-  &-menu {
-    padding: $wdc-spacing-xxs 0;
-    min-width: $_wdc-tooltip-menu-min-width;
-
-    ul {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-
-      li {
-        color: $wdc-color-black-pepper-300;
-        padding: $wdc-spacing-xxxs $wdc-spacing-s;
-        font-size: 13px;
-        cursor: pointer;
-        transition: background-color 0.2s, color 0.2s;
-
-        a {
-          color: inherit;
-          text-decoration: none;
-        }
-
-        &.wdc-tooltip-menu-item-focus,
-        &:focus,
-        &.wdc-tooltip-menu-item-hover,
-        &:hover {
-          color: $wdc-color-french-vanilla-100;
-          background-color: $wdc-color-blueberry-500;
-        }
-      }
-    }
-  }
-
-  &-right,
-  &-left,
-  &-top,
-  &-bottom {
-
-    &:before,
-    &:after {
-      content: ' ';
-      position: absolute;
-      border-style: solid;
-      border-color: transparent;
-    }
-
-    &:before {
-      border-width: $_wdc-tooltip-arrow-size + 1px;
-    }
-
-    &:after {
-      border-width: $_wdc-tooltip-arrow-size;
-    }
-  }
-
   &-right {
-    margin-left: $wdc-spacing-s;
-
-    &:before,
-    &:after {
-      top: $_wdc-tooltip-arrow-offset;
-      right: 100%;
-    }
-
-    &:before {
-      margin-top: -($_wdc-tooltip-arrow-size + 1px);
-      border-right-color: $_wdc-tooltip-border-color;
-    }
-
-    &:after {
-      margin-top: -$_wdc-tooltip-arrow-size;
-      border-right-color: $_wdc-tooltip-bg-color;
-    }
+    margin-left: $wdc-spacing-xxxs;
   }
 
   &-left {
-    margin-right: $wdc-spacing-s;
+    margin-right: $wdc-spacing-xxxs;
+  }
 
-    &:before,
-    &:after {
-      top: $_wdc-tooltip-arrow-offset;
-      left: 100%;
-    }
-
-    &:before {
-      margin-top: -($_wdc-tooltip-arrow-size + 1px);
-      border-left-color: $_wdc-tooltip-border-color;
-    }
-
-    &:after {
-      margin-top: -$_wdc-tooltip-arrow-size;
-      border-left-color: $_wdc-tooltip-bg-color;
-    }
+  &-right,
+  &-left {
+    margin-top: 8px;
   }
 
   &-top {
-    margin-bottom: $wdc-spacing-s;
+    margin-bottom: $wdc-spacing-xxxs;
 
-    &:before,
-    &:after {
-      top: 100%;
-      left: $_wdc-tooltip-arrow-offset;
-    }
-
-    &:before {
-      margin-left: -($_wdc-tooltip-arrow-size + 1px);
-      border-top-color: $_wdc-tooltip-border-color;
-    }
-
-    &:after {
-      margin-left: -$_wdc-tooltip-arrow-size;
-      border-top-color: $_wdc-tooltip-bg-color;
-    }
   }
 
   &-bottom {
-    margin-top: $wdc-spacing-s;
-
-    &:before,
-    &:after {
-      bottom: 100%;
-      left: $_wdc-tooltip-arrow-offset;
-    }
-
-    &:before {
-      margin-left: -($_wdc-tooltip-arrow-size + 1px);
-      border-bottom-color: $_wdc-tooltip-border-color;
-    }
-
-    &:after {
-      margin-left: -$_wdc-tooltip-arrow-size;
-      border-bottom-color: $_wdc-tooltip-bg-color;
-    }
+    margin-top: $wdc-spacing-xxxs;
   }
 
-  padding: $wdc-spacing-xs $wdc-spacing-s;
-  font-size: 14px;
+  padding: $wdc-spacing-xxs;
+  font-size: 13px;
+  color: $wdc-color-french-vanilla-100;
   white-space: nowrap;
   min-width: auto;
   max-width: $_wdc-tooltip-max-width;

--- a/modules/tooltip/css/lib/tooltip.scss
+++ b/modules/tooltip/css/lib/tooltip.scss
@@ -1,25 +1,74 @@
+@keyframes tooltipAnimationTop {
+  from {
+    opacity: 0;
+    transform: translate(-50%, $wdc-spacing-xxxs);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0px);
+  }
+}
+
+@keyframes tooltipAnimationRight {
+  from {
+    opacity: 0;
+    transform: translate(-$wdc-spacing-xxxs, -50%);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate(0px, -50%);
+  }
+}
+
+@keyframes tooltipAnimationLeft {
+  from {
+    opacity: 0;
+    transform: translate($wdc-spacing-xxxs, -50%);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate(0px, -50%);
+  }
+}
+
+@keyframes tooltipAnimationBottom {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -$wdc-spacing-xxxs);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0px);
+  }
+}
+
 .wdc-tooltip {
   @include wdc-type();
   @include wdc-type-body();
-  display: inline-block;
   background-color: $_wdc-tooltip-bg-color;
-  padding: 0;
   border-radius: $wdc-spacing-xxxs;
+  color: $wdc-color-french-vanilla-100;
+  display: inline-block;
+  font-size: 13px;
+  min-width: auto;
+  padding: $wdc-spacing-xxs;
   position: relative;
+  white-space: nowrap;
   width: max-content;
-  max-width: $_wdc-tooltip-max-width;
 
   // Fallback for IE11
   @media screen and (-ms-high-contrast: active),
   screen and (-ms-high-contrast: none) {
     width: auto;
-    min-width: $_wdc-tooltip-menu-min-width;
   }
 
   // Fallback for Edge and browsers that don't support max-content
   @supports not (width: max-content) {
     width: auto;
-    min-width: $_wdc-tooltip-menu-min-width;
   }
 
   &-right {
@@ -37,19 +86,11 @@
 
   &-top {
     margin-bottom: $wdc-spacing-xxxs;
-
   }
 
   &-bottom {
     margin-top: $wdc-spacing-xxxs;
   }
-
-  padding: $wdc-spacing-xxs;
-  font-size: 13px;
-  color: $wdc-color-french-vanilla-100;
-  white-space: nowrap;
-  min-width: auto;
-  max-width: $_wdc-tooltip-max-width;
 
   &.wdc-tooltip-right,
   &.wdc-tooltip-left {
@@ -82,7 +123,6 @@
   .wdc-tooltip {
     visibility: hidden;
     opacity: 0;
-    transition: opacity 0.2s;
 
     &-right,
     &-left,
@@ -94,7 +134,8 @@
 
     &-left,
     &-right {
-      top: -$wdc-spacing-s;
+      top: calc(50% - 8px);
+      transform: translateY(-50%);
     }
 
     &-right {
@@ -107,7 +148,8 @@
 
     &-top,
     &-bottom {
-      left: 0;
+      left: 50%;
+      transform: translateX(-50%);
     }
 
     &-top {
@@ -132,6 +174,24 @@
     .wdc-tooltip {
       visibility: visible;
       opacity: 1;
+      animation-duration: 150ms;
+      animation-timing-function: ease-out;
+
+      &-right {
+        animation-name: tooltipAnimationRight;
+      }
+
+      &-left {
+        animation-name: tooltipAnimationLeft;
+      }
+
+      &-top {
+        animation-name: tooltipAnimationTop;
+      }
+
+      &-bottom {
+        animation-name: tooltipAnimationBottom;
+      }
     }
   }
 }

--- a/modules/tooltip/css/lib/tooltip.scss
+++ b/modules/tooltip/css/lib/tooltip.scss
@@ -61,8 +61,7 @@
   width: max-content;
 
   // Fallback for IE11
-  @media screen and (-ms-high-contrast: active),
-  screen and (-ms-high-contrast: none) {
+  @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
     width: auto;
   }
 
@@ -79,26 +78,12 @@
     margin-right: $wdc-spacing-xxxs;
   }
 
-  &-right,
-  &-left {
-    margin-top: 8px;
-  }
-
   &-top {
     margin-bottom: $wdc-spacing-xxxs;
   }
 
   &-bottom {
     margin-top: $wdc-spacing-xxxs;
-  }
-
-  &.wdc-tooltip-right,
-  &.wdc-tooltip-left {
-
-    &:before,
-    &:after {
-      top: 50%;
-    }
   }
 
   .wdc-tooltip-title {
@@ -134,16 +119,16 @@
 
     &-left,
     &-right {
-      top: calc(50% - 8px);
+      top: 50%;
       transform: translateY(-50%);
     }
 
     &-right {
-      left: calc(100%);
+      left: 100%;
     }
 
     &-left {
-      right: calc(100%);
+      right: 100%;
     }
 
     &-top,
@@ -158,14 +143,6 @@
 
     &-bottom {
       top: 100%;
-    }
-
-    &-tooltip {
-
-      &.wdc-tooltip-left,
-      &.wdc-tooltip-right {
-        top: -$wdc-spacing-xs;
-      }
     }
   }
 

--- a/modules/tooltip/css/lib/variables.scss
+++ b/modules/tooltip/css/lib/variables.scss
@@ -1,6 +1,2 @@
 $_wdc-tooltip-bg-color: rgba(0, 0, 0, .85);
-$_wdc-tooltip-border-color: $wdc-color-soap-500;
 $_wdc-tooltip-z-index: 200 !default;
-$_wdc-tooltip-max-width: 536px;
-$_wdc-tooltip-menu-min-width: 200px;
-$_wdc-tooltip-max-width: 256px;

--- a/modules/tooltip/css/lib/variables.scss
+++ b/modules/tooltip/css/lib/variables.scss
@@ -1,8 +1,5 @@
-$_wdc-tooltip-bg-color: $wdc-color-french-vanilla-100;
+$_wdc-tooltip-bg-color: rgba(0, 0, 0, .85);
 $_wdc-tooltip-border-color: $wdc-color-soap-500;
-$_wdc-tooltip-arrow-size: $wdc-spacing-xxs;
-$_wdc-tooltip-arrow-offset: $_wdc-tooltip-arrow-size+$wdc-spacing-s;
-$_wdc-tooltip-arrow-offset: $_wdc-tooltip-arrow-size+$wdc-spacing-xxs;
 $_wdc-tooltip-z-index: 200 !default;
 $_wdc-tooltip-max-width: 536px;
 $_wdc-tooltip-menu-min-width: 200px;


### PR DESCRIPTION
This PR updates the Tooltip CSS styles so they match the React component. 

|                  | Visual | Code |
|------------------|--------|------|
| Breaking Changes | Yes    | Yes   |

Note : The story doesn't perfectly match the React one because it relies on a Button style that doesn't exists yet in CSS. It will be added to the `css-update` later and we'll update the story of `Tooltip CSS` after that.


### Breaking Changes

**Visual:**

- Updated styling to match React implementation. No longer includes an arrow since the origin of the tooltip should be obvious when your mouse is on it (there's also an animation that helps).

**Code:**

- Removed `wdc-tooltip-menu` implementation. This is moving to the Popup module
- Removed tooltip max width
- Removed a large majority of the tooltip variables as they are no longer needed