### PR TITLE
refactor(layout): Update CSS naming to match React implementation

### DIFF
--- a/modules/layout/css/README.md
+++ b/modules/layout/css/README.md
@@ -1,7 +1,7 @@
-# Canvas Kit Grid System
+# Canvas Kit Layout
 
-Canvas Kit Grid System is based on a 12 column grid. The Canvas Grid System uses the flexbox layout
-for positioning of columns.
+Canvas Kit Layout is based on a 12 column grid. It uses the flexbox layout for positioning of
+columns.
 
 ## Installation
 
@@ -12,27 +12,27 @@ yarn add @workday/canvas-kit-css
 or
 
 ```sh
-yarn add @workday/canvas-kit-css-grid-system
+yarn add @workday/canvas-kit-css-layout
 ```
 
 Add your `node_modules` directory to your SASS `includePaths`. You will then be able to import
 `index.scss`.
 
 ```scss
-@import '~@workday/canvas-kit-css-grid-system/index.scss';
+@import '~@workday/canvas-kit-css-layout/index.scss';
 ```
 
 ## Usage
 
-### Grid Options
+### Layout Options
 
-|              | Small         | Medium        | Large         | Extra Large  |
-| ------------ | ------------- | ------------- | ------------- | ------------ |
-| Breakpoint   | > 320px       | > 768px       | > 992px       | > 1200px     |
-| Gutter Width | 16px          | 16px          | 24px          | 40px         |
-| Class Prefix | `wdc-col-sm-` | `wdc-col-md-` | `wdc-col-lg-` | `wdc-col-xl` |
+|               | Small         | Medium        | Large         | Extra Large  |
+| ------------- | ------------- | ------------- | ------------- | ------------ |
+| Breakpoint    | > 320px       | > 768px       | > 992px       | > 1200px     |
+| Spacing Width | 16px          | 16px          | 24px          | 40px         |
+| Class Prefix  | `wdc-col-sm-` | `wdc-col-md-` | `wdc-col-lg-` | `wdc-col-xl` |
 
-### Responsive Grids
+### Responsive Layout
 
 Responsive modifiers allow you to specify different column sizes for different breakpoints.
 
@@ -53,9 +53,9 @@ Responsive modifiers allow you to specify different column sizes for different b
 </div>
 ```
 
-### Fluid Grids
+### Fluid Layout
 
-Fluid grids are percentage based columns for resizing content.
+Fluid layouts use percentage based columns for resizing content.
 
 ```html
 <div class="wdc-row">
@@ -92,7 +92,7 @@ Fluid grids are percentage based columns for resizing content.
 </div>
 ```
 
-### Grids with Offsets
+### Offsets
 
 Offsets for columns.
 
@@ -177,7 +177,7 @@ Vertical position for columns.
 </div>
 ```
 
-### Grid Distribution
+### Distribution
 
 Position content with `wdc-row-around` and `wdc-row-between`.
 

--- a/modules/layout/css/index.scss
+++ b/modules/layout/css/index.scss
@@ -1,3 +1,3 @@
 @import '~@workday/canvas-kit-css-core/lib/variables';
 @import './lib/variables.scss';
-@import './lib/grid-system.scss';
+@import './lib/layout.scss';

--- a/modules/layout/css/lib/layout.scss
+++ b/modules/layout/css/lib/layout.scss
@@ -9,9 +9,9 @@
 @each $breakpoint in $wdc-grid-system-breakpoints {
   $_name: nth($breakpoint, 1);
   $_size: nth($breakpoint, 2);
-  $_gutter: nth($breakpoint, 3);
-  $_half-gutter: $_gutter * 0.5;
-  $_gutter-compensation: $_half-gutter * -1;
+  $_spacing: nth($breakpoint, 3);
+  $_half-spacing: $_spacing * 0.5;
+  $_spacing-compensation: $_half-spacing * -1;
 
   @media only screen and (min-width: $_size) {
     .wdc-row {
@@ -20,14 +20,14 @@
       flex: 0 1 auto;
       flex-direction: row;
       flex-wrap: wrap;
-      margin-right: $_gutter-compensation;
-      margin-left: $_gutter-compensation;
+      margin-right: $_spacing-compensation;
+      margin-left: $_spacing-compensation;
     }
 
     .wdc-col {
       @include wdc-col-common;
-      padding-left: $_half-gutter;
-      padding-right: $_half-gutter;
+      padding-left: $_half-spacing;
+      padding-right: $_half-spacing;
       flex-grow: 1;
       flex-basis: 0;
       max-width: 100%;
@@ -36,16 +36,16 @@
     @for $_i from 1 through $wdc-grid-system-columns {
       .wdc-col-#{$_i} {
         @include wdc-col-common;
-        padding-left: $_half-gutter;
-        padding-right: $_half-gutter;
+        padding-left: $_half-spacing;
+        padding-right: $_half-spacing;
         flex-basis: 100% / $wdc-grid-system-columns * $_i;
         max-width: 100% / $wdc-grid-system-columns * $_i;
       }
 
       .wdc-col-offset-#{$_i} {
         @include wdc-col-common;
-        padding-left: $_half-gutter;
-        padding-right: $_half-gutter;
+        padding-left: $_half-spacing;
+        padding-right: $_half-spacing;
 
         @if $_i == 0 {
           margin-left: 0;
@@ -56,16 +56,16 @@
 
       .wdc-col-#{$_name}-#{$_i} {
         @include wdc-col-common;
-        padding-left: $_half-gutter;
-        padding-right: $_half-gutter;
+        padding-left: $_half-spacing;
+        padding-right: $_half-spacing;
         flex-basis: 100% / $wdc-grid-system-columns * $_i;
         max-width: 100% / $wdc-grid-system-columns * $_i;
       }
 
       .wdc-col-#{$_name}-offset-#{$_i} {
         @include wdc-col-common;
-        padding-left: $_half-gutter;
-        padding-right: $_half-gutter;
+        padding-left: $_half-spacing;
+        padding-right: $_half-spacing;
 
         @if $_i == 0 {
           margin-left: 0;

--- a/modules/layout/css/lib/layout.scss
+++ b/modules/layout/css/lib/layout.scss
@@ -1,4 +1,4 @@
-// Grid System
+// Layout System
 
 @mixin wdc-col-common {
   box-sizing: border-box;
@@ -6,7 +6,7 @@
   flex-shrink: 0;
 }
 
-@each $breakpoint in $wdc-grid-system-breakpoints {
+@each $breakpoint in $wdc-layout-breakpoints {
   $_name: nth($breakpoint, 1);
   $_size: nth($breakpoint, 2);
   $_spacing: nth($breakpoint, 3);
@@ -33,13 +33,13 @@
       max-width: 100%;
     }
 
-    @for $_i from 1 through $wdc-grid-system-columns {
+    @for $_i from 1 through $wdc-layout-columns {
       .wdc-col-#{$_i} {
         @include wdc-col-common;
         padding-left: $_half-spacing;
         padding-right: $_half-spacing;
-        flex-basis: 100% / $wdc-grid-system-columns * $_i;
-        max-width: 100% / $wdc-grid-system-columns * $_i;
+        flex-basis: 100% / $wdc-layout-columns * $_i;
+        max-width: 100% / $wdc-layout-columns * $_i;
       }
 
       .wdc-col-offset-#{$_i} {
@@ -50,7 +50,7 @@
         @if $_i == 0 {
           margin-left: 0;
         } @else {
-          margin-left: 100% / $wdc-grid-system-columns * $_i;
+          margin-left: 100% / $wdc-layout-columns * $_i;
         }
       }
 
@@ -58,8 +58,8 @@
         @include wdc-col-common;
         padding-left: $_half-spacing;
         padding-right: $_half-spacing;
-        flex-basis: 100% / $wdc-grid-system-columns * $_i;
-        max-width: 100% / $wdc-grid-system-columns * $_i;
+        flex-basis: 100% / $wdc-layout-columns * $_i;
+        max-width: 100% / $wdc-layout-columns * $_i;
       }
 
       .wdc-col-#{$_name}-offset-#{$_i} {
@@ -70,7 +70,7 @@
         @if $_i == 0 {
           margin-left: 0;
         } @else {
-          margin-left: 100% / $wdc-grid-system-columns * $_i;
+          margin-left: 100% / $wdc-layout-columns * $_i;
         }
       }
     }

--- a/modules/layout/css/lib/variables.scss
+++ b/modules/layout/css/lib/variables.scss
@@ -1,7 +1,7 @@
-// Grid Variables
+// Layout Variables
 
-$wdc-grid-system-columns: 12 !default;
+$wdc-layout-columns: 12 !default;
 
 // size, breakpoint, spacing
-$wdc-grid-system-breakpoints: sm 320px $wdc-spacing-s, md 768px $wdc-spacing-s,
+$wdc-layout-breakpoints: sm 320px $wdc-spacing-s, md 768px $wdc-spacing-s,
   lg 992px $wdc-spacing-m, xl 1200px $wdc-spacing-xl !default;

--- a/modules/layout/css/lib/variables.scss
+++ b/modules/layout/css/lib/variables.scss
@@ -2,6 +2,6 @@
 
 $wdc-grid-system-columns: 12 !default;
 
-// size, breakpoint, gutter
+// size, breakpoint, spacing
 $wdc-grid-system-breakpoints: sm 320px $wdc-spacing-s, md 768px $wdc-spacing-s,
   lg 992px $wdc-spacing-m, xl 1200px $wdc-spacing-xl !default;

--- a/modules/layout/css/package.json
+++ b/modules/layout/css/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@workday/canvas-kit-css-layout",
   "version": "3.0.0-alpha.6",
-  "description": "The grid system css for canvas-kit-css",
+  "description": "Layout css for canvas-kit-css",
   "author": "Workday, Inc. (https://www.workday.com)",
   "license": "Apache-2.0",
   "files": [

--- a/modules/layout/css/package.json
+++ b/modules/layout/css/package.json
@@ -26,6 +26,7 @@
     "canvas",
     "canvas-kit",
     "css",
+    "layout",
     "scss",
     "sass",
     "workday",

--- a/modules/layout/css/stories.tsx
+++ b/modules/layout/css/stories.tsx
@@ -5,9 +5,9 @@ import README from './README.md';
 import './index.scss';
 import './stories.scss';
 
-storiesOf('CSS/Grid System', module)
+storiesOf('CSS/Layout', module)
   .addDecorator(withReadme(README))
-  .add('Responsive Grids', () => (
+  .add('Responsive Layout', () => (
     <div className="story story-grid">
       <div>
         <div className="wdc-row">
@@ -46,7 +46,7 @@ storiesOf('CSS/Grid System', module)
       </div>
     </div>
   ))
-  .add('Fluid Grids', () => (
+  .add('Fluid Layout', () => (
     <div className="story story-grid">
       <div>
         <div className="wdc-row">
@@ -140,7 +140,7 @@ storiesOf('CSS/Grid System', module)
       </div>
     </div>
   ))
-  .add('Grids with Offsets', () => (
+  .add('Offsets', () => (
     <div className="story story-grid">
       <div>
         <div className="wdc-row">
@@ -206,7 +206,7 @@ storiesOf('CSS/Grid System', module)
       </div>
     </div>
   ))
-  .add('Auto widths', () => (
+  .add('Auto Widths', () => (
     <div className="story story-grid">
       <div>
         <div className="wdc-row">
@@ -269,7 +269,7 @@ storiesOf('CSS/Grid System', module)
       </div>
     </div>
   ))
-  .add('Grid Horizontal Positioning', () => (
+  .add('Horizontal Positioning', () => (
     <div className="story story-grid">
       <div>
         <div className="wdc-row wdc-row-start">
@@ -290,7 +290,7 @@ storiesOf('CSS/Grid System', module)
       </div>
     </div>
   ))
-  .add('Grid Verical Positioning', () => (
+  .add('Vertical Positioning', () => (
     <div className="story story-grid">
       <div>
         <div className="wdc-row wdc-row-top">
@@ -320,7 +320,7 @@ storiesOf('CSS/Grid System', module)
       </div>
     </div>
   ))
-  .add('Grid Distribution', () => (
+  .add('Distribution', () => (
     <div className="story story-grid">
       <div>
         <div className="wdc-row wdc-row-around">

--- a/modules/layout/css/stories.tsx
+++ b/modules/layout/css/stories.tsx
@@ -8,7 +8,7 @@ import './stories.scss';
 storiesOf('CSS/Layout', module)
   .addDecorator(withReadme(README))
   .add('Responsive Layout', () => (
-    <div className="story story-grid">
+    <div className="story">
       <div>
         <div className="wdc-row">
           <div className="wdc-col-sm-2 wdc-col-md-5 wdc-col-lg-2 wdc-col-xl-1">
@@ -47,7 +47,7 @@ storiesOf('CSS/Layout', module)
     </div>
   ))
   .add('Fluid Layout', () => (
-    <div className="story story-grid">
+    <div className="story">
       <div>
         <div className="wdc-row">
           <div className="wdc-col-11">
@@ -141,7 +141,7 @@ storiesOf('CSS/Layout', module)
     </div>
   ))
   .add('Offsets', () => (
-    <div className="story story-grid">
+    <div className="story">
       <div>
         <div className="wdc-row">
           <div className="wdc-col-offset-11 wdc-col-1">
@@ -207,7 +207,7 @@ storiesOf('CSS/Layout', module)
     </div>
   ))
   .add('Auto Widths', () => (
-    <div className="story story-grid">
+    <div className="story">
       <div>
         <div className="wdc-row">
           <div className="wdc-col">
@@ -270,7 +270,7 @@ storiesOf('CSS/Layout', module)
     </div>
   ))
   .add('Horizontal Positioning', () => (
-    <div className="story story-grid">
+    <div className="story">
       <div>
         <div className="wdc-row wdc-row-start">
           <div className="wdc-col-1">
@@ -291,7 +291,7 @@ storiesOf('CSS/Layout', module)
     </div>
   ))
   .add('Vertical Positioning', () => (
-    <div className="story story-grid">
+    <div className="story">
       <div>
         <div className="wdc-row wdc-row-top">
           <div className="wdc-col">
@@ -321,7 +321,7 @@ storiesOf('CSS/Layout', module)
     </div>
   ))
   .add('Distribution', () => (
-    <div className="story story-grid">
+    <div className="story">
       <div>
         <div className="wdc-row wdc-row-around">
           <div className="wdc-col-1">


### PR DESCRIPTION
This PR updates the Layout (formerly known as Grid) CSS styles so they match the React component. 

|                  | Visual | Code |
|------------------|--------|------|
| Breaking Changes | No    | Yes   |

### Code Changes
- `lib/grid-system.scss` moved to `lib/layout.scss`
- `$wdc-grid-system-breakpoints` > `$wdc-layout-breakpoints`
- `$wdc-grid-system-columns` > `$wdc-layout-columns`

### Squash and Merge Message Proposal
refactor(layout): Update CSS styles to match React implementation (#168)