### PR TITLE
feat: Add faster testing of stories in Cypress

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -39,10 +39,10 @@ addParameters({
 configure(loadStories, module);
 injectGlobal(...fonts);
 
-function setCurrentStory(story, variation) {
+function setCurrentStory(categorization, story) {
   clearCurrentStory();
   addons.getChannel().emit(Events.SET_CURRENT_STORY, {
-    storyId: toId(story, variation),
+    storyId: toId(categorization, story),
   });
   forceReRender();
 }

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,8 +1,13 @@
-import {configure, addDecorator, addParameters} from '@storybook/react';
+import {configure, addDecorator, addParameters, forceReRender} from '@storybook/react';
 import {withKnobs} from '@storybook/addon-knobs/react';
 import {injectGlobal} from 'emotion';
 import fonts from '../modules/fonts/react';
 import {create} from '@storybook/theming';
+import addons from '@storybook/addons';
+import Events from '@storybook/core-events';
+import {toId} from '@storybook/router';
+import ReactDOM from 'react-dom';
+
 import {commonColors, typeColors, fontFamily} from '../modules/core/react';
 import {InputProviderDecorator} from '../utils/storybook';
 const req = require.context('../modules', true, /stories.*\.tsx?$/);
@@ -33,3 +38,18 @@ addParameters({
 
 configure(loadStories, module);
 injectGlobal(...fonts);
+
+function setCurrentStory(story, variation) {
+  clearCurrentStory();
+  addons.getChannel().emit(Events.SET_CURRENT_STORY, {
+    storyId: toId(story, variation),
+  });
+  forceReRender();
+}
+
+function clearCurrentStory() {
+  var root = document.querySelector('#root');
+  ReactDOM.unmountComponentAtNode(root);
+}
+
+window.setCurrentStory = setCurrentStory;

--- a/cypress/helpers/index.ts
+++ b/cypress/helpers/index.ts
@@ -1,0 +1,3 @@
+import * as stories from './stories';
+
+export {stories};

--- a/cypress/helpers/stories.ts
+++ b/cypress/helpers/stories.ts
@@ -1,0 +1,33 @@
+declare global {
+  interface Window {
+    /**
+     * Load a story. This will invoke the storybook router,
+     * unmount a previous story, mount the current story and force a rerender
+     * This should be in a `beforeEach` block to force a fresh new story
+     * @param story Name of the story found in the `.add` function
+     * @param variation Variation of the story found in the `.add` function
+     */
+    setCurrentStory(story: string, variation: string);
+  }
+}
+
+/**
+ * Load a story. This will invoke the storybook router,
+ * unmount a previous story, mount the current story and force a rerender
+ * This should be in a `beforeEach` block to force a fresh new story
+ * @param story Name of the story found in the `.add` function
+ * @param variation Variation of the story found in the `.add` function
+ */
+export function load(story: string, variation: string) {
+  cy.window().then(win => {
+    win.setCurrentStory(story, variation);
+  });
+}
+
+/**
+ * Visit the blank test page. This should be in a `before` block of every test page
+ * To load a story, use h.stories.load(storyName, variation)
+ */
+export function visit() {
+  cy.visit('iframe.html');
+}

--- a/cypress/helpers/stories.ts
+++ b/cypress/helpers/stories.ts
@@ -4,10 +4,12 @@ declare global {
      * Load a story. This will invoke the storybook router,
      * unmount a previous story, mount the current story and force a rerender
      * This should be in a `beforeEach` block to force a fresh new story
-     * @param story Name of the story found in the `.add` function
-     * @param variation Variation of the story found in the `.add` function
+     * @param categorization Categorization information found in the `.add` function - usually used for menu navigation
+     * @param story The specific story example in the `.add` function
+     * @example
+     * setCurrentStory('Button', 'Primary')
      */
-    setCurrentStory(story: string, variation: string);
+    setCurrentStory(categorization: string, story: string);
   }
 }
 
@@ -15,18 +17,20 @@ declare global {
  * Load a story. This will invoke the storybook router,
  * unmount a previous story, mount the current story and force a rerender
  * This should be in a `beforeEach` block to force a fresh new story
- * @param story Name of the story found in the `.add` function
- * @param variation Variation of the story found in the `.add` function
+ * @param categorization Categorization information found in the `.add` function - usually used for menu navigation
+ * @param story Variant of the story example in the `.add` function
+ * @example
+ * h.stories.load('Button', 'Primary')
  */
-export function load(story: string, variation: string) {
+export function load(categorization: string, story: string) {
   cy.window().then(win => {
-    win.setCurrentStory(story, variation);
+    win.setCurrentStory(categorization, story);
   });
 }
 
 /**
  * Visit the blank test page. This should be in a `before` block of every test page
- * To load a story, use h.stories.load(storyName, variation)
+ * To load a story, use h.stories.load(storyName, variant)
  */
 export function visit() {
   cy.visit('iframe.html');

--- a/cypress/integration/Button.spec.ts
+++ b/cypress/integration/Button.spec.ts
@@ -1,11 +1,31 @@
+import * as h from '../helpers';
+
 describe('Button', () => {
-  beforeEach(() => {
-    cy.visit('iframe.html?id=button--primary');
+  before(() => {
+    h.stories.visit();
   });
 
-  it('should render a large primary button', () => {
-    cy.get('button')
-      .first()
-      .should('contain', 'Primary Button');
+  context('given primary buttons are rendered', () => {
+    beforeEach(() => {
+      h.stories.load('button', 'primary');
+    });
+
+    it('should render the correct text', () => {
+      cy.get('button')
+        .first()
+        .should('contain', 'Primary Button');
+    });
+  });
+
+  context('given delete buttons are rendered', () => {
+    beforeEach(() => {
+      h.stories.load('button', 'delete');
+    });
+
+    it('should render the correct text', () => {
+      cy.get('button')
+        .first()
+        .should('contain', 'Delete Button');
+    });
   });
 });

--- a/package.json
+++ b/package.json
@@ -118,9 +118,14 @@
   },
   "lint-staged": {
     "linters": {
-      "*.{ts,tsx}": [
+      "modules/**/*.{ts,tsx}": [
         "prettier --config=./.prettierrc --ignore-path=./.prettierignore --write",
         "tslint --project tsconfig.json --fix",
+        "git add"
+      ],
+      "cypress/**/*.ts": [
+        "prettier --config=./.prettierrc --ignore-path=./.prettierignore --write",
+        "tslint --project cypress/tsconfig.json --fix",
         "git add"
       ],
       "*.{js,jsx,json,md}": [


### PR DESCRIPTION
## Summary

Added `window.setCurrentStory(story: string, variation: string)` to enable faster (re)loading of Storybook stories. The `story` parameter matches the string inside `storiesOf` and the `variation` matches the string inside the `.add` function

Use (in browser's console):
```ts
setCurrentStory('button', 'primary')
```

## Checklist

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md

## Additional References

<details>
    <summary>Animated GIF. Warning! Tests are fast and flash rapidly!</summary>
    <img src="https://user-images.githubusercontent.com/338257/64730006-9406be00-d49b-11e9-9a88-9fce4042a2e1.gif" alt="Cypress tests"/>
</details>
