### PR TITLE
build(travis): skip cleanup on npm publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ git:
   depth: 3
 stages:
 - name: pr-previews
-  if: "(branch = master AND type = pull_request) OR branch != master OR NOT branch =~ /^release-.+$/"
+  if: "(branch = master AND type = pull_request) OR branch != master"
 - name: npm publish
   if: branch = master AND type != pull_request AND tag IS present
 - name: master storybook
@@ -27,8 +27,10 @@ jobs:
   - stage: npm publish
     deploy:
       provider: npm
+      skip_cleanup: true
       email: "$GITHUB_EMAIL"
       api_key: "$NPM_TOKEN"
+      tag: prerelease # TODO: This needs to be changed to 'latest' eventually
       on:
         tags: true
   - stage: master storybook


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary
We need to skip the cleanup phase for Travis since we rely on the artifacts generated from the `install` phase to release.

This PR also tags every publish as prerelease. This models how Lerna does it for us today. We currently need to manually push `latest` as a dist-tag since we have no official `latest` version. 

We'll eventually need to change this up and write a script that pushes the appropriate dist tags during a publish.