### PR TITLE
refactor(table): TableRow API update and cleanup

### DIFF
--- a/modules/table/react/README.md
+++ b/modules/table/react/README.md
@@ -89,7 +89,7 @@ import {Table, TableRow} from '@workday/canvas-kit-react-table';
 
 ## Static Properties
 
-#### `State: TableRowStates`
+#### `State: TableRowState`
 
 ```tsx
 <TableRow state={TableRow.State.Error}>
@@ -111,7 +111,7 @@ the entire row. This style produces a colored row without a darkened border.
 
 ### Optional
 
-#### `state: TableRowStates`
+#### `state: TableRowState`
 
 > The state of the row
 

--- a/modules/table/react/lib/TableRow.tsx
+++ b/modules/table/react/lib/TableRow.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {Interpolation} from 'emotion';
 import styled from 'react-emotion';
 import {rgba} from 'polished';
-import {colors, spacing, spacingNumbers} from '@workday/canvas-kit-react-core';
+import {colors, spacing, spacingNumbers, statusColors} from '@workday/canvas-kit-react-core';
 import {borderColor, borderWidth, cellBorder} from './Table';
 
 export enum TableRowState {
@@ -26,9 +26,9 @@ export interface TableRowProps extends React.HTMLAttributes<HTMLTableRowElement>
   header?: boolean;
 }
 
-const errorColor = colors.cinnamon400;
+const errorColor = statusColors.error;
 const errorColorLight = colors.cinnamon200;
-const alertColor = colors.cantaloupe400;
+const alertColor = statusColors.warning;
 const alertColorLight = colors.cantaloupe200;
 
 function makeColoredRow(_bgColor: string, _borderColor: string): Interpolation {

--- a/modules/table/react/lib/TableRow.tsx
+++ b/modules/table/react/lib/TableRow.tsx
@@ -5,7 +5,7 @@ import {rgba} from 'polished';
 import {colors, spacing, spacingNumbers} from '@workday/canvas-kit-react-core';
 import {borderColor, borderWidth, cellBorder} from './Table';
 
-export enum TableRowStates {
+export enum TableRowState {
   Error,
   Alert,
   InputError,
@@ -18,7 +18,7 @@ export interface TableRowProps extends React.HTMLAttributes<HTMLTableRowElement>
   /**
    * State of the row
    */
-  state?: TableRowStates;
+  state?: TableRowState;
 
   /**
    * Whether or not the row contains header elements
@@ -151,19 +151,19 @@ const Row = styled('tr')<TableRowProps>(
     const styles: Interpolation = [];
 
     switch (state) {
-      case TableRowStates.InputError:
+      case TableRowState.InputError:
         styles.push(makeBorderlessStyle(errorColor));
         break;
-      case TableRowStates.Error:
+      case TableRowState.Error:
         styles.push(makeColoredRowStyle(errorColor, errorColorLight));
         break;
-      case TableRowStates.InputAlert:
+      case TableRowState.InputAlert:
         styles.push(makeBorderlessStyle(alertColor));
         break;
-      case TableRowStates.Alert:
+      case TableRowState.Alert:
         styles.push(makeColoredRowStyle(alertColor, alertColorLight));
         break;
-      case TableRowStates.Selected:
+      case TableRowState.Selected:
         styles.push({
           'th, td': [
             makeColoredRow(colors.blueberry100, colors.blueberry500),
@@ -201,7 +201,7 @@ const Row = styled('tr')<TableRowProps>(
 );
 
 export default class TableRow extends React.Component<TableRowProps> {
-  public static State = TableRowStates;
+  public static State = TableRowState;
 
   public render() {
     const {state, header, children, ...elemProps} = this.props;

--- a/modules/table/react/spec/TableRow.snapshot.tsx
+++ b/modules/table/react/spec/TableRow.snapshot.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
-import TableRow, {TableRowStates} from '../lib/TableRow';
+import TableRow, {TableRowState} from '../lib/TableRow';
 
 describe('Table Row Snapshots', () => {
   test('renders as expected', () => {
@@ -22,7 +22,7 @@ describe('Table Row Snapshots', () => {
   });
 
   describe('states', () => {
-    function createStateComponent(state: TableRowStates) {
+    function createStateComponent(state: TableRowState) {
       return renderer.create(
         <TableRow state={state}>
           <td>cell</td>
@@ -30,32 +30,32 @@ describe('Table Row Snapshots', () => {
       );
     }
     test('Error', () => {
-      const component = createStateComponent(TableRowStates.Error);
+      const component = createStateComponent(TableRowState.Error);
       expect(component).toMatchSnapshot();
     });
 
     test('Alert', () => {
-      const component = createStateComponent(TableRowStates.Alert);
+      const component = createStateComponent(TableRowState.Alert);
       expect(component).toMatchSnapshot();
     });
 
     test('Input Error', () => {
-      const component = createStateComponent(TableRowStates.InputError);
+      const component = createStateComponent(TableRowState.InputError);
       expect(component).toMatchSnapshot();
     });
 
     test('Input Alert', () => {
-      const component = createStateComponent(TableRowStates.InputAlert);
+      const component = createStateComponent(TableRowState.InputAlert);
       expect(component).toMatchSnapshot();
     });
 
     test('Hover', () => {
-      const component = createStateComponent(TableRowStates.Hover);
+      const component = createStateComponent(TableRowState.Hover);
       expect(component).toMatchSnapshot();
     });
 
     test('Selected', () => {
-      const component = createStateComponent(TableRowStates.Selected);
+      const component = createStateComponent(TableRowState.Selected);
       expect(component).toMatchSnapshot();
     });
   });

--- a/modules/table/react/spec/__snapshots__/TableRow.snapshot.tsx.snap
+++ b/modules/table/react/spec/__snapshots__/TableRow.snapshot.tsx.snap
@@ -342,7 +342,7 @@ exports[`Table Row Snapshots states Error 1`] = `
 
 .emotion-0 th,
 .emotion-0 td {
-  background-color: rgba(255,83,71,0.2);
+  background-color: rgba(222,46,33,0.2);
   position: relative;
   border-left-color: #fcc9c5;
   border-right-color: #fcc9c5;
@@ -358,7 +358,7 @@ exports[`Table Row Snapshots states Error 1`] = `
   content: "";
   width: calc(100% + 1px);
   height: 1px;
-  background-color: #ff5347;
+  background-color: #de2e21;
 }
 
 .emotion-0 th:after,
@@ -369,12 +369,12 @@ exports[`Table Row Snapshots states Error 1`] = `
 
 .emotion-0 th:first-child,
 .emotion-0 td:first-child {
-  box-shadow: inset 1px 0 0 #ff5347;
+  box-shadow: inset 1px 0 0 #de2e21;
 }
 
 .emotion-0 th:last-child,
 .emotion-0 td:last-child {
-  box-shadow: inset -1px 0 0 #ff5347;
+  box-shadow: inset -1px 0 0 #de2e21;
 }
 
 .emotion-0 th:last-child:before,
@@ -386,7 +386,7 @@ exports[`Table Row Snapshots states Error 1`] = `
 
 .emotion-0:hover th,
 .emotion-0:hover td {
-  background-color: rgba(255,83,71,0.2);
+  background-color: rgba(222,46,33,0.2);
 }
 
 <tr
@@ -572,7 +572,7 @@ exports[`Table Row Snapshots states Input Error 1`] = `
 
 .emotion-0 th,
 .emotion-0 td {
-  background-color: rgba(255,83,71,0.2);
+  background-color: rgba(222,46,33,0.2);
 }
 
 <tr


### PR DESCRIPTION
## Summary

This addresses #170 

Changes include:
- Updated exports `TableRowStates` to `TableRowState`
- Using `StatusColors` for error and alert colors. This includes a breaking change: Error color is now changed updated `cinnamon500` from `cinnamon400`


| Breaking Changes | Visual | Code |
|--------------------|-------|------|
| | Yes| Yes|


## Checklist

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)
