### PR TITLE
refactor: Move InputProviderDecorators to Storybook config

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -4,7 +4,7 @@ import {injectGlobal} from 'emotion';
 import fonts from '../modules/fonts/react';
 import {create} from '@storybook/theming';
 import {commonColors, typeColors, fontFamily} from '../modules/core/react';
-
+import {InputProviderDecorator} from '../utils/storybook';
 const req = require.context('../modules', true, /stories.*\.tsx?$/);
 
 function loadStories() {
@@ -12,6 +12,7 @@ function loadStories() {
 }
 
 addDecorator(withKnobs);
+addDecorator(InputProviderDecorator);
 
 addParameters({
   options: {

--- a/modules/avatar/react/stories/stories.tsx
+++ b/modules/avatar/react/stories/stories.tsx
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import {storiesOf} from '@storybook/react';
 import withReadme from 'storybook-readme/with-readme';
-import {InputProviderDecorator} from '../../../../utils/storybook';
 
 import Avatar from '../index';
 import README from '../README.md';
@@ -10,7 +9,6 @@ import README from '../README.md';
 const IMAGE_URL = 'https://s3-us-west-2.amazonaws.com/design-assets-internal/avatars/lmcneil.png';
 
 storiesOf('Avatar', module)
-  .addDecorator(InputProviderDecorator)
   .addDecorator(withReadme(README))
   .add('Light', () => (
     <div className="story">

--- a/modules/core/react/README.md
+++ b/modules/core/react/README.md
@@ -422,3 +422,14 @@ storiesOf('My Story', module)
   .addDecorator(InputProviderDecorator)
   .add('All', () => <YourJSX />);
 ```
+
+You can also add this [storybook decorator](../../utils/storybook/InputProviderDecorator.tsx) to
+your `/.storybook/config.js` configuration file so it wraps all your stories automatically.
+
+Example:
+
+```js
+import {InputProviderDecorator} from '../utils/storybook';
+
+addDecorator(InputProviderDecorator);
+```

--- a/modules/core/react/stories/stories.tsx
+++ b/modules/core/react/stories/stories.tsx
@@ -5,7 +5,6 @@ import styled, {css} from 'react-emotion';
 import withReadme from 'storybook-readme/with-readme';
 
 import canvas, {H1, space, spacing} from '..';
-import {InputProviderDecorator} from '../../../../utils/storybook';
 import README from '../README.md';
 
 export const inverseStyle = {
@@ -70,7 +69,6 @@ export const type = (hierarchy: any) => (
 
 storiesOf('Core', module)
   .addDecorator(withReadme(README))
-  .addDecorator(InputProviderDecorator)
   .add('Space', () => {
     const Box = styled('div')(space);
 

--- a/modules/form-field/react/stories/stories_Checkbox.tsx
+++ b/modules/form-field/react/stories/stories_Checkbox.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import {storiesOf} from '@storybook/react';
 import withReadme from 'storybook-readme/with-readme';
-import {InputProviderDecorator, ControlledComponentWrapper} from '../../../../utils/storybook';
+import {ControlledComponentWrapper} from '../../../../utils/storybook';
 
 import {Checkbox} from '../../../checkbox/react/index';
 import FormField from '../index';
@@ -18,7 +18,6 @@ const hintText = 'Helpful text goes here.';
 const hintId = 'error-desc-id';
 
 storiesOf('Form Field/Checkbox/Top Label', module)
-  .addDecorator(InputProviderDecorator)
   .addDecorator(withReadme(README))
   .add('Default', () => (
     <div className="story">
@@ -70,7 +69,6 @@ storiesOf('Form Field/Checkbox/Top Label', module)
   ));
 
 storiesOf('Form Field/Checkbox/Left Label', module)
-  .addDecorator(InputProviderDecorator)
   .addDecorator(withReadme(README))
   .add('Default', () => (
     <div className="story">

--- a/modules/form-field/react/stories/stories_ColorInput.tsx
+++ b/modules/form-field/react/stories/stories_ColorInput.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import {storiesOf} from '@storybook/react';
 import withReadme from 'storybook-readme/with-readme';
-import {InputProviderDecorator, controlComponent} from '../../../../utils/storybook';
+import {controlComponent} from '../../../../utils/storybook';
 
 import {ColorInput} from '../../../color-picker/react/index';
 import FormField from '../index';
@@ -12,7 +12,6 @@ const hintText = 'Helpful text goes here.';
 const hintId = 'error-desc-id';
 
 storiesOf('Form Field/Color Picker/Color Input/Top Label', module)
-  .addDecorator(InputProviderDecorator)
   .addDecorator(withReadme(README))
   .add('Default', () => (
     <FormField label="Label" inputId="input-plain">

--- a/modules/form-field/react/stories/stories_ColorPreview.tsx
+++ b/modules/form-field/react/stories/stories_ColorPreview.tsx
@@ -2,14 +2,12 @@
 import * as React from 'react';
 import {storiesOf} from '@storybook/react';
 import withReadme from 'storybook-readme/with-readme';
-import {InputProviderDecorator} from '../../../../utils/storybook';
 
 import {ColorPreview} from '../../../color-picker/react/index';
 import FormField from '../index';
 import README from '../../../color-picker/react/README.md';
 
 storiesOf('Form Field/Color Picker/Color Preview/Top Label', module)
-  .addDecorator(InputProviderDecorator)
   .addDecorator(withReadme(README))
   .add('Default', () => (
     <FormField label="Label" inputId="input-plain">

--- a/modules/form-field/react/stories/stories_Radio.tsx
+++ b/modules/form-field/react/stories/stories_Radio.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import {storiesOf} from '@storybook/react';
 import withReadme from 'storybook-readme/with-readme';
-import {InputProviderDecorator, ControlledComponentWrapper} from '../../../../utils/storybook';
+import {ControlledComponentWrapper} from '../../../../utils/storybook';
 
 import {Radio, RadioGroup} from '../../../radio/react/index';
 import FormField from '../index';
@@ -12,7 +12,6 @@ const hintText = 'Helpful text goes here.';
 const hintId = 'error-desc-id';
 
 storiesOf('Form Field/Radio/Top Label/Radio Group', module)
-  .addDecorator(InputProviderDecorator)
   .addDecorator(withReadme(README))
   .add('Default', () => (
     <div className="story">
@@ -77,7 +76,6 @@ storiesOf('Form Field/Radio/Top Label/Radio Group', module)
   ));
 
 storiesOf('Form Field/Radio/Top Label/Radio', module)
-  .addDecorator(InputProviderDecorator)
   .addDecorator(withReadme(README))
   .add('Default', () => (
     <div className="story">
@@ -94,7 +92,6 @@ storiesOf('Form Field/Radio/Top Label/Radio', module)
   ));
 
 storiesOf('Form Field/Radio/Left Label/Radio Group', module)
-  .addDecorator(InputProviderDecorator)
   .addDecorator(withReadme(README))
   .add('Default', () => (
     <div className="story">
@@ -161,7 +158,6 @@ storiesOf('Form Field/Radio/Left Label/Radio Group', module)
   ));
 
 storiesOf('Form Field/Radio/Left Label/Radio', module)
-  .addDecorator(InputProviderDecorator)
   .addDecorator(withReadme(README))
   .add('Default', () => (
     <div className="story">

--- a/modules/form-field/react/stories/stories_Select.tsx
+++ b/modules/form-field/react/stories/stories_Select.tsx
@@ -2,11 +2,7 @@
 import * as React from 'react';
 import {storiesOf} from '@storybook/react';
 import withReadme from 'storybook-readme/with-readme';
-import {
-  InputProviderDecorator,
-  SectionDecorator,
-  controlComponent,
-} from '../../../../utils/storybook';
+import {SectionDecorator, controlComponent} from '../../../../utils/storybook';
 
 import FormField from '..';
 import README from '../../../select/react/README.md';
@@ -16,7 +12,6 @@ const hintText = 'Helpful text goes here.';
 const hintId = 'error-desc-id';
 
 storiesOf('Form Field/Select/Top Label', module)
-  .addDecorator(InputProviderDecorator)
   .addDecorator(SectionDecorator('Select'))
   .addDecorator(withReadme(README))
   .add('Plain', () => (

--- a/modules/form-field/react/stories/stories_TextArea.tsx
+++ b/modules/form-field/react/stories/stories_TextArea.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import {storiesOf} from '@storybook/react';
 import withReadme from 'storybook-readme/with-readme';
-import {InputProviderDecorator, controlComponent} from '../../../../utils/storybook';
+import {controlComponent} from '../../../../utils/storybook';
 
 import {TextArea} from '../../../text-area/react/index';
 import FormField from '../index';
@@ -12,7 +12,6 @@ const hintText = 'Helpful text goes here.';
 const hintId = 'error-desc-id';
 
 storiesOf('Form Field/TextArea/Top Label', module)
-  .addDecorator(InputProviderDecorator)
   .addDecorator(withReadme(README))
   .add('Default', () => (
     <FormField label="Label" inputId="textarea-plain">

--- a/modules/form-field/react/stories/stories_TextInput.tsx
+++ b/modules/form-field/react/stories/stories_TextInput.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import {storiesOf} from '@storybook/react';
 import withReadme from 'storybook-readme/with-readme';
-import {InputProviderDecorator, controlComponent} from '../../../../utils/storybook';
+import {controlComponent} from '../../../../utils/storybook';
 
 import {TextInput} from '../../../text-input/react/index';
 import FormField from '../index';
@@ -12,7 +12,6 @@ const hintText = 'Helpful text goes here.';
 const hintId = 'error-desc-id';
 
 storiesOf('Form Field/Text Input/Top Label', module)
-  .addDecorator(InputProviderDecorator)
   .addDecorator(withReadme(README))
   .add('Default', () => (
     <FormField label="Label" inputId="input-plain">

--- a/modules/menu/react/stories/stories.tsx
+++ b/modules/menu/react/stories/stories.tsx
@@ -5,7 +5,6 @@ import {action} from '@storybook/addon-actions';
 import withReadme from 'storybook-readme/with-readme';
 import uuid from 'uuid/v4';
 import {setupIcon, uploadCloudIcon, userIcon, extLinkIcon} from '@workday/canvas-system-icons-web';
-import {InputProviderDecorator} from '../../../../utils/storybook';
 import {CanvasSystemIcon} from '@workday/design-assets-types';
 
 import Popper from '@material-ui/core/Popper';
@@ -403,7 +402,6 @@ class Combobox extends React.Component<{}, ComboboxState> {
 }
 
 storiesOf('Menu', module)
-  .addDecorator(InputProviderDecorator)
   .addDecorator(withReadme(README))
   .add('Default', () => (
     <div className="story">

--- a/modules/side-panel/react/stories/stories.tsx
+++ b/modules/side-panel/react/stories/stories.tsx
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import {storiesOf} from '@storybook/react';
 import withReadme from 'storybook-readme/with-readme';
-import {InputProviderDecorator} from '../../../../utils/storybook';
 import {homeIcon, starIcon, rocketIcon, plusIcon} from '@workday/canvas-system-icons-web';
 import styled from 'react-emotion';
 import {css} from 'emotion';
@@ -154,7 +153,6 @@ class SidePanelWrapper extends React.Component<{}, SidePanelState> {
 }
 
 storiesOf('Side Panel', module)
-  .addDecorator(InputProviderDecorator)
   .addDecorator(withReadme(README))
   .add('Default', () => (
     <div className="story">


### PR DESCRIPTION
## Summary

We're adding `inputProviderDecorator` to the Storybook configuration file instead of adding it every time we need it. This makes sure we can properly style form inputs using `data-whatinput` in both React and CSS.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md
- [x] a11y approved final implementation
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
