### PR TITLE
fix(FormField): Add component prefix to exported enums and interfaces

### DIFF
--- a/modules/form-field/react/README.md
+++ b/modules/form-field/react/README.md
@@ -45,7 +45,7 @@ import TextInput from '@workday/canvas-kit-react-text-input';
 
 ---
 
-#### `LabelPosition: LabelPosition`
+#### `LabelPosition: FormFieldLabelPosition`
 
 ```tsx
 <TextInput labelPosition={TextInput.LabelPosition.Left} />
@@ -121,7 +121,7 @@ Default: `undefined`
 
 ---
 
-#### `labelPosition: LabelPosition`
+#### `labelPosition: FormFieldLabelPosition`
 
 > The position of the label relative to the input field.
 
@@ -201,7 +201,7 @@ import {Label} from '@workday/canvas-kit-react-form-field';
 
 ## Static Properties
 
-#### `Position: LabelPosition`
+#### `Position: FormFieldLabelPosition`
 
 ```tsx
 <Label error={Label.Position.Left} />
@@ -211,7 +211,7 @@ import {Label} from '@workday/canvas-kit-react-form-field';
 
 ### Optional
 
-#### `labelPosition: LabelPosition`
+#### `labelPosition: FormFieldLabelPosition`
 
 > Position of the label.
 

--- a/modules/form-field/react/lib/FormField.tsx
+++ b/modules/form-field/react/lib/FormField.tsx
@@ -4,10 +4,10 @@ import {spacing} from '@workday/canvas-kit-react-core';
 import {GrowthBehavior, ErrorType} from '@workday/canvas-kit-react-common';
 import Hint from './Hint';
 import Label from './Label';
-import {LabelPosition, LabelPositionBehavior} from './types';
+import {FormFieldLabelPosition, FormFieldLabelPositionBehavior} from './types';
 
 export interface FormFieldProps extends GrowthBehavior {
-  labelPosition: LabelPosition;
+  labelPosition: FormFieldLabelPosition;
   label?: React.ReactNode;
   hintText?: React.ReactNode;
   hintId?: string;
@@ -17,19 +17,19 @@ export interface FormFieldProps extends GrowthBehavior {
   children: React.ReactNode;
 }
 
-export interface ErrorBehavior {
+export interface FormFieldErrorBehavior {
   error?: ErrorType;
 }
 
 // Use a fieldset element for accessible radio groups
-const FormFieldFieldsetContainer = styled('fieldset')<LabelPositionBehavior>({
+const FormFieldFieldsetContainer = styled('fieldset')<FormFieldLabelPositionBehavior>({
   padding: 0,
   margin: 0,
   border: 0,
 });
 
-const FormFieldContainer = styled('div')<LabelPositionBehavior>(({labelPosition}) => {
-  if (labelPosition === LabelPosition.Left) {
+const FormFieldContainer = styled('div')<FormFieldLabelPositionBehavior>(({labelPosition}) => {
+  if (labelPosition === FormFieldLabelPosition.Left) {
     return {
       display: 'flex',
       marginBottom: spacing.m,
@@ -41,10 +41,10 @@ const FormFieldContainer = styled('div')<LabelPositionBehavior>(({labelPosition}
   };
 });
 
-const FormFieldInputContainer = styled('div')<GrowthBehavior & LabelPositionBehavior>(
+const FormFieldInputContainer = styled('div')<GrowthBehavior & FormFieldLabelPositionBehavior>(
   ({grow, labelPosition}) => {
     if (grow) {
-      if (labelPosition === LabelPosition.Left) {
+      if (labelPosition === FormFieldLabelPosition.Left) {
         return {
           flexGrow: 1,
         };
@@ -55,7 +55,7 @@ const FormFieldInputContainer = styled('div')<GrowthBehavior & LabelPositionBeha
       };
     }
 
-    if (labelPosition === LabelPosition.Left) {
+    if (labelPosition === FormFieldLabelPosition.Left) {
       return {
         display: 'inline-flex',
         minHeight: 40,
@@ -71,7 +71,7 @@ const FormFieldInputContainer = styled('div')<GrowthBehavior & LabelPositionBeha
 );
 
 export default class FormField extends React.Component<FormFieldProps> {
-  static LabelPosition = LabelPosition;
+  static LabelPosition = FormFieldLabelPosition;
   static ErrorType = ErrorType;
 
   static defaultProps = {
@@ -81,7 +81,9 @@ export default class FormField extends React.Component<FormFieldProps> {
 
   private renderChildren = (child: React.ReactChild): React.ReactNode => {
     if (React.isValidElement<any>(child)) {
-      const props: GrowthBehavior & ErrorBehavior & React.HTMLAttributes<HTMLInputElement> = {
+      const props: GrowthBehavior &
+        FormFieldErrorBehavior &
+        React.HTMLAttributes<HTMLInputElement> = {
         ...child.props,
       };
 
@@ -89,7 +91,10 @@ export default class FormField extends React.Component<FormFieldProps> {
         props.grow = this.props.grow;
       }
 
-      if (typeof this.props.error !== 'undefined' && React.isValidElement<ErrorBehavior>(child)) {
+      if (
+        typeof this.props.error !== 'undefined' &&
+        React.isValidElement<FormFieldErrorBehavior>(child)
+      ) {
         props.error = this.props.error;
 
         if (this.props.hintId) {

--- a/modules/form-field/react/lib/Label.tsx
+++ b/modules/form-field/react/lib/Label.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import styled from 'react-emotion';
 import {spacing, type} from '@workday/canvas-kit-react-core';
-import {LabelPosition, LabelPositionBehavior} from './types';
+import {FormFieldLabelPosition, FormFieldLabelPositionBehavior} from './types';
 
-export interface LabelProps extends LabelPositionBehavior {
-  labelPosition: LabelPosition;
+export interface LabelProps extends FormFieldLabelPositionBehavior {
+  labelPosition: FormFieldLabelPosition;
   isLegend: boolean;
   htmlFor?: string;
 }
@@ -16,7 +16,7 @@ const labelStyles = [
     padding: 0,
   },
   (props: LabelProps) => {
-    if (props.labelPosition === LabelPosition.Left) {
+    if (props.labelPosition === FormFieldLabelPosition.Left) {
       return {
         display: 'inline-block',
         verticalAlign: 'top',
@@ -38,7 +38,7 @@ const LegendComponent = styled('legend')<LabelProps>(...labelStyles);
 const LabelComponent = styled('label')<LabelProps>(...labelStyles);
 
 export default class Label extends React.Component<LabelProps> {
-  static Position = LabelPosition;
+  static Position = FormFieldLabelPosition;
 
   static defaultProps = {
     labelPosition: Label.Position.Top,

--- a/modules/form-field/react/lib/types.ts
+++ b/modules/form-field/react/lib/types.ts
@@ -1,8 +1,8 @@
-export enum LabelPosition {
+export enum FormFieldLabelPosition {
   Top,
   Left,
 }
 
-export interface LabelPositionBehavior {
-  labelPosition?: LabelPosition;
+export interface FormFieldLabelPositionBehavior {
+  labelPosition?: FormFieldLabelPosition;
 }

--- a/modules/form-field/react/spec/FormField.spec.tsx
+++ b/modules/form-field/react/spec/FormField.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {mount} from 'enzyme';
 import {GrowthBehavior} from '@workday/canvas-kit-react-common';
-import FormField, {ErrorBehavior} from '../lib/FormField';
+import FormField, {FormFieldErrorBehavior} from '../lib/FormField';
 
 describe('FormField', () => {
   test('Set a string label', () => {
@@ -95,7 +95,7 @@ describe('FormField', () => {
   });
 
   test('Sets error prop with aria label', () => {
-    const InputComponent: React.SFC<ErrorBehavior> = () => <input type="text" />;
+    const InputComponent: React.SFC<FormFieldErrorBehavior> = () => <input type="text" />;
 
     const component = mount(
       <FormField error={FormField.ErrorType.Error}>
@@ -118,7 +118,7 @@ describe('FormField', () => {
   });
 
   test('Uses fieldset and legend when useFieldset=true (for RadioGroup)', () => {
-    const InputComponent: React.SFC<ErrorBehavior> = () => <input type="text" />;
+    const InputComponent: React.SFC<FormFieldErrorBehavior> = () => <input type="text" />;
 
     const component = mount(
       <FormField useFieldset={true} label="Label">


### PR DESCRIPTION
This PR updates exports `FormField` enums/interfaces to match our API & Pattern guidelines to avoid naming clashes in the future.

|                  | Visual | Code |
|------------------|--------|------|
| Breaking Changes | No    | Yes   |

### Code
- Updated `LabelPosition` to `FormFieldLabelPosition`
- Updated `LabelPositionBehavior` to `FormFieldLabelPositionBehavior`
- Updated `ErrorBehavior` to `FormFieldErrorBehavior`

Closes #100

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
