### PR TITLE
ci(travis): fix npm publish conditional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ stages:
 - name: pr-previews
   if: "(branch = master AND type = pull_request) OR branch != master"
 - name: npm publish
-  if: branch = master AND type != pull_request AND tag IS present
+  if: branch =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND tag IS present
 - name: master storybook
   if: branch = master AND type != pull_request
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# 3.0.0-alpha.4 (2019-08-03)
+# 3.0.0-alpha.4 (2019-08-05)
 
 ### Infrastructure:
 
@@ -11,6 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - ci(travis): Enable tag publishing and re-enable master storybook (#52)
 - chore: Pull in version bumps from old release branch (#71)
 - build(travis): skip cleanup on npm publish (#79)
+- ci(travis): fix npm publish conditional (#81)
 
 ### Components:
 


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

In Travis Git tags are considered a "branch". This fixes the conditional to run `npm publish` on a particular tag format:

`/^v\d+\.\d+(\.\d+)?(-\S*)?$/`

This has been tested by:

```sh
travis-conditions eval "branch =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND tag IS present" --data '{"branch": "v3.0.0-alpha.4", "tag": "v3.0.0-alpha.4"}'
```

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [ ] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
