### PR TITLE
refactor(PageHeader): updated prop marketing -> capWidth

### DIFF
--- a/modules/page-header/react/README.md
+++ b/modules/page-header/react/README.md
@@ -29,7 +29,7 @@ import {exportIcon, fullscreenIcon} from '@workday/canvas-system-icons-web';
   <IconButton icon={fullscreenIcon} />
 </PageHeader>
 
-<PageHeader title="Marketing" marketing={true}>
+<PageHeader title="With Cap Width" capWidth={true}>
   <IconButton icon={exportIcon} />
   <IconButton icon={fullscreenIcon} />
 </PageHeader>
@@ -55,10 +55,10 @@ Default: `''`
 
 ---
 
-#### `marketing: boolean`
+#### `capWidth: boolean`
 
-> Use the page header in the marketing context (non-product). In this context, content is centered
-> and the page header is responsive in all three breakpoints.
+> Use the page header in the non-product page. In this context, content is centered and the page
+> header is responsive in all three breakpoints.
 
 Defalut: `false`
 
@@ -72,8 +72,7 @@ Defalut: `false`
 > For example, by default a mobile screen size would be from 0 to 767 pixels, a 'sm' screen is from
 > 768 to 991, a 'md' screen is from 992 to 1199 pixels, and a 'lg' screen is 1200 pixels and beyond.
 >
-> For a non-marketing (default) context, the page header only adjusts its spacing styles up until
-> the 'sm' size breakpoint. In the `marketing` context, a page header adjusts for spacing in all
-> sizes.
+> In the default context, the page header only adjusts its spacing styles up until the 'sm' size
+> breakpoint. In the `capWidth` context, a page header adjusts for spacing in all sizes.
 
 Default: `{ sm: 768, md: 992, lg: 1200 }`

--- a/modules/page-header/react/lib/PageHeader.tsx
+++ b/modules/page-header/react/lib/PageHeader.tsx
@@ -6,7 +6,7 @@ import {makeMq} from '@workday/canvas-kit-react-common';
 
 export interface PageHeaderProps {
   title: string;
-  marketing: boolean;
+  capWidth: boolean;
   breakpoints: {
     sm: number;
     md: number;
@@ -31,10 +31,10 @@ const Container = styled('div')<PageHeaderProps>(
     overflow: 'hidden',
     padding: `0 ${spacing.s}`,
   },
-  ({marketing, breakpoints}) => {
+  ({capWidth, breakpoints}) => {
     const mq = makeMq(breakpoints);
 
-    if (marketing) {
+    if (capWidth) {
       return {
         boxSizing: 'border-box',
         margin: '0 auto',
@@ -81,7 +81,7 @@ const IconList = styled('div')({
 export default class PageHeader extends React.Component<PageHeaderProps> {
   static defaultProps = {
     title: '',
-    marketing: false,
+    capWidth: false,
     breakpoints: {
       sm: 768,
       md: 992,

--- a/modules/page-header/react/spec/PageHeader.snapshot.tsx
+++ b/modules/page-header/react/spec/PageHeader.snapshot.tsx
@@ -7,9 +7,9 @@ describe('Page Header Snapshots', () => {
     const component = renderer.create(<PageHeader title="Test Page Header" />);
     expect(component).toMatchSnapshot();
   });
-  test('renders a marketing context PageHeader as expected', () => {
+  test('renders a capWidth context PageHeader as expected', () => {
     const component = renderer.create(
-      <PageHeader title="Test Marketing Page Header" marketing={true} />
+      <PageHeader title="Test capWidth Page Header" capWidth={true} />
     );
     expect(component).toMatchSnapshot();
   });

--- a/modules/page-header/react/spec/PageHeader.spec.tsx
+++ b/modules/page-header/react/spec/PageHeader.spec.tsx
@@ -20,8 +20,8 @@ describe('Page Header', () => {
     expect(component.find('h2').contains(testTitle));
   });
 
-  test('should have a maxWidth in marketing contexts', () => {
-    const component = mount(<PageHeader title="Marketing Context" marketing={true} />);
+  test('should have a maxWidth in capWidth contexts', () => {
+    const component = mount(<PageHeader title="capWidth Context" capWidth={true} />);
     expect(component.find('div').first()).toHaveStyleRule('max-width', '1440px');
   });
   test('should render a copy of the children', () => {

--- a/modules/page-header/react/spec/__snapshots__/PageHeader.snapshot.tsx.snap
+++ b/modules/page-header/react/spec/__snapshots__/PageHeader.snapshot.tsx.snap
@@ -75,7 +75,7 @@ exports[`Page Header Snapshots renders a basic PageHeader as expected 1`] = `
 </header>
 `;
 
-exports[`Page Header Snapshots renders a marketing context PageHeader as expected 1`] = `
+exports[`Page Header Snapshots renders a capWidth context PageHeader as expected 1`] = `
 .emotion-6 {
   height: 84px;
   background-image: linear-gradient(to bottom right,#0875e1,#005cb9);
@@ -152,12 +152,12 @@ exports[`Page Header Snapshots renders a marketing context PageHeader as expecte
 >
   <div
     className="emotion-4 emotion-5"
-    title="Test Marketing Page Header"
+    title="Test capWidth Page Header"
   >
     <h2
       className="emotion-0 emotion-1"
     >
-      Test Marketing Page Header
+      Test capWidth Page Header
     </h2>
     <div
       className="emotion-2 emotion-3"

--- a/modules/page-header/react/stories/stories.tsx
+++ b/modules/page-header/react/stories/stories.tsx
@@ -19,9 +19,9 @@ storiesOf('Page Header', module)
       </PageHeader>
     </div>
   ))
-  .add('Marketing Page Header', () => (
+  .add('With Cap Width', () => (
     <div className="story">
-      <PageHeader title="Marketing Context" marketing={true}>
+      <PageHeader title="With Cap Width" capWidth={true}>
         <IconButton icon={exportIcon} />
         <IconButton icon={fullscreenIcon} />
       </PageHeader>


### PR DESCRIPTION
BREAKING CHANGE: PageHeader prop marketing has changed to capWidth

references #51, #104 

<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
