### PR TITLE
docs(core): Fix broken InputProvider helper link

### DIFF
--- a/modules/core/react/README.md
+++ b/modules/core/react/README.md
@@ -375,7 +375,7 @@ handling.
 }
 ```
 
-We provide a [helper](../canvas-kit-react-common/lib/styles/hideMouseFocus.ts) to hide the focus
+We provide a [helper](../../common/react/lib/styles/hideMouseFocus.ts) to hide the focus
 outlines on mouse input. Simply spread it in your styles (i.e. `...hideMouseFocus`).
 
 **Note:** It is best practice to show focus outlines by default and specifically hide them in the


### PR DESCRIPTION
I noticed a link is broken in our `InputProvider docs`