### PR TITLE
feat: Standardize elemProps prop spread behavior

### DIFF
--- a/modules/action-bar/react/lib/ActionBar.tsx
+++ b/modules/action-bar/react/lib/ActionBar.tsx
@@ -51,10 +51,10 @@ const ChildrenContainer = styled('div')({
 
 export default class ActionBar extends React.Component<ActionBarProps> {
   public render() {
-    const {fixed, children, ...props} = this.props;
+    const {fixed, children, ...elemProps} = this.props;
 
     return (
-      <ActionBarContainer {...props} fixed={fixed}>
+      <ActionBarContainer {...elemProps} fixed={fixed}>
         <ChildrenContainer>{children}</ChildrenContainer>
       </ActionBarContainer>
     );

--- a/modules/action-bar/react/spec/ActionBar.spec.tsx
+++ b/modules/action-bar/react/spec/ActionBar.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {mount} from 'enzyme';
 import ActionBar from '../index';
 
-describe(' Action Toolbar', () => {
+describe('ActionBar', () => {
   const cb = jest.fn();
   afterEach(() => {
     cb.mockReset();
@@ -11,6 +11,13 @@ describe(' Action Toolbar', () => {
   test('render a action bar with id', () => {
     const component = mount(<ActionBar id="myActionBar">Button Label</ActionBar>);
     expect(component.find(ActionBar).props().id).toBe('myActionBar');
+    component.unmount();
+  });
+
+  test('ActionBar should spread extra props', () => {
+    const component = mount(<ActionBar data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
     component.unmount();
   });
 });

--- a/modules/avatar/react/spec/Avatar.spec.tsx
+++ b/modules/avatar/react/spec/Avatar.spec.tsx
@@ -23,6 +23,13 @@ describe('Avatar', () => {
     expect(cb.mock.calls.length).toBe(1);
     component.unmount();
   });
+
+  test('Avatar should spread extra props', () => {
+    const component = mount(<Avatar data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
 });
 
 describe('Avatar Accessibility', () => {

--- a/modules/banner/react/spec/Banner.spec.tsx
+++ b/modules/banner/react/spec/Banner.spec.tsx
@@ -1,7 +1,17 @@
 import * as React from 'react';
+import {mount} from 'enzyme';
 import Banner from '../lib/Banner';
 import ReactDOMServer from 'react-dom/server';
 import {axe} from 'jest-axe';
+
+describe('Banner', () => {
+  test('Banner should spread extra props', () => {
+    const component = mount(<Banner data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
+});
 
 describe('Banner Accessibility', () => {
   test('Banner should pass axe DOM accessibility guidelines', async () => {

--- a/modules/button/react/spec/Button.spec.tsx
+++ b/modules/button/react/spec/Button.spec.tsx
@@ -36,6 +36,13 @@ describe('Button', () => {
     expect(cb.mock.calls.length).toBe(0);
     component.unmount();
   });
+
+  test('Button should spread extra props', () => {
+    const component = mount(<Button data-propspread="test">Button Label</Button>);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
 });
 
 describe('TextButton', () => {

--- a/modules/card/react/spec/Card.spec.tsx
+++ b/modules/card/react/spec/Card.spec.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import {mount} from 'enzyme';
+import Card from '../lib/Card';
+
+describe('Card', () => {
+  test('Card should spread extra props', () => {
+    const component = mount(<Card data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
+});

--- a/modules/checkbox/react/lib/Checkbox.tsx
+++ b/modules/checkbox/react/lib/Checkbox.tsx
@@ -232,6 +232,7 @@ export default class Checkbox extends React.Component<CheckboxProps> {
   };
 
   public render() {
+    // TODO: Standardize on prop spread location (see #150)
     const {
       checked,
       disabled,

--- a/modules/checkbox/react/lib/Checkbox.tsx
+++ b/modules/checkbox/react/lib/Checkbox.tsx
@@ -241,7 +241,7 @@ export default class Checkbox extends React.Component<CheckboxProps> {
       onChange,
       value,
       error,
-      ...otherProps
+      ...elemProps
     } = this.props;
 
     return (
@@ -256,7 +256,7 @@ export default class Checkbox extends React.Component<CheckboxProps> {
             type="checkbox"
             value={value}
             error={error}
-            {...otherProps}
+            {...elemProps}
           />
           <CheckboxBackground checked={checked} disabled={disabled}>
             <CheckboxCheck checked={checked}>

--- a/modules/checkbox/react/spec/Checkbox.spec.tsx
+++ b/modules/checkbox/react/spec/Checkbox.spec.tsx
@@ -46,8 +46,10 @@ describe('Checkbox', () => {
 
   test('Checkbox should spread extra props', () => {
     const component = mount(<Checkbox data-propspread="test" />);
-    const container = component.at(0).getDOMNode();
-    expect(container.getAttribute('data-propspread')).toBe('test');
+    const input = component
+      .find('input') // TODO: Standardize on prop spread location (see #150)
+      .getDOMNode();
+    expect(input.getAttribute('data-propspread')).toBe('test');
     component.unmount();
   });
 });

--- a/modules/checkbox/react/spec/Checkbox.spec.tsx
+++ b/modules/checkbox/react/spec/Checkbox.spec.tsx
@@ -43,6 +43,13 @@ describe('Checkbox', () => {
     expect(cb.mock.calls.length).toBe(1);
     component.unmount();
   });
+
+  test('Checkbox should spread extra props', () => {
+    const component = mount(<Checkbox data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
 });
 
 describe('Checkbox Accessibility', () => {

--- a/modules/color-picker/react/lib/ColorInput.tsx
+++ b/modules/color-picker/react/lib/ColorInput.tsx
@@ -105,7 +105,7 @@ export default class ColorInput extends React.Component<ColorInputProps> {
       inputRef,
       disabled,
       placeholder,
-      ...otherProps
+      ...elemProps
     } = this.props;
     const formattedValue = this.formatValue(value);
 
@@ -120,7 +120,7 @@ export default class ColorInput extends React.Component<ColorInputProps> {
           spellCheck={false}
           disabled={disabled}
           maxLength={7} // 7 to allow pasting with a hash
-          {...otherProps}
+          {...elemProps}
         />
         <SwatchTile
           style={{

--- a/modules/color-picker/react/lib/ColorInput.tsx
+++ b/modules/color-picker/react/lib/ColorInput.tsx
@@ -97,6 +97,7 @@ export default class ColorInput extends React.Component<ColorInputProps> {
   };
 
   public render() {
+    // TODO: Standardize on prop spread location (see #150)
     const {
       showCheck,
       value,

--- a/modules/color-picker/react/lib/ColorPreview.tsx
+++ b/modules/color-picker/react/lib/ColorPreview.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import ColorInput from './ColorInput';
+import {TextInputProps} from '@workday/canvas-kit-react-text-input';
 import styled from 'react-emotion';
 import {colors} from '@workday/canvas-kit-react-core';
 
-export interface ColorPreviewProps {
+export interface ColorPreviewProps extends TextInputProps {
   value: string;
   id?: string;
 }
@@ -16,13 +17,10 @@ const ColorPreviewComponent = styled(ColorInput)({
 
 export default class ColorPreview extends React.Component<ColorPreviewProps> {
   public render() {
+    const {id, value, ...elemProps} = this.props;
+
     return (
-      <ColorPreviewComponent
-        id={this.props.id}
-        value={this.props.value}
-        readOnly={true}
-        placeholder=""
-      />
+      <ColorPreviewComponent id={id} value={value} readOnly={true} placeholder="" {...elemProps} />
     );
   }
 }

--- a/modules/color-picker/react/lib/ColorPreview.tsx
+++ b/modules/color-picker/react/lib/ColorPreview.tsx
@@ -17,6 +17,7 @@ const ColorPreviewComponent = styled(ColorInput)({
 
 export default class ColorPreview extends React.Component<ColorPreviewProps> {
   public render() {
+    // TODO: Standardize on prop spread location (see #150)
     const {id, value, ...elemProps} = this.props;
 
     return (

--- a/modules/color-picker/react/spec/ColorInput.spec.tsx
+++ b/modules/color-picker/react/spec/ColorInput.spec.tsx
@@ -95,8 +95,10 @@ describe('ColorInput', () => {
 
   test('ColorInput should spread extra props', () => {
     const component = mount(<ColorInput data-propspread="test" />);
-    const container = component.at(0).getDOMNode();
-    expect(container.getAttribute('data-propspread')).toBe('test');
+    const input = component
+      .find('input') // TODO: Standardize on prop spread location (see #150)
+      .getDOMNode();
+    expect(input.getAttribute('data-propspread')).toBe('test');
     component.unmount();
   });
 });

--- a/modules/color-picker/react/spec/ColorInput.spec.tsx
+++ b/modules/color-picker/react/spec/ColorInput.spec.tsx
@@ -92,6 +92,13 @@ describe('ColorInput', () => {
     mount(<ColorInput inputRef={ref} value={''} />);
     expect(ref.current && ref.current.tagName && ref.current.tagName.toUpperCase()).toBe('INPUT');
   });
+
+  test('ColorInput should spread extra props', () => {
+    const component = mount(<ColorInput data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
 });
 
 describe('ColorInput Accessibility', () => {

--- a/modules/color-picker/react/spec/ColorPreview.spec.tsx
+++ b/modules/color-picker/react/spec/ColorPreview.spec.tsx
@@ -8,8 +8,10 @@ import ColorPreview from '../lib/ColorPreview';
 describe('ColorPreview', () => {
   test('Card should spread extra props', () => {
     const component = mount(<ColorPreview value={'#ffffff'} data-propspread="test" />);
-    const container = component.at(0).getDOMNode();
-    expect(container.getAttribute('data-propspread')).toBe('test');
+    const input = component
+      .find('input') // TODO: Standardize on prop spread location (see #150)
+      .getDOMNode();
+    expect(input.getAttribute('data-propspread')).toBe('test');
     component.unmount();
   });
 });

--- a/modules/color-picker/react/spec/ColorPreview.spec.tsx
+++ b/modules/color-picker/react/spec/ColorPreview.spec.tsx
@@ -1,8 +1,18 @@
 import * as React from 'react';
+import {mount} from 'enzyme';
 import ReactDOMServer from 'react-dom/server';
 import {axe} from 'jest-axe';
 import FormField from '@workday/canvas-kit-react-form-field';
 import ColorPreview from '../lib/ColorPreview';
+
+describe('ColorPreview', () => {
+  test('Card should spread extra props', () => {
+    const component = mount(<ColorPreview value={'#ffffff'} data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
+});
 
 describe('ColorPreview Accessibility', () => {
   test('ColorPreview should pass axe DOM accessibility guidelines', async () => {

--- a/modules/cookie-banner/react/lib/CookieBanner.tsx
+++ b/modules/cookie-banner/react/lib/CookieBanner.tsx
@@ -87,10 +87,10 @@ export default class CookieBanner extends React.Component<CookieBannerProps> {
   };
 
   public render(): React.ReactNode {
-    const {isClosed, onAccept, onClickSettings, notice} = this.props;
+    const {isClosed, onAccept, onClickSettings, notice, ...elemProps} = this.props;
 
     return (
-      <Banner isClosed={isClosed}>
+      <Banner isClosed={isClosed} {...elemProps}>
         <BannerItem>{notice}</BannerItem>
         <BannerItem className={rowStyle}>
           {onClickSettings && (

--- a/modules/cookie-banner/react/spec/CookieBanner.spec.tsx
+++ b/modules/cookie-banner/react/spec/CookieBanner.spec.tsx
@@ -37,4 +37,11 @@ describe('Cookie Banner', () => {
     component.find('button[children="Cookie Settings"]').simulate('click');
     expect(cb).toHaveBeenCalled();
   });
+
+  test('Cookie Banner should spread extra props', () => {
+    const component = mount(<CookieBanner onAccept={noop} data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
 });

--- a/modules/form-field/react/lib/FormField.tsx
+++ b/modules/form-field/react/lib/FormField.tsx
@@ -6,7 +6,7 @@ import Hint from './Hint';
 import Label from './Label';
 import {FormFieldLabelPosition, FormFieldLabelPositionBehavior} from './types';
 
-export interface FormFieldProps extends GrowthBehavior {
+export interface FormFieldProps extends React.HTMLAttributes<HTMLDivElement>, GrowthBehavior {
   labelPosition: FormFieldLabelPosition;
   label?: React.ReactNode;
   hintText?: React.ReactNode;
@@ -125,12 +125,13 @@ export default class FormField extends React.Component<FormFieldProps> {
       grow,
       children,
       useFieldset,
-      ...inputProps
+      labelPosition,
+      error,
+      ...elemProps
     } = this.props;
-    const {labelPosition, error} = inputProps;
 
     const field = (
-      <FormFieldContainer labelPosition={labelPosition}>
+      <FormFieldContainer labelPosition={labelPosition} {...elemProps}>
         {typeof label === 'string' ? (
           <Label labelPosition={labelPosition} htmlFor={inputId} isLegend={useFieldset}>
             {label}

--- a/modules/form-field/react/spec/FormField.spec.tsx
+++ b/modules/form-field/react/spec/FormField.spec.tsx
@@ -131,4 +131,16 @@ describe('FormField', () => {
 
     component.unmount();
   });
+
+  test('FormField should spread extra props', () => {
+    const InputComponent: React.SFC<FormFieldErrorBehavior> = () => <input type="text" />;
+    const component = mount(
+      <FormField data-propspread="test">
+        <InputComponent />
+      </FormField>
+    );
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
 });

--- a/modules/form-field/react/spec/Hint.spec.tsx
+++ b/modules/form-field/react/spec/Hint.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {shallow} from 'enzyme';
+import {shallow, mount} from 'enzyme';
 import Hint from '../lib/Hint';
 
 describe('Hint', () => {
@@ -16,6 +16,13 @@ describe('Hint', () => {
 
     expect(component.render().text()).toEqual(expect.stringContaining('Alert:'));
 
+    component.unmount();
+  });
+
+  test('Hint should spread extra props', () => {
+    const component = mount(<Hint data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
     component.unmount();
   });
 });

--- a/modules/header/react/lib/parts/WorkdayLogoTitle.tsx
+++ b/modules/header/react/lib/parts/WorkdayLogoTitle.tsx
@@ -67,11 +67,11 @@ export class WorkdayLogoTitle extends React.Component<WorkdayLogoTitleProps> {
   };
 
   public render() {
-    const {themeColor, title, variant, ...otherProps} = this.props;
+    const {themeColor, title, variant, ...elemProps} = this.props;
 
     return (
       <LockupContainer>
-        <Lockup {...this.props} {...otherProps}>
+        <Lockup {...this.props} {...elemProps}>
           <WorkdayLogo
             {...this.props}
             dangerouslySetInnerHTML={{

--- a/modules/header/react/spec/Header.spec.tsx
+++ b/modules/header/react/spec/Header.spec.tsx
@@ -126,6 +126,13 @@ describe('Header', () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
+  test('Header should spread extra props', () => {
+    const component = mount(<Header data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
+
   describe('How Header children render', () => {
     beforeEach(() => {
       window.resizeBy(1280, 1024);

--- a/modules/header/react/spec/Search.spec.tsx
+++ b/modules/header/react/spec/Search.spec.tsx
@@ -141,4 +141,11 @@ describe('Header Search', () => {
     expect(component.state('value')).toBe('');
     component.unmount();
   });
+
+  test('Search should spread extra props', () => {
+    const component = mount(<Search data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
 });

--- a/modules/icon/react/spec/AccentIcon.spec.tsx
+++ b/modules/icon/react/spec/AccentIcon.spec.tsx
@@ -1,5 +1,8 @@
-import {accentIconStyles} from '../lib/AccentIcon';
+import * as React from 'react';
+import {mount} from 'enzyme';
+import AccentIcon, {accentIconStyles} from '../lib/AccentIcon';
 import {colors} from '@workday/canvas-kit-react-core';
+import {shieldIcon} from '@workday/canvas-accent-icons-web';
 
 describe('Accent Icon', () => {
   test('Defaults styles are set correctly', () => {
@@ -16,5 +19,12 @@ describe('Accent Icon', () => {
   test('Can set icon color correctly', () => {
     const componentStyle = accentIconStyles({color: colors.cinnamon500});
     expect(componentStyle['& .color-500']).toHaveProperty('fill', colors.cinnamon500);
+  });
+
+  test('AccentIcon should spread extra props', () => {
+    const component = mount(<AccentIcon icon={shieldIcon} data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
   });
 });

--- a/modules/icon/react/spec/AppletIcon.spec.tsx
+++ b/modules/icon/react/spec/AppletIcon.spec.tsx
@@ -1,4 +1,7 @@
-import {appletIconStyles} from '../lib/AppletIcon';
+import * as React from 'react';
+import {mount} from 'enzyme';
+import AppletIcon, {appletIconStyles} from '../lib/AppletIcon';
+import {benefitsIcon} from '@workday/canvas-applet-icons-web';
 
 describe('Applet Icon', () => {
   test('Throws error if using unofficial color names', () => {
@@ -11,5 +14,12 @@ describe('Applet Icon', () => {
     };
 
     expect(iconOfUnknownColor).toThrow();
+  });
+
+  test('AppletIcon should spread extra props', () => {
+    const component = mount(<AppletIcon icon={benefitsIcon} data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
   });
 });

--- a/modules/icon/react/spec/Graphic.spec.tsx
+++ b/modules/icon/react/spec/Graphic.spec.tsx
@@ -1,18 +1,18 @@
 import * as React from 'react';
-import {shallow} from 'enzyme';
+import {shallow, mount} from 'enzyme';
 import Graphic, {graphicStyles} from '../lib/Graphic';
 import Svg from '../lib/Svg';
 import {CanvasGraphic, CanvasIconTypes} from '@workday/design-assets-types';
 
+const mockGraphic: CanvasGraphic = {
+  name: 'mockGraphic',
+  type: CanvasIconTypes.Graphic,
+  svg: '<svg></svg>',
+  filename: 'mock-graphic.svg',
+};
+
 describe('Graphic', () => {
   test('Icon is of type graphic', () => {
-    const mockGraphic: CanvasGraphic = {
-      name: 'mockGraphic',
-      type: CanvasIconTypes.Graphic,
-      svg: '<svg></svg>',
-      filename: 'mock-graphic.svg',
-    };
-
     const component = shallow(<Graphic src={mockGraphic} />);
     expect(component.find(Svg).prop('type')).toEqual('graphic');
     component.unmount();
@@ -49,5 +49,12 @@ describe('Graphic', () => {
         },
       })
     );
+  });
+
+  test('AccentIcon should spread extra props', () => {
+    const component = mount(<Graphic src={mockGraphic} data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
   });
 });

--- a/modules/icon/react/spec/SystemIcon.spec.tsx
+++ b/modules/icon/react/spec/SystemIcon.spec.tsx
@@ -1,5 +1,8 @@
-import {systemIconStyles} from '../lib/SystemIcon';
+import * as React from 'react';
+import {mount} from 'enzyme';
+import SystemIcon, {systemIconStyles} from '../lib/SystemIcon';
 import {colors, iconColors} from '@workday/canvas-kit-react-core';
+import {activityStreamIcon} from '@workday/canvas-system-icons-web';
 
 describe('System Icon', () => {
   test('Defaults styles are set correctly', () => {
@@ -43,5 +46,12 @@ describe('System Icon', () => {
     expect(componentStyle[':hover .wd-icon-fill']).toHaveProperty('fill', fillHover);
     expect(componentStyle['& .wd-icon-accent']).toHaveProperty('fill', accent);
     expect(componentStyle[':hover .wd-icon-accent']).toHaveProperty('fill', accentHover);
+  });
+
+  test('SystemIcon should spread extra props', () => {
+    const component = mount(<SystemIcon icon={activityStreamIcon} data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
   });
 });

--- a/modules/layout/react/lib/Column.tsx
+++ b/modules/layout/react/lib/Column.tsx
@@ -56,6 +56,12 @@ const ColumnContainer = styled('div')<ColumnProps>(
 
 export default class Column extends React.Component<ColumnProps> {
   public render() {
-    return <ColumnContainer {...this.props}>{this.props.children}</ColumnContainer>;
+    const {children, spacing, columns, width, ...elemProps} = this.props;
+
+    return (
+      <ColumnContainer spacing={spacing} columns={columns} width={width} {...elemProps}>
+        {children}
+      </ColumnContainer>
+    );
   }
 }

--- a/modules/layout/react/lib/Layout.tsx
+++ b/modules/layout/react/lib/Layout.tsx
@@ -81,9 +81,11 @@ export default class Layout extends React.Component<LayoutProps> {
   };
 
   public render() {
+    const {children, spacing, gutter, capWidth, ...elemProps} = this.props;
+
     return (
-      <LayoutContainer {...this.props}>
-        {React.Children.map(this.props.children, this.renderChild)}
+      <LayoutContainer gutter={gutter} capWidth={capWidth} {...elemProps}>
+        {React.Children.map(children, this.renderChild)}
       </LayoutContainer>
     );
   }

--- a/modules/layout/react/spec/Layout.spec.tsx
+++ b/modules/layout/react/spec/Layout.spec.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import {mount} from 'enzyme';
+import Layout from '../lib/Layout';
+
+describe('Layout', () => {
+  test('Layout should spread extra props', () => {
+    const component = mount(
+      <Layout data-propspread="test">
+        <Layout.Column />
+      </Layout>
+    );
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
+});
+
+describe('Column', () => {
+  test('Column should spread extra props', () => {
+    const component = mount(<Layout.Column data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
+});

--- a/modules/layout/react/spec/__snapshots__/Layout.snapshot.tsx.snap
+++ b/modules/layout/react/spec/__snapshots__/Layout.snapshot.tsx.snap
@@ -125,7 +125,6 @@ exports[`Layout Snapshots renders a layout and columns with custom spacing 1`] =
 
 <div
   className="emotion-6 emotion-7"
-  spacing={60}
 >
   <div
     className="emotion-0 emotion-1"

--- a/modules/loading-animation/react/lib/LoadingDots.tsx
+++ b/modules/loading-animation/react/lib/LoadingDots.tsx
@@ -60,9 +60,11 @@ const Container = styled('div')({
 /**
  * A simple component that displays three horizontal dots, to be used when some data is loading.
  */
-export default function LoadingDots() {
+export default function LoadingDots(props: React.HTMLAttributes<HTMLDivElement>) {
+  const {...elemProps} = props;
+
   return (
-    <Container>
+    <Container {...elemProps}>
       <LoadingAnimationDot animationDelay={0} />
       <LoadingAnimationDot animationDelay={160} />
       <LoadingAnimationDot animationDelay={320} />

--- a/modules/loading-animation/react/spec/LoadingDots.spec.tsx
+++ b/modules/loading-animation/react/spec/LoadingDots.spec.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import {mount} from 'enzyme';
+import LoadingDots from '../lib/LoadingDots';
+
+describe('LoadingDots', () => {
+  test('LoadingDots should spread extra props', () => {
+    const component = mount(<LoadingDots data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
+});

--- a/modules/menu/react/lib/Menu.tsx
+++ b/modules/menu/react/lib/Menu.tsx
@@ -74,6 +74,7 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
   }
 
   public render() {
+    // TODO: Standardize on prop spread location (see #150)
     const {
       children,
       id,
@@ -88,6 +89,7 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
     } = this.props;
     const {selectedItemIndex} = this.state;
     const cardWidth = grow ? '100%' : width;
+
     return (
       <Card
         style={{display: 'inline-block', minWidth: minWidth + 2}}

--- a/modules/menu/react/spec/Menu.spec.tsx
+++ b/modules/menu/react/spec/Menu.spec.tsx
@@ -123,8 +123,10 @@ describe('Menu', () => {
 
   test('Menu should spread extra props', () => {
     const component = mount(<Menu data-propspread="test" />);
-    const container = component.at(0).getDOMNode();
-    expect(container.getAttribute('data-propspread')).toBe('test');
+    const list = component
+      .find('ul') // TODO: Standardize on prop spread location (see #150)
+      .getDOMNode();
+    expect(list.getAttribute('data-propspread')).toBe('test');
     component.unmount();
   });
 

--- a/modules/menu/react/spec/Menu.spec.tsx
+++ b/modules/menu/react/spec/Menu.spec.tsx
@@ -59,7 +59,7 @@ describe('Menu', () => {
   test('should not call on close function when item is clicked with shouldClose disabled', () => {
     const component = mount(
       <Menu onClose={cb}>
-        <MenuItem shouldClose={false}/>
+        <MenuItem shouldClose={false} />
       </Menu>
     );
     const item = component.find('li');
@@ -118,6 +118,20 @@ describe('Menu', () => {
     expect(component.find('span').getDOMNode().innerHTML).toEqual(
       mount(labelText).getDOMNode().outerHTML
     );
+    component.unmount();
+  });
+
+  test('Menu should spread extra props', () => {
+    const component = mount(<Menu data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
+
+  test('Menu Item should spread extra props', () => {
+    const component = mount(<MenuItem data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
     component.unmount();
   });
 });

--- a/modules/modal/react/lib/Modal.tsx
+++ b/modules/modal/react/lib/Modal.tsx
@@ -9,7 +9,7 @@ export enum ModalWidth {
   m = '800px',
 }
 
-export interface ModalProps {
+export interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
   open: boolean;
   padding: PopupPadding;
   transformOrigin: TransformOrigin;
@@ -70,10 +70,10 @@ export default class Modal extends React.Component<ModalProps> {
   };
 
   public render() {
-    const {open, handleClose, padding, width, heading, transformOrigin} = this.props;
+    const {open, handleClose, padding, width, heading, transformOrigin, ...elemProps} = this.props;
     return (
       open && (
-        <Container onClick={e => this.handleOutsideClick(handleClose, e)}>
+        <Container onClick={e => this.handleOutsideClick(handleClose, e)} {...elemProps}>
           <Popup
             popupRef={this.modalRef}
             width={width}

--- a/modules/modal/react/spec/Modal.spec.tsx
+++ b/modules/modal/react/spec/Modal.spec.tsx
@@ -21,7 +21,7 @@ describe('Modal', () => {
   });
 
   test('Modal should spread extra props', () => {
-    const component = mount(<Modal data-propspread="test" />);
+    const component = mount(<Modal open={true} data-propspread="test" />);
     const container = component.at(0).getDOMNode();
     expect(container.getAttribute('data-propspread')).toBe('test');
     component.unmount();

--- a/modules/modal/react/spec/Modal.spec.tsx
+++ b/modules/modal/react/spec/Modal.spec.tsx
@@ -19,4 +19,11 @@ describe('Modal', () => {
     expect(cb.mock.calls.length).toBe(1);
     component.unmount();
   });
+
+  test('Modal should spread extra props', () => {
+    const component = mount(<Modal data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
 });

--- a/modules/page-header/react/lib/PageHeader.tsx
+++ b/modules/page-header/react/lib/PageHeader.tsx
@@ -81,11 +81,12 @@ export default class PageHeader extends React.Component<PageHeaderProps> {
   }
 
   public render() {
+    // TODO: Standardize on prop spread location (see #150)
     const {title, children, breakpoint, capWidth, ...elemProps} = this.props;
 
     return (
-      <Header {...elemProps}>
-        <Container breakpoint={breakpoint} capWidth={capWidth}>
+      <Header>
+        <Container breakpoint={breakpoint} capWidth={capWidth} {...elemProps}>
           <Title>{title}</Title>
           <IconList>{this.renderChildren(children)}</IconList>
         </Container>

--- a/modules/page-header/react/lib/PageHeader.tsx
+++ b/modules/page-header/react/lib/PageHeader.tsx
@@ -17,7 +17,7 @@ const Header = styled('header')({
   MozOsxFontSmoothing: 'grayscale',
 });
 
-const Container = styled('div')<PageHeaderProps>(
+const Container = styled('div')<Pick<PageHeaderProps, 'breakpoint' | 'capWidth'>>(
   {
     display: 'flex',
     alignItems: 'center',
@@ -81,11 +81,11 @@ export default class PageHeader extends React.Component<PageHeaderProps> {
   }
 
   public render() {
-    const {title, children} = this.props;
+    const {title, children, breakpoint, capWidth, ...elemProps} = this.props;
 
     return (
-      <Header>
-        <Container {...this.props}>
+      <Header {...elemProps}>
+        <Container breakpoint={breakpoint} capWidth={capWidth}>
           <Title>{title}</Title>
           <IconList>{this.renderChildren(children)}</IconList>
         </Container>

--- a/modules/page-header/react/spec/PageHeader.spec.tsx
+++ b/modules/page-header/react/spec/PageHeader.spec.tsx
@@ -49,7 +49,10 @@ describe('Page Header', () => {
 
   test('PageHeader should spread extra props', () => {
     const component = mount(<PageHeader data-propspread="test" />);
-    const container = component.at(0).getDOMNode();
+    const container = component
+      .find('header')
+      .childAt(0) // TODO: Standardize on prop spread location (see #150)
+      .getDOMNode();
     expect(container.getAttribute('data-propspread')).toBe('test');
     component.unmount();
   });

--- a/modules/page-header/react/spec/PageHeader.spec.tsx
+++ b/modules/page-header/react/spec/PageHeader.spec.tsx
@@ -46,4 +46,11 @@ describe('Page Header', () => {
       PageHeader
     ); // this should render what was passed in, not an <a> tag
   });
+
+  test('PageHeader should spread extra props', () => {
+    const component = mount(<PageHeader data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
 });

--- a/modules/page-header/react/spec/__snapshots__/PageHeader.snapshot.tsx.snap
+++ b/modules/page-header/react/spec/__snapshots__/PageHeader.snapshot.tsx.snap
@@ -61,7 +61,6 @@ exports[`Page Header Snapshots renders a basic PageHeader as expected 1`] = `
 >
   <div
     className="emotion-4 emotion-5"
-    title="Test Page Header"
   >
     <h2
       className="emotion-0 emotion-1"
@@ -140,7 +139,6 @@ exports[`Page Header Snapshots renders a capWidth context PageHeader as expected
 >
   <div
     className="emotion-4 emotion-5"
-    title="Test capWidth Page Header"
   >
     <h2
       className="emotion-0 emotion-1"

--- a/modules/popup/react/lib/Popup.tsx
+++ b/modules/popup/react/lib/Popup.tsx
@@ -87,7 +87,7 @@ export default class Popup extends React.Component<PopupProps> {
       closeIconSize,
       transformOrigin,
       popupRef,
-      ...otherProps
+      ...elemProps
     } = this.props;
     return (
       <Container
@@ -95,7 +95,7 @@ export default class Popup extends React.Component<PopupProps> {
         width={width}
         role="dialog"
         innerRef={popupRef}
-        {...otherProps}
+        {...elemProps}
       >
         {handleClose && (
           <CloseIconContainer closeIconSize={closeIconSize}>

--- a/modules/popup/react/spec/Popup.spec.tsx
+++ b/modules/popup/react/spec/Popup.spec.tsx
@@ -15,4 +15,11 @@ describe('Popup', () => {
     expect(cb.mock.calls.length).toBe(1);
     component.unmount();
   });
+
+  test('Popup should spread extra props', () => {
+    const component = mount(<Popup data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
 });

--- a/modules/radio/react/lib/Radio.tsx
+++ b/modules/radio/react/lib/Radio.tsx
@@ -184,6 +184,7 @@ export default class Radio extends React.Component<RadioProps> {
   };
 
   public render() {
+    // TODO: Standardize on prop spread location (see #150)
     const {
       checked,
       disabled,

--- a/modules/radio/react/lib/Radio.tsx
+++ b/modules/radio/react/lib/Radio.tsx
@@ -193,7 +193,7 @@ export default class Radio extends React.Component<RadioProps> {
       name,
       onChange,
       value,
-      ...otherProps
+      ...elemProps
     } = this.props;
 
     return (
@@ -208,7 +208,7 @@ export default class Radio extends React.Component<RadioProps> {
             onChange={onChange}
             type="radio"
             value={value}
-            {...otherProps}
+            {...elemProps}
           />
           <RadioBackground checked={checked} disabled={disabled}>
             <RadioCheck checked={checked} />

--- a/modules/radio/react/lib/RadioGroup.tsx
+++ b/modules/radio/react/lib/RadioGroup.tsx
@@ -67,9 +67,9 @@ export default class RadioGroup extends React.Component<RadioGroupProps> {
   };
 
   render(): React.ReactNode {
-    const {children, error, onChange, value, grow, ...otherProps} = this.props;
+    const {children, error, onChange, value, grow, ...elemProps} = this.props;
     return (
-      <Container error={error} grow={grow} {...otherProps}>
+      <Container error={error} grow={grow} {...elemProps}>
         {React.Children.map(children, this.renderChild)}
       </Container>
     );

--- a/modules/radio/react/spec/Radio.spec.tsx
+++ b/modules/radio/react/spec/Radio.spec.tsx
@@ -49,6 +49,13 @@ describe('Radio Input', () => {
     expect(cb.mock.calls.length).toBe(1);
     component.unmount();
   });
+
+  test('Radio input should spread extra props', () => {
+    const component = mount(<Radio data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
 });
 
 describe('Radio Accessibility', () => {

--- a/modules/radio/react/spec/Radio.spec.tsx
+++ b/modules/radio/react/spec/Radio.spec.tsx
@@ -52,8 +52,10 @@ describe('Radio Input', () => {
 
   test('Radio input should spread extra props', () => {
     const component = mount(<Radio data-propspread="test" />);
-    const container = component.at(0).getDOMNode();
-    expect(container.getAttribute('data-propspread')).toBe('test');
+    const input = component
+      .find('input') // TODO: Standardize on prop spread location (see #150)
+      .getDOMNode();
+    expect(input.getAttribute('data-propspread')).toBe('test');
     component.unmount();
   });
 });

--- a/modules/radio/react/spec/RadioGroup.spec.tsx
+++ b/modules/radio/react/spec/RadioGroup.spec.tsx
@@ -136,4 +136,16 @@ describe('Radio', () => {
 
     expect(cb.mock.calls.length).toBe(1);
   });
+
+  test('RadioGroup should spread extra props', () => {
+    const component = mount(
+      <RadioGroup data-propspread="test">
+        <Radio id="1" value="email" label="E-mail" />
+        <Radio id="2" value="phone" label="Phone" />
+      </RadioGroup>
+    );
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
 });

--- a/modules/select/react/lib/Select.tsx
+++ b/modules/select/react/lib/Select.tsx
@@ -96,6 +96,7 @@ export default class Select extends React.Component<SelectProps> {
   };
 
   public render() {
+    // TODO: Standardize on prop spread location (see #150)
     const {error, disabled, grow, children, value, onChange, ...elemProps} = this.props;
 
     return (

--- a/modules/select/react/lib/SelectOption.tsx
+++ b/modules/select/react/lib/SelectOption.tsx
@@ -16,10 +16,10 @@ export default class SelectOption extends React.Component<SelectOptionProps> {
   };
 
   public render() {
-    const {value, label, disabled, ...otherProps} = this.props;
+    const {value, label, disabled, ...elemProps} = this.props;
 
     return (
-      <option value={value} label={label} disabled={disabled} {...otherProps}>
+      <option value={value} label={label} disabled={disabled} {...elemProps}>
         {label}
       </option>
     );

--- a/modules/select/react/spec/Select.spec.tsx
+++ b/modules/select/react/spec/Select.spec.tsx
@@ -29,8 +29,10 @@ describe('Select', () => {
         <SelectOption value="phone" label="Phone" />
       </Select>
     );
-    const container = component.at(0).getDOMNode();
-    expect(container.getAttribute('data-propspread')).toBe('test');
+    const select = component
+      .find('select') // TODO: Standardize on prop spread location (see #150)
+      .getDOMNode();
+    expect(select.getAttribute('data-propspread')).toBe('test');
     component.unmount();
   });
 });

--- a/modules/select/react/spec/Select.spec.tsx
+++ b/modules/select/react/spec/Select.spec.tsx
@@ -21,4 +21,16 @@ describe('Select', () => {
 
     expect(options.length).toEqual(2);
   });
+
+  test('Select should spread extra props', () => {
+    const component = mount(
+      <Select name="contact" data-propspread="test">
+        <SelectOption value="email" label="E-mail" />
+        <SelectOption value="phone" label="Phone" />
+      </Select>
+    );
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
 });

--- a/modules/side-panel/react/lib/SidePanel.tsx
+++ b/modules/side-panel/react/lib/SidePanel.tsx
@@ -158,7 +158,7 @@ export default class SidePanel extends React.Component<SidePanelProps, SidePanel
       onBreakpointChange,
       openWidth,
       backgroundColor,
-      ...otherProps
+      ...elemProps
     } = this.props;
 
     return (
@@ -170,7 +170,7 @@ export default class SidePanel extends React.Component<SidePanelProps, SidePanel
         openWidth={openWidth}
         backgroundColor={backgroundColor}
         open={open}
-        {...otherProps}
+        {...elemProps}
       >
         <ChildrenContainer openWidth={openWidth}>
           {header && open ? <Header>{header}</Header> : null}

--- a/modules/side-panel/react/spec/SidePanel.spec.tsx
+++ b/modules/side-panel/react/spec/SidePanel.spec.tsx
@@ -81,4 +81,11 @@ describe('SidePanel', () => {
     expect(mockFunction).toHaveBeenCalledTimes(1);
     component.unmount();
   });
+
+  test('SidePanel should spread extra props', () => {
+    const component = mount(<SidePanel open={true} data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
 });

--- a/modules/skeleton/react/lib/parts/skeletonHeader.tsx
+++ b/modules/skeleton/react/lib/parts/skeletonHeader.tsx
@@ -2,14 +2,16 @@ import * as React from 'react';
 import SkeletonShape from './skeletonShape';
 import {TEXT_BORDER_RADIUS} from './utils';
 
-export default class SkeletonHeader extends React.Component {
+export default class SkeletonHeader extends React.Component<React.HTMLAttributes<HTMLDivElement>> {
   render(): React.ReactNode {
+    const {...elemProps} = this.props;
+
     const lineProps = {
       borderRadius: TEXT_BORDER_RADIUS,
       height: '28px',
       width: '100%',
     };
 
-    return <SkeletonShape {...lineProps} />;
+    return <SkeletonShape {...lineProps} {...elemProps} />;
   }
 }

--- a/modules/skeleton/react/lib/parts/skeletonShape.tsx
+++ b/modules/skeleton/react/lib/parts/skeletonShape.tsx
@@ -18,7 +18,7 @@ const Shape = styled('div')<{
   };
 });
 
-export interface SkeletonShapeProps {
+export interface SkeletonShapeProps extends React.HTMLAttributes<HTMLDivElement> {
   width?: number | string;
   height?: number | string;
   borderRadius?: number | string;
@@ -26,8 +26,8 @@ export interface SkeletonShapeProps {
 
 export default class SkeletonShape extends React.Component<SkeletonShapeProps> {
   render(): React.ReactNode {
-    const {width, height, borderRadius} = this.props;
+    const {width, height, borderRadius, ...elemProps} = this.props;
 
-    return <Shape width={width} height={height} borderRadius={borderRadius} />;
+    return <Shape width={width} height={height} borderRadius={borderRadius} {...elemProps} />;
   }
 }

--- a/modules/skeleton/react/lib/parts/skeletonText.tsx
+++ b/modules/skeleton/react/lib/parts/skeletonText.tsx
@@ -7,7 +7,7 @@ const TextContainer = styled('div')({
   marginBottom: canvas.spacing.m,
 });
 
-export interface SkeletonTextProps {
+export interface SkeletonTextProps extends React.HTMLAttributes<HTMLDivElement> {
   lineCount: number;
 }
 
@@ -32,8 +32,13 @@ export default class SkeletonText extends React.Component<SkeletonTextProps> {
   };
 
   render(): React.ReactNode {
-    const {lineCount} = this.props;
-    return lineCount > 0 ? <TextContainer>{this.createTextLines()}</TextContainer> : null;
+    const {lineCount, ...elemProps} = this.props;
+
+    if (lineCount <= 0) {
+      return null;
+    }
+
+    return <TextContainer {...elemProps}>{this.createTextLines()}</TextContainer>;
   }
 
   private readonly createTextLines = () => {

--- a/modules/skeleton/react/lib/skeleton.tsx
+++ b/modules/skeleton/react/lib/skeleton.tsx
@@ -54,7 +54,7 @@ export default class Skeleton extends React.Component<{}, SkeletonState> {
   };
 
   render(): React.ReactNode {
-    const {children} = this.props;
+    const {children, ...elemProps} = this.props;
     const {width, height} = this.state;
     const diagonal = Math.sqrt(width * width + height * height) + WHITE_SHEEN_WIDTH;
     const topPosition = (-1 * (diagonal - height)) / 2;
@@ -65,6 +65,7 @@ export default class Skeleton extends React.Component<{}, SkeletonState> {
         aria-live={'polite'}
         role={'status'}
         innerRef={this.ref}
+        {...elemProps}
       >
         <SkeletonAnimator diagonal={diagonal} topPosition={topPosition} width={width} />
         <div aria-hidden={true}>{children}</div>

--- a/modules/skeleton/react/spec/skeleton.spec.tsx
+++ b/modules/skeleton/react/spec/skeleton.spec.tsx
@@ -14,6 +14,13 @@ describe('Skeleton', () => {
     subject.unmount();
   });
 
+  test('Skeleton should spread extra props', () => {
+    const component = mount(<Skeleton data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
+
   describe('Accessibility', () => {
     it('should add aria-hidden to all of the children', () => {
       const subject = mount(

--- a/modules/status-indicator/react/lib/StatusIndicator.tsx
+++ b/modules/status-indicator/react/lib/StatusIndicator.tsx
@@ -151,11 +151,11 @@ export default class StatusIndicator extends React.Component<StatusIndicatorProp
   };
 
   public render() {
-    const {type, emphasis, icon, label, ...otherProps} = this.props;
+    const {type, emphasis, icon, label, ...elemProps} = this.props;
     const variant = statusIndicatorStyles.variants[type][emphasis]!;
 
     return (
-      <Container type={type} emphasis={emphasis} {...otherProps}>
+      <Container type={type} emphasis={emphasis} {...elemProps}>
         {icon && (
           <SystemIcon
             colorHover={variant.color}

--- a/modules/status-indicator/react/spec/StatusIndicator.spec.tsx
+++ b/modules/status-indicator/react/spec/StatusIndicator.spec.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import {mount} from 'enzyme';
+import StatusIndicator from '../lib/StatusIndicator';
+
+describe('StatusIndicator', () => {
+  test('Card should spread extra props', () => {
+    const component = mount(
+      <StatusIndicator label="test" type={StatusIndicator.Type.Gray} data-propspread="test" />
+    );
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
+});

--- a/modules/switch/react/lib/Switch.tsx
+++ b/modules/switch/react/lib/Switch.tsx
@@ -75,6 +75,7 @@ export default class Switch extends React.Component<SwitchProps> {
   };
 
   public render() {
+    // TODO: Standardize on prop spread location (see #150)
     const {checked, disabled, id, inputRef, onChange, value, ...elemProps} = this.props;
 
     return (

--- a/modules/switch/react/lib/Switch.tsx
+++ b/modules/switch/react/lib/Switch.tsx
@@ -75,7 +75,7 @@ export default class Switch extends React.Component<SwitchProps> {
   };
 
   public render() {
-    const {checked, disabled, id, inputRef, onChange, value, ...otherProps} = this.props;
+    const {checked, disabled, id, inputRef, onChange, value, ...elemProps} = this.props;
 
     return (
       <SwitchContainer>
@@ -89,7 +89,7 @@ export default class Switch extends React.Component<SwitchProps> {
           tabIndex={0}
           type="checkbox"
           value={value}
-          {...otherProps}
+          {...elemProps}
         />
         <SwitchBackground checked={checked} disabled={disabled}>
           <SwitchCircle checked={checked} />

--- a/modules/switch/react/spec/Switch.spec.tsx
+++ b/modules/switch/react/spec/Switch.spec.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import {mount} from 'enzyme';
+import Switch from '../lib/Switch';
+
+describe('Switch', () => {
+  test('Switch should spread extra props', () => {
+    const component = mount(<Switch data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
+});

--- a/modules/switch/react/spec/Switch.spec.tsx
+++ b/modules/switch/react/spec/Switch.spec.tsx
@@ -5,8 +5,11 @@ import Switch from '../lib/Switch';
 describe('Switch', () => {
   test('Switch should spread extra props', () => {
     const component = mount(<Switch data-propspread="test" />);
-    const container = component.at(0).getDOMNode();
-    expect(container.getAttribute('data-propspread')).toBe('test');
+    const input = component
+      .find('input')
+      // TODO: Standardize on prop spread location (see #150)
+      .getDOMNode();
+    expect(input.getAttribute('data-propspread')).toBe('test');
     component.unmount();
   });
 });

--- a/modules/table/react/lib/Table.tsx
+++ b/modules/table/react/lib/Table.tsx
@@ -18,6 +18,8 @@ const TableComponent = styled('table')(type.body, {
 
 export default class Table extends React.Component<React.TableHTMLAttributes<HTMLTableElement>> {
   public render() {
-    return <TableComponent {...this.props}>{this.props.children}</TableComponent>;
+    const {children, ...elemProps} = this.props;
+
+    return <TableComponent {...elemProps}>{children}</TableComponent>;
   }
 }

--- a/modules/table/react/lib/TableRow.tsx
+++ b/modules/table/react/lib/TableRow.tsx
@@ -204,6 +204,12 @@ export default class TableRow extends React.Component<TableRowProps> {
   public static State = TableRowStates;
 
   public render() {
-    return <Row {...this.props}>{this.props.children}</Row>;
+    const {state, header, children, ...elemProps} = this.props;
+
+    return (
+      <Row state={state} header={header} {...elemProps}>
+        {children}
+      </Row>
+    );
   }
 }

--- a/modules/table/react/spec/Table.spec.tsx
+++ b/modules/table/react/spec/Table.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {shallow} from 'enzyme';
+import {shallow, mount} from 'enzyme';
 import Table from '../lib/Table';
 
 describe('Table', () => {
@@ -12,6 +12,13 @@ describe('Table', () => {
 
     expect(component.props().className.includes(customClassName));
 
+    component.unmount();
+  });
+
+  test('Table should spread extra props', () => {
+    const component = mount(<Table data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
     component.unmount();
   });
 });

--- a/modules/table/react/spec/TableRow.spec.tsx
+++ b/modules/table/react/spec/TableRow.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {shallow} from 'enzyme';
+import {shallow, mount} from 'enzyme';
 import TableRow from '../lib/TableRow';
 
 describe('TableRow', () => {
@@ -12,6 +12,13 @@ describe('TableRow', () => {
 
     expect(component.props().className.includes(customClassName));
 
+    component.unmount();
+  });
+
+  test('TableRow should spread extra props', () => {
+    const component = mount(<TableRow data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
     component.unmount();
   });
 });

--- a/modules/text-area/react/spec/TextArea.spec.tsx
+++ b/modules/text-area/react/spec/TextArea.spec.tsx
@@ -1,11 +1,21 @@
 import * as React from 'react';
+import {mount} from 'enzyme';
 import ReactDOMServer from 'react-dom/server';
 import TextArea from '../lib/TextArea';
 import {axe} from 'jest-axe';
 import FormField from '@workday/canvas-kit-react-form-field';
 
-describe('Text Input Accessibility', () => {
-  test('Text Input in a FormField should pass axe DOM accessibility guidelines', async () => {
+describe('TextArea', () => {
+  test('TextArea should spread extra props', () => {
+    const component = mount(<TextArea data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
+});
+
+describe('Text Area Accessibility', () => {
+  test('Text Area in a FormField should pass axe DOM accessibility guidelines', async () => {
     const html = ReactDOMServer.renderToString(
       <FormField label="My Field" inputId="my-input-field">
         <TextArea placeholder="Placeholder" value={'Hello'} onChange={jest.fn()} />;
@@ -14,7 +24,7 @@ describe('Text Input Accessibility', () => {
     expect(await axe(html)).toHaveNoViolations();
   });
 
-  test('Text Input with `aria-labelledBy` should pass axe DOM accessibility guidelines', async () => {
+  test('Text Area with `aria-labelledBy` should pass axe DOM accessibility guidelines', async () => {
     const html = ReactDOMServer.renderToString(
       <>
         <label id="123">Label</label>

--- a/modules/text-input/react/lib/TextInput.tsx
+++ b/modules/text-input/react/lib/TextInput.tsx
@@ -75,6 +75,7 @@ export default class TextInput extends React.Component<TextInputProps> {
   };
 
   render() {
+    // TODO: Standardize on prop spread location (see #150)
     const {grow, inputRef, error, ...inputProps} = this.props;
 
     let icon: React.ReactElement<SystemIcon> | undefined;

--- a/modules/text-input/react/spec/TextInput.spec.tsx
+++ b/modules/text-input/react/spec/TextInput.spec.tsx
@@ -8,8 +8,10 @@ import FormField from '@workday/canvas-kit-react-form-field';
 describe('TextInput', () => {
   test('TextInput should spread extra props', () => {
     const component = mount(<TextInput data-propspread="test" />);
-    const container = component.at(0).getDOMNode();
-    expect(container.getAttribute('data-propspread')).toBe('test');
+    const input = component
+      .find('input') // TODO: Standardize on prop spread location (see #150)
+      .getDOMNode();
+    expect(input.getAttribute('data-propspread')).toBe('test');
     component.unmount();
   });
 });

--- a/modules/text-input/react/spec/TextInput.spec.tsx
+++ b/modules/text-input/react/spec/TextInput.spec.tsx
@@ -1,8 +1,18 @@
 import * as React from 'react';
+import {mount} from 'enzyme';
 import ReactDOMServer from 'react-dom/server';
 import TextInput from '../lib/TextInput';
 import {axe} from 'jest-axe';
 import FormField from '@workday/canvas-kit-react-form-field';
+
+describe('TextInput', () => {
+  test('TextInput should spread extra props', () => {
+    const component = mount(<TextInput data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
+});
 
 describe('Text Input Accessibility', () => {
   test('Text Input in a FormField should pass axe DOM accessibility guidelines', async () => {

--- a/modules/toast/react/lib/Toast.tsx
+++ b/modules/toast/react/lib/Toast.tsx
@@ -63,7 +63,7 @@ export default class Toast extends React.Component<ToastProps> {
       icon,
       iconColor,
       transformOrigin,
-      ...otherProps
+      ...elemProps
     } = this.props;
     return (
       <Popup
@@ -72,7 +72,7 @@ export default class Toast extends React.Component<ToastProps> {
         padding={PopupPadding.s}
         handleClose={onClose}
         closeIconSize={ButtonSizes.Small}
-        {...otherProps}
+        {...elemProps}
       >
         <ToastContentContainer onClose={onClose}>
           {icon && <ToastSystemIcon color={iconColor} colorHover={iconColor} icon={icon} />}

--- a/modules/toast/react/spec/Toast.snapshot.tsx
+++ b/modules/toast/react/spec/Toast.snapshot.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {mount} from 'enzyme';
 import Toast from '../lib/Toast';
 import * as renderer from 'react-test-renderer';
 import {checkIcon} from '@workday/canvas-system-icons-web';
@@ -29,5 +30,12 @@ describe('Toast Snapshots', () => {
       </Toast>
     );
     expect(component).toMatchSnapshot();
+  });
+
+  test('Toast should spread extra props', () => {
+    const component = mount(<Toast data-propspread="test">Message</Toast>);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
   });
 });

--- a/modules/tooltip/react/spec/Tooltip.spec.tsx
+++ b/modules/tooltip/react/spec/Tooltip.spec.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import {mount} from 'enzyme';
+import Tooltip from '../lib/Tooltip';
+
+describe('Tooltip', () => {
+  test('Tooltip should spread extra props', () => {
+    const component = mount(<Tooltip data-propspread="test" />);
+    const container = component.at(0).getDOMNode();
+    expect(container.getAttribute('data-propspread')).toBe('test');
+    component.unmount();
+  });
+});


### PR DESCRIPTION
## Summary

Several components were missing our [`elemProps` support for prop spread behavior](https://github.com/Workday/canvas-kit/blob/master/API_PATTERN_GUIDELINES.md#prop-spread-behavior). This PR adds support to `FormField`, `LoadingDots`, `Modal`, `SkeletonShape`, `SkeletonHeader`, `SkeletonText`, `Table`, `TableRow`, and `ColorPreview`.

Closes https://github.com/Workday/canvas-kit/issues/99 and closes https://github.com/Workday/canvas-kit/issues/95

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md
- [x] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [x] design approved final implementation
- [x] a11y approved final implementation
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)
