### PR TITLE
refactor(tooltip): Update CSS story to match the React version

### DIFF
--- a/modules/tooltip/css/stories.tsx
+++ b/modules/tooltip/css/stories.tsx
@@ -1,18 +1,16 @@
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import withReadme from 'storybook-readme/with-readme';
+import {SystemIcon} from '@workday/canvas-kit-react-icon';
+import {xIcon} from '@workday/canvas-system-icons-web';
 import README from './README.md';
 import {css} from 'emotion';
 import './index.scss';
+import './../../button/css/index.scss';
 
 const containerStyle = css({
-  paddingTop: '20px',
-  '> *': {
-    margin: '20px !important',
-
-    '&:first-child': {
-      marginLeft: 0,
-    },
+  h3: {
+    marginBottom: '18px;',
   },
 });
 
@@ -20,25 +18,13 @@ storiesOf('CSS/Tooltip', module)
   .addDecorator(withReadme(README))
   .add('Default', () => (
     <div className="story">
-      <div className={containerStyle + ' wdc-type'}>
+      <div className={containerStyle}>
+        <h3>Hover over the icon.</h3>
         <div className="wdc-tooltip-container">
-          Right tooltip
-          <div className="wdc-tooltip wdc-tooltip-right">Tooltip text</div>
-        </div>
-
-        <div className="wdc-tooltip-container">
-          Left tooltip
-          <div className="wdc-tooltip wdc-tooltip-left">Tooltip text</div>
-        </div>
-
-        <div className="wdc-tooltip-container">
-          Top tooltip
-          <div className="wdc-tooltip wdc-tooltip-top">Tooltip text</div>
-        </div>
-
-        <div className="wdc-tooltip-container">
-          Bottom tooltip
-          <div className="wdc-tooltip wdc-tooltip-bottom">Tooltip text</div>
+          <button className="wdc-btn-icon-circle" aria-label="Activity Stream">
+            <SystemIcon icon={xIcon} />
+          </button>
+          <div className="wdc-tooltip wdc-tooltip-top">Close</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR doesn't have any breaking changes. It updates the story of CSS `Tooltip` to match the story of React `Tooltip`, now that we have CSS `Button`.

### Squash and Merge Message Proposal

refactor(tooltip): Update story (#198)