### PR TITLE
refactor(core): Rename enums to singular

### DIFF
--- a/modules/core/react/index.ts
+++ b/modules/core/react/index.ts
@@ -6,7 +6,7 @@ import depth, {CanvasDepth, CanvasDepthValue} from './lib/depth';
 import InputProvider from './lib/InputProvider';
 import spacing, {
   CanvasSpacing,
-  CanvasSpacingNumbers,
+  CanvasSpacingNumber,
   CanvasSpacingValue,
   space,
   SpaceProps,
@@ -44,7 +44,7 @@ export {
   CanvasDepth,
   CanvasDepthValue,
   CanvasSpacing,
-  CanvasSpacingNumbers,
+  CanvasSpacingNumber,
   CanvasSpacingValue,
   CanvasType,
   CanvasColor,

--- a/modules/core/react/index.ts
+++ b/modules/core/react/index.ts
@@ -1,7 +1,7 @@
 import * as canvasColorsWeb from '@workday/canvas-colors-web';
 
 import beta_type from './lib/beta_type';
-import {BrandingColors, CanvasColor} from './lib/colors.types';
+import {BrandingColor, CanvasColor} from './lib/colors.types';
 import depth, {CanvasDepth, CanvasDepthValue} from './lib/depth';
 import InputProvider from './lib/InputProvider';
 import spacing, {
@@ -40,7 +40,7 @@ export {
   beta_type,
   fontFamily,
   monoFontFamily,
-  BrandingColors,
+  BrandingColor,
   CanvasDepth,
   CanvasDepthValue,
   CanvasSpacing,

--- a/modules/core/react/lib/colors.types.ts
+++ b/modules/core/react/lib/colors.types.ts
@@ -1,6 +1,6 @@
 import colors from '@workday/canvas-colors-web';
 
-export enum BrandingColors {
+export enum BrandingColor {
   Cinnamon = 'cinnamon',
   Peach = 'peach',
   ChiliMango = 'chiliMango',

--- a/modules/core/react/lib/spacing.ts
+++ b/modules/core/react/lib/spacing.ts
@@ -4,7 +4,7 @@ import spacing, {
 } from '@workday/canvas-space-web';
 import {CSSObject} from 'create-emotion';
 
-export interface CanvasSpacingNumbers {
+export interface CanvasSpacingNumber {
   zero: number;
   xxxs: number;
   xxs: number;
@@ -21,7 +21,7 @@ function stripUnit(value: string): number {
   return parseInt(`${value}`.replace('px', ''), 10);
 }
 
-export const spacingNumbers: CanvasSpacingNumbers = {
+export const spacingNumbers: CanvasSpacingNumber = {
   zero: stripUnit(spacing.zero),
   xxxs: stripUnit(spacing.xxxs),
   xxs: stripUnit(spacing.xxs),

--- a/modules/icon/react/README.md
+++ b/modules/icon/react/README.md
@@ -100,7 +100,7 @@ import { benefitsIcon } from '@workday/canvas-applet-icons-web'
 
 ## Static Properties
 
-#### `Colors: BrandingColors`
+#### `Colors: BrandingColor`
 
 > An enum of the various Canvas hues (`Pomegranate`, `Blueberry`, `Cinnamon`, etc.).
 

--- a/modules/icon/react/lib/AppletIcon.tsx
+++ b/modules/icon/react/lib/AppletIcon.tsx
@@ -1,19 +1,19 @@
 import * as React from 'react';
-import {colors, BrandingColors, CanvasColor} from '@workday/canvas-kit-react-core';
+import {colors, BrandingColor, CanvasColor} from '@workday/canvas-kit-react-core';
 import {CanvasAppletIcon, CanvasIconTypes} from '@workday/design-assets-types';
 import {CSSObject} from 'create-emotion';
 import Icon from './Icon';
 import {SpanProps} from './types';
 
 export interface AppletIconStyles {
-  color?: BrandingColors;
+  color?: BrandingColor;
 }
 
 export const appletIconStyles = ({
-  color = BrandingColors.Blueberry,
+  color = BrandingColor.Blueberry,
 }: AppletIconStyles): CSSObject => {
   // Check if valid color
-  if (!Object.values(BrandingColors).includes(color)) {
+  if (!Object.values(BrandingColor).includes(color)) {
     throw Error(`Color "${color}" not found`);
   }
 
@@ -53,7 +53,7 @@ export interface AppletIconProps extends AppletIconStyles {
 }
 
 export default class AppletIcon extends React.Component<SpanProps & AppletIconProps> {
-  public static Colors = BrandingColors;
+  public static Colors = BrandingColor;
 
   public render() {
     const {icon, color, size, ...elemProps} = this.props;


### PR DESCRIPTION
This is part of the API changes ongoing work https://github.com/Workday/canvas-kit/issues/51, we want to rename enums to singular

### Breaking code changes
- Rename `CanvasSpacingNumbers` -> `CanvasSpacingNumber`
- Rename `BrandingColors` to `BrandingColor`