### PR TITLE
fix(Layout): Add check for null children

### DIFF
--- a/modules/layout/react/lib/Layout.tsx
+++ b/modules/layout/react/lib/Layout.tsx
@@ -61,6 +61,10 @@ export default class Layout extends React.Component<LayoutProps> {
   public static Column = Column;
 
   private renderChild = (child: React.ReactElement<ColumnProps>): React.ReactNode => {
+    if (!child) {
+      return;
+    }
+
     if (typeof child.type === typeof Column) {
       const childProps = child.props;
 

--- a/modules/layout/react/spec/Layout.snapshot.tsx
+++ b/modules/layout/react/spec/Layout.snapshot.tsx
@@ -50,6 +50,16 @@ describe('Layout Snapshots', () => {
     expect(component).toMatchSnapshot();
   });
 
+  test('renders a layout with conditional columns', () => {
+    const component = renderer.create(
+      <Layout>
+        <Layout.Column />
+        {false && <Layout.Column />}
+      </Layout>
+    );
+    expect(component).toMatchSnapshot();
+  });
+
   test('renders a layout and columns with 12 column grid widths', () => {
     const component = renderer.create(
       <Layout>

--- a/modules/layout/react/spec/__snapshots__/Layout.snapshot.tsx.snap
+++ b/modules/layout/react/spec/__snapshots__/Layout.snapshot.tsx.snap
@@ -247,6 +247,41 @@ exports[`Layout Snapshots renders a layout with capWidth 1`] = `
 </div>
 `;
 
+exports[`Layout Snapshots renders a layout with conditional columns 1`] = `
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0 12px;
+}
+
+.emotion-0 {
+  padding: 0 12px;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-0:first-child {
+  padding-left: 0;
+}
+
+.emotion-0:last-child {
+  padding-right: 0;
+}
+
+<div
+  className="emotion-2 emotion-3"
+>
+  <div
+    className="emotion-0 emotion-1"
+  />
+</div>
+`;
+
 exports[`Layout Snapshots renders a layout with fluid columns 1`] = `
 .emotion-6 {
   display: -webkit-box;


### PR DESCRIPTION
## Summary

There was a type error happening when a child of `Layout` returned null. It should be possible to have conditional columns, so this change makes that possible.

Closes https://github.com/Workday/canvas-kit/issues/84

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)
