### PR TITLE
refactor(switch): Add a11y messaging in Readme and move story location

### DIFF
--- a/modules/form-field/react/stories/stories_Switch.tsx
+++ b/modules/form-field/react/stories/stories_Switch.tsx
@@ -2,49 +2,64 @@
 import * as React from 'react';
 import {storiesOf} from '@storybook/react';
 import withReadme from 'storybook-readme/with-readme';
+import {ControlledComponentWrapper} from '../../../../utils/storybook';
 
 import {Switch} from '../../../switch/react/index';
 import FormField from '../index';
 import README from '../../../switch/react/README.md';
 
-interface SwitchWrapperState {
-  isChecked: boolean;
-}
+const control = (child: React.ReactNode) => (
+  <ControlledComponentWrapper controlledProp={ControlledComponentWrapper.ControlledProp.Checked}>
+    {child}
+  </ControlledComponentWrapper>
+);
 
-class SwitchWrapper extends React.Component<{}, SwitchWrapperState> {
-  public constructor(props: {}) {
-    super(props);
-    this.state = {
-      isChecked: true,
-    };
-    this.handleCheck = this.handleCheck.bind(this);
-  }
-
-  public render() {
-    return (
-      <div style={{textAlign: 'left', marginBottom: '24px'}}>
-        <Switch
-          disabled={false}
-          checked={this.state.isChecked}
-          onChange={this.handleCheck}
-          id="my-switch-field"
-        />
-      </div>
-    );
-  }
-
-  private handleCheck() {
-    this.setState({isChecked: !this.state.isChecked});
-  }
-}
-
-storiesOf('Form Field/Switch', module)
+storiesOf('Form Field/Switch/Top Label', module)
   .addDecorator(withReadme(README))
   .add('Default', () => (
     <div className="story">
-      <h1 className="section-label">Switch</h1>
-      <FormField label="My Switch Field" inputId="my-switch-field">
-        <SwitchWrapper />
-      </FormField>
+      <div style={{textAlign: 'left', marginBottom: '24px'}}>
+        <FormField label="Label" inputId="my-switch-field">
+          {control(<Switch />)}
+        </FormField>
+      </div>
+    </div>
+  ))
+  .add('Disabled', () => (
+    <div className="story">
+      <div style={{textAlign: 'left', marginBottom: '24px'}}>
+        <FormField label="Label" inputId="my-switch-field">
+          {control(<Switch disabled={true} />)}
+        </FormField>
+      </div>
+    </div>
+  ));
+
+storiesOf('Form Field/Switch/Left Label', module)
+  .addDecorator(withReadme(README))
+  .add('Default', () => (
+    <div className="story">
+      <div style={{textAlign: 'left', marginBottom: '24px'}}>
+        <FormField
+          label="Label"
+          inputId="my-switch-field"
+          labelPosition={FormField.LabelPosition.Left}
+        >
+          {control(<Switch />)}
+        </FormField>
+      </div>
+    </div>
+  ))
+  .add('Disabled', () => (
+    <div className="story">
+      <div style={{textAlign: 'left', marginBottom: '24px'}}>
+        <FormField
+          label="Label"
+          inputId="my-switch-field"
+          labelPosition={FormField.LabelPosition.Left}
+        >
+          {control(<Switch disabled={true} />)}
+        </FormField>
+      </div>
     </div>
   ));

--- a/modules/form-field/react/stories/stories_Switch.tsx
+++ b/modules/form-field/react/stories/stories_Switch.tsx
@@ -3,8 +3,9 @@ import * as React from 'react';
 import {storiesOf} from '@storybook/react';
 import withReadme from 'storybook-readme/with-readme';
 
-import Switch from '..';
-import README from '../README.md';
+import {Switch} from '../../../switch/react/index';
+import FormField from '../index';
+import README from '../../../switch/react/README.md';
 
 interface SwitchWrapperState {
   isChecked: boolean;
@@ -22,7 +23,12 @@ class SwitchWrapper extends React.Component<{}, SwitchWrapperState> {
   public render() {
     return (
       <div style={{textAlign: 'left', marginBottom: '24px'}}>
-        <Switch disabled={false} checked={this.state.isChecked} onChange={this.handleCheck} />
+        <Switch
+          disabled={false}
+          checked={this.state.isChecked}
+          onChange={this.handleCheck}
+          id="my-switch-field"
+        />
       </div>
     );
   }
@@ -32,11 +38,13 @@ class SwitchWrapper extends React.Component<{}, SwitchWrapperState> {
   }
 }
 
-storiesOf('Switch', module)
+storiesOf('Form Field/Switch', module)
   .addDecorator(withReadme(README))
   .add('Default', () => (
     <div className="story">
       <h1 className="section-label">Switch</h1>
-      <SwitchWrapper />
+      <FormField label="My Switch Field" inputId="my-switch-field">
+        <SwitchWrapper />
+      </FormField>
     </div>
   ));

--- a/modules/switch/react/README.md
+++ b/modules/switch/react/README.md
@@ -18,11 +18,40 @@ yarn add @workday/canvas-kit-react-switch
 
 ## Usage
 
+#### Simple Example
+
+**Note:** While a base switch component is provided in this package, it is **not accessible** when
+used as is. It should be used in tandem with [`FormField`](../../form-field/react) to be made fully
+accessible (see below).
+
 ```tsx
 import * as React from 'react';
 import {Switch} from '@workday/canvas-kit-react-switch';
 
 <Switch disabled={false} checked={checked} onChange={this.handleCheck} />;
+```
+
+#### Accessible Example
+
+```tsx
+import * as React from 'react';
+import {Switch} from '@workday/canvas-kit-react-switch';
+import FormField from '@workday/canvas-kit-react-form-field';
+
+<FormField label="My Field" inputId="my-switch-field">
+  <Switch disabled={false} checked={checked} onChange={this.handleCheck} id="my-switch-field" />;
+</FormField>;
+```
+
+If use inside a FormField doesn't work for your use case, you can use the `aria-labelledBy`
+attribute.
+
+```tsx
+import * as React from 'react';
+import {Switch} from '@workday/canvas-kit-react-switch';
+<label id="123">Label</label>
+...
+<Switch disabled={false} checked={checked} onChange={this.handleCheck} aria-labelledBy="123" />;
 ```
 
 ## Static Properties


### PR DESCRIPTION
This is part of the API changes ongoing work https://github.com/Workday/canvas-kit/issues/51, we want to add a11y messaging in `switch`'s Readme 

### Squash and Merge Message Proposal

docs(switch): Add a11y messaging in Readme and move story location (#197)