### PR TITLE
refactor(avatar): Change themeColor to variant

### DIFF
--- a/modules/avatar/react/README.md
+++ b/modules/avatar/react/README.md
@@ -18,7 +18,7 @@ yarn add @workday/canvas-kit-react-avatar
 
 ```tsx
 import * as React from 'react';
-import {Avatar, Variant} from '@workday/canvas-kit-react-avatar';
+import {Avatar, AvatarVariant} from '@workday/canvas-kit-react-avatar';
 
 // Basic
 <Avatar />
@@ -26,20 +26,20 @@ import {Avatar, Variant} from '@workday/canvas-kit-react-avatar';
 // Using static properties on Avatar
 <Avatar
   size={Avatar.Size.xs}
-  variant={Avatar.variant.Dark}
+  variant={Avatar.Variant.Dark}
   onClick={() => { window.alert('Avatar Clicked') }}
 />
 
-// Using Variant import directly
-<Avatar size={Avatar.Size.xs} variant={Variant.Dark} />
+// Using AvatarVariant import directly
+<Avatar size={Avatar.Size.xs} variant={AvatarVariant.Dark} />
 ```
 
 ## Static Properties
 
-#### `variant: Variant`
+#### `variant: AvatarVariant`
 
 ```tsx
-<Avatar variant={Avatar.variant.Dark} />
+<Avatar variant={Avatar.Variant.Dark} />
 ```
 
 ---
@@ -62,7 +62,7 @@ import {Avatar, Variant} from '@workday/canvas-kit-react-avatar';
 
 ### Optional
 
-#### `variant: Variant`
+#### `variant: AvatarVariant`
 
 > The variant of the avatar if using a default image.
 

--- a/modules/avatar/react/README.md
+++ b/modules/avatar/react/README.md
@@ -66,7 +66,7 @@ import {Avatar, AvatarVariant} from '@workday/canvas-kit-react-avatar';
 
 > The variant of the avatar if using a default image.
 
-Default: `Variant.Light`
+Default: `AvatarVariant.Light`
 
 | Variant | Description                      |
 | ------- | -------------------------------- |

--- a/modules/avatar/react/README.md
+++ b/modules/avatar/react/README.md
@@ -18,7 +18,7 @@ yarn add @workday/canvas-kit-react-avatar
 
 ```tsx
 import * as React from 'react';
-import {Avatar, AvatarTheme} from '@workday/canvas-kit-react-avatar';
+import {Avatar, Variant} from '@workday/canvas-kit-react-avatar';
 
 // Basic
 <Avatar />
@@ -26,20 +26,20 @@ import {Avatar, AvatarTheme} from '@workday/canvas-kit-react-avatar';
 // Using static properties on Avatar
 <Avatar
   size={Avatar.Size.xs}
-  themeColor={Avatar.ThemeColor.Dark}
+  variant={Avatar.variant.Dark}
   onClick={() => { window.alert('Avatar Clicked') }}
 />
 
-// Using AvatarTheme import directly
-<Avatar size={Avatar.Size.xs} themeColor={AvatarTheme.Dark} />
+// Using Variant import directly
+<Avatar size={Avatar.Size.xs} variant={Variant.Dark} />
 ```
 
 ## Static Properties
 
-#### `ThemeColor: AvatarTheme`
+#### `variant: Variant`
 
 ```tsx
-<Avatar themeColor={Avatar.ThemeColor.Dark} />
+<Avatar variant={Avatar.variant.Dark} />
 ```
 
 ---
@@ -62,13 +62,13 @@ import {Avatar, AvatarTheme} from '@workday/canvas-kit-react-avatar';
 
 ### Optional
 
-#### `themeColor: AvatarTheme`
+#### `variant: Variant`
 
-> The theme of the avatar if using a default image.
+> The variant of the avatar if using a default image.
 
-Default: `AvatarTheme.Light`
+Default: `Variant.Light`
 
-| Theme   | Description                      |
+| Variant | Description                      |
 | ------- | -------------------------------- |
 | `Light` | Light grey background, dark icon |
 | `Dark`  | Dark blue background, white icon |

--- a/modules/avatar/react/lib/Avatar.tsx
+++ b/modules/avatar/react/lib/Avatar.tsx
@@ -6,16 +6,16 @@ import {focusRing, hideMouseFocus} from '@workday/canvas-kit-react-common';
 import {SystemIconCircle, SystemIconCircleSize} from '@workday/canvas-kit-react-icon';
 import {userIcon} from '@workday/canvas-system-icons-web';
 
-export enum AvatarTheme {
+export enum Variant {
   Light,
   Dark,
 }
 
 export interface AvatarProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /**
-   * An AvatarTheme enum indicating which theme to use for the default state (Light vs. Dark)
+   * An Variant enum indicating which variant to use for the default state (Light vs. Dark)
    */
-  themeColor: AvatarTheme;
+  variant: Variant;
   /**
    * An SystemIconCircleSize enum or number value indicating the size of the avatar
    */
@@ -55,7 +55,7 @@ const Container = styled('button', {
       height: '100%',
     },
   },
-  ({themeColor, size, onClick}) => ({
+  ({variant, size, onClick}) => ({
     background: colors.soap200,
     height: size,
     width: size,
@@ -63,7 +63,7 @@ const Container = styled('button', {
     '&:not([disabled])': {
       '&:focus': {
         outline: 'none',
-        ...(themeColor === AvatarTheme.Dark ? focusRing(2, 2) : focusRing(2)),
+        ...(variant === Variant.Dark ? focusRing(2, 2) : focusRing(2)),
       },
     },
     ...hideMouseFocus,
@@ -71,22 +71,22 @@ const Container = styled('button', {
 );
 
 export default class Avatar extends React.Component<AvatarProps> {
-  static ThemeColor = AvatarTheme;
+  static variant = Variant;
   static Size = SystemIconCircleSize;
 
   static defaultProps = {
-    themeColor: AvatarTheme.Light,
+    variant: Variant.Light,
     size: SystemIconCircleSize.m,
     altText: 'Avatar',
   };
 
   render() {
-    const {buttonRef, themeColor, altText, size, url, onClick, ...elemProps} = this.props;
+    const {buttonRef, variant, altText, size, url, onClick, ...elemProps} = this.props;
 
-    const background = themeColor === AvatarTheme.Dark ? colors.blueberry400 : colors.soap300;
+    const background = variant === Variant.Dark ? colors.blueberry400 : colors.soap300;
     return (
       <Container
-        themeColor={themeColor}
+        variant={variant}
         size={size}
         onClick={onClick}
         disabled={onClick ? false : true}

--- a/modules/avatar/react/lib/Avatar.tsx
+++ b/modules/avatar/react/lib/Avatar.tsx
@@ -71,7 +71,7 @@ const Container = styled('button', {
 );
 
 export default class Avatar extends React.Component<AvatarProps> {
-  static variant = AvatarVariant;
+  static Variant = AvatarVariant;
   static Size = SystemIconCircleSize;
 
   static defaultProps = {

--- a/modules/avatar/react/lib/Avatar.tsx
+++ b/modules/avatar/react/lib/Avatar.tsx
@@ -6,16 +6,16 @@ import {focusRing, hideMouseFocus} from '@workday/canvas-kit-react-common';
 import {SystemIconCircle, SystemIconCircleSize} from '@workday/canvas-kit-react-icon';
 import {userIcon} from '@workday/canvas-system-icons-web';
 
-export enum Variant {
+export enum AvatarVariant {
   Light,
   Dark,
 }
 
 export interface AvatarProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /**
-   * An Variant enum indicating which variant to use for the default state (Light vs. Dark)
+   * An AvatarVariant enum indicating which variant to use for the default state (Light vs. Dark)
    */
-  variant: Variant;
+  variant: AvatarVariant;
   /**
    * An SystemIconCircleSize enum or number value indicating the size of the avatar
    */
@@ -63,7 +63,7 @@ const Container = styled('button', {
     '&:not([disabled])': {
       '&:focus': {
         outline: 'none',
-        ...(variant === Variant.Dark ? focusRing(2, 2) : focusRing(2)),
+        ...(variant === AvatarVariant.Dark ? focusRing(2, 2) : focusRing(2)),
       },
     },
     ...hideMouseFocus,
@@ -71,11 +71,11 @@ const Container = styled('button', {
 );
 
 export default class Avatar extends React.Component<AvatarProps> {
-  static variant = Variant;
+  static variant = AvatarVariant;
   static Size = SystemIconCircleSize;
 
   static defaultProps = {
-    variant: Variant.Light,
+    variant: AvatarVariant.Light,
     size: SystemIconCircleSize.m,
     altText: 'Avatar',
   };
@@ -83,7 +83,7 @@ export default class Avatar extends React.Component<AvatarProps> {
   render() {
     const {buttonRef, variant, altText, size, url, onClick, ...elemProps} = this.props;
 
-    const background = variant === Variant.Dark ? colors.blueberry400 : colors.soap300;
+    const background = variant === AvatarVariant.Dark ? colors.blueberry400 : colors.soap300;
     return (
       <Container
         variant={variant}

--- a/modules/avatar/react/spec/Avatar.snapshot.tsx
+++ b/modules/avatar/react/spec/Avatar.snapshot.tsx
@@ -13,7 +13,7 @@ describe('Avatar Snapshots', () => {
   });
   test('renders a large, dark Avatar', () => {
     const component = renderer.create(
-      <Avatar size={Avatar.Size.xl} themeColor={Avatar.ThemeColor.Dark} />
+      <Avatar size={Avatar.Size.xl} variant={Avatar.variant.Dark} />
     );
     expect(component).toMatchSnapshot();
   });

--- a/modules/avatar/react/spec/Avatar.snapshot.tsx
+++ b/modules/avatar/react/spec/Avatar.snapshot.tsx
@@ -13,7 +13,7 @@ describe('Avatar Snapshots', () => {
   });
   test('renders a large, dark Avatar', () => {
     const component = renderer.create(
-      <Avatar size={Avatar.Size.xl} variant={Avatar.variant.Dark} />
+      <Avatar size={Avatar.Size.xl} variant={Avatar.Variant.Dark} />
     );
     expect(component).toMatchSnapshot();
   });

--- a/modules/avatar/react/stories/stories.tsx
+++ b/modules/avatar/react/stories/stories.tsx
@@ -29,17 +29,17 @@ storiesOf('Avatar', module)
   .add('Dark', () => (
     <div className="story">
       <h3>Extra-Extra Large</h3>
-      <Avatar size={Avatar.Size.xxl} themeColor={Avatar.ThemeColor.Dark} />
+      <Avatar size={Avatar.Size.xxl} variant={Avatar.variant.Dark} />
       <h3>Extra Large</h3>
-      <Avatar size={Avatar.Size.xl} themeColor={Avatar.ThemeColor.Dark} />
+      <Avatar size={Avatar.Size.xl} variant={Avatar.variant.Dark} />
       <h3>Large</h3>
-      <Avatar size={Avatar.Size.l} themeColor={Avatar.ThemeColor.Dark} />
+      <Avatar size={Avatar.Size.l} variant={Avatar.variant.Dark} />
       <h3>Medium</h3>
-      <Avatar size={Avatar.Size.m} themeColor={Avatar.ThemeColor.Dark} />
+      <Avatar size={Avatar.Size.m} variant={Avatar.variant.Dark} />
       <h3>Small</h3>
-      <Avatar size={Avatar.Size.s} themeColor={Avatar.ThemeColor.Dark} />
+      <Avatar size={Avatar.Size.s} variant={Avatar.variant.Dark} />
       <h3>Extra Small</h3>
-      <Avatar size={Avatar.Size.xs} themeColor={Avatar.ThemeColor.Dark} />
+      <Avatar size={Avatar.Size.xs} variant={Avatar.variant.Dark} />
     </div>
   ))
   .add('Image', () => (

--- a/modules/avatar/react/stories/stories.tsx
+++ b/modules/avatar/react/stories/stories.tsx
@@ -29,17 +29,17 @@ storiesOf('Avatar', module)
   .add('Dark', () => (
     <div className="story">
       <h3>Extra-Extra Large</h3>
-      <Avatar size={Avatar.Size.xxl} variant={Avatar.variant.Dark} />
+      <Avatar size={Avatar.Size.xxl} variant={Avatar.Variant.Dark} />
       <h3>Extra Large</h3>
-      <Avatar size={Avatar.Size.xl} variant={Avatar.variant.Dark} />
+      <Avatar size={Avatar.Size.xl} variant={Avatar.Variant.Dark} />
       <h3>Large</h3>
-      <Avatar size={Avatar.Size.l} variant={Avatar.variant.Dark} />
+      <Avatar size={Avatar.Size.l} variant={Avatar.Variant.Dark} />
       <h3>Medium</h3>
-      <Avatar size={Avatar.Size.m} variant={Avatar.variant.Dark} />
+      <Avatar size={Avatar.Size.m} variant={Avatar.Variant.Dark} />
       <h3>Small</h3>
-      <Avatar size={Avatar.Size.s} variant={Avatar.variant.Dark} />
+      <Avatar size={Avatar.Size.s} variant={Avatar.Variant.Dark} />
       <h3>Extra Small</h3>
-      <Avatar size={Avatar.Size.xs} variant={Avatar.variant.Dark} />
+      <Avatar size={Avatar.Size.xs} variant={Avatar.Variant.Dark} />
     </div>
   ))
   .add('Image', () => (


### PR DESCRIPTION
This is part of the API changes ongoing work https://github.com/Workday/canvas-kit/issues/51, we want to rename the `themeColor` prop to `variant`.

### Breaking Code Changes
- `AvatarTheme` changed to `AvatarVariant`
- `Avatar`'s `themeColor` prop renamed to `variant`

### Squash and Merge Message Proposal

refactor(avatar): Change themeColor to AvatarVariant (#194)