### PR TITLE
fix(avatar): Update background color when url is defined

### DIFF
--- a/modules/avatar/react/lib/Avatar.tsx
+++ b/modules/avatar/react/lib/Avatar.tsx
@@ -53,7 +53,7 @@ const Container = styled('button')<Omit<AvatarProps, 'altText'>>(
     },
   },
   ({themeColor, size, onClick}) => ({
-    background: themeColor === AvatarTheme.Dark ? colors.blueberry400 : colors.soap300,
+    background: colors.soap200,
     height: size,
     width: size,
     cursor: onClick ? 'pointer' : 'default',

--- a/modules/avatar/react/spec/__snapshots__/Avatar.snapshot.tsx.snap
+++ b/modules/avatar/react/spec/__snapshots__/Avatar.snapshot.tsx.snap
@@ -19,7 +19,7 @@ exports[`Avatar Snapshots renders a large Avatar 1`] = `
   border-radius: 100%;
   box-sizing: border-box;
   overflow: hidden;
-  background: #e8ebed;
+  background: #f0f1f2;
   height: 64px;
   width: 64px;
   cursor: default;
@@ -152,7 +152,7 @@ exports[`Avatar Snapshots renders a large avatar with a photo 1`] = `
   border-radius: 100%;
   box-sizing: border-box;
   overflow: hidden;
-  background: #e8ebed;
+  background: #f0f1f2;
   height: 64px;
   width: 64px;
   cursor: default;
@@ -211,7 +211,7 @@ exports[`Avatar Snapshots renders a large, dark Avatar 1`] = `
   border-radius: 100%;
   box-sizing: border-box;
   overflow: hidden;
-  background: #0875e1;
+  background: #f0f1f2;
   height: 64px;
   width: 64px;
   cursor: default;
@@ -344,7 +344,7 @@ exports[`Avatar Snapshots renders an avatar with a photo 1`] = `
   border-radius: 100%;
   box-sizing: border-box;
   overflow: hidden;
-  background: #e8ebed;
+  background: #f0f1f2;
   height: 32px;
   width: 32px;
   cursor: default;
@@ -403,7 +403,7 @@ exports[`Avatar Snapshots renders an avatar with an aria label and an alt text 1
   border-radius: 100%;
   box-sizing: border-box;
   overflow: hidden;
-  background: #e8ebed;
+  background: #f0f1f2;
   height: 64px;
   width: 64px;
   cursor: default;
@@ -462,7 +462,7 @@ exports[`Avatar Snapshots renders as expected 1`] = `
   border-radius: 100%;
   box-sizing: border-box;
   overflow: hidden;
-  background: #e8ebed;
+  background: #f0f1f2;
   height: 32px;
   width: 32px;
   cursor: default;

--- a/modules/header/react/spec/__snapshots__/GlobalHeader.snapshot.tsx.snap
+++ b/modules/header/react/spec/__snapshots__/GlobalHeader.snapshot.tsx.snap
@@ -397,7 +397,7 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
   border-radius: 100%;
   box-sizing: border-box;
   overflow: hidden;
-  background: #e8ebed;
+  background: #f0f1f2;
   height: 32px;
   width: 32px;
   cursor: default;
@@ -1647,7 +1647,7 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
   border-radius: 100%;
   box-sizing: border-box;
   overflow: hidden;
-  background: #e8ebed;
+  background: #f0f1f2;
   height: 32px;
   width: 32px;
   cursor: default;


### PR DESCRIPTION
## Summary

We never removed the background when we replaced the `SystemIcon` with `SystemIconCircle`. If the user passes the theme of Blue with an image, they get a flash of blue while the image loads (see https://ghe.megaleo.com/design/canvas-kit-react/issues/470). This change always uses our standard `Skeleton` background color (`soap200`) while the image is loading if `url` is defined.

Closes https://ghe.megaleo.com/design/canvas-kit-react/issues/470

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [ ] `yarn test` passes
