### PR TITLE
feat: Add watch support for faster development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,6 +147,11 @@ fix: Add missing static class variable to IconButton and Avatar
 2.  Run `yarn build`
 3.  Run `yarn start` to start [Storybook](https://storybook.js.org/)
 4.  Visit [http://localhost:9001/](http://localhost:9001/)
+5.  To quickly rebuild on file changes, run `yarn watch` in another terminal. This will rebuild
+    modules for each file change. **Note** this command will take a lot of memory (1-2GB). If you
+    are working on a specific module, you can navigate to the module your are working on and run
+    `yarn watch` from there. This will only watch a specific module at a fraction of the memory
+    requirements
 
 ### Creating a module
 

--- a/create-module.sh
+++ b/create-module.sh
@@ -58,6 +58,7 @@ cat > $packageJson << EOF
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",

--- a/modules/_canvas-kit-react/package.json
+++ b/modules/_canvas-kit-react/package.json
@@ -17,6 +17,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/action-bar/react/package.json
+++ b/modules/action-bar/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/avatar/react/package.json
+++ b/modules/avatar/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/banner/react/package.json
+++ b/modules/banner/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/button/react/package.json
+++ b/modules/button/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "babel --no-babelrc --plugins babel-plugin-transform-es2015-modules-commonjs dist/es6 --out-dir dist/commonjs  --copy-files",

--- a/modules/card/react/package.json
+++ b/modules/card/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/checkbox/react/package.json
+++ b/modules/checkbox/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/color-picker/react/package.json
+++ b/modules/color-picker/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/common/react/package.json
+++ b/modules/common/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/cookie-banner/react/package.json
+++ b/modules/cookie-banner/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/core/react/package.json
+++ b/modules/core/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/fonts/react/package.json
+++ b/modules/fonts/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/form-field/react/package.json
+++ b/modules/form-field/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/header/react/package.json
+++ b/modules/header/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/icon/react/package.json
+++ b/modules/icon/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/layout/react/package.json
+++ b/modules/layout/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/loading-animation/react/package.json
+++ b/modules/loading-animation/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/menu/react/package.json
+++ b/modules/menu/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/modal/react/package.json
+++ b/modules/modal/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/page-header/react/package.json
+++ b/modules/page-header/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/popup/react/package.json
+++ b/modules/popup/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/radio/react/package.json
+++ b/modules/radio/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/select/react/package.json
+++ b/modules/select/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/side-panel/react/package.json
+++ b/modules/side-panel/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/skeleton/react/package.json
+++ b/modules/skeleton/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/status-indicator/react/package.json
+++ b/modules/status-indicator/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/switch/react/package.json
+++ b/modules/switch/react/package.json
@@ -17,6 +17,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/table/react/package.json
+++ b/modules/table/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/text-area/react/package.json
+++ b/modules/text-area/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/text-input/react/package.json
+++ b/modules/text-input/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/toast/react/package.json
+++ b/modules/toast/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/modules/tooltip/react/package.json
+++ b/modules/tooltip/react/package.json
@@ -18,6 +18,7 @@
     "index.ts"
   ],
   "scripts": {
+    "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
   },
   "scripts": {
     "start": "node --max-old-space-size=2048 node_modules/.bin/start-storybook -p 9001 -c .storybook",
+    "watch": "TSC_NONPOLLING_WATCHER=1 lerna run watch --parallel --stream",
     "clean": "lerna run clean",
     "build": "lerna run build",
     "build:rebuild": "lerna run build:rebuild",


### PR DESCRIPTION
## Summary

This feature adds watch support for development mode. Some changes require a rebuild of Typescript files. On a dev machine, `yarn build` takes about 120s. `yarn watch` now will reduce that time down to about 5s. The command takes a lot of memory (multiple typescript compiler instances) and so each module has its own `yarn watch` for more targetted watching at a fraction of the memory. Each Typescript watch instance takes about 120-250MB and that is per module. Perhaps in the future we will change the way modules work so that a single Typescript instance could run for builds rather than an instance per module.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

![yarn-watch](https://user-images.githubusercontent.com/338257/64039204-527b2800-cb17-11e9-812c-cd6f08573cff.gif)

