### PR TITLE
refactor(banner): Change BannerTheme to ErrorType

### DIFF
--- a/modules/banner/react/README.md
+++ b/modules/banner/react/README.md
@@ -25,7 +25,7 @@ import Banner from '@workday/canvas-kit-react-banner';
 
 ## Static Properties
 
-#### `ErrorType: BannerErrorType`
+#### `ErrorType: ErrorType`
 
 ```tsx
 <Banner error={Banner.ErrorType.Error} label="3 errors" />
@@ -57,10 +57,16 @@ import Banner from '@workday/canvas-kit-react-banner';
 
 > Set the banner variant as `full` or `sticky`
 
-#### `type: ErrorType`
+Default: `BannerVariant.Full`
+
+#### `error: ErrorType`
 
 > Set the banner type as `alert` or `error`
+
+Default: `ErrorType.Alert`
 
 #### `actionText: string`
 
 > Set the action text in the `full` variant
+
+Default: `'View All'`

--- a/modules/banner/react/README.md
+++ b/modules/banner/react/README.md
@@ -57,7 +57,7 @@ import Banner from '@workday/canvas-kit-react-banner';
 
 > Set the banner variant as `full` or `sticky`
 
-#### `type: BannerErrorType`
+#### `type: ErrorType`
 
 > Set the banner type as `alert` or `error`
 

--- a/modules/banner/react/README.md
+++ b/modules/banner/react/README.md
@@ -25,10 +25,10 @@ import Banner from '@workday/canvas-kit-react-banner';
 
 ## Static Properties
 
-#### `Theme: BannerTheme`
+#### `ErrorType: BannerErrorType`
 
 ```tsx
-<Banner theme={Banner.Theme.Error} label="3 errors" />
+<Banner error={Banner.ErrorType.Error} label="3 errors" />
 ```
 
 ---
@@ -57,9 +57,9 @@ import Banner from '@workday/canvas-kit-react-banner';
 
 > Set the banner variant as `full` or `sticky`
 
-#### `theme: BannerTheme`
+#### `type: BannerErrorType`
 
-> Set the banner theme as `alert` or `error`
+> Set the banner type as `alert` or `error`
 
 #### `actionText: string`
 

--- a/modules/banner/react/index.ts
+++ b/modules/banner/react/index.ts
@@ -3,4 +3,3 @@ import Banner from './lib/Banner';
 export default Banner;
 export {Banner};
 export * from './lib/Banner';
-export * from './lib/types';

--- a/modules/banner/react/lib/Banner.tsx
+++ b/modules/banner/react/lib/Banner.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styled from 'react-emotion';
 import {colors, spacing, type} from '@workday/canvas-kit-react-core';
-import {BannerVariant, BannerTheme} from './types';
+import {BannerVariant, BannerErrorType} from './types';
 import {SystemIcon} from '@workday/canvas-kit-react-icon';
 import {exclamationCircleIcon, exclamationTriangleIcon} from '@workday/canvas-system-icons-web';
 import {focusRing} from '@workday/canvas-kit-react-common';
@@ -20,9 +20,9 @@ export interface BannerProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
    */
   variant?: BannerVariant;
   /**
-   * Color theme of the banner
+   * Color of the banner based on the type of the error
    */
-  theme?: BannerTheme;
+  error?: BannerErrorType;
   /**
    * Text on the right, call to action
    */
@@ -51,14 +51,14 @@ const BannerWrapper = styled('button')<BannerProps>(
       cursor: 'pointer',
     },
   },
-  ({theme, variant}) => ({
-    backgroundColor: theme === BannerTheme.Error ? colors.cinnamon500 : colors.cantaloupe400,
-    color: theme === BannerTheme.Error ? colors.frenchVanilla100 : colors.blackPepper400,
+  ({error, variant}) => ({
+    backgroundColor: error === BannerErrorType.Error ? colors.cinnamon500 : colors.cantaloupe400,
+    color: error === BannerErrorType.Error ? colors.frenchVanilla100 : colors.blackPepper400,
     borderRadius:
       variant === BannerVariant.Sticky ? `${spacing.xxxs} 0 0 ${spacing.xxxs}` : spacing.xxxs,
     width: variant === BannerVariant.Sticky ? '222px' : '328px',
     '&:hover': {
-      backgroundColor: theme === BannerTheme.Error ? colors.cinnamon600 : colors.cantaloupe500,
+      backgroundColor: error === BannerErrorType.Error ? colors.cinnamon600 : colors.cantaloupe500,
     },
   })
 );
@@ -82,11 +82,11 @@ const BannerViewAll = styled('span')<BannerProps>(
 
 export default class Banner extends React.Component<BannerProps> {
   static Variant = BannerVariant;
-  static Theme = BannerTheme;
+  static ErrorType = BannerErrorType;
 
   public static defaultProps = {
     actionText: 'View All',
-    theme: BannerTheme.Alert,
+    error: BannerErrorType.Alert,
     variant: BannerVariant.Full,
   };
 
@@ -94,9 +94,9 @@ export default class Banner extends React.Component<BannerProps> {
     const {label, onClick, actionText, variant, ...props} = this.props;
 
     const bannerIcon =
-      this.props.theme === BannerTheme.Error ? exclamationCircleIcon : exclamationTriangleIcon;
+      this.props.error === BannerErrorType.Error ? exclamationCircleIcon : exclamationTriangleIcon;
     const iconColor =
-      this.props.theme === BannerTheme.Error ? colors.frenchVanilla100 : colors.blackPepper400;
+      this.props.error === BannerErrorType.Error ? colors.frenchVanilla100 : colors.blackPepper400;
     const iconSize = 24;
 
     return (

--- a/modules/banner/react/lib/Banner.tsx
+++ b/modules/banner/react/lib/Banner.tsx
@@ -95,12 +95,10 @@ export default class Banner extends React.Component<BannerProps> {
   };
 
   public render() {
-    const {label, onClick, actionText, variant, ...props} = this.props;
+    const {label, onClick, actionText, variant, error, ...props} = this.props;
 
-    const bannerIcon =
-      this.props.error === ErrorType.Error ? exclamationCircleIcon : exclamationTriangleIcon;
-    const iconColor =
-      this.props.error === ErrorType.Error ? colors.frenchVanilla100 : colors.blackPepper400;
+    const bannerIcon = error === ErrorType.Error ? exclamationCircleIcon : exclamationTriangleIcon;
+    const iconColor = error === ErrorType.Error ? colors.frenchVanilla100 : colors.blackPepper400;
     const iconSize = 24;
 
     return (
@@ -110,11 +108,12 @@ export default class Banner extends React.Component<BannerProps> {
         variant={variant}
         tabIndex={0}
         onClick={onClick}
+        error={error}
         {...props}
       >
         <BannerIcon icon={bannerIcon} color={iconColor} colorHover={iconColor} size={iconSize} />
-        <BannerLabel>{this.props.label}</BannerLabel>
-        <BannerViewAll variant={variant}>{this.props.actionText}</BannerViewAll>
+        <BannerLabel>{label}</BannerLabel>
+        <BannerViewAll variant={variant}>{actionText}</BannerViewAll>
       </BannerWrapper>
     );
   }

--- a/modules/banner/react/lib/Banner.tsx
+++ b/modules/banner/react/lib/Banner.tsx
@@ -1,10 +1,14 @@
 import * as React from 'react';
 import styled from 'react-emotion';
 import {colors, spacing, type} from '@workday/canvas-kit-react-core';
-import {BannerVariant, BannerErrorType} from './types';
 import {SystemIcon} from '@workday/canvas-kit-react-icon';
 import {exclamationCircleIcon, exclamationTriangleIcon} from '@workday/canvas-system-icons-web';
-import {focusRing} from '@workday/canvas-kit-react-common';
+import {ErrorType, focusRing} from '@workday/canvas-kit-react-common';
+
+export enum BannerVariant {
+  Full,
+  Sticky,
+}
 
 export interface BannerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /**
@@ -22,7 +26,7 @@ export interface BannerProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
   /**
    * Color of the banner based on the type of the error
    */
-  error?: BannerErrorType;
+  error?: ErrorType;
   /**
    * Text on the right, call to action
    */
@@ -52,13 +56,13 @@ const BannerWrapper = styled('button')<BannerProps>(
     },
   },
   ({error, variant}) => ({
-    backgroundColor: error === BannerErrorType.Error ? colors.cinnamon500 : colors.cantaloupe400,
-    color: error === BannerErrorType.Error ? colors.frenchVanilla100 : colors.blackPepper400,
+    backgroundColor: error === ErrorType.Error ? colors.cinnamon500 : colors.cantaloupe400,
+    color: error === ErrorType.Error ? colors.frenchVanilla100 : colors.blackPepper400,
     borderRadius:
       variant === BannerVariant.Sticky ? `${spacing.xxxs} 0 0 ${spacing.xxxs}` : spacing.xxxs,
     width: variant === BannerVariant.Sticky ? '222px' : '328px',
     '&:hover': {
-      backgroundColor: error === BannerErrorType.Error ? colors.cinnamon600 : colors.cantaloupe500,
+      backgroundColor: error === ErrorType.Error ? colors.cinnamon600 : colors.cantaloupe500,
     },
   })
 );
@@ -82,11 +86,11 @@ const BannerViewAll = styled('span')<BannerProps>(
 
 export default class Banner extends React.Component<BannerProps> {
   static Variant = BannerVariant;
-  static ErrorType = BannerErrorType;
+  static ErrorType = ErrorType;
 
   public static defaultProps = {
     actionText: 'View All',
-    error: BannerErrorType.Alert,
+    error: ErrorType.Alert,
     variant: BannerVariant.Full,
   };
 
@@ -94,9 +98,9 @@ export default class Banner extends React.Component<BannerProps> {
     const {label, onClick, actionText, variant, ...props} = this.props;
 
     const bannerIcon =
-      this.props.error === BannerErrorType.Error ? exclamationCircleIcon : exclamationTriangleIcon;
+      this.props.error === ErrorType.Error ? exclamationCircleIcon : exclamationTriangleIcon;
     const iconColor =
-      this.props.error === BannerErrorType.Error ? colors.frenchVanilla100 : colors.blackPepper400;
+      this.props.error === ErrorType.Error ? colors.frenchVanilla100 : colors.blackPepper400;
     const iconSize = 24;
 
     return (

--- a/modules/banner/react/lib/types.tsx
+++ b/modules/banner/react/lib/types.tsx
@@ -1,9 +1,0 @@
-export enum BannerErrorType {
-  Alert,
-  Error,
-}
-
-export enum BannerVariant {
-  Full,
-  Sticky,
-}

--- a/modules/banner/react/lib/types.tsx
+++ b/modules/banner/react/lib/types.tsx
@@ -1,4 +1,4 @@
-export enum BannerTheme {
+export enum BannerErrorType {
   Alert,
   Error,
 }

--- a/modules/banner/react/spec/Banner.snapshot.tsx
+++ b/modules/banner/react/spec/Banner.snapshot.tsx
@@ -16,11 +16,11 @@ describe('Banner Snapshots', () => {
     expect(component).toMatchSnapshot();
   });
   test('renders an error banner as expected', () => {
-    const component = renderer.create(<Banner theme={Banner.Theme.Error} />);
+    const component = renderer.create(<Banner error={Banner.ErrorType.Error} />);
     expect(component).toMatchSnapshot();
   });
   test('renders an alert banner as expected', () => {
-    const component = renderer.create(<Banner theme={Banner.Theme.Alert} />);
+    const component = renderer.create(<Banner error={Banner.ErrorType.Alert} />);
     expect(component).toMatchSnapshot();
   });
   test('renders a banner with a custom action text expected', () => {

--- a/modules/banner/react/stories/stories.tsx
+++ b/modules/banner/react/stories/stories.tsx
@@ -20,7 +20,7 @@ storiesOf('Banner/Alert', module)
         onClick={handleBannerClick}
         label={text('label', '3 Alerts')}
         actionText={text('actionText', 'View All')}
-        theme={Banner.Theme.Alert}
+        error={Banner.ErrorType.Alert}
         variant={select(
           'variant',
           {
@@ -38,7 +38,7 @@ storiesOf('Banner/Alert', module)
         onClick={handleBannerClick}
         label={text('label', '3 Alerts')}
         actionText={text('actionText', 'View All')}
-        theme={Banner.Theme.Alert}
+        error={Banner.ErrorType.Alert}
         variant={select(
           'variant',
           {
@@ -60,7 +60,7 @@ storiesOf('Banner/Error', module)
         onClick={handleBannerClick}
         label={text('label', '3 Errors')}
         actionText={text('actionText', 'View All')}
-        theme={Banner.Theme.Error}
+        error={Banner.ErrorType.Error}
         variant={select(
           'variant',
           {
@@ -78,7 +78,7 @@ storiesOf('Banner/Error', module)
         onClick={handleBannerClick}
         label={text('label', '3 Errors')}
         actionText={text('actionText', 'View All')}
-        theme={Banner.Theme.Error}
+        error={Banner.ErrorType.Error}
         variant={select(
           'variant',
           {


### PR DESCRIPTION
This is part of the API changes ongoing work https://github.com/Workday/canvas-kit/issues/51, we want to rename the `BannerTheme ` prop to `BannerErrorType `.

### Breaking code changes
- `BannerTheme` removed. We're now using `ErrorType` from `@workday/canvas-kit-react-common`
- Banner `theme` prop renamed to `error`


### Squash and Merge Message Proposal

refactor(banner): Change BannerTheme to BannerErrorType (#195)