### PR TITLE
fix(header): Remove duplicate icon buttons

### DIFF
--- a/modules/header/react/stories/stories.tsx
+++ b/modules/header/react/stories/stories.tsx
@@ -8,7 +8,6 @@ import chroma from 'chroma-js';
 import {notificationsIcon, inboxIcon} from '@workday/canvas-system-icons-web';
 
 import {Avatar} from '../../../avatar/react/index';
-import {SystemIcon} from '../../../icon/react/index';
 import {colors, spacing} from '../../../core/react/index';
 import {Button, IconButton} from '../../../button/react/index';
 import {GlobalHeader, Header, DubLogoTitle, WorkdayLogoTitle, HeaderVariant} from '../index';
@@ -152,19 +151,15 @@ storiesOf('Header', module)
       </div>
       <div className={containerStyle}>
         <Header title="Icons Only" brandUrl="#" onSearchSubmit={handleSearchSubmitTest}>
-          {/* Test states and padding on various types of icons */}
-          <a href="/">
-            <SystemIcon icon={notificationsIcon} />
-          </a>
           <IconButton
-            icon={inboxIcon}
             buttonType={IconButton.Types.Circle}
-            title="Inbox"
-            aria-label="Inbox"
+            icon={notificationsIcon}
+            title="Notifications"
+            aria-label="Notifications"
           />
           <IconButton
+            buttonType={IconButton.Types.Circle}
             icon={inboxIcon}
-            buttonType={IconButton.Types.Plain}
             title="Inbox"
             aria-label="Inbox"
           />
@@ -213,12 +208,6 @@ storiesOf('Header', module)
             icon={notificationsIcon}
             title="Notifications"
             aria-label="Notifications"
-          />
-          <IconButton
-            buttonType={IconButton.Types.Circle}
-            icon={inboxIcon}
-            title="Inbox"
-            aria-label="Inbox"
           />
           <IconButton
             buttonType={IconButton.Types.Circle}


### PR DESCRIPTION
## Summary

@jessespencer noticed there were some duplicate icons in the header stories. These were due to incorrect rebase merges. This PR removes the duplicates.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] `yarn test` passes

## Additional References

Before:
![Screen Shot 2019-08-14 at 1 57 18 PM](https://user-images.githubusercontent.com/908478/63055784-83aef380-be9b-11e9-93f0-a0368375e734.png)

After:
![Screen Shot 2019-08-14 at 1 57 35 PM](https://user-images.githubusercontent.com/908478/63055778-80b40300-be9b-11e9-8a17-3f2f6058ecf7.png)