### PR TITLE
feat(core): Add border radius variables to CSS and React

### DIFF
--- a/modules/avatar/react/lib/Avatar.tsx
+++ b/modules/avatar/react/lib/Avatar.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import styled from 'react-emotion';
 import isPropValid from '@emotion/is-prop-valid';
-import {colors} from '@workday/canvas-kit-react-core';
-import {SystemIconCircle, SystemIconCircleSize} from '@workday/canvas-kit-react-icon';
-import {userIcon} from '@workday/canvas-system-icons-web';
+import { borderRadius, colors } from '@workday/canvas-kit-react-core';
+import { SystemIconCircle, SystemIconCircleSize } from '@workday/canvas-kit-react-icon';
+import { userIcon } from '@workday/canvas-system-icons-web';
 
 export enum AvatarVariant {
   Light,
@@ -29,7 +29,7 @@ export interface AvatarLocalProps {
   url?: string;
 }
 
-export interface AvatarProps extends AvatarLocalProps, React.HTMLAttributes<HTMLDivElement> {}
+export interface AvatarProps extends AvatarLocalProps, React.HTMLAttributes<HTMLDivElement> { }
 
 export const AvatarStyledComponent = styled('div', {
   shouldForwardProp: prop => isPropValid(prop) && prop !== 'size',
@@ -41,7 +41,7 @@ export const AvatarStyledComponent = styled('div', {
     justifyContent: 'center',
     padding: 0,
     border: 0,
-    borderRadius: '100%',
+    borderRadius: borderRadius.circle,
     boxSizing: 'border-box',
     overflow: 'hidden',
     '& img': {
@@ -49,7 +49,7 @@ export const AvatarStyledComponent = styled('div', {
       height: '100%',
     },
   },
-  ({size}) => ({
+  ({ size }) => ({
     height: size,
     width: size,
   })
@@ -66,7 +66,7 @@ export default class Avatar extends React.Component<AvatarProps> {
   };
 
   render() {
-    const {variant, altText, size, url, ...elemProps} = this.props;
+    const { variant, altText, size, url, ...elemProps } = this.props;
 
     const background = variant === AvatarVariant.Dark ? colors.blueberry400 : colors.soap300;
     return (
@@ -74,8 +74,8 @@ export default class Avatar extends React.Component<AvatarProps> {
         {url ? (
           <img src={url} alt={altText} />
         ) : (
-          <SystemIconCircle icon={userIcon} background={background} size={size} />
-        )}
+            <SystemIconCircle icon={userIcon} background={background} size={size} />
+          )}
       </AvatarStyledComponent>
     );
   }

--- a/modules/avatar/react/spec/__snapshots__/Avatar.snapshot.tsx.snap
+++ b/modules/avatar/react/spec/__snapshots__/Avatar.snapshot.tsx.snap
@@ -17,7 +17,7 @@ exports[`Avatar Snapshots renders a large Avatar 1`] = `
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: 100%;
+  border-radius: 999px;
   box-sizing: border-box;
   overflow: hidden;
   height: 64px;
@@ -44,7 +44,7 @@ exports[`Avatar Snapshots renders a large Avatar 1`] = `
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: 100%;
+  border-radius: 999px;
   box-sizing: border-box;
   overflow: hidden;
   background: #e8ebed;
@@ -130,7 +130,7 @@ exports[`Avatar Snapshots renders a large avatar with a photo 1`] = `
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: 100%;
+  border-radius: 999px;
   box-sizing: border-box;
   overflow: hidden;
   height: 64px;
@@ -170,7 +170,7 @@ exports[`Avatar Snapshots renders a large, dark Avatar 1`] = `
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: 100%;
+  border-radius: 999px;
   box-sizing: border-box;
   overflow: hidden;
   height: 64px;
@@ -197,7 +197,7 @@ exports[`Avatar Snapshots renders a large, dark Avatar 1`] = `
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: 100%;
+  border-radius: 999px;
   box-sizing: border-box;
   overflow: hidden;
   background: #0875e1;
@@ -283,7 +283,7 @@ exports[`Avatar Snapshots renders an avatar with a photo 1`] = `
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: 100%;
+  border-radius: 999px;
   box-sizing: border-box;
   overflow: hidden;
   height: 32px;
@@ -323,7 +323,7 @@ exports[`Avatar Snapshots renders an avatar with an aria label and an alt text 1
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: 100%;
+  border-radius: 999px;
   box-sizing: border-box;
   overflow: hidden;
   height: 64px;
@@ -363,7 +363,7 @@ exports[`Avatar Snapshots renders as expected 1`] = `
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: 100%;
+  border-radius: 999px;
   box-sizing: border-box;
   overflow: hidden;
   height: 32px;
@@ -390,7 +390,7 @@ exports[`Avatar Snapshots renders as expected 1`] = `
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: 100%;
+  border-radius: 999px;
   box-sizing: border-box;
   overflow: hidden;
   background: #e8ebed;

--- a/modules/avatar/react/spec/__snapshots__/Avatar.snapshot.tsx.snap
+++ b/modules/avatar/react/spec/__snapshots__/Avatar.snapshot.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Avatar Snapshots renders a large Avatar 1`] = `
-.emotion-2 {
+.emotion-3 {
   background: #f0f1f2;
   display: -webkit-box;
   display: -webkit-flex;
@@ -24,7 +24,7 @@ exports[`Avatar Snapshots renders a large Avatar 1`] = `
   width: 64px;
 }
 
-.emotion-2 img {
+.emotion-3 img {
   width: 100%;
   height: 100%;
 }
@@ -96,10 +96,10 @@ exports[`Avatar Snapshots renders a large Avatar 1`] = `
 
 <div
   aria-label="Avatar"
-  className="emotion-2 emotion-3"
+  className="emotion-3 emotion-4"
 >
   <div
-    className="emotion-1"
+    className="emotion-1 emotion-2"
   >
     <span
       className="emotion-0"
@@ -154,7 +154,7 @@ exports[`Avatar Snapshots renders a large avatar with a photo 1`] = `
 `;
 
 exports[`Avatar Snapshots renders a large, dark Avatar 1`] = `
-.emotion-2 {
+.emotion-3 {
   background: #f0f1f2;
   display: -webkit-box;
   display: -webkit-flex;
@@ -177,7 +177,7 @@ exports[`Avatar Snapshots renders a large, dark Avatar 1`] = `
   width: 64px;
 }
 
-.emotion-2 img {
+.emotion-3 img {
   width: 100%;
   height: 100%;
 }
@@ -249,10 +249,10 @@ exports[`Avatar Snapshots renders a large, dark Avatar 1`] = `
 
 <div
   aria-label="Avatar"
-  className="emotion-2 emotion-3"
+  className="emotion-3 emotion-4"
 >
   <div
-    className="emotion-1"
+    className="emotion-1 emotion-2"
   >
     <span
       className="emotion-0"
@@ -347,7 +347,7 @@ exports[`Avatar Snapshots renders an avatar with an aria label and an alt text 1
 `;
 
 exports[`Avatar Snapshots renders as expected 1`] = `
-.emotion-2 {
+.emotion-3 {
   background: #f0f1f2;
   display: -webkit-box;
   display: -webkit-flex;
@@ -370,7 +370,7 @@ exports[`Avatar Snapshots renders as expected 1`] = `
   width: 32px;
 }
 
-.emotion-2 img {
+.emotion-3 img {
   width: 100%;
   height: 100%;
 }
@@ -442,10 +442,10 @@ exports[`Avatar Snapshots renders as expected 1`] = `
 
 <div
   aria-label="Avatar"
-  className="emotion-2 emotion-3"
+  className="emotion-3 emotion-4"
 >
   <div
-    className="emotion-1"
+    className="emotion-1 emotion-2"
   >
     <span
       className="emotion-0"

--- a/modules/avatar/react/spec/__snapshots__/Avatar.snapshot.tsx.snap
+++ b/modules/avatar/react/spec/__snapshots__/Avatar.snapshot.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Avatar Snapshots renders a large Avatar 1`] = `
-.emotion-3 {
+.emotion-2 {
   background: #f0f1f2;
   display: -webkit-box;
   display: -webkit-flex;
@@ -24,7 +24,7 @@ exports[`Avatar Snapshots renders a large Avatar 1`] = `
   width: 64px;
 }
 
-.emotion-3 img {
+.emotion-2 img {
   width: 100%;
   height: 100%;
 }
@@ -96,10 +96,10 @@ exports[`Avatar Snapshots renders a large Avatar 1`] = `
 
 <div
   aria-label="Avatar"
-  className="emotion-3 emotion-4"
+  className="emotion-2 emotion-3"
 >
   <div
-    className="emotion-1 emotion-2"
+    className="emotion-1"
   >
     <span
       className="emotion-0"
@@ -154,7 +154,7 @@ exports[`Avatar Snapshots renders a large avatar with a photo 1`] = `
 `;
 
 exports[`Avatar Snapshots renders a large, dark Avatar 1`] = `
-.emotion-3 {
+.emotion-2 {
   background: #f0f1f2;
   display: -webkit-box;
   display: -webkit-flex;
@@ -177,7 +177,7 @@ exports[`Avatar Snapshots renders a large, dark Avatar 1`] = `
   width: 64px;
 }
 
-.emotion-3 img {
+.emotion-2 img {
   width: 100%;
   height: 100%;
 }
@@ -249,10 +249,10 @@ exports[`Avatar Snapshots renders a large, dark Avatar 1`] = `
 
 <div
   aria-label="Avatar"
-  className="emotion-3 emotion-4"
+  className="emotion-2 emotion-3"
 >
   <div
-    className="emotion-1 emotion-2"
+    className="emotion-1"
   >
     <span
       className="emotion-0"
@@ -347,7 +347,7 @@ exports[`Avatar Snapshots renders an avatar with an aria label and an alt text 1
 `;
 
 exports[`Avatar Snapshots renders as expected 1`] = `
-.emotion-3 {
+.emotion-2 {
   background: #f0f1f2;
   display: -webkit-box;
   display: -webkit-flex;
@@ -370,7 +370,7 @@ exports[`Avatar Snapshots renders as expected 1`] = `
   width: 32px;
 }
 
-.emotion-3 img {
+.emotion-2 img {
   width: 100%;
   height: 100%;
 }
@@ -442,10 +442,10 @@ exports[`Avatar Snapshots renders as expected 1`] = `
 
 <div
   aria-label="Avatar"
-  className="emotion-3 emotion-4"
+  className="emotion-2 emotion-3"
 >
   <div
-    className="emotion-1 emotion-2"
+    className="emotion-1"
   >
     <span
       className="emotion-0"

--- a/modules/avatar/react/spec/__snapshots__/AvatarButton.snapshot.tsx.snap
+++ b/modules/avatar/react/spec/__snapshots__/AvatarButton.snapshot.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AvatarButton Snapshots renders a large AvatarButton 1`] = `
-.emotion-2 {
+.emotion-3 {
   background: #f0f1f2;
   display: -webkit-box;
   display: -webkit-flex;
@@ -17,7 +17,7 @@ exports[`AvatarButton Snapshots renders a large AvatarButton 1`] = `
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: 100%;
+  border-radius: 999px;
   box-sizing: border-box;
   overflow: hidden;
   height: 64px;
@@ -25,21 +25,21 @@ exports[`AvatarButton Snapshots renders a large AvatarButton 1`] = `
   cursor: default;
 }
 
-.emotion-2 img {
+.emotion-3 img {
   width: 100%;
   height: 100%;
 }
 
-.emotion-2:not([disabled]):focus {
+.emotion-3:not([disabled]):focus {
   outline: none;
   -webkit-animation: animation-os2b9x 100ms;
   animation: animation-os2b9x 100ms;
   box-shadow: 0 0 0 0px #ffffff,0 0 0 2px #0875e1;
 }
 
-[data-whatinput='mouse'] .emotion-2:focus,
-[data-whatinput='touch'] .emotion-2:focus,
-[data-whatinput='pointer'] .emotion-2:focus {
+[data-whatinput='mouse'] .emotion-3:focus,
+[data-whatinput='touch'] .emotion-3:focus,
+[data-whatinput='pointer'] .emotion-3:focus {
   outline: none;
   box-shadow: none;
   -webkit-animation: none;
@@ -61,7 +61,7 @@ exports[`AvatarButton Snapshots renders a large AvatarButton 1`] = `
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: 100%;
+  border-radius: 999px;
   box-sizing: border-box;
   overflow: hidden;
   background: #e8ebed;
@@ -113,12 +113,12 @@ exports[`AvatarButton Snapshots renders a large AvatarButton 1`] = `
 
 <button
   aria-label="Avatar"
-  className="emotion-2 emotion-3"
+  className="emotion-3 emotion-4"
   disabled={true}
   size={64}
 >
   <div
-    className="emotion-1"
+    className="emotion-1 emotion-2"
   >
     <span
       className="emotion-0"
@@ -149,7 +149,7 @@ exports[`AvatarButton Snapshots renders a large avatar with a photo 1`] = `
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: 100%;
+  border-radius: 999px;
   box-sizing: border-box;
   overflow: hidden;
   height: 64px;
@@ -208,7 +208,7 @@ exports[`AvatarButton Snapshots renders a large avatar with a photo and a button
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: 100%;
+  border-radius: 999px;
   box-sizing: border-box;
   overflow: hidden;
   height: 64px;
@@ -252,7 +252,7 @@ exports[`AvatarButton Snapshots renders a large avatar with a photo and a button
 `;
 
 exports[`AvatarButton Snapshots renders a large, dark AvatarButton 1`] = `
-.emotion-2 {
+.emotion-3 {
   background: #f0f1f2;
   display: -webkit-box;
   display: -webkit-flex;
@@ -268,7 +268,7 @@ exports[`AvatarButton Snapshots renders a large, dark AvatarButton 1`] = `
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: 100%;
+  border-radius: 999px;
   box-sizing: border-box;
   overflow: hidden;
   height: 64px;
@@ -276,21 +276,21 @@ exports[`AvatarButton Snapshots renders a large, dark AvatarButton 1`] = `
   cursor: default;
 }
 
-.emotion-2 img {
+.emotion-3 img {
   width: 100%;
   height: 100%;
 }
 
-.emotion-2:not([disabled]):focus {
+.emotion-3:not([disabled]):focus {
   outline: none;
   -webkit-animation: animation-1h1pob6 100ms;
   animation: animation-1h1pob6 100ms;
   box-shadow: 0 0 0 2px #ffffff,0 0 0 4px #0875e1;
 }
 
-[data-whatinput='mouse'] .emotion-2:focus,
-[data-whatinput='touch'] .emotion-2:focus,
-[data-whatinput='pointer'] .emotion-2:focus {
+[data-whatinput='mouse'] .emotion-3:focus,
+[data-whatinput='touch'] .emotion-3:focus,
+[data-whatinput='pointer'] .emotion-3:focus {
   outline: none;
   box-shadow: none;
   -webkit-animation: none;
@@ -312,7 +312,7 @@ exports[`AvatarButton Snapshots renders a large, dark AvatarButton 1`] = `
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: 100%;
+  border-radius: 999px;
   box-sizing: border-box;
   overflow: hidden;
   background: #0875e1;
@@ -364,12 +364,12 @@ exports[`AvatarButton Snapshots renders a large, dark AvatarButton 1`] = `
 
 <button
   aria-label="Avatar"
-  className="emotion-2 emotion-3"
+  className="emotion-3 emotion-4"
   disabled={true}
   size={64}
 >
   <div
-    className="emotion-1"
+    className="emotion-1 emotion-2"
   >
     <span
       className="emotion-0"
@@ -400,7 +400,7 @@ exports[`AvatarButton Snapshots renders an AvatarButton with a photo 1`] = `
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: 100%;
+  border-radius: 999px;
   box-sizing: border-box;
   overflow: hidden;
   height: 32px;
@@ -459,7 +459,7 @@ exports[`AvatarButton Snapshots renders an avatar with an aria label and an alt 
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: 100%;
+  border-radius: 999px;
   box-sizing: border-box;
   overflow: hidden;
   height: 64px;
@@ -502,7 +502,7 @@ exports[`AvatarButton Snapshots renders an avatar with an aria label and an alt 
 `;
 
 exports[`AvatarButton Snapshots renders as expected 1`] = `
-.emotion-2 {
+.emotion-3 {
   background: #f0f1f2;
   display: -webkit-box;
   display: -webkit-flex;
@@ -518,7 +518,7 @@ exports[`AvatarButton Snapshots renders as expected 1`] = `
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: 100%;
+  border-radius: 999px;
   box-sizing: border-box;
   overflow: hidden;
   height: 32px;
@@ -526,21 +526,21 @@ exports[`AvatarButton Snapshots renders as expected 1`] = `
   cursor: default;
 }
 
-.emotion-2 img {
+.emotion-3 img {
   width: 100%;
   height: 100%;
 }
 
-.emotion-2:not([disabled]):focus {
+.emotion-3:not([disabled]):focus {
   outline: none;
   -webkit-animation: animation-os2b9x 100ms;
   animation: animation-os2b9x 100ms;
   box-shadow: 0 0 0 0px #ffffff,0 0 0 2px #0875e1;
 }
 
-[data-whatinput='mouse'] .emotion-2:focus,
-[data-whatinput='touch'] .emotion-2:focus,
-[data-whatinput='pointer'] .emotion-2:focus {
+[data-whatinput='mouse'] .emotion-3:focus,
+[data-whatinput='touch'] .emotion-3:focus,
+[data-whatinput='pointer'] .emotion-3:focus {
   outline: none;
   box-shadow: none;
   -webkit-animation: none;
@@ -562,7 +562,7 @@ exports[`AvatarButton Snapshots renders as expected 1`] = `
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: 100%;
+  border-radius: 999px;
   box-sizing: border-box;
   overflow: hidden;
   background: #e8ebed;
@@ -614,12 +614,12 @@ exports[`AvatarButton Snapshots renders as expected 1`] = `
 
 <button
   aria-label="Avatar"
-  className="emotion-2 emotion-3"
+  className="emotion-3 emotion-4"
   disabled={true}
   size={32}
 >
   <div
-    className="emotion-1"
+    className="emotion-1 emotion-2"
   >
     <span
       className="emotion-0"

--- a/modules/avatar/react/spec/__snapshots__/AvatarButton.snapshot.tsx.snap
+++ b/modules/avatar/react/spec/__snapshots__/AvatarButton.snapshot.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AvatarButton Snapshots renders a large AvatarButton 1`] = `
-.emotion-3 {
+.emotion-2 {
   background: #f0f1f2;
   display: -webkit-box;
   display: -webkit-flex;
@@ -25,21 +25,21 @@ exports[`AvatarButton Snapshots renders a large AvatarButton 1`] = `
   cursor: default;
 }
 
-.emotion-3 img {
+.emotion-2 img {
   width: 100%;
   height: 100%;
 }
 
-.emotion-3:not([disabled]):focus {
+.emotion-2:not([disabled]):focus {
   outline: none;
   -webkit-animation: animation-os2b9x 100ms;
   animation: animation-os2b9x 100ms;
   box-shadow: 0 0 0 0px #ffffff,0 0 0 2px #0875e1;
 }
 
-[data-whatinput='mouse'] .emotion-3:focus,
-[data-whatinput='touch'] .emotion-3:focus,
-[data-whatinput='pointer'] .emotion-3:focus {
+[data-whatinput='mouse'] .emotion-2:focus,
+[data-whatinput='touch'] .emotion-2:focus,
+[data-whatinput='pointer'] .emotion-2:focus {
   outline: none;
   box-shadow: none;
   -webkit-animation: none;
@@ -113,12 +113,12 @@ exports[`AvatarButton Snapshots renders a large AvatarButton 1`] = `
 
 <button
   aria-label="Avatar"
-  className="emotion-3 emotion-4"
+  className="emotion-2 emotion-3"
   disabled={true}
   size={64}
 >
   <div
-    className="emotion-1 emotion-2"
+    className="emotion-1"
   >
     <span
       className="emotion-0"
@@ -252,7 +252,7 @@ exports[`AvatarButton Snapshots renders a large avatar with a photo and a button
 `;
 
 exports[`AvatarButton Snapshots renders a large, dark AvatarButton 1`] = `
-.emotion-3 {
+.emotion-2 {
   background: #f0f1f2;
   display: -webkit-box;
   display: -webkit-flex;
@@ -276,21 +276,21 @@ exports[`AvatarButton Snapshots renders a large, dark AvatarButton 1`] = `
   cursor: default;
 }
 
-.emotion-3 img {
+.emotion-2 img {
   width: 100%;
   height: 100%;
 }
 
-.emotion-3:not([disabled]):focus {
+.emotion-2:not([disabled]):focus {
   outline: none;
   -webkit-animation: animation-1h1pob6 100ms;
   animation: animation-1h1pob6 100ms;
   box-shadow: 0 0 0 2px #ffffff,0 0 0 4px #0875e1;
 }
 
-[data-whatinput='mouse'] .emotion-3:focus,
-[data-whatinput='touch'] .emotion-3:focus,
-[data-whatinput='pointer'] .emotion-3:focus {
+[data-whatinput='mouse'] .emotion-2:focus,
+[data-whatinput='touch'] .emotion-2:focus,
+[data-whatinput='pointer'] .emotion-2:focus {
   outline: none;
   box-shadow: none;
   -webkit-animation: none;
@@ -364,12 +364,12 @@ exports[`AvatarButton Snapshots renders a large, dark AvatarButton 1`] = `
 
 <button
   aria-label="Avatar"
-  className="emotion-3 emotion-4"
+  className="emotion-2 emotion-3"
   disabled={true}
   size={64}
 >
   <div
-    className="emotion-1 emotion-2"
+    className="emotion-1"
   >
     <span
       className="emotion-0"
@@ -502,7 +502,7 @@ exports[`AvatarButton Snapshots renders an avatar with an aria label and an alt 
 `;
 
 exports[`AvatarButton Snapshots renders as expected 1`] = `
-.emotion-3 {
+.emotion-2 {
   background: #f0f1f2;
   display: -webkit-box;
   display: -webkit-flex;
@@ -526,21 +526,21 @@ exports[`AvatarButton Snapshots renders as expected 1`] = `
   cursor: default;
 }
 
-.emotion-3 img {
+.emotion-2 img {
   width: 100%;
   height: 100%;
 }
 
-.emotion-3:not([disabled]):focus {
+.emotion-2:not([disabled]):focus {
   outline: none;
   -webkit-animation: animation-os2b9x 100ms;
   animation: animation-os2b9x 100ms;
   box-shadow: 0 0 0 0px #ffffff,0 0 0 2px #0875e1;
 }
 
-[data-whatinput='mouse'] .emotion-3:focus,
-[data-whatinput='touch'] .emotion-3:focus,
-[data-whatinput='pointer'] .emotion-3:focus {
+[data-whatinput='mouse'] .emotion-2:focus,
+[data-whatinput='touch'] .emotion-2:focus,
+[data-whatinput='pointer'] .emotion-2:focus {
   outline: none;
   box-shadow: none;
   -webkit-animation: none;
@@ -614,12 +614,12 @@ exports[`AvatarButton Snapshots renders as expected 1`] = `
 
 <button
   aria-label="Avatar"
-  className="emotion-3 emotion-4"
+  className="emotion-2 emotion-3"
   disabled={true}
   size={32}
 >
   <div
-    className="emotion-1 emotion-2"
+    className="emotion-1"
   >
     <span
       className="emotion-0"

--- a/modules/banner/css/lib/variables.scss
+++ b/modules/banner/css/lib/variables.scss
@@ -1,4 +1,4 @@
-$wdc-banner-border-radius: 4px;
+$wdc-banner-border-radius: $wdc-border-radius-m;
 $wdc-banner-min-width: 328px;
 $wdc-banner-height: 40px;
 $wdc-banner-sticky-width: 222px;

--- a/modules/banner/react/lib/Banner.tsx
+++ b/modules/banner/react/lib/Banner.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import styled from 'react-emotion';
-import {colors, spacing, type} from '@workday/canvas-kit-react-core';
+import {colors, spacing, borderRadius, type} from '@workday/canvas-kit-react-core';
 import {SystemIcon} from '@workday/canvas-kit-react-icon';
 import {exclamationCircleIcon, exclamationTriangleIcon} from '@workday/canvas-system-icons-web';
 import {ErrorType, focusRing} from '@workday/canvas-kit-react-common';
@@ -59,7 +59,7 @@ const BannerWrapper = styled('button')<BannerProps>(
     backgroundColor: error === ErrorType.Error ? colors.cinnamon500 : colors.cantaloupe400,
     color: error === ErrorType.Error ? colors.frenchVanilla100 : colors.blackPepper400,
     borderRadius:
-      variant === BannerVariant.Sticky ? `${spacing.xxxs} 0 0 ${spacing.xxxs}` : spacing.xxxs,
+      variant === BannerVariant.Sticky ? `${borderRadius.m} 0 0 ${borderRadius.m}` : borderRadius.m,
     width: variant === BannerVariant.Sticky ? '222px' : '328px',
     '&:hover': {
       backgroundColor: error === ErrorType.Error ? colors.cinnamon600 : colors.cantaloupe500,

--- a/modules/button/css/lib/icon-button.scss
+++ b/modules/button/css/lib/icon-button.scss
@@ -18,7 +18,7 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border-radius: 999;
+    border-radius: $wdc-border-radius-circle;
 
     .wd-icon {
       display: inline-block;
@@ -275,7 +275,7 @@
 
     &-circle,
     &-circle-filled {
-      border-radius: 999;
+      border-radius: $wdc-border-radius-circle;
 
       &:not([disabled]):not(.wdc-btn-disabled) {
         &:focus,

--- a/modules/button/css/stories.tsx
+++ b/modules/button/css/stories.tsx
@@ -15,7 +15,7 @@ const blueBackground = css({
   margin: '0 10px',
   padding: '24px',
   maxWidth: 'max-content',
-  borderRadius: '3px',
+  borderRadius: '4px',
   button: {
     margin: '0 12px',
   },

--- a/modules/button/react/lib/ButtonStyles.ts
+++ b/modules/button/react/lib/ButtonStyles.ts
@@ -261,7 +261,7 @@ export const textButtonStyles: ButtonGenericStyle = {
   classname: 'text-button',
   styles: {
     ...canvasButtonStyles.styles,
-    borderRadius: '3px;',
+    borderRadius: borderRadius.m,
     border: '0',
     margin: '0 8px',
     minWidth: 'auto',
@@ -303,7 +303,7 @@ export const iconButtonStyles: ButtonGenericStyle = {
     // TODO: Support data-whatinput='input' css
     ...canvasButtonStyles.styles,
     borderWidth: '0',
-    borderRadius: '50%',
+    borderRadius: borderRadius.circle,
     ['& .wd-icon']: {
       display: 'inline-block',
       verticalAlign: 'middle',

--- a/modules/button/react/lib/ButtonStyles.ts
+++ b/modules/button/react/lib/ButtonStyles.ts
@@ -1,4 +1,4 @@
-import canvas from '@workday/canvas-kit-react-core';
+import canvas, {borderRadius} from '@workday/canvas-kit-react-core';
 import {focusRing, GenericStyle} from '@workday/canvas-kit-react-common';
 import {CSSObject} from 'create-emotion';
 import {
@@ -137,7 +137,7 @@ export const canvasButtonStyles: ButtonGenericStyle = {
     alignItems: 'center',
     justifyContent: 'center',
     fontSize: '13px',
-    borderRadius: '999px',
+    borderRadius: borderRadius.circle,
     border: '1px solid transparent',
     boxShadow: 'none',
     position: 'relative',
@@ -326,13 +326,13 @@ export const iconButtonStyles: ButtonGenericStyle = {
     },
     types: {
       [IconButtonVariant.Square]: {
-        borderRadius: '4px',
+        borderRadius: borderRadius.m,
         width: canvas.spacing.l,
         height: canvas.spacing.l,
         ...getButtonStateStyle(IconButtonVariant.Square),
       },
       [IconButtonVariant.SquareFilled]: {
-        borderRadius: '4px',
+        borderRadius: borderRadius.m,
         width: canvas.spacing.l,
         height: canvas.spacing.l,
         ...getButtonStateStyle(IconButtonVariant.SquareFilled),

--- a/modules/button/react/lib/IconButtonToggleGroup.tsx
+++ b/modules/button/react/lib/IconButtonToggleGroup.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import styled from 'react-emotion';
-import {spacing} from '@workday/canvas-kit-react-core';
+import {spacing, borderRadius} from '@workday/canvas-kit-react-core';
 import IconButton, {IconButtonCon, IconButtonProps} from './IconButton';
 
 export interface IconButtonToggleGroupProps {
@@ -31,7 +31,7 @@ export interface IconButtonToggleGroupProps {
 
 const Container = styled('div')({
   [IconButtonCon as any]: {
-    borderRadius: 0,
+    borderRadius: borderRadius.zero,
     borderWidth: '1px',
     marginLeft: '-1px',
     '&:first-child': {

--- a/modules/button/react/spec/__snapshots__/IconButton.snapshot.tsx.snap
+++ b/modules/button/react/spec/__snapshots__/IconButton.snapshot.tsx.snap
@@ -16,7 +16,7 @@ exports[`Icon Button Snapshots renders a medium icon button 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -183,7 +183,7 @@ exports[`Icon Button Snapshots renders a small icon button 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -387,7 +387,7 @@ exports[`Icon Button Snapshots renders an icon button, toggled 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -552,7 +552,7 @@ exports[`Icon Button Snapshots renders as expected 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -715,7 +715,7 @@ Array [
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -882,7 +882,7 @@ Array [
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -1037,7 +1037,7 @@ Array [
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -1172,7 +1172,7 @@ Array [
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -1368,7 +1368,7 @@ Array [
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -1519,7 +1519,7 @@ Array [
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -1620,7 +1620,7 @@ Array [
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;

--- a/modules/button/react/spec/__snapshots__/IconButtonToggleGroup.snapshot.tsx.snap
+++ b/modules/button/react/spec/__snapshots__/IconButtonToggleGroup.snapshot.tsx.snap
@@ -42,7 +42,7 @@ exports[`Icon Toggle Button Snapshot Toggle buttons with RTL true, with disabled
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -238,7 +238,7 @@ exports[`Icon Toggle Button Snapshot Toggle buttons with RTL true, with disabled
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -446,7 +446,7 @@ exports[`Icon Toggle Button Snapshot Toggle buttons with more than two items (us
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -642,7 +642,7 @@ exports[`Icon Toggle Button Snapshot Toggle buttons with more than two items (us
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -849,7 +849,7 @@ exports[`Icon Toggle Button Snapshot two buttons render as expected (w/ first se
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -1045,7 +1045,7 @@ exports[`Icon Toggle Button Snapshot two buttons render as expected (w/ first se
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;

--- a/modules/button/react/spec/__snapshots__/beta_Button_Icon.snapshot.tsx.snap
+++ b/modules/button/react/spec/__snapshots__/beta_Button_Icon.snapshot.tsx.snap
@@ -48,7 +48,7 @@ exports[`Button (Icon) Snapshots renders a default icon button 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -215,7 +215,7 @@ exports[`Button (Icon) Snapshots renders a default icon button, toggled off 1`] 
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -351,7 +351,7 @@ exports[`Button (Icon) Snapshots renders a default icon button, toggled on 1`] =
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -548,7 +548,7 @@ exports[`Button (Icon) Snapshots renders a default icon button, toggled on 2`] =
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -777,7 +777,7 @@ exports[`Button (Icon) Snapshots renders a filled icon button 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -931,7 +931,7 @@ exports[`Button (Icon) Snapshots renders a filled icon button, toggled off 1`] =
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -1086,7 +1086,7 @@ exports[`Button (Icon) Snapshots renders a filled icon button, toggled on 1`] = 
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -1273,7 +1273,7 @@ exports[`Button (Icon) Snapshots renders a medium default icon button 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -1440,7 +1440,7 @@ exports[`Button (Icon) Snapshots renders a medium filled icon button 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -1594,7 +1594,7 @@ exports[`Button (Icon) Snapshots renders a medium inverse filled icon button 1`]
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -1752,7 +1752,7 @@ exports[`Button (Icon) Snapshots renders a medium inverse icon button 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -1901,7 +1901,7 @@ exports[`Button (Icon) Snapshots renders a medium plain icon button 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -2071,7 +2071,7 @@ exports[`Button (Icon) Snapshots renders a plain icon button 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -2241,7 +2241,7 @@ exports[`Button (Icon) Snapshots renders a small default icon button 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -2413,7 +2413,7 @@ exports[`Button (Icon) Snapshots renders a small filled icon button 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -2572,7 +2572,7 @@ exports[`Button (Icon) Snapshots renders a small inverse filled icon button 1`] 
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -2735,7 +2735,7 @@ exports[`Button (Icon) Snapshots renders a small inverse icon button 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -2889,7 +2889,7 @@ exports[`Button (Icon) Snapshots renders a small plain icon button 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -3064,7 +3064,7 @@ exports[`Button (Icon) Snapshots renders an inverse filled icon button 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -3222,7 +3222,7 @@ exports[`Button (Icon) Snapshots renders an inverse filled icon button, toggled 
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -3381,7 +3381,7 @@ exports[`Button (Icon) Snapshots renders an inverse filled icon button, toggled 
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -3568,7 +3568,7 @@ exports[`Button (Icon) Snapshots renders an inverse icon button 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -3717,7 +3717,7 @@ exports[`Button (Icon) Snapshots renders an inverse icon button, toggled off 1`]
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -3867,7 +3867,7 @@ exports[`Button (Icon) Snapshots renders an inverse icon button, toggled on 1`] 
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;

--- a/modules/button/react/spec/__snapshots__/beta_Button_Text.snapshot.tsx.snap
+++ b/modules/button/react/spec/__snapshots__/beta_Button_Text.snapshot.tsx.snap
@@ -16,7 +16,7 @@ exports[`Button (Text) Snapshots renders a large, text all caps button 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;
@@ -225,7 +225,7 @@ exports[`Button (Text) Snapshots renders a large, text all caps button with a le
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;
@@ -446,7 +446,7 @@ exports[`Button (Text) Snapshots renders a large, text all caps button with a ri
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;
@@ -621,7 +621,7 @@ exports[`Button (Text) Snapshots renders a large, text button 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;
@@ -776,7 +776,7 @@ exports[`Button (Text) Snapshots renders a large, text button with a left icon 
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;
@@ -989,7 +989,7 @@ exports[`Button (Text) Snapshots renders a large, text button with a right icon
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;
@@ -1227,7 +1227,7 @@ exports[`Button (Text) Snapshots renders a large, text inverse all caps button 1
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;
@@ -1435,7 +1435,7 @@ exports[`Button (Text) Snapshots renders a large, text inverse all caps button w
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;
@@ -1655,7 +1655,7 @@ exports[`Button (Text) Snapshots renders a large, text inverse all caps button w
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;
@@ -1822,7 +1822,7 @@ exports[`Button (Text) Snapshots renders a large, text inverse button 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;
@@ -2022,7 +2022,7 @@ exports[`Button (Text) Snapshots renders a large, text inverse button with a lef
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;
@@ -2234,7 +2234,7 @@ exports[`Button (Text) Snapshots renders a large, text inverse button with a rig
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;
@@ -2407,7 +2407,7 @@ exports[`Button (Text) Snapshots renders a large, text inverse all caps button 
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;
@@ -2615,7 +2615,7 @@ exports[`Button (Text) Snapshots renders a large, text inverse all caps button 
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;
@@ -2835,7 +2835,7 @@ exports[`Button (Text) Snapshots renders a large, text inverse all caps button 
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;
@@ -2984,7 +2984,7 @@ exports[`Button (Text) Snapshots renders a small, text button 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;
@@ -3148,7 +3148,7 @@ exports[`Button (Text) Snapshots renders a small, text button with a left icon 1
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;
@@ -3361,7 +3361,7 @@ exports[`Button (Text) Snapshots renders a small, text button with a right icon 
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;
@@ -3565,7 +3565,7 @@ exports[`Button (Text) Snapshots renders a small, text button with all caps 1`] 
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;
@@ -3774,7 +3774,7 @@ exports[`Button (Text) Snapshots renders a small, text button with all caps with
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;
@@ -3995,7 +3995,7 @@ exports[`Button (Text) Snapshots renders a small, text button with all caps with
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;
@@ -4188,7 +4188,7 @@ exports[`Button (Text) Snapshots renders a small, text inverse button 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;
@@ -4388,7 +4388,7 @@ exports[`Button (Text) Snapshots renders a small, text inverse button with a lef
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;
@@ -4600,7 +4600,7 @@ exports[`Button (Text) Snapshots renders a small, text inverse button with a rig
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;
@@ -4773,7 +4773,7 @@ exports[`Button (Text) Snapshots renders a small, text inverse button with all c
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;
@@ -4981,7 +4981,7 @@ exports[`Button (Text) Snapshots renders a small, text inverse button with all c
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;
@@ -5201,7 +5201,7 @@ exports[`Button (Text) Snapshots renders a small, text inverse button with all c
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 0px;
   box-shadow: none;
   position: relative;

--- a/modules/button/react/stories/stories_beta.tsx
+++ b/modules/button/react/stories/stories_beta.tsx
@@ -26,7 +26,7 @@ const blueBackground: CSSObject = {
   margin: '0 10px',
   padding: '12px',
   maxWidth: 'max-content',
-  borderRadius: '3px',
+  borderRadius: '4px',
   button: {
     margin: '12px',
   },

--- a/modules/button/react/stories/stories_iconButton.tsx
+++ b/modules/button/react/stories/stories_iconButton.tsx
@@ -31,7 +31,7 @@ const blueBackground: CSSObject = {
   margin: '0 10px',
   padding: '24px',
   maxWidth: 'max-content',
-  borderRadius: '3px',
+  borderRadius: '4px',
   button: {
     margin: '0 12px',
   },

--- a/modules/button/react/stories/stories_iconButtonToggle.tsx
+++ b/modules/button/react/stories/stories_iconButtonToggle.tsx
@@ -30,7 +30,7 @@ const blueBackground: CSSObject = {
   margin: '0 10px',
   padding: '24px',
   maxWidth: 'max-content',
-  borderRadius: '3px',
+  borderRadius: '4px',
 };
 
 // Wrapper to add state mgmt to IconButtons

--- a/modules/card/css/lib/card.scss
+++ b/modules/card/css/lib/card.scss
@@ -16,7 +16,7 @@ $_wdc-container-positions: 'start' flex-start, 'end' flex-end, 'center' center,
 @mixin card-common() {
   @include wdc-depth-2();
   border: 1px solid $_wdc-card-border-color;
-  border-radius: $wdc-border-radius-m;
+  border-radius: $wdc-border-radius-l;
   padding: $wdc-spacing-l;
   margin: $wdc-spacing-s 0;
   background-color: $wdc-color-french-vanilla-100;

--- a/modules/card/css/lib/card.scss
+++ b/modules/card/css/lib/card.scss
@@ -16,7 +16,7 @@ $_wdc-container-positions: 'start' flex-start, 'end' flex-end, 'center' center,
 @mixin card-common() {
   @include wdc-depth-2();
   border: 1px solid $_wdc-card-border-color;
-  border-radius: 3px;
+  border-radius: $wdc-border-radius-m;
   padding: $wdc-spacing-l;
   margin: $wdc-spacing-s 0;
   background-color: $wdc-color-french-vanilla-100;

--- a/modules/card/react/lib/Card.tsx
+++ b/modules/card/react/lib/Card.tsx
@@ -5,6 +5,7 @@ import {
   depth as depthValues,
   type,
   spacing,
+  borderRadius,
   CanvasDepthValue,
   CanvasSpacingValue,
 } from '@workday/canvas-kit-react-core';
@@ -40,7 +41,7 @@ const Box = styled('div')<CardProps>(
   {
     backgroundColor: colors.frenchVanilla100,
     border: `1px solid ${colors.soap500}`,
-    borderRadius: 3,
+    borderRadius: borderRadius.m,
     boxSizing: 'border-box',
   },
   ({depth}) => depth,

--- a/modules/card/react/lib/Card.tsx
+++ b/modules/card/react/lib/Card.tsx
@@ -41,7 +41,7 @@ const Box = styled('div')<CardProps>(
   {
     backgroundColor: colors.frenchVanilla100,
     border: `1px solid ${colors.soap500}`,
-    borderRadius: borderRadius.m,
+    borderRadius: borderRadius.l,
     boxSizing: 'border-box',
   },
   ({depth}) => depth,

--- a/modules/card/react/spec/__snapshots__/Card.snapshot.tsx.snap
+++ b/modules/card/react/spec/__snapshots__/Card.snapshot.tsx.snap
@@ -12,7 +12,7 @@ exports[`Card Snapshots renders a card with depth 1`] = `
 .emotion-2 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 2px 4px 0 rgba(0,0,0,0.08);
   padding: 32px;
@@ -33,7 +33,7 @@ exports[`Card Snapshots renders a card with heading 1`] = `
 .emotion-4 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 32px;
@@ -84,7 +84,7 @@ exports[`Card Snapshots renders a card with height 1`] = `
 .emotion-2 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 32px;
@@ -115,7 +115,7 @@ exports[`Card Snapshots renders a card with padding 1`] = `
 .emotion-2 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 12px;
@@ -144,7 +144,7 @@ exports[`Card Snapshots renders a card with width 1`] = `
 .emotion-2 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 32px;
@@ -167,7 +167,7 @@ exports[`Card Snapshots renders as expected 1`] = `
 .emotion-2 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 32px;

--- a/modules/card/react/spec/__snapshots__/Card.snapshot.tsx.snap
+++ b/modules/card/react/spec/__snapshots__/Card.snapshot.tsx.snap
@@ -12,7 +12,7 @@ exports[`Card Snapshots renders a card with depth 1`] = `
 .emotion-2 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 2px 4px 0 rgba(0,0,0,0.08);
   padding: 32px;
@@ -33,7 +33,7 @@ exports[`Card Snapshots renders a card with heading 1`] = `
 .emotion-4 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 32px;
@@ -84,7 +84,7 @@ exports[`Card Snapshots renders a card with height 1`] = `
 .emotion-2 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 32px;
@@ -115,7 +115,7 @@ exports[`Card Snapshots renders a card with padding 1`] = `
 .emotion-2 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 12px;
@@ -144,7 +144,7 @@ exports[`Card Snapshots renders a card with width 1`] = `
 .emotion-2 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 32px;
@@ -167,7 +167,7 @@ exports[`Card Snapshots renders as expected 1`] = `
 .emotion-2 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 32px;

--- a/modules/checkbox/react/lib/Checkbox.tsx
+++ b/modules/checkbox/react/lib/Checkbox.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import styled from 'react-emotion';
 import {ErrorType, focusRing, mouseFocusBehavior} from '@workday/canvas-kit-react-common';
 import canvas, {
+  borderRadius,
   colors,
   iconColors,
   inputColors,
@@ -22,7 +23,6 @@ export interface CheckboxProps extends React.InputHTMLAttributes<HTMLInputElemen
   error?: ErrorType;
 }
 
-const checkboxBorderRadius = 2;
 const checkboxHeight = 18;
 const checkboxTapArea = spacing.m;
 const checkboxContainerHeight = checkboxTapArea + spacing.xxs;
@@ -46,7 +46,7 @@ const CheckboxInputWrapper = styled('div')<Pick<CheckboxProps, 'disabled'>>(
   {
     height: checkboxHeight,
     '&::after': {
-      borderRadius: 999,
+      borderRadius: borderRadius.circle,
       boxShadow: '0 0 0 0 ' + colors.soap200,
       content: '""',
       display: 'inline-block',
@@ -69,7 +69,7 @@ const CheckboxInputWrapper = styled('div')<Pick<CheckboxProps, 'disabled'>>(
  */
 const CheckboxInput = styled('input')<CheckboxProps>(
   {
-    borderRadius: checkboxBorderRadius,
+    borderRadius: borderRadius.s,
     width: checkboxTapArea,
     height: checkboxTapArea,
     margin: 0,
@@ -177,7 +177,7 @@ const CheckboxInput = styled('input')<CheckboxProps>(
 const CheckboxBackground = styled('div')<CheckboxProps>({
   alignItems: 'center',
   backgroundColor: colors.frenchVanilla100,
-  borderRadius: checkboxBorderRadius,
+  borderRadius: borderRadius.s,
   border: '1px solid ' + inputColors.border,
   boxSizing: 'border-box',
   display: 'flex',

--- a/modules/checkbox/react/spec/__snapshots__/Checkbox.snapshot.tsx.snap
+++ b/modules/checkbox/react/spec/__snapshots__/Checkbox.snapshot.tsx.snap
@@ -19,7 +19,7 @@ exports[`Checkbox Snapshots alert renders as expected 1`] = `
 }
 
 .emotion-7::after {
-  border-radius: 100%;
+  border-radius: 999px;
   box-shadow: 0 0 0 0 #f0f1f2;
   content: "";
   display: inline-block;
@@ -295,7 +295,7 @@ exports[`Checkbox Snapshots checked alert renders as expected 1`] = `
 }
 
 .emotion-7::after {
-  border-radius: 100%;
+  border-radius: 999px;
   box-shadow: 0 0 0 0 #f0f1f2;
   content: "";
   display: inline-block;
@@ -571,7 +571,7 @@ exports[`Checkbox Snapshots checked error renders as expected 1`] = `
 }
 
 .emotion-7::after {
-  border-radius: 100%;
+  border-radius: 999px;
   box-shadow: 0 0 0 0 #f0f1f2;
   content: "";
   display: inline-block;
@@ -847,7 +847,7 @@ exports[`Checkbox Snapshots error renders as expected 1`] = `
 }
 
 .emotion-7::after {
-  border-radius: 100%;
+  border-radius: 999px;
   box-shadow: 0 0 0 0 #f0f1f2;
   content: "";
   display: inline-block;
@@ -1123,7 +1123,7 @@ exports[`Checkbox Snapshots renders as expected 1`] = `
 }
 
 .emotion-7::after {
-  border-radius: 100%;
+  border-radius: 999px;
   box-shadow: 0 0 0 0 #f0f1f2;
   content: "";
   display: inline-block;
@@ -1521,7 +1521,7 @@ exports[`Checkbox Snapshots renders as expected 2`] = `
 }
 
 .emotion-7::after {
-  border-radius: 100%;
+  border-radius: 999px;
   box-shadow: 0 0 0 0 #f0f1f2;
   content: "";
   display: inline-block;
@@ -1727,7 +1727,7 @@ exports[`Checkbox Snapshots renders as expected 3`] = `
 }
 
 .emotion-7::after {
-  border-radius: 100%;
+  border-radius: 999px;
   box-shadow: 0 0 0 0 #f0f1f2;
   content: "";
   display: inline-block;
@@ -1836,7 +1836,7 @@ exports[`Checkbox Snapshots renders as expected 4`] = `
 }
 
 .emotion-7::after {
-  border-radius: 100%;
+  border-radius: 999px;
   box-shadow: 0 0 0 0 #f0f1f2;
   content: "";
   display: inline-block;

--- a/modules/checkbox/react/spec/__snapshots__/Checkbox.snapshot.tsx.snap
+++ b/modules/checkbox/react/spec/__snapshots__/Checkbox.snapshot.tsx.snap
@@ -19,7 +19,7 @@ exports[`Checkbox Snapshots alert renders as expected 1`] = `
 }
 
 .emotion-7::after {
-  border-radius: 999px;
+  border-radius: 100%;
   box-shadow: 0 0 0 0 #f0f1f2;
   content: "";
   display: inline-block;
@@ -295,7 +295,7 @@ exports[`Checkbox Snapshots checked alert renders as expected 1`] = `
 }
 
 .emotion-7::after {
-  border-radius: 999px;
+  border-radius: 100%;
   box-shadow: 0 0 0 0 #f0f1f2;
   content: "";
   display: inline-block;
@@ -571,7 +571,7 @@ exports[`Checkbox Snapshots checked error renders as expected 1`] = `
 }
 
 .emotion-7::after {
-  border-radius: 999px;
+  border-radius: 100%;
   box-shadow: 0 0 0 0 #f0f1f2;
   content: "";
   display: inline-block;
@@ -847,7 +847,7 @@ exports[`Checkbox Snapshots error renders as expected 1`] = `
 }
 
 .emotion-7::after {
-  border-radius: 999px;
+  border-radius: 100%;
   box-shadow: 0 0 0 0 #f0f1f2;
   content: "";
   display: inline-block;
@@ -1123,7 +1123,7 @@ exports[`Checkbox Snapshots renders as expected 1`] = `
 }
 
 .emotion-7::after {
-  border-radius: 999px;
+  border-radius: 100%;
   box-shadow: 0 0 0 0 #f0f1f2;
   content: "";
   display: inline-block;
@@ -1521,7 +1521,7 @@ exports[`Checkbox Snapshots renders as expected 2`] = `
 }
 
 .emotion-7::after {
-  border-radius: 999px;
+  border-radius: 100%;
   box-shadow: 0 0 0 0 #f0f1f2;
   content: "";
   display: inline-block;
@@ -1727,7 +1727,7 @@ exports[`Checkbox Snapshots renders as expected 3`] = `
 }
 
 .emotion-7::after {
-  border-radius: 999px;
+  border-radius: 100%;
   box-shadow: 0 0 0 0 #f0f1f2;
   content: "";
   display: inline-block;
@@ -1836,7 +1836,7 @@ exports[`Checkbox Snapshots renders as expected 4`] = `
 }
 
 .emotion-7::after {
-  border-radius: 999px;
+  border-radius: 100%;
   box-shadow: 0 0 0 0 #f0f1f2;
   content: "";
   display: inline-block;

--- a/modules/color-picker/react/lib/ColorInput.tsx
+++ b/modules/color-picker/react/lib/ColorInput.tsx
@@ -6,7 +6,7 @@ import {
   GrowthBehavior,
   ErrorType,
 } from '@workday/canvas-kit-react-common';
-import {colors, spacing, type, inputColors} from '@workday/canvas-kit-react-core';
+import {colors, borderRadius, spacing, type, inputColors} from '@workday/canvas-kit-react-core';
 import {css} from 'emotion';
 import {checkSmallIcon} from '@workday/canvas-system-icons-web';
 import {SystemIcon} from '@workday/canvas-kit-react-icon';
@@ -76,7 +76,7 @@ const SwatchTile = styled('div')({
   marginTop: '10px', // Fix vertical alignment on IE11
   boxShadow: 'inset 0 0 0 1px rgba(0,0,0,0.25)',
   pointerEvents: 'none',
-  borderRadius: '2px',
+  borderRadius: borderRadius.s,
 });
 
 const swatchCheckIcon = css({

--- a/modules/color-picker/react/spec/__snapshots__/ColorInput.snapshot.tsx.snap
+++ b/modules/color-picker/react/spec/__snapshots__/ColorInput.snapshot.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ColorInput Snapshots renders a dark checkIcon if hex value is light 1`] = `
-.emotion-8 {
+.emotion-7 {
   position: relative;
 }
 
@@ -92,7 +92,7 @@ exports[`ColorInput Snapshots renders a dark checkIcon if hex value is light 1`]
   color: transparent;
 }
 
-.emotion-3 {
+.emotion-2 {
   position: absolute;
   cursor: pointer;
   height: 20px;
@@ -107,7 +107,7 @@ exports[`ColorInput Snapshots renders a dark checkIcon if hex value is light 1`]
   border-radius: 2px;
 }
 
-.emotion-6 {
+.emotion-5 {
   position: absolute;
   left: 36px;
   top: 10px;
@@ -118,46 +118,46 @@ exports[`ColorInput Snapshots renders a dark checkIcon if hex value is light 1`]
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-5 {
+.emotion-4 {
   display: inline-block;
   position: absolute;
   left: 6px;
   top: 8px;
 }
 
-.emotion-5 svg {
+.emotion-4 svg {
   display: block;
 }
 
-.emotion-5 .wd-icon-fill {
+.emotion-4 .wd-icon-fill {
   fill: #000000;
 }
 
-.emotion-5:hover .wd-icon-fill {
+.emotion-4:hover .wd-icon-fill {
   fill: #000000;
 }
 
-.emotion-5 .wd-icon-accent {
+.emotion-4 .wd-icon-accent {
   fill: #7b858f;
 }
 
-.emotion-5:hover .wd-icon-accent {
+.emotion-4:hover .wd-icon-accent {
   fill: #333d47;
 }
 
-.emotion-5 .wd-icon-background {
+.emotion-4 .wd-icon-background {
   fill: transparent;
 }
 
-.emotion-5:hover .wd-icon-background {
+.emotion-4:hover .wd-icon-background {
   fill: transparent;
 }
 
 <div
-  className="emotion-8 emotion-9"
+  className="emotion-7 emotion-8"
 >
   <input
-    className="emotion-0 emotion-1 emotion-2"
+    className="emotion-0 emotion-1"
     maxLength={7}
     onChange={[Function]}
     placeholder="FFFFFF"
@@ -166,7 +166,7 @@ exports[`ColorInput Snapshots renders a dark checkIcon if hex value is light 1`]
     value="ffffff"
   />
   <div
-    className="emotion-3 emotion-4"
+    className="emotion-2 emotion-3"
     style={
       Object {
         "backgroundColor": "#ffffff",
@@ -174,7 +174,7 @@ exports[`ColorInput Snapshots renders a dark checkIcon if hex value is light 1`]
     }
   />
   <span
-    className="emotion-5"
+    className="emotion-4"
     dangerouslySetInnerHTML={
       Object {
         "__html": "<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"24\\" height=\\"24\\" class=\\"wd-icon-check-small wd-icon\\" focusable=\\"false\\" role=\\"presentation\\" viewBox=\\"0 0 24 24\\"><g fill-rule=\\"evenodd\\" class=\\"wd-icon-container\\"><path fill-rule=\\"nonzero\\" d=\\"M17.314 6.828l1.06 1.061a.5.5 0 0 1 0 .707l-7.778 7.778a.5.5 0 0 1-.707 0L6.354 12.84a.5.5 0 0 1 0-.707l1.06-1.06a.5.5 0 0 1 .707 0l2.122 2.12 6.364-6.364a.5.5 0 0 1 .707 0z\\" class=\\"wd-icon-fill\\"/></g></svg>",
@@ -182,7 +182,7 @@ exports[`ColorInput Snapshots renders a dark checkIcon if hex value is light 1`]
     }
   />
   <span
-    className="emotion-6 emotion-7"
+    className="emotion-5 emotion-6"
   >
     #
   </span>
@@ -190,11 +190,11 @@ exports[`ColorInput Snapshots renders a dark checkIcon if hex value is light 1`]
 `;
 
 exports[`ColorInput Snapshots renders a disabled input 1`] = `
-.emotion-7 {
+.emotion-6 {
   position: relative;
 }
 
-.emotion-3 {
+.emotion-2 {
   position: absolute;
   cursor: pointer;
   height: 20px;
@@ -296,7 +296,7 @@ exports[`ColorInput Snapshots renders a disabled input 1`] = `
   color: transparent;
 }
 
-.emotion-5 {
+.emotion-4 {
   position: absolute;
   left: 36px;
   top: 10px;
@@ -309,10 +309,10 @@ exports[`ColorInput Snapshots renders a disabled input 1`] = `
 }
 
 <div
-  className="emotion-7 emotion-8"
+  className="emotion-6 emotion-7"
 >
   <input
-    className="emotion-0 emotion-1 emotion-2"
+    className="emotion-0 emotion-1"
     disabled={true}
     maxLength={7}
     onChange={[Function]}
@@ -322,7 +322,7 @@ exports[`ColorInput Snapshots renders a disabled input 1`] = `
     value="ffffff"
   />
   <div
-    className="emotion-3 emotion-4"
+    className="emotion-2 emotion-3"
     style={
       Object {
         "backgroundColor": "#ffffff",
@@ -330,7 +330,7 @@ exports[`ColorInput Snapshots renders a disabled input 1`] = `
     }
   />
   <span
-    className="emotion-5 emotion-6"
+    className="emotion-4 emotion-5"
     disabled={true}
   >
     #
@@ -339,195 +339,6 @@ exports[`ColorInput Snapshots renders a disabled input 1`] = `
 `;
 
 exports[`ColorInput Snapshots renders a light checkIcon if hex value is dark 1`] = `
-.emotion-8 {
-  position: relative;
-}
-
-.emotion-1 {
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 400;
-  color: #494949;
-  font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
-  border: 1px solid #7b858f;
-  display: block;
-  background-color: #ffffff;
-  border-radius: 4px;
-  box-sizing: border-box;
-  height: 40px;
-  min-width: 280px;
-  -webkit-transition: 0.2s box-shadow,0.2s border-color;
-  transition: 0.2s box-shadow,0.2s border-color;
-  padding: 8px;
-  box-sizing: border-box;
-  padding-left: 46px;
-  min-width: 116px;
-  width: 116px;
-  background-color: px;
-}
-
-.emotion-1::-webkit-input-placeholder {
-  color: #5e6a75;
-}
-
-.emotion-1::-moz-placeholder {
-  color: #5e6a75;
-}
-
-.emotion-1:-ms-input-placeholder {
-  color: #5e6a75;
-}
-
-.emotion-1::placeholder {
-  color: #5e6a75;
-}
-
-.emotion-1:hover {
-  border-color: #333d47;
-}
-
-.emotion-1:focus:not([disabled]) {
-  border-color: #0875e1;
-  box-shadow: inset 0 0 0 1px #0875e1;
-  outline: none;
-}
-
-.emotion-1:disabled {
-  background-color: #f6f7f8;
-  border-color: #b9c0c7;
-  color: #a1aab3;
-}
-
-.emotion-1:disabled::-webkit-input-placeholder {
-  color: #a1aab3;
-}
-
-.emotion-1:disabled::-moz-placeholder {
-  color: #a1aab3;
-}
-
-.emotion-1:disabled:-ms-input-placeholder {
-  color: #a1aab3;
-}
-
-.emotion-1:disabled::placeholder {
-  color: #a1aab3;
-}
-
-.emotion-1:focus::-webkit-input-placeholder {
-  color: transparent;
-}
-
-.emotion-1:focus::-moz-placeholder {
-  color: transparent;
-}
-
-.emotion-1:focus:-ms-input-placeholder {
-  color: transparent;
-}
-
-.emotion-1:focus::placeholder {
-  color: transparent;
-}
-
-.emotion-3 {
-  position: absolute;
-  cursor: pointer;
-  height: 20px;
-  width: 20px;
-  top: 0px;
-  bottom: 0px;
-  left: 8px;
-  margin: auto;
-  margin-top: 10px;
-  box-shadow: inset 0 0 0 1px rgba(0,0,0,0.25);
-  pointer-events: none;
-  border-radius: 2px;
-}
-
-.emotion-6 {
-  position: absolute;
-  left: 36px;
-  top: 10px;
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 400;
-  color: #5e6a75;
-  font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
-}
-
-.emotion-5 {
-  display: inline-block;
-  position: absolute;
-  left: 6px;
-  top: 8px;
-}
-
-.emotion-5 svg {
-  display: block;
-}
-
-.emotion-5 .wd-icon-fill {
-  fill: #ffffff;
-}
-
-.emotion-5:hover .wd-icon-fill {
-  fill: #ffffff;
-}
-
-.emotion-5 .wd-icon-accent {
-  fill: #7b858f;
-}
-
-.emotion-5:hover .wd-icon-accent {
-  fill: #333d47;
-}
-
-.emotion-5 .wd-icon-background {
-  fill: transparent;
-}
-
-.emotion-5:hover .wd-icon-background {
-  fill: transparent;
-}
-
-<div
-  className="emotion-8 emotion-9"
->
-  <input
-    className="emotion-0 emotion-1 emotion-2"
-    maxLength={7}
-    onChange={[Function]}
-    placeholder="FFFFFF"
-    spellCheck={false}
-    type="text"
-    value="e6e"
-  />
-  <div
-    className="emotion-3 emotion-4"
-    style={
-      Object {
-        "backgroundColor": "#e6e",
-      }
-    }
-  />
-  <span
-    className="emotion-5"
-    dangerouslySetInnerHTML={
-      Object {
-        "__html": "<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"24\\" height=\\"24\\" class=\\"wd-icon-check-small wd-icon\\" focusable=\\"false\\" role=\\"presentation\\" viewBox=\\"0 0 24 24\\"><g fill-rule=\\"evenodd\\" class=\\"wd-icon-container\\"><path fill-rule=\\"nonzero\\" d=\\"M17.314 6.828l1.06 1.061a.5.5 0 0 1 0 .707l-7.778 7.778a.5.5 0 0 1-.707 0L6.354 12.84a.5.5 0 0 1 0-.707l1.06-1.06a.5.5 0 0 1 .707 0l2.122 2.12 6.364-6.364a.5.5 0 0 1 .707 0z\\" class=\\"wd-icon-fill\\"/></g></svg>",
-      }
-    }
-  />
-  <span
-    className="emotion-6 emotion-7"
-  >
-    #
-  </span>
-</div>
-`;
-
-exports[`ColorInput Snapshots renders as expected 1`] = `
 .emotion-7 {
   position: relative;
 }
@@ -619,7 +430,7 @@ exports[`ColorInput Snapshots renders as expected 1`] = `
   color: transparent;
 }
 
-.emotion-3 {
+.emotion-2 {
   position: absolute;
   cursor: pointer;
   height: 20px;
@@ -645,23 +456,66 @@ exports[`ColorInput Snapshots renders as expected 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
+.emotion-4 {
+  display: inline-block;
+  position: absolute;
+  left: 6px;
+  top: 8px;
+}
+
+.emotion-4 svg {
+  display: block;
+}
+
+.emotion-4 .wd-icon-fill {
+  fill: #ffffff;
+}
+
+.emotion-4:hover .wd-icon-fill {
+  fill: #ffffff;
+}
+
+.emotion-4 .wd-icon-accent {
+  fill: #7b858f;
+}
+
+.emotion-4:hover .wd-icon-accent {
+  fill: #333d47;
+}
+
+.emotion-4 .wd-icon-background {
+  fill: transparent;
+}
+
+.emotion-4:hover .wd-icon-background {
+  fill: transparent;
+}
+
 <div
   className="emotion-7 emotion-8"
 >
   <input
-    className="emotion-0 emotion-1 emotion-2"
+    className="emotion-0 emotion-1"
     maxLength={7}
     onChange={[Function]}
     placeholder="FFFFFF"
     spellCheck={false}
     type="text"
-    value=""
+    value="e6e"
   />
   <div
-    className="emotion-3 emotion-4"
+    className="emotion-2 emotion-3"
     style={
       Object {
-        "backgroundColor": "",
+        "backgroundColor": "#e6e",
+      }
+    }
+  />
+  <span
+    className="emotion-4"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"24\\" height=\\"24\\" class=\\"wd-icon-check-small wd-icon\\" focusable=\\"false\\" role=\\"presentation\\" viewBox=\\"0 0 24 24\\"><g fill-rule=\\"evenodd\\" class=\\"wd-icon-container\\"><path fill-rule=\\"nonzero\\" d=\\"M17.314 6.828l1.06 1.061a.5.5 0 0 1 0 .707l-7.778 7.778a.5.5 0 0 1-.707 0L6.354 12.84a.5.5 0 0 1 0-.707l1.06-1.06a.5.5 0 0 1 .707 0l2.122 2.12 6.364-6.364a.5.5 0 0 1 .707 0z\\" class=\\"wd-icon-fill\\"/></g></svg>",
       }
     }
   />
@@ -673,8 +527,8 @@ exports[`ColorInput Snapshots renders as expected 1`] = `
 </div>
 `;
 
-exports[`ColorInput Snapshots renders valid empty color input 1`] = `
-.emotion-7 {
+exports[`ColorInput Snapshots renders as expected 1`] = `
+.emotion-6 {
   position: relative;
 }
 
@@ -765,7 +619,7 @@ exports[`ColorInput Snapshots renders valid empty color input 1`] = `
   color: transparent;
 }
 
-.emotion-3 {
+.emotion-2 {
   position: absolute;
   cursor: pointer;
   height: 20px;
@@ -780,7 +634,7 @@ exports[`ColorInput Snapshots renders valid empty color input 1`] = `
   border-radius: 2px;
 }
 
-.emotion-5 {
+.emotion-4 {
   position: absolute;
   left: 36px;
   top: 10px;
@@ -792,10 +646,156 @@ exports[`ColorInput Snapshots renders valid empty color input 1`] = `
 }
 
 <div
-  className="emotion-7 emotion-8"
+  className="emotion-6 emotion-7"
 >
   <input
-    className="emotion-0 emotion-1 emotion-2"
+    className="emotion-0 emotion-1"
+    maxLength={7}
+    onChange={[Function]}
+    placeholder="FFFFFF"
+    spellCheck={false}
+    type="text"
+    value=""
+  />
+  <div
+    className="emotion-2 emotion-3"
+    style={
+      Object {
+        "backgroundColor": "",
+      }
+    }
+  />
+  <span
+    className="emotion-4 emotion-5"
+  >
+    #
+  </span>
+</div>
+`;
+
+exports[`ColorInput Snapshots renders valid empty color input 1`] = `
+.emotion-6 {
+  position: relative;
+}
+
+.emotion-1 {
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
+  color: #494949;
+  font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
+  border: 1px solid #7b858f;
+  display: block;
+  background-color: #ffffff;
+  border-radius: 4px;
+  box-sizing: border-box;
+  height: 40px;
+  min-width: 280px;
+  -webkit-transition: 0.2s box-shadow,0.2s border-color;
+  transition: 0.2s box-shadow,0.2s border-color;
+  padding: 8px;
+  box-sizing: border-box;
+  padding-left: 46px;
+  min-width: 116px;
+  width: 116px;
+  background-color: px;
+}
+
+.emotion-1::-webkit-input-placeholder {
+  color: #5e6a75;
+}
+
+.emotion-1::-moz-placeholder {
+  color: #5e6a75;
+}
+
+.emotion-1:-ms-input-placeholder {
+  color: #5e6a75;
+}
+
+.emotion-1::placeholder {
+  color: #5e6a75;
+}
+
+.emotion-1:hover {
+  border-color: #333d47;
+}
+
+.emotion-1:focus:not([disabled]) {
+  border-color: #0875e1;
+  box-shadow: inset 0 0 0 1px #0875e1;
+  outline: none;
+}
+
+.emotion-1:disabled {
+  background-color: #f6f7f8;
+  border-color: #b9c0c7;
+  color: #a1aab3;
+}
+
+.emotion-1:disabled::-webkit-input-placeholder {
+  color: #a1aab3;
+}
+
+.emotion-1:disabled::-moz-placeholder {
+  color: #a1aab3;
+}
+
+.emotion-1:disabled:-ms-input-placeholder {
+  color: #a1aab3;
+}
+
+.emotion-1:disabled::placeholder {
+  color: #a1aab3;
+}
+
+.emotion-1:focus::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-1:focus::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-1:focus:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-1:focus::placeholder {
+  color: transparent;
+}
+
+.emotion-2 {
+  position: absolute;
+  cursor: pointer;
+  height: 20px;
+  width: 20px;
+  top: 0px;
+  bottom: 0px;
+  left: 8px;
+  margin: auto;
+  margin-top: 10px;
+  box-shadow: inset 0 0 0 1px rgba(0,0,0,0.25);
+  pointer-events: none;
+  border-radius: 2px;
+}
+
+.emotion-4 {
+  position: absolute;
+  left: 36px;
+  top: 10px;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
+  color: #5e6a75;
+  font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
+}
+
+<div
+  className="emotion-6 emotion-7"
+>
+  <input
+    className="emotion-0 emotion-1"
     disabled={false}
     maxLength={7}
     onChange={[Function]}
@@ -805,7 +805,7 @@ exports[`ColorInput Snapshots renders valid empty color input 1`] = `
     value=""
   />
   <div
-    className="emotion-3 emotion-4"
+    className="emotion-2 emotion-3"
     style={
       Object {
         "backgroundColor": "",
@@ -813,7 +813,7 @@ exports[`ColorInput Snapshots renders valid empty color input 1`] = `
     }
   />
   <span
-    className="emotion-5 emotion-6"
+    className="emotion-4 emotion-5"
     disabled={false}
   >
     #
@@ -822,7 +822,7 @@ exports[`ColorInput Snapshots renders valid empty color input 1`] = `
 `;
 
 exports[`ColorInput Snapshots renders with a selected color 1`] = `
-.emotion-7 {
+.emotion-6 {
   position: relative;
 }
 
@@ -913,7 +913,7 @@ exports[`ColorInput Snapshots renders with a selected color 1`] = `
   color: transparent;
 }
 
-.emotion-3 {
+.emotion-2 {
   position: absolute;
   cursor: pointer;
   height: 20px;
@@ -928,7 +928,7 @@ exports[`ColorInput Snapshots renders with a selected color 1`] = `
   border-radius: 2px;
 }
 
-.emotion-5 {
+.emotion-4 {
   position: absolute;
   left: 36px;
   top: 10px;
@@ -940,10 +940,10 @@ exports[`ColorInput Snapshots renders with a selected color 1`] = `
 }
 
 <div
-  className="emotion-7 emotion-8"
+  className="emotion-6 emotion-7"
 >
   <input
-    className="emotion-0 emotion-1 emotion-2"
+    className="emotion-0 emotion-1"
     maxLength={7}
     onChange={[Function]}
     placeholder="FFFFFF"
@@ -952,7 +952,7 @@ exports[`ColorInput Snapshots renders with a selected color 1`] = `
     value="e6e"
   />
   <div
-    className="emotion-3 emotion-4"
+    className="emotion-2 emotion-3"
     style={
       Object {
         "backgroundColor": "#e6e",
@@ -960,7 +960,7 @@ exports[`ColorInput Snapshots renders with a selected color 1`] = `
     }
   />
   <span
-    className="emotion-5 emotion-6"
+    className="emotion-4 emotion-5"
   >
     #
   </span>
@@ -968,7 +968,7 @@ exports[`ColorInput Snapshots renders with a selected color 1`] = `
 `;
 
 exports[`ColorInput Snapshots renders with a selected color without # 1`] = `
-.emotion-7 {
+.emotion-6 {
   position: relative;
 }
 
@@ -1059,7 +1059,7 @@ exports[`ColorInput Snapshots renders with a selected color without # 1`] = `
   color: transparent;
 }
 
-.emotion-3 {
+.emotion-2 {
   position: absolute;
   cursor: pointer;
   height: 20px;
@@ -1074,7 +1074,7 @@ exports[`ColorInput Snapshots renders with a selected color without # 1`] = `
   border-radius: 2px;
 }
 
-.emotion-5 {
+.emotion-4 {
   position: absolute;
   left: 36px;
   top: 10px;
@@ -1086,10 +1086,10 @@ exports[`ColorInput Snapshots renders with a selected color without # 1`] = `
 }
 
 <div
-  className="emotion-7 emotion-8"
+  className="emotion-6 emotion-7"
 >
   <input
-    className="emotion-0 emotion-1 emotion-2"
+    className="emotion-0 emotion-1"
     maxLength={7}
     onChange={[Function]}
     placeholder="FFFFFF"
@@ -1098,7 +1098,7 @@ exports[`ColorInput Snapshots renders with a selected color without # 1`] = `
     value="e6e"
   />
   <div
-    className="emotion-3 emotion-4"
+    className="emotion-2 emotion-3"
     style={
       Object {
         "backgroundColor": "#e6e",
@@ -1106,7 +1106,7 @@ exports[`ColorInput Snapshots renders with a selected color without # 1`] = `
     }
   />
   <span
-    className="emotion-5 emotion-6"
+    className="emotion-4 emotion-5"
   >
     #
   </span>

--- a/modules/color-picker/react/spec/__snapshots__/ColorInput.snapshot.tsx.snap
+++ b/modules/color-picker/react/spec/__snapshots__/ColorInput.snapshot.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ColorInput Snapshots renders a dark checkIcon if hex value is light 1`] = `
-.emotion-7 {
+.emotion-8 {
   position: relative;
 }
 
@@ -92,7 +92,7 @@ exports[`ColorInput Snapshots renders a dark checkIcon if hex value is light 1`]
   color: transparent;
 }
 
-.emotion-2 {
+.emotion-3 {
   position: absolute;
   cursor: pointer;
   height: 20px;
@@ -107,7 +107,7 @@ exports[`ColorInput Snapshots renders a dark checkIcon if hex value is light 1`]
   border-radius: 2px;
 }
 
-.emotion-5 {
+.emotion-6 {
   position: absolute;
   left: 36px;
   top: 10px;
@@ -118,46 +118,46 @@ exports[`ColorInput Snapshots renders a dark checkIcon if hex value is light 1`]
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-4 {
+.emotion-5 {
   display: inline-block;
   position: absolute;
   left: 6px;
   top: 8px;
 }
 
-.emotion-4 svg {
+.emotion-5 svg {
   display: block;
 }
 
-.emotion-4 .wd-icon-fill {
+.emotion-5 .wd-icon-fill {
   fill: #000000;
 }
 
-.emotion-4:hover .wd-icon-fill {
+.emotion-5:hover .wd-icon-fill {
   fill: #000000;
 }
 
-.emotion-4 .wd-icon-accent {
+.emotion-5 .wd-icon-accent {
   fill: #7b858f;
 }
 
-.emotion-4:hover .wd-icon-accent {
+.emotion-5:hover .wd-icon-accent {
   fill: #333d47;
 }
 
-.emotion-4 .wd-icon-background {
+.emotion-5 .wd-icon-background {
   fill: transparent;
 }
 
-.emotion-4:hover .wd-icon-background {
+.emotion-5:hover .wd-icon-background {
   fill: transparent;
 }
 
 <div
-  className="emotion-7 emotion-8"
+  className="emotion-8 emotion-9"
 >
   <input
-    className="emotion-0 emotion-1"
+    className="emotion-0 emotion-1 emotion-2"
     maxLength={7}
     onChange={[Function]}
     placeholder="FFFFFF"
@@ -166,7 +166,7 @@ exports[`ColorInput Snapshots renders a dark checkIcon if hex value is light 1`]
     value="ffffff"
   />
   <div
-    className="emotion-2 emotion-3"
+    className="emotion-3 emotion-4"
     style={
       Object {
         "backgroundColor": "#ffffff",
@@ -174,7 +174,7 @@ exports[`ColorInput Snapshots renders a dark checkIcon if hex value is light 1`]
     }
   />
   <span
-    className="emotion-4"
+    className="emotion-5"
     dangerouslySetInnerHTML={
       Object {
         "__html": "<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"24\\" height=\\"24\\" class=\\"wd-icon-check-small wd-icon\\" focusable=\\"false\\" role=\\"presentation\\" viewBox=\\"0 0 24 24\\"><g fill-rule=\\"evenodd\\" class=\\"wd-icon-container\\"><path fill-rule=\\"nonzero\\" d=\\"M17.314 6.828l1.06 1.061a.5.5 0 0 1 0 .707l-7.778 7.778a.5.5 0 0 1-.707 0L6.354 12.84a.5.5 0 0 1 0-.707l1.06-1.06a.5.5 0 0 1 .707 0l2.122 2.12 6.364-6.364a.5.5 0 0 1 .707 0z\\" class=\\"wd-icon-fill\\"/></g></svg>",
@@ -182,7 +182,7 @@ exports[`ColorInput Snapshots renders a dark checkIcon if hex value is light 1`]
     }
   />
   <span
-    className="emotion-5 emotion-6"
+    className="emotion-6 emotion-7"
   >
     #
   </span>
@@ -190,11 +190,11 @@ exports[`ColorInput Snapshots renders a dark checkIcon if hex value is light 1`]
 `;
 
 exports[`ColorInput Snapshots renders a disabled input 1`] = `
-.emotion-6 {
+.emotion-7 {
   position: relative;
 }
 
-.emotion-2 {
+.emotion-3 {
   position: absolute;
   cursor: pointer;
   height: 20px;
@@ -296,7 +296,7 @@ exports[`ColorInput Snapshots renders a disabled input 1`] = `
   color: transparent;
 }
 
-.emotion-4 {
+.emotion-5 {
   position: absolute;
   left: 36px;
   top: 10px;
@@ -309,10 +309,10 @@ exports[`ColorInput Snapshots renders a disabled input 1`] = `
 }
 
 <div
-  className="emotion-6 emotion-7"
+  className="emotion-7 emotion-8"
 >
   <input
-    className="emotion-0 emotion-1"
+    className="emotion-0 emotion-1 emotion-2"
     disabled={true}
     maxLength={7}
     onChange={[Function]}
@@ -322,7 +322,7 @@ exports[`ColorInput Snapshots renders a disabled input 1`] = `
     value="ffffff"
   />
   <div
-    className="emotion-2 emotion-3"
+    className="emotion-3 emotion-4"
     style={
       Object {
         "backgroundColor": "#ffffff",
@@ -330,7 +330,7 @@ exports[`ColorInput Snapshots renders a disabled input 1`] = `
     }
   />
   <span
-    className="emotion-4 emotion-5"
+    className="emotion-5 emotion-6"
     disabled={true}
   >
     #
@@ -339,6 +339,195 @@ exports[`ColorInput Snapshots renders a disabled input 1`] = `
 `;
 
 exports[`ColorInput Snapshots renders a light checkIcon if hex value is dark 1`] = `
+.emotion-8 {
+  position: relative;
+}
+
+.emotion-1 {
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
+  color: #494949;
+  font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
+  border: 1px solid #7b858f;
+  display: block;
+  background-color: #ffffff;
+  border-radius: 4px;
+  box-sizing: border-box;
+  height: 40px;
+  min-width: 280px;
+  -webkit-transition: 0.2s box-shadow,0.2s border-color;
+  transition: 0.2s box-shadow,0.2s border-color;
+  padding: 8px;
+  box-sizing: border-box;
+  padding-left: 46px;
+  min-width: 116px;
+  width: 116px;
+  background-color: px;
+}
+
+.emotion-1::-webkit-input-placeholder {
+  color: #5e6a75;
+}
+
+.emotion-1::-moz-placeholder {
+  color: #5e6a75;
+}
+
+.emotion-1:-ms-input-placeholder {
+  color: #5e6a75;
+}
+
+.emotion-1::placeholder {
+  color: #5e6a75;
+}
+
+.emotion-1:hover {
+  border-color: #333d47;
+}
+
+.emotion-1:focus:not([disabled]) {
+  border-color: #0875e1;
+  box-shadow: inset 0 0 0 1px #0875e1;
+  outline: none;
+}
+
+.emotion-1:disabled {
+  background-color: #f6f7f8;
+  border-color: #b9c0c7;
+  color: #a1aab3;
+}
+
+.emotion-1:disabled::-webkit-input-placeholder {
+  color: #a1aab3;
+}
+
+.emotion-1:disabled::-moz-placeholder {
+  color: #a1aab3;
+}
+
+.emotion-1:disabled:-ms-input-placeholder {
+  color: #a1aab3;
+}
+
+.emotion-1:disabled::placeholder {
+  color: #a1aab3;
+}
+
+.emotion-1:focus::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.emotion-1:focus::-moz-placeholder {
+  color: transparent;
+}
+
+.emotion-1:focus:-ms-input-placeholder {
+  color: transparent;
+}
+
+.emotion-1:focus::placeholder {
+  color: transparent;
+}
+
+.emotion-3 {
+  position: absolute;
+  cursor: pointer;
+  height: 20px;
+  width: 20px;
+  top: 0px;
+  bottom: 0px;
+  left: 8px;
+  margin: auto;
+  margin-top: 10px;
+  box-shadow: inset 0 0 0 1px rgba(0,0,0,0.25);
+  pointer-events: none;
+  border-radius: 2px;
+}
+
+.emotion-6 {
+  position: absolute;
+  left: 36px;
+  top: 10px;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
+  color: #5e6a75;
+  font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
+}
+
+.emotion-5 {
+  display: inline-block;
+  position: absolute;
+  left: 6px;
+  top: 8px;
+}
+
+.emotion-5 svg {
+  display: block;
+}
+
+.emotion-5 .wd-icon-fill {
+  fill: #ffffff;
+}
+
+.emotion-5:hover .wd-icon-fill {
+  fill: #ffffff;
+}
+
+.emotion-5 .wd-icon-accent {
+  fill: #7b858f;
+}
+
+.emotion-5:hover .wd-icon-accent {
+  fill: #333d47;
+}
+
+.emotion-5 .wd-icon-background {
+  fill: transparent;
+}
+
+.emotion-5:hover .wd-icon-background {
+  fill: transparent;
+}
+
+<div
+  className="emotion-8 emotion-9"
+>
+  <input
+    className="emotion-0 emotion-1 emotion-2"
+    maxLength={7}
+    onChange={[Function]}
+    placeholder="FFFFFF"
+    spellCheck={false}
+    type="text"
+    value="e6e"
+  />
+  <div
+    className="emotion-3 emotion-4"
+    style={
+      Object {
+        "backgroundColor": "#e6e",
+      }
+    }
+  />
+  <span
+    className="emotion-5"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"24\\" height=\\"24\\" class=\\"wd-icon-check-small wd-icon\\" focusable=\\"false\\" role=\\"presentation\\" viewBox=\\"0 0 24 24\\"><g fill-rule=\\"evenodd\\" class=\\"wd-icon-container\\"><path fill-rule=\\"nonzero\\" d=\\"M17.314 6.828l1.06 1.061a.5.5 0 0 1 0 .707l-7.778 7.778a.5.5 0 0 1-.707 0L6.354 12.84a.5.5 0 0 1 0-.707l1.06-1.06a.5.5 0 0 1 .707 0l2.122 2.12 6.364-6.364a.5.5 0 0 1 .707 0z\\" class=\\"wd-icon-fill\\"/></g></svg>",
+      }
+    }
+  />
+  <span
+    className="emotion-6 emotion-7"
+  >
+    #
+  </span>
+</div>
+`;
+
+exports[`ColorInput Snapshots renders as expected 1`] = `
 .emotion-7 {
   position: relative;
 }
@@ -430,7 +619,7 @@ exports[`ColorInput Snapshots renders a light checkIcon if hex value is dark 1`]
   color: transparent;
 }
 
-.emotion-2 {
+.emotion-3 {
   position: absolute;
   cursor: pointer;
   height: 20px;
@@ -456,66 +645,23 @@ exports[`ColorInput Snapshots renders a light checkIcon if hex value is dark 1`]
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-4 {
-  display: inline-block;
-  position: absolute;
-  left: 6px;
-  top: 8px;
-}
-
-.emotion-4 svg {
-  display: block;
-}
-
-.emotion-4 .wd-icon-fill {
-  fill: #ffffff;
-}
-
-.emotion-4:hover .wd-icon-fill {
-  fill: #ffffff;
-}
-
-.emotion-4 .wd-icon-accent {
-  fill: #7b858f;
-}
-
-.emotion-4:hover .wd-icon-accent {
-  fill: #333d47;
-}
-
-.emotion-4 .wd-icon-background {
-  fill: transparent;
-}
-
-.emotion-4:hover .wd-icon-background {
-  fill: transparent;
-}
-
 <div
   className="emotion-7 emotion-8"
 >
   <input
-    className="emotion-0 emotion-1"
+    className="emotion-0 emotion-1 emotion-2"
     maxLength={7}
     onChange={[Function]}
     placeholder="FFFFFF"
     spellCheck={false}
     type="text"
-    value="e6e"
+    value=""
   />
   <div
-    className="emotion-2 emotion-3"
+    className="emotion-3 emotion-4"
     style={
       Object {
-        "backgroundColor": "#e6e",
-      }
-    }
-  />
-  <span
-    className="emotion-4"
-    dangerouslySetInnerHTML={
-      Object {
-        "__html": "<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"24\\" height=\\"24\\" class=\\"wd-icon-check-small wd-icon\\" focusable=\\"false\\" role=\\"presentation\\" viewBox=\\"0 0 24 24\\"><g fill-rule=\\"evenodd\\" class=\\"wd-icon-container\\"><path fill-rule=\\"nonzero\\" d=\\"M17.314 6.828l1.06 1.061a.5.5 0 0 1 0 .707l-7.778 7.778a.5.5 0 0 1-.707 0L6.354 12.84a.5.5 0 0 1 0-.707l1.06-1.06a.5.5 0 0 1 .707 0l2.122 2.12 6.364-6.364a.5.5 0 0 1 .707 0z\\" class=\\"wd-icon-fill\\"/></g></svg>",
+        "backgroundColor": "",
       }
     }
   />
@@ -527,154 +673,8 @@ exports[`ColorInput Snapshots renders a light checkIcon if hex value is dark 1`]
 </div>
 `;
 
-exports[`ColorInput Snapshots renders as expected 1`] = `
-.emotion-6 {
-  position: relative;
-}
-
-.emotion-1 {
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 400;
-  color: #494949;
-  font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
-  border: 1px solid #7b858f;
-  display: block;
-  background-color: #ffffff;
-  border-radius: 4px;
-  box-sizing: border-box;
-  height: 40px;
-  min-width: 280px;
-  -webkit-transition: 0.2s box-shadow,0.2s border-color;
-  transition: 0.2s box-shadow,0.2s border-color;
-  padding: 8px;
-  box-sizing: border-box;
-  padding-left: 46px;
-  min-width: 116px;
-  width: 116px;
-  background-color: px;
-}
-
-.emotion-1::-webkit-input-placeholder {
-  color: #5e6a75;
-}
-
-.emotion-1::-moz-placeholder {
-  color: #5e6a75;
-}
-
-.emotion-1:-ms-input-placeholder {
-  color: #5e6a75;
-}
-
-.emotion-1::placeholder {
-  color: #5e6a75;
-}
-
-.emotion-1:hover {
-  border-color: #333d47;
-}
-
-.emotion-1:focus:not([disabled]) {
-  border-color: #0875e1;
-  box-shadow: inset 0 0 0 1px #0875e1;
-  outline: none;
-}
-
-.emotion-1:disabled {
-  background-color: #f6f7f8;
-  border-color: #b9c0c7;
-  color: #a1aab3;
-}
-
-.emotion-1:disabled::-webkit-input-placeholder {
-  color: #a1aab3;
-}
-
-.emotion-1:disabled::-moz-placeholder {
-  color: #a1aab3;
-}
-
-.emotion-1:disabled:-ms-input-placeholder {
-  color: #a1aab3;
-}
-
-.emotion-1:disabled::placeholder {
-  color: #a1aab3;
-}
-
-.emotion-1:focus::-webkit-input-placeholder {
-  color: transparent;
-}
-
-.emotion-1:focus::-moz-placeholder {
-  color: transparent;
-}
-
-.emotion-1:focus:-ms-input-placeholder {
-  color: transparent;
-}
-
-.emotion-1:focus::placeholder {
-  color: transparent;
-}
-
-.emotion-2 {
-  position: absolute;
-  cursor: pointer;
-  height: 20px;
-  width: 20px;
-  top: 0px;
-  bottom: 0px;
-  left: 8px;
-  margin: auto;
-  margin-top: 10px;
-  box-shadow: inset 0 0 0 1px rgba(0,0,0,0.25);
-  pointer-events: none;
-  border-radius: 2px;
-}
-
-.emotion-4 {
-  position: absolute;
-  left: 36px;
-  top: 10px;
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 400;
-  color: #5e6a75;
-  font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
-}
-
-<div
-  className="emotion-6 emotion-7"
->
-  <input
-    className="emotion-0 emotion-1"
-    maxLength={7}
-    onChange={[Function]}
-    placeholder="FFFFFF"
-    spellCheck={false}
-    type="text"
-    value=""
-  />
-  <div
-    className="emotion-2 emotion-3"
-    style={
-      Object {
-        "backgroundColor": "",
-      }
-    }
-  />
-  <span
-    className="emotion-4 emotion-5"
-  >
-    #
-  </span>
-</div>
-`;
-
 exports[`ColorInput Snapshots renders valid empty color input 1`] = `
-.emotion-6 {
+.emotion-7 {
   position: relative;
 }
 
@@ -765,7 +765,7 @@ exports[`ColorInput Snapshots renders valid empty color input 1`] = `
   color: transparent;
 }
 
-.emotion-2 {
+.emotion-3 {
   position: absolute;
   cursor: pointer;
   height: 20px;
@@ -780,7 +780,7 @@ exports[`ColorInput Snapshots renders valid empty color input 1`] = `
   border-radius: 2px;
 }
 
-.emotion-4 {
+.emotion-5 {
   position: absolute;
   left: 36px;
   top: 10px;
@@ -792,10 +792,10 @@ exports[`ColorInput Snapshots renders valid empty color input 1`] = `
 }
 
 <div
-  className="emotion-6 emotion-7"
+  className="emotion-7 emotion-8"
 >
   <input
-    className="emotion-0 emotion-1"
+    className="emotion-0 emotion-1 emotion-2"
     disabled={false}
     maxLength={7}
     onChange={[Function]}
@@ -805,7 +805,7 @@ exports[`ColorInput Snapshots renders valid empty color input 1`] = `
     value=""
   />
   <div
-    className="emotion-2 emotion-3"
+    className="emotion-3 emotion-4"
     style={
       Object {
         "backgroundColor": "",
@@ -813,7 +813,7 @@ exports[`ColorInput Snapshots renders valid empty color input 1`] = `
     }
   />
   <span
-    className="emotion-4 emotion-5"
+    className="emotion-5 emotion-6"
     disabled={false}
   >
     #
@@ -822,7 +822,7 @@ exports[`ColorInput Snapshots renders valid empty color input 1`] = `
 `;
 
 exports[`ColorInput Snapshots renders with a selected color 1`] = `
-.emotion-6 {
+.emotion-7 {
   position: relative;
 }
 
@@ -913,7 +913,7 @@ exports[`ColorInput Snapshots renders with a selected color 1`] = `
   color: transparent;
 }
 
-.emotion-2 {
+.emotion-3 {
   position: absolute;
   cursor: pointer;
   height: 20px;
@@ -928,7 +928,7 @@ exports[`ColorInput Snapshots renders with a selected color 1`] = `
   border-radius: 2px;
 }
 
-.emotion-4 {
+.emotion-5 {
   position: absolute;
   left: 36px;
   top: 10px;
@@ -940,10 +940,10 @@ exports[`ColorInput Snapshots renders with a selected color 1`] = `
 }
 
 <div
-  className="emotion-6 emotion-7"
+  className="emotion-7 emotion-8"
 >
   <input
-    className="emotion-0 emotion-1"
+    className="emotion-0 emotion-1 emotion-2"
     maxLength={7}
     onChange={[Function]}
     placeholder="FFFFFF"
@@ -952,7 +952,7 @@ exports[`ColorInput Snapshots renders with a selected color 1`] = `
     value="e6e"
   />
   <div
-    className="emotion-2 emotion-3"
+    className="emotion-3 emotion-4"
     style={
       Object {
         "backgroundColor": "#e6e",
@@ -960,7 +960,7 @@ exports[`ColorInput Snapshots renders with a selected color 1`] = `
     }
   />
   <span
-    className="emotion-4 emotion-5"
+    className="emotion-5 emotion-6"
   >
     #
   </span>
@@ -968,7 +968,7 @@ exports[`ColorInput Snapshots renders with a selected color 1`] = `
 `;
 
 exports[`ColorInput Snapshots renders with a selected color without # 1`] = `
-.emotion-6 {
+.emotion-7 {
   position: relative;
 }
 
@@ -1059,7 +1059,7 @@ exports[`ColorInput Snapshots renders with a selected color without # 1`] = `
   color: transparent;
 }
 
-.emotion-2 {
+.emotion-3 {
   position: absolute;
   cursor: pointer;
   height: 20px;
@@ -1074,7 +1074,7 @@ exports[`ColorInput Snapshots renders with a selected color without # 1`] = `
   border-radius: 2px;
 }
 
-.emotion-4 {
+.emotion-5 {
   position: absolute;
   left: 36px;
   top: 10px;
@@ -1086,10 +1086,10 @@ exports[`ColorInput Snapshots renders with a selected color without # 1`] = `
 }
 
 <div
-  className="emotion-6 emotion-7"
+  className="emotion-7 emotion-8"
 >
   <input
-    className="emotion-0 emotion-1"
+    className="emotion-0 emotion-1 emotion-2"
     maxLength={7}
     onChange={[Function]}
     placeholder="FFFFFF"
@@ -1098,7 +1098,7 @@ exports[`ColorInput Snapshots renders with a selected color without # 1`] = `
     value="e6e"
   />
   <div
-    className="emotion-2 emotion-3"
+    className="emotion-3 emotion-4"
     style={
       Object {
         "backgroundColor": "#e6e",
@@ -1106,7 +1106,7 @@ exports[`ColorInput Snapshots renders with a selected color without # 1`] = `
     }
   />
   <span
-    className="emotion-4 emotion-5"
+    className="emotion-5 emotion-6"
   >
     #
   </span>

--- a/modules/color-picker/react/spec/__snapshots__/ColorPreview.snapshot.spec.tsx.snap
+++ b/modules/color-picker/react/spec/__snapshots__/ColorPreview.snapshot.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ColorPreview Snapshots renders as expected 1`] = `
-.emotion-8 {
+.emotion-7 {
   position: relative;
 }
 
@@ -95,7 +95,7 @@ exports[`ColorPreview Snapshots renders as expected 1`] = `
   color: transparent;
 }
 
-.emotion-4 {
+.emotion-3 {
   position: absolute;
   cursor: pointer;
   height: 20px;
@@ -110,7 +110,7 @@ exports[`ColorPreview Snapshots renders as expected 1`] = `
   border-radius: 2px;
 }
 
-.emotion-6 {
+.emotion-5 {
   position: absolute;
   left: 36px;
   top: 10px;
@@ -122,10 +122,10 @@ exports[`ColorPreview Snapshots renders as expected 1`] = `
 }
 
 <div
-  className="emotion-8 emotion-9"
+  className="emotion-7 emotion-8"
 >
   <input
-    className="emotion-0 emotion-1 emotion-2 emotion-3"
+    className="emotion-0 emotion-1 emotion-2"
     maxLength={7}
     onChange={[Function]}
     placeholder=""
@@ -135,7 +135,7 @@ exports[`ColorPreview Snapshots renders as expected 1`] = `
     value=""
   />
   <div
-    className="emotion-4 emotion-5"
+    className="emotion-3 emotion-4"
     style={
       Object {
         "backgroundColor": "",
@@ -143,7 +143,7 @@ exports[`ColorPreview Snapshots renders as expected 1`] = `
     }
   />
   <span
-    className="emotion-6 emotion-7"
+    className="emotion-5 emotion-6"
   >
     #
   </span>
@@ -151,7 +151,7 @@ exports[`ColorPreview Snapshots renders as expected 1`] = `
 `;
 
 exports[`ColorPreview Snapshots renders valid empty color input 1`] = `
-.emotion-8 {
+.emotion-7 {
   position: relative;
 }
 
@@ -245,7 +245,7 @@ exports[`ColorPreview Snapshots renders valid empty color input 1`] = `
   color: transparent;
 }
 
-.emotion-4 {
+.emotion-3 {
   position: absolute;
   cursor: pointer;
   height: 20px;
@@ -260,7 +260,7 @@ exports[`ColorPreview Snapshots renders valid empty color input 1`] = `
   border-radius: 2px;
 }
 
-.emotion-6 {
+.emotion-5 {
   position: absolute;
   left: 36px;
   top: 10px;
@@ -272,10 +272,10 @@ exports[`ColorPreview Snapshots renders valid empty color input 1`] = `
 }
 
 <div
-  className="emotion-8 emotion-9"
+  className="emotion-7 emotion-8"
 >
   <input
-    className="emotion-0 emotion-1 emotion-2 emotion-3"
+    className="emotion-0 emotion-1 emotion-2"
     maxLength={7}
     onChange={[Function]}
     placeholder=""
@@ -285,7 +285,7 @@ exports[`ColorPreview Snapshots renders valid empty color input 1`] = `
     value=""
   />
   <div
-    className="emotion-4 emotion-5"
+    className="emotion-3 emotion-4"
     style={
       Object {
         "backgroundColor": "",
@@ -293,7 +293,7 @@ exports[`ColorPreview Snapshots renders valid empty color input 1`] = `
     }
   />
   <span
-    className="emotion-6 emotion-7"
+    className="emotion-5 emotion-6"
   >
     #
   </span>
@@ -301,7 +301,7 @@ exports[`ColorPreview Snapshots renders valid empty color input 1`] = `
 `;
 
 exports[`ColorPreview Snapshots renders with a selected color 1`] = `
-.emotion-8 {
+.emotion-7 {
   position: relative;
 }
 
@@ -395,7 +395,7 @@ exports[`ColorPreview Snapshots renders with a selected color 1`] = `
   color: transparent;
 }
 
-.emotion-4 {
+.emotion-3 {
   position: absolute;
   cursor: pointer;
   height: 20px;
@@ -410,7 +410,7 @@ exports[`ColorPreview Snapshots renders with a selected color 1`] = `
   border-radius: 2px;
 }
 
-.emotion-6 {
+.emotion-5 {
   position: absolute;
   left: 36px;
   top: 10px;
@@ -422,10 +422,10 @@ exports[`ColorPreview Snapshots renders with a selected color 1`] = `
 }
 
 <div
-  className="emotion-8 emotion-9"
+  className="emotion-7 emotion-8"
 >
   <input
-    className="emotion-0 emotion-1 emotion-2 emotion-3"
+    className="emotion-0 emotion-1 emotion-2"
     maxLength={7}
     onChange={[Function]}
     placeholder=""
@@ -435,7 +435,7 @@ exports[`ColorPreview Snapshots renders with a selected color 1`] = `
     value="e6e"
   />
   <div
-    className="emotion-4 emotion-5"
+    className="emotion-3 emotion-4"
     style={
       Object {
         "backgroundColor": "#e6e",
@@ -443,7 +443,7 @@ exports[`ColorPreview Snapshots renders with a selected color 1`] = `
     }
   />
   <span
-    className="emotion-6 emotion-7"
+    className="emotion-5 emotion-6"
   >
     #
   </span>
@@ -451,7 +451,7 @@ exports[`ColorPreview Snapshots renders with a selected color 1`] = `
 `;
 
 exports[`ColorPreview Snapshots renders with a selected color with # 1`] = `
-.emotion-8 {
+.emotion-7 {
   position: relative;
 }
 
@@ -545,7 +545,7 @@ exports[`ColorPreview Snapshots renders with a selected color with # 1`] = `
   color: transparent;
 }
 
-.emotion-4 {
+.emotion-3 {
   position: absolute;
   cursor: pointer;
   height: 20px;
@@ -560,7 +560,7 @@ exports[`ColorPreview Snapshots renders with a selected color with # 1`] = `
   border-radius: 2px;
 }
 
-.emotion-6 {
+.emotion-5 {
   position: absolute;
   left: 36px;
   top: 10px;
@@ -572,10 +572,10 @@ exports[`ColorPreview Snapshots renders with a selected color with # 1`] = `
 }
 
 <div
-  className="emotion-8 emotion-9"
+  className="emotion-7 emotion-8"
 >
   <input
-    className="emotion-0 emotion-1 emotion-2 emotion-3"
+    className="emotion-0 emotion-1 emotion-2"
     maxLength={7}
     onChange={[Function]}
     placeholder=""
@@ -585,7 +585,7 @@ exports[`ColorPreview Snapshots renders with a selected color with # 1`] = `
     value="e6e"
   />
   <div
-    className="emotion-4 emotion-5"
+    className="emotion-3 emotion-4"
     style={
       Object {
         "backgroundColor": "#e6e",
@@ -593,7 +593,7 @@ exports[`ColorPreview Snapshots renders with a selected color with # 1`] = `
     }
   />
   <span
-    className="emotion-6 emotion-7"
+    className="emotion-5 emotion-6"
   >
     #
   </span>

--- a/modules/color-picker/react/spec/__snapshots__/ColorPreview.snapshot.spec.tsx.snap
+++ b/modules/color-picker/react/spec/__snapshots__/ColorPreview.snapshot.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ColorPreview Snapshots renders as expected 1`] = `
-.emotion-7 {
+.emotion-8 {
   position: relative;
 }
 
@@ -95,7 +95,7 @@ exports[`ColorPreview Snapshots renders as expected 1`] = `
   color: transparent;
 }
 
-.emotion-3 {
+.emotion-4 {
   position: absolute;
   cursor: pointer;
   height: 20px;
@@ -110,7 +110,7 @@ exports[`ColorPreview Snapshots renders as expected 1`] = `
   border-radius: 2px;
 }
 
-.emotion-5 {
+.emotion-6 {
   position: absolute;
   left: 36px;
   top: 10px;
@@ -122,10 +122,10 @@ exports[`ColorPreview Snapshots renders as expected 1`] = `
 }
 
 <div
-  className="emotion-7 emotion-8"
+  className="emotion-8 emotion-9"
 >
   <input
-    className="emotion-0 emotion-1 emotion-2"
+    className="emotion-0 emotion-1 emotion-2 emotion-3"
     maxLength={7}
     onChange={[Function]}
     placeholder=""
@@ -135,7 +135,7 @@ exports[`ColorPreview Snapshots renders as expected 1`] = `
     value=""
   />
   <div
-    className="emotion-3 emotion-4"
+    className="emotion-4 emotion-5"
     style={
       Object {
         "backgroundColor": "",
@@ -143,7 +143,7 @@ exports[`ColorPreview Snapshots renders as expected 1`] = `
     }
   />
   <span
-    className="emotion-5 emotion-6"
+    className="emotion-6 emotion-7"
   >
     #
   </span>
@@ -151,7 +151,7 @@ exports[`ColorPreview Snapshots renders as expected 1`] = `
 `;
 
 exports[`ColorPreview Snapshots renders valid empty color input 1`] = `
-.emotion-7 {
+.emotion-8 {
   position: relative;
 }
 
@@ -245,7 +245,7 @@ exports[`ColorPreview Snapshots renders valid empty color input 1`] = `
   color: transparent;
 }
 
-.emotion-3 {
+.emotion-4 {
   position: absolute;
   cursor: pointer;
   height: 20px;
@@ -260,7 +260,7 @@ exports[`ColorPreview Snapshots renders valid empty color input 1`] = `
   border-radius: 2px;
 }
 
-.emotion-5 {
+.emotion-6 {
   position: absolute;
   left: 36px;
   top: 10px;
@@ -272,10 +272,10 @@ exports[`ColorPreview Snapshots renders valid empty color input 1`] = `
 }
 
 <div
-  className="emotion-7 emotion-8"
+  className="emotion-8 emotion-9"
 >
   <input
-    className="emotion-0 emotion-1 emotion-2"
+    className="emotion-0 emotion-1 emotion-2 emotion-3"
     maxLength={7}
     onChange={[Function]}
     placeholder=""
@@ -285,7 +285,7 @@ exports[`ColorPreview Snapshots renders valid empty color input 1`] = `
     value=""
   />
   <div
-    className="emotion-3 emotion-4"
+    className="emotion-4 emotion-5"
     style={
       Object {
         "backgroundColor": "",
@@ -293,7 +293,7 @@ exports[`ColorPreview Snapshots renders valid empty color input 1`] = `
     }
   />
   <span
-    className="emotion-5 emotion-6"
+    className="emotion-6 emotion-7"
   >
     #
   </span>
@@ -301,7 +301,7 @@ exports[`ColorPreview Snapshots renders valid empty color input 1`] = `
 `;
 
 exports[`ColorPreview Snapshots renders with a selected color 1`] = `
-.emotion-7 {
+.emotion-8 {
   position: relative;
 }
 
@@ -395,7 +395,7 @@ exports[`ColorPreview Snapshots renders with a selected color 1`] = `
   color: transparent;
 }
 
-.emotion-3 {
+.emotion-4 {
   position: absolute;
   cursor: pointer;
   height: 20px;
@@ -410,7 +410,7 @@ exports[`ColorPreview Snapshots renders with a selected color 1`] = `
   border-radius: 2px;
 }
 
-.emotion-5 {
+.emotion-6 {
   position: absolute;
   left: 36px;
   top: 10px;
@@ -422,10 +422,10 @@ exports[`ColorPreview Snapshots renders with a selected color 1`] = `
 }
 
 <div
-  className="emotion-7 emotion-8"
+  className="emotion-8 emotion-9"
 >
   <input
-    className="emotion-0 emotion-1 emotion-2"
+    className="emotion-0 emotion-1 emotion-2 emotion-3"
     maxLength={7}
     onChange={[Function]}
     placeholder=""
@@ -435,7 +435,7 @@ exports[`ColorPreview Snapshots renders with a selected color 1`] = `
     value="e6e"
   />
   <div
-    className="emotion-3 emotion-4"
+    className="emotion-4 emotion-5"
     style={
       Object {
         "backgroundColor": "#e6e",
@@ -443,7 +443,7 @@ exports[`ColorPreview Snapshots renders with a selected color 1`] = `
     }
   />
   <span
-    className="emotion-5 emotion-6"
+    className="emotion-6 emotion-7"
   >
     #
   </span>
@@ -451,7 +451,7 @@ exports[`ColorPreview Snapshots renders with a selected color 1`] = `
 `;
 
 exports[`ColorPreview Snapshots renders with a selected color with # 1`] = `
-.emotion-7 {
+.emotion-8 {
   position: relative;
 }
 
@@ -545,7 +545,7 @@ exports[`ColorPreview Snapshots renders with a selected color with # 1`] = `
   color: transparent;
 }
 
-.emotion-3 {
+.emotion-4 {
   position: absolute;
   cursor: pointer;
   height: 20px;
@@ -560,7 +560,7 @@ exports[`ColorPreview Snapshots renders with a selected color with # 1`] = `
   border-radius: 2px;
 }
 
-.emotion-5 {
+.emotion-6 {
   position: absolute;
   left: 36px;
   top: 10px;
@@ -572,10 +572,10 @@ exports[`ColorPreview Snapshots renders with a selected color with # 1`] = `
 }
 
 <div
-  className="emotion-7 emotion-8"
+  className="emotion-8 emotion-9"
 >
   <input
-    className="emotion-0 emotion-1 emotion-2"
+    className="emotion-0 emotion-1 emotion-2 emotion-3"
     maxLength={7}
     onChange={[Function]}
     placeholder=""
@@ -585,7 +585,7 @@ exports[`ColorPreview Snapshots renders with a selected color with # 1`] = `
     value="e6e"
   />
   <div
-    className="emotion-3 emotion-4"
+    className="emotion-4 emotion-5"
     style={
       Object {
         "backgroundColor": "#e6e",
@@ -593,7 +593,7 @@ exports[`ColorPreview Snapshots renders with a selected color with # 1`] = `
     }
   />
   <span
-    className="emotion-5 emotion-6"
+    className="emotion-6 emotion-7"
   >
     #
   </span>

--- a/modules/common/css/lib/errors.scss
+++ b/modules/common/css/lib/errors.scss
@@ -251,7 +251,7 @@
   }
 
   .wdc-form-group &.wdc-form-group-fields {
-    border-radius: 4px;
+    border-radius: $wdc-border-radius-m;
     box-shadow: $_boxShadow;
     box-sizing: border-box;
     display: inline-block;

--- a/modules/common/css/lib/forms.scss
+++ b/modules/common/css/lib/forms.scss
@@ -63,7 +63,7 @@
   min-height: $wdc-spacing-s + $wdc-spacing-xxxs;
 
   input {
-    border-radius: 2px;
+    border-radius: $wdc-border-radius-s;
     width: $wdc-spacing-m;
     height: $wdc-spacing-m;
     margin: 0;
@@ -91,7 +91,7 @@
         content: '';
         display: inline-block;
         background-color: $wdc-color-french-vanilla-100;
-        border-radius: 2px;
+        border-radius: $wdc-border-radius-s;
         border: 1px solid $wdc-color-licorice-200;
         box-sizing: border-box;
         width: $wdc-form-selection-control-size;
@@ -107,7 +107,7 @@
         content: '';
         display: inline-block;
         position: absolute;
-        border-radius: 16px;
+        border-radius: $wdc-border-radius-circle;
         margin-top: 1px;
         left: -30px;
         width: $wdc-form-selection-control-size;

--- a/modules/core/css/README.md
+++ b/modules/core/css/README.md
@@ -77,6 +77,19 @@ Licorice
 French Vanilla  
 Black Pepper
 
+## Border Radius
+
+Border Radius variables in t-shirt size format. Spacing values are in `px` format, except for
+`cicle` which is in percentage.
+
+| Variable              | Size |
+| --------------------- | ---- |
+| `$wdc-spacing-zero`   | 0    |
+| `$wdc-spacing-s`      | 2px  |
+| `$wdc-spacing-m`      | 4px  |
+| `$wdc-spacing-l`      | 8px  |
+| `$wdc-spacing-circle` | 100% |
+
 ## Spacing
 
 Spacing variables in t-shirt size format. Spacing values are in `px` format.

--- a/modules/core/css/README.md
+++ b/modules/core/css/README.md
@@ -79,16 +79,15 @@ Black Pepper
 
 ## Border Radius
 
-Border Radius variables in t-shirt size format. Spacing values are in `px` format, except for
-`cicle` which is in percentage.
+Border Radius variables in t-shirt size format. Spacing values are in `px` format.
 
-| Variable              | Size |
-| --------------------- | ---- |
-| `$wdc-spacing-zero`   | 0    |
-| `$wdc-spacing-s`      | 2px  |
-| `$wdc-spacing-m`      | 4px  |
-| `$wdc-spacing-l`      | 8px  |
-| `$wdc-spacing-circle` | 100% |
+| Variable              | Size  |
+| --------------------- | ----- |
+| `$wdc-spacing-zero`   | 0     |
+| `$wdc-spacing-s`      | 2px   |
+| `$wdc-spacing-m`      | 4px   |
+| `$wdc-spacing-l`      | 8px   |
+| `$wdc-spacing-circle` | 999px |
 
 ## Spacing
 

--- a/modules/core/css/index.scss
+++ b/modules/core/css/index.scss
@@ -1,4 +1,5 @@
 @import './lib/assets.scss';
+@import './lib/border-radius.scss';
 @import './lib/breakpoints.scss';
 @import './lib/colors.scss';
 @import './lib/depth.scss';

--- a/modules/core/css/lib/border-radius.scss
+++ b/modules/core/css/lib/border-radius.scss
@@ -1,0 +1,2 @@
+// Border Radius
+@import 'variables/border-radius';

--- a/modules/core/css/lib/variables.scss
+++ b/modules/core/css/lib/variables.scss
@@ -1,4 +1,5 @@
 @import 'variables/assets';
+@import 'variables/border-radius';
 @import 'variables/breakpoints';
 @import 'variables/colors';
 @import 'variables/depth';

--- a/modules/core/css/lib/variables/border-radius.scss
+++ b/modules/core/css/lib/variables/border-radius.scss
@@ -4,4 +4,4 @@ $wdc-border-radius-zero: 0;
 $wdc-border-radius-s: 2px;
 $wdc-border-radius-m: 4px;
 $wdc-border-radius-l: 8px;
-$wdc-border-radius-circle: 100%;
+$wdc-border-radius-circle: 999px;

--- a/modules/core/css/lib/variables/border-radius.scss
+++ b/modules/core/css/lib/variables/border-radius.scss
@@ -1,0 +1,7 @@
+// Border Radius
+
+$wdc-border-radius-zero: 0;
+$wdc-border-radius-s: 2px;
+$wdc-border-radius-m: 4px;
+$wdc-border-radius-l: 8px;
+$wdc-border-radius-circle: 100%;

--- a/modules/core/css/stories.tsx
+++ b/modules/core/css/stories.tsx
@@ -11,7 +11,7 @@ storiesOf('CSS/Core', module)
       display: 'inline-block',
       background: '#667380',
       padding: '2px 8px',
-      borderRadius: '3px',
+      borderRadius: '4px',
       marginTop: 0,
     };
 

--- a/modules/core/react/README.md
+++ b/modules/core/react/README.md
@@ -5,6 +5,7 @@ Canvas Kit Core contains values and base styles that are shared across the kit.
 Includes:
 
 - [Colors](#colors)
+- [Border Radius](#border-radius)
 - [Spacing](#spacing)
 - [Depth](#depth)
 - [Type](#type)
@@ -96,6 +97,19 @@ import {iconColors} from '@workday/canvas-kit-react-core';
 
 iconColors.hover;
 ```
+
+# Border Radius
+
+Border Radius variables are in a "t-shirt size" format. Border Radius values are in `px` format
+(`spacing`), except for `cicle` which is in percentage.
+
+| Variable | Size (px) |
+| -------- | --------- |
+| `zero`   | `0`       |
+| `s`      | `'2px'`   |
+| `m`      | `'4px'`   |
+| `l`      | `'8px'`   |
+| `xxxl`   | `'100%'`  |
 
 # Spacing
 
@@ -375,8 +389,8 @@ handling.
 }
 ```
 
-We provide a [helper](../../common/react/lib/styles/hideMouseFocus.ts) to hide the focus
-outlines on mouse input. Simply spread it in your styles (i.e. `...hideMouseFocus`).
+We provide a [helper](../../common/react/lib/styles/hideMouseFocus.ts) to hide the focus outlines on
+mouse input. Simply spread it in your styles (i.e. `...hideMouseFocus`).
 
 **Note:** It is best practice to show focus outlines by default and specifically hide them in the
 cases you would like (i.e. mouse/touch/pointer input).

--- a/modules/core/react/README.md
+++ b/modules/core/react/README.md
@@ -100,8 +100,7 @@ iconColors.hover;
 
 # Border Radius
 
-Border Radius variables are in a "t-shirt size" format. Border Radius values are in `px` format
-(`spacing`), except for `cicle` which is in percentage.
+Border Radius variables are in a "t-shirt size" format. Border Radius values are in `px` format.
 
 | Variable | Size (px) |
 | -------- | --------- |
@@ -109,7 +108,7 @@ Border Radius variables are in a "t-shirt size" format. Border Radius values are
 | `s`      | `'2px'`   |
 | `m`      | `'4px'`   |
 | `l`      | `'8px'`   |
-| `xxxl`   | `'100%'`  |
+| `circle` | `'999px'` |
 
 # Spacing
 

--- a/modules/core/react/index.ts
+++ b/modules/core/react/index.ts
@@ -1,6 +1,7 @@
 import * as canvasColorsWeb from '@workday/canvas-colors-web';
 
 import beta_type from './lib/beta_type';
+import {borderRadius} from './lib/radius';
 import {BrandingColor, CanvasColor} from './lib/colors.types';
 import depth, {CanvasDepth, CanvasDepthValue} from './lib/depth';
 import InputProvider from './lib/InputProvider';
@@ -30,6 +31,7 @@ const canvas = {
 export * from './lib/TypeWrappers';
 export * from '@workday/canvas-colors-web';
 export {
+  borderRadius,
   colors,
   depth,
   spacing,

--- a/modules/core/react/lib/radius.ts
+++ b/modules/core/react/lib/radius.ts
@@ -1,0 +1,17 @@
+export interface CanvasBorderRadiusNumber {
+  zero: number;
+  s: number;
+  m: number;
+  l: number;
+  circle: string;
+}
+
+export const borderRadius: CanvasBorderRadiusNumber = {
+  zero: 0,
+  s: 2,
+  m: 4,
+  l: 8,
+  circle: '100%',
+};
+
+export default borderRadius;

--- a/modules/core/react/lib/radius.ts
+++ b/modules/core/react/lib/radius.ts
@@ -1,16 +1,16 @@
 export interface CanvasBorderRadiusNumber {
   zero: number;
-  s: number;
-  m: number;
-  l: number;
+  s: string;
+  m: string;
+  l: string;
   circle: string;
 }
 
 export const borderRadius: CanvasBorderRadiusNumber = {
   zero: 0,
-  s: 2,
-  m: 4,
-  l: 8,
+  s: '2px',
+  m: '4px',
+  l: '8px',
   circle: '100%',
 };
 

--- a/modules/core/react/lib/radius.ts
+++ b/modules/core/react/lib/radius.ts
@@ -1,4 +1,4 @@
-export interface CanvasBorderRadiusNumber {
+export interface CanvasBorderRadius {
   zero: number;
   s: string;
   m: string;
@@ -6,12 +6,12 @@ export interface CanvasBorderRadiusNumber {
   circle: string;
 }
 
-export const borderRadius: CanvasBorderRadiusNumber = {
+export const borderRadius: CanvasBorderRadius = {
   zero: 0,
   s: '2px',
   m: '4px',
   l: '8px',
-  circle: '100%',
+  circle: '999px',
 };
 
 export default borderRadius;

--- a/modules/core/react/spec/__snapshots__/type.snapshot.tsx.snap
+++ b/modules/core/react/spec/__snapshots__/type.snapshot.tsx.snap
@@ -9,7 +9,7 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-1 {
+.emotion-2 {
   font-size: 24px;
   line-height: 32px;
   font-weight: 700;
@@ -17,7 +17,7 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-2 {
+.emotion-4 {
   font-size: 20px;
   line-height: 28px;
   font-weight: 700;
@@ -25,7 +25,7 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-3 {
+.emotion-6 {
   font-size: 16px;
   line-height: 24px;
   font-weight: 700;
@@ -33,7 +33,7 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-4 {
+.emotion-8 {
   font-size: 16px;
   line-height: 24px;
   font-weight: 400;
@@ -41,7 +41,7 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-5 {
+.emotion-10 {
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
@@ -50,7 +50,7 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
   font-weight: 600;
 }
 
-.emotion-6 {
+.emotion-11 {
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
@@ -64,7 +64,7 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
   text-transform: uppercase;
 }
 
-.emotion-7 {
+.emotion-12 {
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
@@ -73,7 +73,7 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
   font-weight: 500;
 }
 
-.emotion-8 {
+.emotion-13 {
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
@@ -82,7 +82,7 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
   color: #5e6a75;
 }
 
-.emotion-9 {
+.emotion-14 {
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
@@ -91,7 +91,7 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
   color: #de2e21;
 }
 
-.emotion-10 {
+.emotion-15 {
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
@@ -103,21 +103,21 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
   cursor: pointer;
 }
 
-.emotion-10:hover,
-.emotion-10:active {
+.emotion-15:hover,
+.emotion-15:active {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0875e1;
 }
 
-.emotion-10:focus {
+.emotion-15:focus {
   background: #d7eafc;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   outline: 2px solid #d7eafc;
 }
 
-.emotion-11 {
+.emotion-16 {
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
@@ -130,7 +130,7 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
   border-radius: 3px;
 }
 
-.emotion-12 {
+.emotion-17 {
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
@@ -168,27 +168,27 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
   </h1>
   <div>
     <h1
-      className="emotion-0"
+      className="emotion-0 emotion-1"
     >
       H1 Header
     </h1>
     <h2
-      className="emotion-1"
+      className="emotion-2 emotion-3"
     >
       H2 Header
     </h2>
     <h3
-      className="emotion-2"
+      className="emotion-4 emotion-5"
     >
       H3 Header
     </h3>
     <h4
-      className="emotion-3"
+      className="emotion-6 emotion-7"
     >
       H4 Header
     </h4>
     <h5
-      className="emotion-4"
+      className="emotion-8 emotion-9"
     >
       H5 Header
     </h5>
@@ -320,50 +320,50 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
       Variants
     </h3>
     <span
-      className="emotion-5"
+      className="emotion-10"
     >
       Button Text
     </span>
     <br />
     <span
-      className="emotion-6"
+      className="emotion-11"
     >
       Caps Text
     </span>
     <br />
     <label
-      className="emotion-7"
+      className="emotion-12"
     >
       Label Text
     </label>
     <br />
     <span
-      className="emotion-8"
+      className="emotion-13"
     >
       Hint Text
     </span>
     <br />
     <span
-      className="emotion-9"
+      className="emotion-14"
     >
       Error Text
     </span>
     <br />
     <a
-      className="emotion-10"
+      className="emotion-15"
       href="#"
     >
       Link Text
     </a>
     <br />
     <span
-      className="emotion-11"
+      className="emotion-16"
     >
       Inverse Text
     </span>
     <br />
     <span
-      className="emotion-12"
+      className="emotion-17"
     >
       Mono Text
     </span>
@@ -372,7 +372,7 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
 `;
 
 exports[`Type Snapshots renders current type hierarchy 1`] = `
-.emotion-5 {
+.emotion-10 {
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
@@ -381,7 +381,7 @@ exports[`Type Snapshots renders current type hierarchy 1`] = `
   font-weight: 500;
 }
 
-.emotion-6 {
+.emotion-11 {
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
@@ -391,7 +391,7 @@ exports[`Type Snapshots renders current type hierarchy 1`] = `
   text-transform: uppercase;
 }
 
-.emotion-8 {
+.emotion-13 {
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
@@ -400,7 +400,7 @@ exports[`Type Snapshots renders current type hierarchy 1`] = `
   color: #5e6a75;
 }
 
-.emotion-9 {
+.emotion-14 {
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
@@ -409,7 +409,7 @@ exports[`Type Snapshots renders current type hierarchy 1`] = `
   color: #de2e21;
 }
 
-.emotion-10 {
+.emotion-15 {
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
@@ -421,21 +421,21 @@ exports[`Type Snapshots renders current type hierarchy 1`] = `
   cursor: pointer;
 }
 
-.emotion-10:hover,
-.emotion-10:active {
+.emotion-15:hover,
+.emotion-15:active {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0875e1;
 }
 
-.emotion-10:focus {
+.emotion-15:focus {
   background: #d7eafc;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   outline: 2px solid #d7eafc;
 }
 
-.emotion-11 {
+.emotion-16 {
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
@@ -448,7 +448,7 @@ exports[`Type Snapshots renders current type hierarchy 1`] = `
   border-radius: 3px;
 }
 
-.emotion-12 {
+.emotion-17 {
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
@@ -465,7 +465,7 @@ exports[`Type Snapshots renders current type hierarchy 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-1 {
+.emotion-2 {
   font-size: 24px;
   line-height: 32px;
   font-weight: 700;
@@ -473,7 +473,7 @@ exports[`Type Snapshots renders current type hierarchy 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-2 {
+.emotion-4 {
   font-size: 20px;
   line-height: 28px;
   font-weight: 700;
@@ -481,7 +481,7 @@ exports[`Type Snapshots renders current type hierarchy 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-3 {
+.emotion-6 {
   font-size: 16px;
   line-height: 24px;
   font-weight: 700;
@@ -489,7 +489,7 @@ exports[`Type Snapshots renders current type hierarchy 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-4 {
+.emotion-8 {
   font-size: 16px;
   line-height: 24px;
   font-weight: 400;
@@ -526,27 +526,27 @@ exports[`Type Snapshots renders current type hierarchy 1`] = `
   </h1>
   <div>
     <h1
-      className="emotion-0"
+      className="emotion-0 emotion-1"
     >
       H1 Header
     </h1>
     <h2
-      className="emotion-1"
+      className="emotion-2 emotion-3"
     >
       H2 Header
     </h2>
     <h3
-      className="emotion-2"
+      className="emotion-4 emotion-5"
     >
       H3 Header
     </h3>
     <h4
-      className="emotion-3"
+      className="emotion-6 emotion-7"
     >
       H4 Header
     </h4>
     <h5
-      className="emotion-4"
+      className="emotion-8 emotion-9"
     >
       H5 Header
     </h5>
@@ -678,50 +678,50 @@ exports[`Type Snapshots renders current type hierarchy 1`] = `
       Variants
     </h3>
     <span
-      className="emotion-5"
+      className="emotion-10"
     >
       Button Text
     </span>
     <br />
     <span
-      className="emotion-6"
+      className="emotion-11"
     >
       Caps Text
     </span>
     <br />
     <label
-      className="emotion-5"
+      className="emotion-10"
     >
       Label Text
     </label>
     <br />
     <span
-      className="emotion-8"
+      className="emotion-13"
     >
       Hint Text
     </span>
     <br />
     <span
-      className="emotion-9"
+      className="emotion-14"
     >
       Error Text
     </span>
     <br />
     <a
-      className="emotion-10"
+      className="emotion-15"
       href="#"
     >
       Link Text
     </a>
     <br />
     <span
-      className="emotion-11"
+      className="emotion-16"
     >
       Inverse Text
     </span>
     <br />
     <span
-      className="emotion-12"
+      className="emotion-17"
     >
       Mono Text
     </span>

--- a/modules/core/react/spec/__snapshots__/type.snapshot.tsx.snap
+++ b/modules/core/react/spec/__snapshots__/type.snapshot.tsx.snap
@@ -9,7 +9,7 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-2 {
+.emotion-1 {
   font-size: 24px;
   line-height: 32px;
   font-weight: 700;
@@ -17,7 +17,7 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-4 {
+.emotion-2 {
   font-size: 20px;
   line-height: 28px;
   font-weight: 700;
@@ -25,7 +25,7 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-6 {
+.emotion-3 {
   font-size: 16px;
   line-height: 24px;
   font-weight: 700;
@@ -33,7 +33,7 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-8 {
+.emotion-4 {
   font-size: 16px;
   line-height: 24px;
   font-weight: 400;
@@ -41,7 +41,7 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-10 {
+.emotion-5 {
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
@@ -50,7 +50,7 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
   font-weight: 600;
 }
 
-.emotion-11 {
+.emotion-6 {
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
@@ -64,7 +64,7 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
   text-transform: uppercase;
 }
 
-.emotion-12 {
+.emotion-7 {
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
@@ -73,7 +73,7 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
   font-weight: 500;
 }
 
-.emotion-13 {
+.emotion-8 {
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
@@ -82,7 +82,7 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
   color: #5e6a75;
 }
 
-.emotion-14 {
+.emotion-9 {
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
@@ -91,7 +91,7 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
   color: #de2e21;
 }
 
-.emotion-15 {
+.emotion-10 {
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
@@ -103,21 +103,21 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
   cursor: pointer;
 }
 
-.emotion-15:hover,
-.emotion-15:active {
+.emotion-10:hover,
+.emotion-10:active {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0875e1;
 }
 
-.emotion-15:focus {
+.emotion-10:focus {
   background: #d7eafc;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   outline: 2px solid #d7eafc;
 }
 
-.emotion-16 {
+.emotion-11 {
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
@@ -130,7 +130,7 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
   border-radius: 3px;
 }
 
-.emotion-17 {
+.emotion-12 {
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
@@ -168,27 +168,27 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
   </h1>
   <div>
     <h1
-      className="emotion-0 emotion-1"
+      className="emotion-0"
     >
       H1 Header
     </h1>
     <h2
-      className="emotion-2 emotion-3"
+      className="emotion-1"
     >
       H2 Header
     </h2>
     <h3
-      className="emotion-4 emotion-5"
+      className="emotion-2"
     >
       H3 Header
     </h3>
     <h4
-      className="emotion-6 emotion-7"
+      className="emotion-3"
     >
       H4 Header
     </h4>
     <h5
-      className="emotion-8 emotion-9"
+      className="emotion-4"
     >
       H5 Header
     </h5>
@@ -320,50 +320,50 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
       Variants
     </h3>
     <span
-      className="emotion-10"
+      className="emotion-5"
     >
       Button Text
     </span>
     <br />
     <span
-      className="emotion-11"
+      className="emotion-6"
     >
       Caps Text
     </span>
     <br />
     <label
-      className="emotion-12"
+      className="emotion-7"
     >
       Label Text
     </label>
     <br />
     <span
-      className="emotion-13"
+      className="emotion-8"
     >
       Hint Text
     </span>
     <br />
     <span
-      className="emotion-14"
+      className="emotion-9"
     >
       Error Text
     </span>
     <br />
     <a
-      className="emotion-15"
+      className="emotion-10"
       href="#"
     >
       Link Text
     </a>
     <br />
     <span
-      className="emotion-16"
+      className="emotion-11"
     >
       Inverse Text
     </span>
     <br />
     <span
-      className="emotion-17"
+      className="emotion-12"
     >
       Mono Text
     </span>
@@ -372,7 +372,7 @@ exports[`Type Snapshots renders beta type hierarchy 1`] = `
 `;
 
 exports[`Type Snapshots renders current type hierarchy 1`] = `
-.emotion-10 {
+.emotion-5 {
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
@@ -381,7 +381,7 @@ exports[`Type Snapshots renders current type hierarchy 1`] = `
   font-weight: 500;
 }
 
-.emotion-11 {
+.emotion-6 {
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
@@ -391,7 +391,7 @@ exports[`Type Snapshots renders current type hierarchy 1`] = `
   text-transform: uppercase;
 }
 
-.emotion-13 {
+.emotion-8 {
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
@@ -400,7 +400,7 @@ exports[`Type Snapshots renders current type hierarchy 1`] = `
   color: #5e6a75;
 }
 
-.emotion-14 {
+.emotion-9 {
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
@@ -409,7 +409,7 @@ exports[`Type Snapshots renders current type hierarchy 1`] = `
   color: #de2e21;
 }
 
-.emotion-15 {
+.emotion-10 {
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
@@ -421,21 +421,21 @@ exports[`Type Snapshots renders current type hierarchy 1`] = `
   cursor: pointer;
 }
 
-.emotion-15:hover,
-.emotion-15:active {
+.emotion-10:hover,
+.emotion-10:active {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0875e1;
 }
 
-.emotion-15:focus {
+.emotion-10:focus {
   background: #d7eafc;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   outline: 2px solid #d7eafc;
 }
 
-.emotion-16 {
+.emotion-11 {
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
@@ -448,7 +448,7 @@ exports[`Type Snapshots renders current type hierarchy 1`] = `
   border-radius: 3px;
 }
 
-.emotion-17 {
+.emotion-12 {
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
@@ -465,7 +465,7 @@ exports[`Type Snapshots renders current type hierarchy 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-2 {
+.emotion-1 {
   font-size: 24px;
   line-height: 32px;
   font-weight: 700;
@@ -473,7 +473,7 @@ exports[`Type Snapshots renders current type hierarchy 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-4 {
+.emotion-2 {
   font-size: 20px;
   line-height: 28px;
   font-weight: 700;
@@ -481,7 +481,7 @@ exports[`Type Snapshots renders current type hierarchy 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-6 {
+.emotion-3 {
   font-size: 16px;
   line-height: 24px;
   font-weight: 700;
@@ -489,7 +489,7 @@ exports[`Type Snapshots renders current type hierarchy 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-8 {
+.emotion-4 {
   font-size: 16px;
   line-height: 24px;
   font-weight: 400;
@@ -526,27 +526,27 @@ exports[`Type Snapshots renders current type hierarchy 1`] = `
   </h1>
   <div>
     <h1
-      className="emotion-0 emotion-1"
+      className="emotion-0"
     >
       H1 Header
     </h1>
     <h2
-      className="emotion-2 emotion-3"
+      className="emotion-1"
     >
       H2 Header
     </h2>
     <h3
-      className="emotion-4 emotion-5"
+      className="emotion-2"
     >
       H3 Header
     </h3>
     <h4
-      className="emotion-6 emotion-7"
+      className="emotion-3"
     >
       H4 Header
     </h4>
     <h5
-      className="emotion-8 emotion-9"
+      className="emotion-4"
     >
       H5 Header
     </h5>
@@ -678,50 +678,50 @@ exports[`Type Snapshots renders current type hierarchy 1`] = `
       Variants
     </h3>
     <span
-      className="emotion-10"
+      className="emotion-5"
     >
       Button Text
     </span>
     <br />
     <span
-      className="emotion-11"
+      className="emotion-6"
     >
       Caps Text
     </span>
     <br />
     <label
-      className="emotion-10"
+      className="emotion-5"
     >
       Label Text
     </label>
     <br />
     <span
-      className="emotion-13"
+      className="emotion-8"
     >
       Hint Text
     </span>
     <br />
     <span
-      className="emotion-14"
+      className="emotion-9"
     >
       Error Text
     </span>
     <br />
     <a
-      className="emotion-15"
+      className="emotion-10"
       href="#"
     >
       Link Text
     </a>
     <br />
     <span
-      className="emotion-16"
+      className="emotion-11"
     >
       Inverse Text
     </span>
     <br />
     <span
-      className="emotion-17"
+      className="emotion-12"
     >
       Mono Text
     </span>

--- a/modules/core/react/stories/stories.tsx
+++ b/modules/core/react/stories/stories.tsx
@@ -11,7 +11,7 @@ export const inverseStyle = {
   display: 'inline-block',
   background: '#667380',
   padding: '2px 8px',
-  borderRadius: '3px',
+  borderRadius: '4px',
 };
 export const type = (hierarchy: any) => (
   <div style={{margin: '0 !important'}}>
@@ -87,7 +87,7 @@ storiesOf('Core', module)
       width: 200,
       height: 200,
       margin: 20,
-      borderRadius: 3,
+      borderRadius: 4,
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',

--- a/modules/header/react/lib/Header.tsx
+++ b/modules/header/react/lib/Header.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {css} from 'emotion';
 import styled from 'react-emotion';
-import {type, spacing} from '@workday/canvas-kit-react-core';
+import {type, spacing, borderRadius} from '@workday/canvas-kit-react-core';
 import {DubLogoTitle, Search, WorkdayLogoTitle} from './parts';
 import {themes} from './shared/themes';
 import {HeaderTheme, HeaderVariant, HeaderHeight} from './shared/types';
@@ -182,7 +182,7 @@ const navStyle = ({themeColor}: Pick<HeaderProps, 'themeColor'>) => {
               height: 4,
               width: '100%',
               backgroundColor: theme.chipColor,
-              borderRadius: '3px 3px 0 0',
+              borderRadius: `${borderRadius.m} ${borderRadius.m} 0 0`,
             },
           },
         },

--- a/modules/header/react/lib/parts/Search.tsx
+++ b/modules/header/react/lib/parts/Search.tsx
@@ -3,7 +3,7 @@ import styled from 'react-emotion';
 import {CSSObject} from 'create-emotion';
 import {CSSTransition} from 'react-transition-group';
 import {HeaderHeight, HeaderTheme} from '../shared/types';
-import {colors, spacing, spacingNumbers, type} from '@workday/canvas-kit-react-core';
+import {colors, borderRadius, spacing, spacingNumbers, type} from '@workday/canvas-kit-react-core';
 import {focusRing} from '@workday/canvas-kit-react-common';
 import {IconButton} from '@workday/canvas-kit-react-button';
 import {searchIcon, xIcon, xSmallIcon} from '@workday/canvas-system-icons-web';
@@ -100,7 +100,7 @@ const SearchInput = styled('input')<Pick<SearchProps, 'themeColor' | 'collapse'>
     minWidth: spacingNumbers.xs * 10,
     width: '100%',
     height: spacingNumbers.xl + spacingNumbers.xxxs,
-    borderRadius: '4px',
+    borderRadius: borderRadius.m,
     boxSizing: 'border-box',
     border: 'none',
     WebkitAppearance: 'none',

--- a/modules/header/react/spec/__snapshots__/GlobalHeader.snapshot.tsx.snap
+++ b/modules/header/react/spec/__snapshots__/GlobalHeader.snapshot.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconButton children 1`] = `
-.emotion-19 {
+.emotion-21 {
   overflow: hidden;
   display: -webkit-box;
   display: -webkit-flex;
@@ -56,16 +56,16 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
   line-height: 0;
 }
 
-.emotion-17 {
+.emotion-19 {
   margin-right: 24px;
 }
 
-.emotion-17 > .canvas-header--menu-icon {
+.emotion-19 > .canvas-header--menu-icon {
   cursor: pointer;
 }
 
 @media (min-width:0px) {
-  .emotion-17 {
+  .emotion-19 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -82,21 +82,21 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
     margin-right: 24px;
   }
 
-  .emotion-17 > * {
+  .emotion-19 > * {
     margin-left: 16px;
   }
 
-  .emotion-17 > *:not(.canvas-header--menu-icon) {
+  .emotion-19 > *:not(.canvas-header--menu-icon) {
     display: none;
   }
 }
 
 @media (min-width:1px) {
-  .emotion-17 > *:last-child {
+  .emotion-19 > *:last-child {
     margin-right: 0;
   }
 
-  .emotion-17 > *:not(.canvas-header--menu-icon) {
+  .emotion-19 > *:not(.canvas-header--menu-icon) {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -105,7 +105,7 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
 }
 
 @media (min-width:600px) {
-  .emotion-17 {
+  .emotion-19 {
     -webkit-box-flex: unset;
     -webkit-flex-grow: unset;
     -ms-flex-positive: unset;
@@ -113,7 +113,7 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
   }
 }
 
-.emotion-17 nav {
+.emotion-19 nav {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -130,7 +130,7 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
   margin-left: 40px;
 }
 
-.emotion-17 nav ul {
+.emotion-19 nav ul {
   color: #333333;
   display: -webkit-box;
   display: -webkit-flex;
@@ -150,11 +150,11 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
   height: inherit;
 }
 
-.emotion-17 nav ul:hover {
+.emotion-19 nav ul:hover {
   color: #7b858f;
 }
 
-.emotion-17 nav ul li {
+.emotion-19 nav ul li {
   box-sizing: border-box;
   position: relative;
   display: -webkit-box;
@@ -173,15 +173,15 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
   cursor: pointer;
 }
 
-.emotion-17 nav ul li:first-child > * {
+.emotion-19 nav ul li:first-child > * {
   margin-left: 0;
 }
 
-.emotion-17 nav ul li:last-child > * {
+.emotion-19 nav ul li:last-child > * {
   margin-right: 0;
 }
 
-.emotion-17 nav ul li > * {
+.emotion-19 nav ul li > * {
   color: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -198,29 +198,29 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
   height: inherit;
 }
 
-.emotion-17 nav ul li > *:visited {
+.emotion-19 nav ul li > *:visited {
   color: inherit;
 }
 
-.emotion-17 nav ul li:hover,
-.emotion-17 nav ul li:active {
+.emotion-19 nav ul li:hover,
+.emotion-19 nav ul li:active {
   color: #333333;
 }
 
-.emotion-17 nav ul li.current {
+.emotion-19 nav ul li.current {
   color: #005cb9;
 }
 
-.emotion-17 nav ul li.current a {
+.emotion-19 nav ul li.current a {
   cursor: default;
 }
 
-.emotion-17 nav ul li.current:hover,
-.emotion-17 nav ul li.current:active {
+.emotion-19 nav ul li.current:hover,
+.emotion-19 nav ul li.current:active {
   color: #005cb9;
 }
 
-.emotion-17 nav ul li.current:after {
+.emotion-19 nav ul li.current:after {
   position: absolute;
   bottom: 0;
   left: 0;
@@ -385,7 +385,7 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
   box-shadow: 0 0 0 0px #ffffff,0 0 0 2px #0875e1;
 }
 
-.emotion-16 {
+.emotion-17 {
   background: #f0f1f2;
   display: -webkit-box;
   display: -webkit-flex;
@@ -408,7 +408,7 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
   width: 32px;
 }
 
-.emotion-16 img {
+.emotion-17 img {
   width: 100%;
   height: 100%;
 }
@@ -479,7 +479,7 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
 }
 
 <div
-  className="emotion-19 emotion-20"
+  className="emotion-21 emotion-22"
 >
   <div
     className="emotion-6 emotion-7"
@@ -504,7 +504,7 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
     </span>
   </div>
   <div
-    className="emotion-17 emotion-18"
+    className="emotion-19 emotion-20"
   >
     <button
       aria-label="Notifications"
@@ -544,10 +544,10 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
     </button>
     <div
       aria-label="Avatar"
-      className="emotion-16"
+      className="emotion-17 emotion-18"
     >
       <div
-        className="emotion-15"
+        className="emotion-15 emotion-16"
       >
         <span
           className="emotion-14"
@@ -1259,7 +1259,7 @@ exports[`App GlobalHeader Snapshots renders a header with a search bar 1`] = `
 `;
 
 exports[`App GlobalHeader Snapshots renders a header with content with a search bar 1`] = `
-.emotion-31 {
+.emotion-33 {
   overflow: hidden;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1306,16 +1306,16 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
   line-height: 0;
 }
 
-.emotion-29 {
+.emotion-31 {
   margin-right: 24px;
 }
 
-.emotion-29 > .canvas-header--menu-icon {
+.emotion-31 > .canvas-header--menu-icon {
   cursor: pointer;
 }
 
 @media (min-width:0px) {
-  .emotion-29 {
+  .emotion-31 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1332,21 +1332,21 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
     margin-right: 24px;
   }
 
-  .emotion-29 > * {
+  .emotion-31 > * {
     margin-left: 16px;
   }
 
-  .emotion-29 > *:not(.canvas-header--menu-icon) {
+  .emotion-31 > *:not(.canvas-header--menu-icon) {
     display: none;
   }
 }
 
 @media (min-width:1px) {
-  .emotion-29 > *:last-child {
+  .emotion-31 > *:last-child {
     margin-right: 0;
   }
 
-  .emotion-29 > *:not(.canvas-header--menu-icon) {
+  .emotion-31 > *:not(.canvas-header--menu-icon) {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1355,7 +1355,7 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
 }
 
 @media (min-width:600px) {
-  .emotion-29 {
+  .emotion-31 {
     -webkit-box-flex: unset;
     -webkit-flex-grow: unset;
     -ms-flex-positive: unset;
@@ -1363,7 +1363,7 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
   }
 }
 
-.emotion-29 nav {
+.emotion-31 nav {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1380,7 +1380,7 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
   margin-left: 40px;
 }
 
-.emotion-29 nav ul {
+.emotion-31 nav ul {
   color: #333333;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1400,11 +1400,11 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
   height: inherit;
 }
 
-.emotion-29 nav ul:hover {
+.emotion-31 nav ul:hover {
   color: #7b858f;
 }
 
-.emotion-29 nav ul li {
+.emotion-31 nav ul li {
   box-sizing: border-box;
   position: relative;
   display: -webkit-box;
@@ -1423,15 +1423,15 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
   cursor: pointer;
 }
 
-.emotion-29 nav ul li:first-child > * {
+.emotion-31 nav ul li:first-child > * {
   margin-left: 0;
 }
 
-.emotion-29 nav ul li:last-child > * {
+.emotion-31 nav ul li:last-child > * {
   margin-right: 0;
 }
 
-.emotion-29 nav ul li > * {
+.emotion-31 nav ul li > * {
   color: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1448,29 +1448,29 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
   height: inherit;
 }
 
-.emotion-29 nav ul li > *:visited {
+.emotion-31 nav ul li > *:visited {
   color: inherit;
 }
 
-.emotion-29 nav ul li:hover,
-.emotion-29 nav ul li:active {
+.emotion-31 nav ul li:hover,
+.emotion-31 nav ul li:active {
   color: #333333;
 }
 
-.emotion-29 nav ul li.current {
+.emotion-31 nav ul li.current {
   color: #005cb9;
 }
 
-.emotion-29 nav ul li.current a {
+.emotion-31 nav ul li.current a {
   cursor: default;
 }
 
-.emotion-29 nav ul li.current:hover,
-.emotion-29 nav ul li.current:active {
+.emotion-31 nav ul li.current:hover,
+.emotion-31 nav ul li.current:active {
   color: #005cb9;
 }
 
-.emotion-29 nav ul li.current:after {
+.emotion-31 nav ul li.current:after {
   position: absolute;
   bottom: 0;
   left: 0;
@@ -1635,7 +1635,7 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
   box-shadow: 0 0 0 0px #ffffff,0 0 0 2px #0875e1;
 }
 
-.emotion-28 {
+.emotion-29 {
   background: #f0f1f2;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1658,7 +1658,7 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
   width: 32px;
 }
 
-.emotion-28 img {
+.emotion-29 img {
   width: 100%;
   height: 100%;
 }
@@ -2084,7 +2084,7 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
 }
 
 <div
-  className="emotion-31 emotion-32"
+  className="emotion-33 emotion-34"
 >
   <div
     className="emotion-6 emotion-7"
@@ -2158,7 +2158,7 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
     </button>
   </form>
   <div
-    className="emotion-29 emotion-30"
+    className="emotion-31 emotion-32"
   >
     <button
       aria-label="Notifications"
@@ -2198,10 +2198,10 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
     </button>
     <div
       aria-label="Avatar"
-      className="emotion-28"
+      className="emotion-29 emotion-30"
     >
       <div
-        className="emotion-27"
+        className="emotion-27 emotion-28"
       >
         <span
           className="emotion-26"

--- a/modules/header/react/spec/__snapshots__/GlobalHeader.snapshot.tsx.snap
+++ b/modules/header/react/spec/__snapshots__/GlobalHeader.snapshot.tsx.snap
@@ -401,7 +401,7 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: 100%;
+  border-radius: 999px;
   box-sizing: border-box;
   overflow: hidden;
   height: 32px;
@@ -428,7 +428,7 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: 100%;
+  border-radius: 999px;
   box-sizing: border-box;
   overflow: hidden;
   background: #e8ebed;
@@ -1651,7 +1651,7 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: 100%;
+  border-radius: 999px;
   box-sizing: border-box;
   overflow: hidden;
   height: 32px;
@@ -1678,7 +1678,7 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: 100%;
+  border-radius: 999px;
   box-sizing: border-box;
   overflow: hidden;
   background: #e8ebed;

--- a/modules/header/react/spec/__snapshots__/GlobalHeader.snapshot.tsx.snap
+++ b/modules/header/react/spec/__snapshots__/GlobalHeader.snapshot.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconButton children 1`] = `
-.emotion-21 {
+.emotion-19 {
   overflow: hidden;
   display: -webkit-box;
   display: -webkit-flex;
@@ -56,16 +56,16 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
   line-height: 0;
 }
 
-.emotion-19 {
+.emotion-17 {
   margin-right: 24px;
 }
 
-.emotion-19 > .canvas-header--menu-icon {
+.emotion-17 > .canvas-header--menu-icon {
   cursor: pointer;
 }
 
 @media (min-width:0px) {
-  .emotion-19 {
+  .emotion-17 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -82,21 +82,21 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
     margin-right: 24px;
   }
 
-  .emotion-19 > * {
+  .emotion-17 > * {
     margin-left: 16px;
   }
 
-  .emotion-19 > *:not(.canvas-header--menu-icon) {
+  .emotion-17 > *:not(.canvas-header--menu-icon) {
     display: none;
   }
 }
 
 @media (min-width:1px) {
-  .emotion-19 > *:last-child {
+  .emotion-17 > *:last-child {
     margin-right: 0;
   }
 
-  .emotion-19 > *:not(.canvas-header--menu-icon) {
+  .emotion-17 > *:not(.canvas-header--menu-icon) {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -105,7 +105,7 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
 }
 
 @media (min-width:600px) {
-  .emotion-19 {
+  .emotion-17 {
     -webkit-box-flex: unset;
     -webkit-flex-grow: unset;
     -ms-flex-positive: unset;
@@ -113,7 +113,7 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
   }
 }
 
-.emotion-19 nav {
+.emotion-17 nav {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -130,7 +130,7 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
   margin-left: 40px;
 }
 
-.emotion-19 nav ul {
+.emotion-17 nav ul {
   color: #333333;
   display: -webkit-box;
   display: -webkit-flex;
@@ -150,11 +150,11 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
   height: inherit;
 }
 
-.emotion-19 nav ul:hover {
+.emotion-17 nav ul:hover {
   color: #7b858f;
 }
 
-.emotion-19 nav ul li {
+.emotion-17 nav ul li {
   box-sizing: border-box;
   position: relative;
   display: -webkit-box;
@@ -173,15 +173,15 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
   cursor: pointer;
 }
 
-.emotion-19 nav ul li:first-child > * {
+.emotion-17 nav ul li:first-child > * {
   margin-left: 0;
 }
 
-.emotion-19 nav ul li:last-child > * {
+.emotion-17 nav ul li:last-child > * {
   margin-right: 0;
 }
 
-.emotion-19 nav ul li > * {
+.emotion-17 nav ul li > * {
   color: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -198,29 +198,29 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
   height: inherit;
 }
 
-.emotion-19 nav ul li > *:visited {
+.emotion-17 nav ul li > *:visited {
   color: inherit;
 }
 
-.emotion-19 nav ul li:hover,
-.emotion-19 nav ul li:active {
+.emotion-17 nav ul li:hover,
+.emotion-17 nav ul li:active {
   color: #333333;
 }
 
-.emotion-19 nav ul li.current {
+.emotion-17 nav ul li.current {
   color: #005cb9;
 }
 
-.emotion-19 nav ul li.current a {
+.emotion-17 nav ul li.current a {
   cursor: default;
 }
 
-.emotion-19 nav ul li.current:hover,
-.emotion-19 nav ul li.current:active {
+.emotion-17 nav ul li.current:hover,
+.emotion-17 nav ul li.current:active {
   color: #005cb9;
 }
 
-.emotion-19 nav ul li.current:after {
+.emotion-17 nav ul li.current:after {
   position: absolute;
   bottom: 0;
   left: 0;
@@ -228,7 +228,7 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
   height: 4px;
   width: 100%;
   background-color: #0875e1;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 .emotion-8 {
@@ -278,7 +278,7 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -385,7 +385,7 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
   box-shadow: 0 0 0 0px #ffffff,0 0 0 2px #0875e1;
 }
 
-.emotion-17 {
+.emotion-16 {
   background: #f0f1f2;
   display: -webkit-box;
   display: -webkit-flex;
@@ -408,7 +408,7 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
   width: 32px;
 }
 
-.emotion-17 img {
+.emotion-16 img {
   width: 100%;
   height: 100%;
 }
@@ -479,7 +479,7 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
 }
 
 <div
-  className="emotion-21 emotion-22"
+  className="emotion-19 emotion-20"
 >
   <div
     className="emotion-6 emotion-7"
@@ -504,7 +504,7 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
     </span>
   </div>
   <div
-    className="emotion-19 emotion-20"
+    className="emotion-17 emotion-18"
   >
     <button
       aria-label="Notifications"
@@ -544,10 +544,10 @@ exports[`App GlobalHeader Snapshots renders a header with SystemIcon and IconBut
     </button>
     <div
       aria-label="Avatar"
-      className="emotion-17 emotion-18"
+      className="emotion-16"
     >
       <div
-        className="emotion-15 emotion-16"
+        className="emotion-15"
       >
         <span
           className="emotion-14"
@@ -791,7 +791,7 @@ exports[`App GlobalHeader Snapshots renders a header with a search bar 1`] = `
   height: 4px;
   width: 100%;
   background-color: #0875e1;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 .emotion-8 {
@@ -863,7 +863,7 @@ exports[`App GlobalHeader Snapshots renders a header with a search bar 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -1066,7 +1066,7 @@ exports[`App GlobalHeader Snapshots renders a header with a search bar 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -1259,7 +1259,7 @@ exports[`App GlobalHeader Snapshots renders a header with a search bar 1`] = `
 `;
 
 exports[`App GlobalHeader Snapshots renders a header with content with a search bar 1`] = `
-.emotion-33 {
+.emotion-31 {
   overflow: hidden;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1306,16 +1306,16 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
   line-height: 0;
 }
 
-.emotion-31 {
+.emotion-29 {
   margin-right: 24px;
 }
 
-.emotion-31 > .canvas-header--menu-icon {
+.emotion-29 > .canvas-header--menu-icon {
   cursor: pointer;
 }
 
 @media (min-width:0px) {
-  .emotion-31 {
+  .emotion-29 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1332,21 +1332,21 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
     margin-right: 24px;
   }
 
-  .emotion-31 > * {
+  .emotion-29 > * {
     margin-left: 16px;
   }
 
-  .emotion-31 > *:not(.canvas-header--menu-icon) {
+  .emotion-29 > *:not(.canvas-header--menu-icon) {
     display: none;
   }
 }
 
 @media (min-width:1px) {
-  .emotion-31 > *:last-child {
+  .emotion-29 > *:last-child {
     margin-right: 0;
   }
 
-  .emotion-31 > *:not(.canvas-header--menu-icon) {
+  .emotion-29 > *:not(.canvas-header--menu-icon) {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1355,7 +1355,7 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
 }
 
 @media (min-width:600px) {
-  .emotion-31 {
+  .emotion-29 {
     -webkit-box-flex: unset;
     -webkit-flex-grow: unset;
     -ms-flex-positive: unset;
@@ -1363,7 +1363,7 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
   }
 }
 
-.emotion-31 nav {
+.emotion-29 nav {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1380,7 +1380,7 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
   margin-left: 40px;
 }
 
-.emotion-31 nav ul {
+.emotion-29 nav ul {
   color: #333333;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1400,11 +1400,11 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
   height: inherit;
 }
 
-.emotion-31 nav ul:hover {
+.emotion-29 nav ul:hover {
   color: #7b858f;
 }
 
-.emotion-31 nav ul li {
+.emotion-29 nav ul li {
   box-sizing: border-box;
   position: relative;
   display: -webkit-box;
@@ -1423,15 +1423,15 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
   cursor: pointer;
 }
 
-.emotion-31 nav ul li:first-child > * {
+.emotion-29 nav ul li:first-child > * {
   margin-left: 0;
 }
 
-.emotion-31 nav ul li:last-child > * {
+.emotion-29 nav ul li:last-child > * {
   margin-right: 0;
 }
 
-.emotion-31 nav ul li > * {
+.emotion-29 nav ul li > * {
   color: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1448,29 +1448,29 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
   height: inherit;
 }
 
-.emotion-31 nav ul li > *:visited {
+.emotion-29 nav ul li > *:visited {
   color: inherit;
 }
 
-.emotion-31 nav ul li:hover,
-.emotion-31 nav ul li:active {
+.emotion-29 nav ul li:hover,
+.emotion-29 nav ul li:active {
   color: #333333;
 }
 
-.emotion-31 nav ul li.current {
+.emotion-29 nav ul li.current {
   color: #005cb9;
 }
 
-.emotion-31 nav ul li.current a {
+.emotion-29 nav ul li.current a {
   cursor: default;
 }
 
-.emotion-31 nav ul li.current:hover,
-.emotion-31 nav ul li.current:active {
+.emotion-29 nav ul li.current:hover,
+.emotion-29 nav ul li.current:active {
   color: #005cb9;
 }
 
-.emotion-31 nav ul li.current:after {
+.emotion-29 nav ul li.current:after {
   position: absolute;
   bottom: 0;
   left: 0;
@@ -1478,7 +1478,7 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
   height: 4px;
   width: 100%;
   background-color: #0875e1;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 .emotion-8 {
@@ -1528,7 +1528,7 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -1635,7 +1635,7 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
   box-shadow: 0 0 0 0px #ffffff,0 0 0 2px #0875e1;
 }
 
-.emotion-29 {
+.emotion-28 {
   background: #f0f1f2;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1658,7 +1658,7 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
   width: 32px;
 }
 
-.emotion-29 img {
+.emotion-28 img {
   width: 100%;
   height: 100%;
 }
@@ -1743,7 +1743,7 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -1946,7 +1946,7 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -2084,7 +2084,7 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
 }
 
 <div
-  className="emotion-33 emotion-34"
+  className="emotion-31 emotion-32"
 >
   <div
     className="emotion-6 emotion-7"
@@ -2158,7 +2158,7 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
     </button>
   </form>
   <div
-    className="emotion-31 emotion-32"
+    className="emotion-29 emotion-30"
   >
     <button
       aria-label="Notifications"
@@ -2198,10 +2198,10 @@ exports[`App GlobalHeader Snapshots renders a header with content with a search 
     </button>
     <div
       aria-label="Avatar"
-      className="emotion-29 emotion-30"
+      className="emotion-28"
     >
       <div
-        className="emotion-27 emotion-28"
+        className="emotion-27"
       >
         <span
           className="emotion-26"
@@ -2445,7 +2445,7 @@ exports[`App GlobalHeader Snapshots renders an app header 1`] = `
   height: 4px;
   width: 100%;
   background-color: #0875e1;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 <div
@@ -2689,7 +2689,7 @@ exports[`App GlobalHeader Snapshots renders an app header width Workday Logo 1`]
   height: 4px;
   width: 100%;
   background-color: #0875e1;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 .emotion-2 {
@@ -2728,7 +2728,7 @@ exports[`App GlobalHeader Snapshots renders an app header width Workday Logo 1`]
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;

--- a/modules/header/react/spec/__snapshots__/Header.snapshot.tsx.snap
+++ b/modules/header/react/spec/__snapshots__/Header.snapshot.tsx.snap
@@ -228,7 +228,7 @@ exports[`Dub Header Snapshots renders a default header 1`] = `
   height: 4px;
   width: 100%;
   background-color: #0875e1;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 <div
@@ -493,7 +493,7 @@ exports[`Dub Header Snapshots renders a default header with title 1`] = `
   height: 4px;
   width: 100%;
   background-color: #0875e1;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 .emotion-2 {
@@ -774,7 +774,7 @@ exports[`Dub Header Snapshots renders a header with SystemIcon and IconButton ch
   height: 4px;
   width: 100%;
   background-color: #0875e1;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 .emotion-9 {
@@ -792,7 +792,7 @@ exports[`Dub Header Snapshots renders a header with SystemIcon and IconButton ch
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -1182,7 +1182,7 @@ exports[`Dub Header Snapshots renders a header with a custom brand element 1`] =
   height: 4px;
   width: 100%;
   background-color: #0875e1;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 <div
@@ -1431,7 +1431,7 @@ exports[`Dub Header Snapshots renders a header with a search bar 1`] = `
   height: 4px;
   width: 100%;
   background-color: #0875e1;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 .emotion-8 {
@@ -1503,7 +1503,7 @@ exports[`Dub Header Snapshots renders a header with a search bar 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -1706,7 +1706,7 @@ exports[`Dub Header Snapshots renders a header with a search bar 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -2129,7 +2129,7 @@ exports[`Dub Header Snapshots renders a header with content with a search bar 1`
   height: 4px;
   width: 100%;
   background-color: #0875e1;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 .emotion-12 {
@@ -2147,7 +2147,7 @@ exports[`Dub Header Snapshots renders a header with content with a search bar 1`
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -2298,7 +2298,7 @@ exports[`Dub Header Snapshots renders a header with content with a search bar 1`
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -2702,7 +2702,7 @@ exports[`Dub Header Snapshots renders a header with custom breakpoints 1`] = `
   height: 4px;
   width: 100%;
   background-color: #0875e1;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 <div
@@ -2967,7 +2967,7 @@ exports[`Dub Header Snapshots renders a header with nav elements 1`] = `
   height: 4px;
   width: 100%;
   background-color: #0875e1;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 .emotion-9 {
@@ -2985,7 +2985,7 @@ exports[`Dub Header Snapshots renders a header with nav elements 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -3240,7 +3240,7 @@ exports[`Dub Header Snapshots renders a header with nav elements 2`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -3548,7 +3548,7 @@ exports[`Dub Header Snapshots renders a header with nav elements 2`] = `
   height: 4px;
   width: 100%;
   background-color: #0875e1;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 <div
@@ -3827,7 +3827,7 @@ exports[`Dub Header Snapshots renders themed headers: <Header /> with blue theme
   height: 4px;
   width: 100%;
   background-color: #ffffff;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 <div
@@ -4067,7 +4067,7 @@ exports[`Dub Header Snapshots renders themed headers: <Header /> with transparen
   height: 4px;
   width: 100%;
   background-color: #ffffff;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 .emotion-10 {
@@ -4357,7 +4357,7 @@ exports[`Dub Header Snapshots renders themed headers: <Header /> with white them
   height: 4px;
   width: 100%;
   background-color: #0875e1;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 <div
@@ -4579,7 +4579,7 @@ exports[`Full Header Snapshots renders a blue header with a search bar and no ch
   height: 4px;
   width: 100%;
   background-color: #ffffff;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 .emotion-8 {
@@ -4651,7 +4651,7 @@ exports[`Full Header Snapshots renders a blue header with a search bar and no ch
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -4824,7 +4824,7 @@ exports[`Full Header Snapshots renders a blue header with a search bar and no ch
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -5254,7 +5254,7 @@ exports[`Full Header Snapshots renders a default header 1`] = `
   height: 4px;
   width: 100%;
   background-color: #0875e1;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 .emotion-10 {
@@ -5522,7 +5522,7 @@ exports[`Full Header Snapshots renders a default header with title 1`] = `
   height: 4px;
   width: 100%;
   background-color: #0875e1;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 .emotion-12 {
@@ -5851,7 +5851,7 @@ exports[`Full Header Snapshots renders a header in a lg screen with search 1`] =
   height: 4px;
   width: 100%;
   background-color: #0875e1;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 .emotion-10 {
@@ -5923,7 +5923,7 @@ exports[`Full Header Snapshots renders a header in a lg screen with search 1`] =
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -6126,7 +6126,7 @@ exports[`Full Header Snapshots renders a header in a lg screen with search 1`] =
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -6517,7 +6517,7 @@ exports[`Full Header Snapshots renders a header with a custom brand element 1`] 
   height: 4px;
   width: 100%;
   background-color: #0875e1;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 .emotion-4 {
@@ -6748,7 +6748,7 @@ exports[`Full Header Snapshots renders a header with a search bar 1`] = `
   height: 4px;
   width: 100%;
   background-color: #0875e1;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 .emotion-8 {
@@ -6820,7 +6820,7 @@ exports[`Full Header Snapshots renders a header with a search bar 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -7023,7 +7023,7 @@ exports[`Full Header Snapshots renders a header with a search bar 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -7449,7 +7449,7 @@ exports[`Full Header Snapshots renders a header with content with a search bar 1
   height: 4px;
   width: 100%;
   background-color: #ffffff;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 .emotion-8 {
@@ -7545,7 +7545,7 @@ exports[`Full Header Snapshots renders a header with content with a search bar 1
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -7885,7 +7885,7 @@ exports[`Full Header Snapshots renders a header with custom breakpoints 1`] = `
   height: 4px;
   width: 100%;
   background-color: #0875e1;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 .emotion-10 {
@@ -8153,7 +8153,7 @@ exports[`Full Header Snapshots renders a header with nav elements 1`] = `
   height: 4px;
   width: 100%;
   background-color: #0875e1;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 .emotion-9 {
@@ -8171,7 +8171,7 @@ exports[`Full Header Snapshots renders a header with nav elements 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -8429,7 +8429,7 @@ exports[`Full Header Snapshots renders a header with nav elements 2`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -8737,7 +8737,7 @@ exports[`Full Header Snapshots renders a header with nav elements 2`] = `
   height: 4px;
   width: 100%;
   background-color: #0875e1;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 .emotion-13 {
@@ -9019,7 +9019,7 @@ exports[`Full Header Snapshots renders a header with system icon children 1`] = 
   height: 4px;
   width: 100%;
   background-color: #0875e1;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 .emotion-9 {
@@ -9037,7 +9037,7 @@ exports[`Full Header Snapshots renders a header with system icon children 1`] = 
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -9452,7 +9452,7 @@ exports[`Full Header Snapshots renders themed headers: <Header /> with blue them
   height: 4px;
   width: 100%;
   background-color: #ffffff;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 .emotion-2 {
@@ -9720,7 +9720,7 @@ exports[`Full Header Snapshots renders themed headers: <Header /> with transpare
   height: 4px;
   width: 100%;
   background-color: #ffffff;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 .emotion-2 {
@@ -9988,7 +9988,7 @@ exports[`Full Header Snapshots renders themed headers: <Header /> with white the
   height: 4px;
   width: 100%;
   background-color: #0875e1;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 .emotion-10 {

--- a/modules/header/react/spec/__snapshots__/Search.snapshot.tsx.snap
+++ b/modules/header/react/spec/__snapshots__/Search.snapshot.tsx.snap
@@ -16,7 +16,7 @@ exports[`Header Search Snapshots Renders a collapsed search bar 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -243,7 +243,7 @@ exports[`Header Search Snapshots Renders a search bar with a value 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -446,7 +446,7 @@ exports[`Header Search Snapshots Renders a search bar with a value 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -674,7 +674,7 @@ exports[`Header Search Snapshots Renders a search bar with a value 2`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -877,7 +877,7 @@ exports[`Header Search Snapshots Renders a search bar with a value 2`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -1105,7 +1105,7 @@ exports[`Header Search Snapshots renders themed search bars: <Search /> with blu
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -1282,7 +1282,7 @@ exports[`Header Search Snapshots renders themed search bars: <Search /> with blu
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -1510,7 +1510,7 @@ exports[`Header Search Snapshots renders themed search bars: <Search /> with blu
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -1687,7 +1687,7 @@ exports[`Header Search Snapshots renders themed search bars: <Search /> with blu
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -1915,7 +1915,7 @@ exports[`Header Search Snapshots renders themed search bars: <Search /> with tra
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -2092,7 +2092,7 @@ exports[`Header Search Snapshots renders themed search bars: <Search /> with tra
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -2320,7 +2320,7 @@ exports[`Header Search Snapshots renders themed search bars: <Search /> with tra
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -2497,7 +2497,7 @@ exports[`Header Search Snapshots renders themed search bars: <Search /> with tra
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -2725,7 +2725,7 @@ exports[`Header Search Snapshots renders themed search bars: <Search /> with whi
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -2928,7 +2928,7 @@ exports[`Header Search Snapshots renders themed search bars: <Search /> with whi
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -3156,7 +3156,7 @@ exports[`Header Search Snapshots renders themed search bars: <Search /> with whi
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -3359,7 +3359,7 @@ exports[`Header Search Snapshots renders themed search bars: <Search /> with whi
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -3570,7 +3570,7 @@ exports[`Header Search Snapshots renders themed, collapsed search bars: <Search 
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -3727,7 +3727,7 @@ exports[`Header Search Snapshots renders themed, collapsed search bars: <Search 
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -3852,7 +3852,7 @@ exports[`Header Search Snapshots renders themed, collapsed search bars: <Search 
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;

--- a/modules/icon/css/lib/icon-list.scss
+++ b/modules/icon/css/lib/icon-list.scss
@@ -18,7 +18,7 @@
     &:focus,
     &.wdc-icon-list-icon-focus {
       outline: none;
-      border-radius: 3px;
+      border-radius: $wdc-border-radius-m;
       box-shadow: 0 0 0 2px $wdc-color-blueberry-500;
     }
 

--- a/modules/icon/css/lib/icon.scss
+++ b/modules/icon/css/lib/icon.scss
@@ -1,6 +1,6 @@
 .wdc-icon-circle-container {
   align-items: center;
-  border-radius: 100%;
+  border-radius: $wdc-border-radius-circle;
   display: flex;
   justify-content: center;
 }

--- a/modules/icon/react/lib/SystemIconCircle.tsx
+++ b/modules/icon/react/lib/SystemIconCircle.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styled from 'react-emotion';
 import isPropValid from '@emotion/is-prop-valid';
-import {colors} from '@workday/canvas-kit-react-core';
+import {colors, borderRadius} from '@workday/canvas-kit-react-core';
 import SystemIcon from './SystemIcon';
 import {CanvasSystemIcon} from '@workday/design-assets-types';
 import {pickForegroundColor} from '@workday/canvas-kit-react-common';
@@ -30,7 +30,7 @@ const Container = styled('div', {
     justifyContent: 'center',
     padding: 0,
     border: 0,
-    borderRadius: '100%',
+    borderRadius: borderRadius.circle,
     boxSizing: 'border-box',
     overflow: 'hidden',
     '& img': {

--- a/modules/icon/react/spec/__snapshots__/SystemIcon.snapshot.tsx.snap
+++ b/modules/icon/react/spec/__snapshots__/SystemIcon.snapshot.tsx.snap
@@ -16,7 +16,7 @@ exports[`System Icon Circle Snapshots renders as expected 1`] = `
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: 100%;
+  border-radius: 999px;
   box-sizing: border-box;
   overflow: hidden;
   background: #e8ebed;
@@ -96,7 +96,7 @@ exports[`System Icon Circle Snapshots renders as expected with colored backgroun
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: 100%;
+  border-radius: 999px;
   box-sizing: border-box;
   overflow: hidden;
   background: #0875e1;

--- a/modules/layout/css/stories.scss
+++ b/modules/layout/css/stories.scss
@@ -8,7 +8,7 @@
   margin-bottom: $wdc-spacing-s;
   background: $wdc-color-blueberry-500;
   border: 1px solid #fff;
-  border-radius: 2px;
+  border-radius: $wdc-border-radius-s;
   overflow: hidden;
   text-align: center;
   color: #fff;

--- a/modules/loading-animation/css/index.scss
+++ b/modules/loading-animation/css/index.scss
@@ -1,3 +1,4 @@
 @import '~@workday/canvas-kit-css-core/lib/variables/spacing.scss';
+@import '~@workday/canvas-kit-css-core/lib/variables/border-radius.scss';
 @import '~@workday/canvas-kit-css-core/lib/variables/colors.scss';
 @import './lib/loading-dots.scss';

--- a/modules/loading-animation/css/lib/loading-dots.scss
+++ b/modules/loading-animation/css/lib/loading-dots.scss
@@ -33,7 +33,7 @@
   position: absolute;
   font-size: 0px;
   content: ' ';
-  border-radius: 100%;
+  border-radius: $wdc-border-radius-circle;
   transform: scale(0);
 }
 .wdc-loading-dots::after {

--- a/modules/loading-animation/react/lib/LoadingDots.tsx
+++ b/modules/loading-animation/react/lib/LoadingDots.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {keyframes} from 'emotion';
 import styled from 'react-emotion';
-import canvas from '@workday/canvas-kit-react-core';
+import canvas, {borderRadius} from '@workday/canvas-kit-react-core';
 
 /**
  * Keyframe for the dots loading animation.
@@ -32,7 +32,7 @@ const LoadingAnimationDot = styled('div')<LoadingDotProps>(
     width: canvas.spacing.s,
     height: canvas.spacing.s,
     fontSize: '0px',
-    borderRadius: '100%',
+    borderRadius: borderRadius.circle,
     transform: 'scale(0)',
     display: 'inline-block',
     marginRight: canvas.spacing.xxs,

--- a/modules/loading-animation/react/spec/__snapshots__/LoadingDots.snapshot.tsx.snap
+++ b/modules/loading-animation/react/spec/__snapshots__/LoadingDots.snapshot.tsx.snap
@@ -10,7 +10,7 @@ exports[`LoadingDots Snapshots renders as expected 1`] = `
   width: 16px;
   height: 16px;
   font-size: 0px;
-  border-radius: 100%;
+  border-radius: 999px;
   -webkit-transform: scale(0);
   -ms-transform: scale(0);
   transform: scale(0);
@@ -39,7 +39,7 @@ exports[`LoadingDots Snapshots renders as expected 1`] = `
   width: 16px;
   height: 16px;
   font-size: 0px;
-  border-radius: 100%;
+  border-radius: 999px;
   -webkit-transform: scale(0);
   -ms-transform: scale(0);
   transform: scale(0);
@@ -68,7 +68,7 @@ exports[`LoadingDots Snapshots renders as expected 1`] = `
   width: 16px;
   height: 16px;
   font-size: 0px;
-  border-radius: 100%;
+  border-radius: 999px;
   -webkit-transform: scale(0);
   -ms-transform: scale(0);
   transform: scale(0);

--- a/modules/menu/css/lib/menu.scss
+++ b/modules/menu/css/lib/menu.scss
@@ -4,15 +4,14 @@
   @include wdc-depth-2();
   display: inline-block;
   background-color: $_wdc-menu-bg-color;
-  border-radius: 3px;
+  border-radius: $wdc-border-radius-m;
   border: 1px solid $_wdc-menu-border-color;
   box-sizing: border-box;
   position: relative;
   width: max-content;
 
   // Fallback for IE11
-  @media screen and (-ms-high-contrast: active),
-  screen and (-ms-high-contrast: none) {
+  @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
     width: auto;
     min-width: $_wdc-menu-menu-min-width;
   }

--- a/modules/menu/react/lib/Menu.tsx
+++ b/modules/menu/react/lib/Menu.tsx
@@ -3,7 +3,7 @@ import styled from 'react-emotion';
 import uuid from 'uuid/v4';
 import {MenuItemProps} from './MenuItem';
 import {Card} from '@workday/canvas-kit-react-card';
-import {commonColors, spacing} from '@workday/canvas-kit-react-core';
+import {commonColors, spacing, borderRadius} from '@workday/canvas-kit-react-core';
 import {hideMouseFocus, GrowthBehavior} from '@workday/canvas-kit-react-common';
 
 export interface MenuProps extends GrowthBehavior, React.HTMLAttributes<HTMLUListElement> {
@@ -26,7 +26,7 @@ const minWidth = 100;
 const List = styled('ul')({
   background: commonColors.background,
   minWidth: `${minWidth}px`,
-  borderRadius: '3px',
+  borderRadius: borderRadius.m,
   padding: 0,
   margin: `${spacing.xxs} 0`,
   '&:focus': {

--- a/modules/menu/react/spec/__snapshots__/Menu.snapshot.tsx.snap
+++ b/modules/menu/react/spec/__snapshots__/Menu.snapshot.tsx.snap
@@ -223,7 +223,7 @@ exports[`Menu Snapshots renders a focused menu item 1`] = `
 `;
 
 exports[`Menu Snapshots renders a hidden menu 1`] = `
-.emotion-4 {
+.emotion-3 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -243,7 +243,7 @@ exports[`Menu Snapshots renders a hidden menu 1`] = `
 .emotion-0 {
   background: #ffffff;
   min-width: 100px;
-  border-radius: 3px;
+  border-radius: 4px;
   padding: 0;
   margin: 8px 0;
 }
@@ -262,7 +262,7 @@ exports[`Menu Snapshots renders a hidden menu 1`] = `
 }
 
 <div
-  className="emotion-4 emotion-5"
+  className="emotion-3"
   style={
     Object {
       "display": "inline-block",
@@ -271,7 +271,7 @@ exports[`Menu Snapshots renders a hidden menu 1`] = `
   }
 >
   <div
-    className="emotion-2 emotion-3"
+    className="emotion-2"
   >
     <ul
       aria-activedescendant="myId--1"
@@ -286,7 +286,7 @@ exports[`Menu Snapshots renders a hidden menu 1`] = `
 `;
 
 exports[`Menu Snapshots renders a menu with aria attributes 1`] = `
-.emotion-8 {
+.emotion-7 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -306,7 +306,7 @@ exports[`Menu Snapshots renders a menu with aria attributes 1`] = `
 .emotion-4 {
   background: #ffffff;
   min-width: 100px;
-  border-radius: 3px;
+  border-radius: 4px;
   padding: 0;
   margin: 8px 0;
 }
@@ -394,7 +394,7 @@ exports[`Menu Snapshots renders a menu with aria attributes 1`] = `
 }
 
 <div
-  className="emotion-8 emotion-9"
+  className="emotion-7"
   style={
     Object {
       "display": "inline-block",
@@ -403,7 +403,7 @@ exports[`Menu Snapshots renders a menu with aria attributes 1`] = `
   }
 >
   <div
-    className="emotion-6 emotion-7"
+    className="emotion-6"
   >
     <ul
       aria-activedescendant="myId-0"
@@ -446,7 +446,7 @@ exports[`Menu Snapshots renders a menu with grow=true 1`] = `
 .emotion-8 {
   background: #ffffff;
   min-width: 100px;
-  border-radius: 3px;
+  border-radius: 4px;
   padding: 0;
   margin: 8px 0;
 }
@@ -572,7 +572,7 @@ exports[`Menu Snapshots renders a menu with grow=true 1`] = `
   fill: #333d47;
 }
 
-.emotion-12 {
+.emotion-11 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -583,7 +583,7 @@ exports[`Menu Snapshots renders a menu with grow=true 1`] = `
 }
 
 <div
-  className="emotion-12 emotion-13"
+  className="emotion-11"
   style={
     Object {
       "display": "inline-block",
@@ -593,7 +593,7 @@ exports[`Menu Snapshots renders a menu with grow=true 1`] = `
   width="100%"
 >
   <div
-    className="emotion-10 emotion-11"
+    className="emotion-10"
   >
     <ul
       aria-activedescendant="myId-0"
@@ -637,7 +637,7 @@ exports[`Menu Snapshots renders a menu with grow=true 1`] = `
 `;
 
 exports[`Menu Snapshots renders an empty menu 1`] = `
-.emotion-4 {
+.emotion-3 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -657,7 +657,7 @@ exports[`Menu Snapshots renders an empty menu 1`] = `
 .emotion-0 {
   background: #ffffff;
   min-width: 100px;
-  border-radius: 3px;
+  border-radius: 4px;
   padding: 0;
   margin: 8px 0;
 }
@@ -676,7 +676,7 @@ exports[`Menu Snapshots renders an empty menu 1`] = `
 }
 
 <div
-  className="emotion-4 emotion-5"
+  className="emotion-3"
   style={
     Object {
       "display": "inline-block",
@@ -685,7 +685,7 @@ exports[`Menu Snapshots renders an empty menu 1`] = `
   }
 >
   <div
-    className="emotion-2 emotion-3"
+    className="emotion-2"
   >
     <ul
       aria-activedescendant="myId--1"
@@ -700,7 +700,7 @@ exports[`Menu Snapshots renders an empty menu 1`] = `
 `;
 
 exports[`Menu Snapshots renders an menu with one item 1`] = `
-.emotion-8 {
+.emotion-7 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -720,7 +720,7 @@ exports[`Menu Snapshots renders an menu with one item 1`] = `
 .emotion-4 {
   background: #ffffff;
   min-width: 100px;
-  border-radius: 3px;
+  border-radius: 4px;
   padding: 0;
   margin: 8px 0;
 }
@@ -808,7 +808,7 @@ exports[`Menu Snapshots renders an menu with one item 1`] = `
 }
 
 <div
-  className="emotion-8 emotion-9"
+  className="emotion-7"
   style={
     Object {
       "display": "inline-block",
@@ -817,7 +817,7 @@ exports[`Menu Snapshots renders an menu with one item 1`] = `
   }
 >
   <div
-    className="emotion-6 emotion-7"
+    className="emotion-6"
   >
     <ul
       aria-activedescendant="myId-0"
@@ -847,7 +847,7 @@ exports[`Menu Snapshots renders an menu with one item 1`] = `
 `;
 
 exports[`Menu Snapshots renders an menu with two items 1`] = `
-.emotion-12 {
+.emotion-11 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -867,7 +867,7 @@ exports[`Menu Snapshots renders an menu with two items 1`] = `
 .emotion-8 {
   background: #ffffff;
   min-width: 100px;
-  border-radius: 3px;
+  border-radius: 4px;
   padding: 0;
   margin: 8px 0;
 }
@@ -994,7 +994,7 @@ exports[`Menu Snapshots renders an menu with two items 1`] = `
 }
 
 <div
-  className="emotion-12 emotion-13"
+  className="emotion-11"
   style={
     Object {
       "display": "inline-block",
@@ -1003,7 +1003,7 @@ exports[`Menu Snapshots renders an menu with two items 1`] = `
   }
 >
   <div
-    className="emotion-10 emotion-11"
+    className="emotion-10"
   >
     <ul
       aria-activedescendant="myId-0"
@@ -1047,7 +1047,7 @@ exports[`Menu Snapshots renders an menu with two items 1`] = `
 `;
 
 exports[`Menu Snapshots renders with icon 1`] = `
-.emotion-12 {
+.emotion-11 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -1067,7 +1067,7 @@ exports[`Menu Snapshots renders with icon 1`] = `
 .emotion-8 {
   background: #ffffff;
   min-width: 100px;
-  border-radius: 3px;
+  border-radius: 4px;
   padding: 0;
   margin: 8px 0;
 }
@@ -1243,7 +1243,7 @@ exports[`Menu Snapshots renders with icon 1`] = `
 }
 
 <div
-  className="emotion-12 emotion-13"
+  className="emotion-11"
   style={
     Object {
       "display": "inline-block",
@@ -1252,7 +1252,7 @@ exports[`Menu Snapshots renders with icon 1`] = `
   }
 >
   <div
-    className="emotion-10 emotion-11"
+    className="emotion-10"
   >
     <ul
       aria-activedescendant="myId-0"

--- a/modules/menu/react/spec/__snapshots__/Menu.snapshot.tsx.snap
+++ b/modules/menu/react/spec/__snapshots__/Menu.snapshot.tsx.snap
@@ -223,7 +223,7 @@ exports[`Menu Snapshots renders a focused menu item 1`] = `
 `;
 
 exports[`Menu Snapshots renders a hidden menu 1`] = `
-.emotion-3 {
+.emotion-4 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -262,7 +262,7 @@ exports[`Menu Snapshots renders a hidden menu 1`] = `
 }
 
 <div
-  className="emotion-3"
+  className="emotion-4 emotion-5"
   style={
     Object {
       "display": "inline-block",
@@ -271,7 +271,7 @@ exports[`Menu Snapshots renders a hidden menu 1`] = `
   }
 >
   <div
-    className="emotion-2"
+    className="emotion-2 emotion-3"
   >
     <ul
       aria-activedescendant="myId--1"
@@ -286,7 +286,7 @@ exports[`Menu Snapshots renders a hidden menu 1`] = `
 `;
 
 exports[`Menu Snapshots renders a menu with aria attributes 1`] = `
-.emotion-7 {
+.emotion-8 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -394,7 +394,7 @@ exports[`Menu Snapshots renders a menu with aria attributes 1`] = `
 }
 
 <div
-  className="emotion-7"
+  className="emotion-8 emotion-9"
   style={
     Object {
       "display": "inline-block",
@@ -403,7 +403,7 @@ exports[`Menu Snapshots renders a menu with aria attributes 1`] = `
   }
 >
   <div
-    className="emotion-6"
+    className="emotion-6 emotion-7"
   >
     <ul
       aria-activedescendant="myId-0"
@@ -572,7 +572,7 @@ exports[`Menu Snapshots renders a menu with grow=true 1`] = `
   fill: #333d47;
 }
 
-.emotion-11 {
+.emotion-12 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -583,7 +583,7 @@ exports[`Menu Snapshots renders a menu with grow=true 1`] = `
 }
 
 <div
-  className="emotion-11"
+  className="emotion-12 emotion-13"
   style={
     Object {
       "display": "inline-block",
@@ -593,7 +593,7 @@ exports[`Menu Snapshots renders a menu with grow=true 1`] = `
   width="100%"
 >
   <div
-    className="emotion-10"
+    className="emotion-10 emotion-11"
   >
     <ul
       aria-activedescendant="myId-0"
@@ -637,7 +637,7 @@ exports[`Menu Snapshots renders a menu with grow=true 1`] = `
 `;
 
 exports[`Menu Snapshots renders an empty menu 1`] = `
-.emotion-3 {
+.emotion-4 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -676,7 +676,7 @@ exports[`Menu Snapshots renders an empty menu 1`] = `
 }
 
 <div
-  className="emotion-3"
+  className="emotion-4 emotion-5"
   style={
     Object {
       "display": "inline-block",
@@ -685,7 +685,7 @@ exports[`Menu Snapshots renders an empty menu 1`] = `
   }
 >
   <div
-    className="emotion-2"
+    className="emotion-2 emotion-3"
   >
     <ul
       aria-activedescendant="myId--1"
@@ -700,7 +700,7 @@ exports[`Menu Snapshots renders an empty menu 1`] = `
 `;
 
 exports[`Menu Snapshots renders an menu with one item 1`] = `
-.emotion-7 {
+.emotion-8 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -808,7 +808,7 @@ exports[`Menu Snapshots renders an menu with one item 1`] = `
 }
 
 <div
-  className="emotion-7"
+  className="emotion-8 emotion-9"
   style={
     Object {
       "display": "inline-block",
@@ -817,7 +817,7 @@ exports[`Menu Snapshots renders an menu with one item 1`] = `
   }
 >
   <div
-    className="emotion-6"
+    className="emotion-6 emotion-7"
   >
     <ul
       aria-activedescendant="myId-0"
@@ -847,7 +847,7 @@ exports[`Menu Snapshots renders an menu with one item 1`] = `
 `;
 
 exports[`Menu Snapshots renders an menu with two items 1`] = `
-.emotion-11 {
+.emotion-12 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -994,7 +994,7 @@ exports[`Menu Snapshots renders an menu with two items 1`] = `
 }
 
 <div
-  className="emotion-11"
+  className="emotion-12 emotion-13"
   style={
     Object {
       "display": "inline-block",
@@ -1003,7 +1003,7 @@ exports[`Menu Snapshots renders an menu with two items 1`] = `
   }
 >
   <div
-    className="emotion-10"
+    className="emotion-10 emotion-11"
   >
     <ul
       aria-activedescendant="myId-0"
@@ -1047,7 +1047,7 @@ exports[`Menu Snapshots renders an menu with two items 1`] = `
 `;
 
 exports[`Menu Snapshots renders with icon 1`] = `
-.emotion-11 {
+.emotion-12 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -1243,7 +1243,7 @@ exports[`Menu Snapshots renders with icon 1`] = `
 }
 
 <div
-  className="emotion-11"
+  className="emotion-12 emotion-13"
   style={
     Object {
       "display": "inline-block",
@@ -1252,7 +1252,7 @@ exports[`Menu Snapshots renders with icon 1`] = `
   }
 >
   <div
-    className="emotion-10"
+    className="emotion-10 emotion-11"
   >
     <ul
       aria-activedescendant="myId-0"

--- a/modules/menu/react/spec/__snapshots__/Menu.snapshot.tsx.snap
+++ b/modules/menu/react/spec/__snapshots__/Menu.snapshot.tsx.snap
@@ -226,7 +226,7 @@ exports[`Menu Snapshots renders a hidden menu 1`] = `
 .emotion-3 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;
@@ -289,7 +289,7 @@ exports[`Menu Snapshots renders a menu with aria attributes 1`] = `
 .emotion-7 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;
@@ -575,7 +575,7 @@ exports[`Menu Snapshots renders a menu with grow=true 1`] = `
 .emotion-11 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;
@@ -640,7 +640,7 @@ exports[`Menu Snapshots renders an empty menu 1`] = `
 .emotion-3 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;
@@ -703,7 +703,7 @@ exports[`Menu Snapshots renders an menu with one item 1`] = `
 .emotion-7 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;
@@ -850,7 +850,7 @@ exports[`Menu Snapshots renders an menu with two items 1`] = `
 .emotion-11 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;
@@ -1050,7 +1050,7 @@ exports[`Menu Snapshots renders with icon 1`] = `
 .emotion-11 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;

--- a/modules/menu/react/spec/__snapshots__/Menu.snapshot.tsx.snap
+++ b/modules/menu/react/spec/__snapshots__/Menu.snapshot.tsx.snap
@@ -226,7 +226,7 @@ exports[`Menu Snapshots renders a hidden menu 1`] = `
 .emotion-3 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;
@@ -289,7 +289,7 @@ exports[`Menu Snapshots renders a menu with aria attributes 1`] = `
 .emotion-7 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;
@@ -575,7 +575,7 @@ exports[`Menu Snapshots renders a menu with grow=true 1`] = `
 .emotion-11 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;
@@ -640,7 +640,7 @@ exports[`Menu Snapshots renders an empty menu 1`] = `
 .emotion-3 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;
@@ -703,7 +703,7 @@ exports[`Menu Snapshots renders an menu with one item 1`] = `
 .emotion-7 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;
@@ -850,7 +850,7 @@ exports[`Menu Snapshots renders an menu with two items 1`] = `
 .emotion-11 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;
@@ -1050,7 +1050,7 @@ exports[`Menu Snapshots renders with icon 1`] = `
 .emotion-11 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;

--- a/modules/modal/react/spec/__snapshots__/Modal.snapshot.tsx.snap
+++ b/modules/modal/react/spec/__snapshots__/Modal.snapshot.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Modal Snapshots renders Modal with a different width 1`] = `
-.emotion-6 {
+.emotion-3 {
   position: fixed;
   top: 0;
   left: 0;
@@ -34,11 +34,11 @@ exports[`Modal Snapshots renders Modal with a different width 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-4 {
+.emotion-2 {
   position: relative;
   width: 800px;
-  -webkit-animation: animation-1htt9yb;
-  animation: animation-1htt9yb;
+  -webkit-animation: animation-221pkp;
+  animation: animation-221pkp;
   -webkit-animation-duration: 150ms;
   animation-duration: 150ms;
   -webkit-animation-timing-function: ease-out;
@@ -48,7 +48,7 @@ exports[`Modal Snapshots renders Modal with a different width 1`] = `
   transform-origin: top center;
 }
 
-.emotion-2 {
+.emotion-1 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -59,20 +59,20 @@ exports[`Modal Snapshots renders Modal with a different width 1`] = `
 }
 
 <div
-  className="emotion-6 emotion-7"
+  className="emotion-3 emotion-4"
   onClick={[Function]}
 >
   <div
-    className="emotion-4 emotion-5"
+    className="emotion-2"
     role="dialog"
     width="800px"
   >
     <div
-      className="emotion-2 emotion-3"
+      className="emotion-1"
       width="800px"
     >
       <div
-        className="emotion-0 emotion-1"
+        className="emotion-0"
       >
         <span>
           hello world
@@ -84,7 +84,7 @@ exports[`Modal Snapshots renders Modal with a different width 1`] = `
 `;
 
 exports[`Modal Snapshots renders Modal with children elements 1`] = `
-.emotion-11 {
+.emotion-7 {
   position: fixed;
   top: 0;
   left: 0;
@@ -109,11 +109,11 @@ exports[`Modal Snapshots renders Modal with children elements 1`] = `
   animation-duration: 0.3s;
 }
 
-.emotion-9 {
+.emotion-6 {
   position: relative;
   width: 440px;
-  -webkit-animation: animation-1htt9yb;
-  animation: animation-1htt9yb;
+  -webkit-animation: animation-221pkp;
+  animation: animation-221pkp;
   -webkit-animation-duration: 150ms;
   animation-duration: 150ms;
   -webkit-animation-timing-function: ease-out;
@@ -123,7 +123,7 @@ exports[`Modal Snapshots renders Modal with children elements 1`] = `
   transform-origin: top center;
 }
 
-.emotion-5 {
+.emotion-4 {
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
@@ -152,7 +152,7 @@ exports[`Modal Snapshots renders Modal with children elements 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -291,7 +291,7 @@ exports[`Modal Snapshots renders Modal with children elements 1`] = `
   fill: transparent;
 }
 
-.emotion-7 {
+.emotion-5 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -302,16 +302,16 @@ exports[`Modal Snapshots renders Modal with children elements 1`] = `
 }
 
 <div
-  className="emotion-11 emotion-12"
+  className="emotion-7 emotion-8"
   onClick={[Function]}
 >
   <div
-    className="emotion-9 emotion-10"
+    className="emotion-6"
     role="dialog"
     width="440px"
   >
     <div
-      className="emotion-3 emotion-4"
+      className="emotion-3"
     >
       <button
         aria-label="Close"
@@ -330,11 +330,11 @@ exports[`Modal Snapshots renders Modal with children elements 1`] = `
       </button>
     </div>
     <div
-      className="emotion-7 emotion-8"
+      className="emotion-5"
       width="440px"
     >
       <div
-        className="emotion-5 emotion-6"
+        className="emotion-4"
       >
         <span>
           hello world
@@ -346,7 +346,7 @@ exports[`Modal Snapshots renders Modal with children elements 1`] = `
 `;
 
 exports[`Modal Snapshots renders Modal with close icon 1`] = `
-.emotion-11 {
+.emotion-7 {
   position: fixed;
   top: 0;
   left: 0;
@@ -371,11 +371,11 @@ exports[`Modal Snapshots renders Modal with close icon 1`] = `
   animation-duration: 0.3s;
 }
 
-.emotion-9 {
+.emotion-6 {
   position: relative;
   width: 440px;
-  -webkit-animation: animation-1htt9yb;
-  animation: animation-1htt9yb;
+  -webkit-animation: animation-221pkp;
+  animation: animation-221pkp;
   -webkit-animation-duration: 150ms;
   animation-duration: 150ms;
   -webkit-animation-timing-function: ease-out;
@@ -385,7 +385,7 @@ exports[`Modal Snapshots renders Modal with close icon 1`] = `
   transform-origin: top center;
 }
 
-.emotion-7 {
+.emotion-5 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -395,7 +395,7 @@ exports[`Modal Snapshots renders Modal with close icon 1`] = `
   width: 440px;
 }
 
-.emotion-5 {
+.emotion-4 {
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
@@ -424,7 +424,7 @@ exports[`Modal Snapshots renders Modal with close icon 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -564,16 +564,16 @@ exports[`Modal Snapshots renders Modal with close icon 1`] = `
 }
 
 <div
-  className="emotion-11 emotion-12"
+  className="emotion-7 emotion-8"
   onClick={[Function]}
 >
   <div
-    className="emotion-9 emotion-10"
+    className="emotion-6"
     role="dialog"
     width="440px"
   >
     <div
-      className="emotion-3 emotion-4"
+      className="emotion-3"
     >
       <button
         aria-label="Close"
@@ -592,11 +592,11 @@ exports[`Modal Snapshots renders Modal with close icon 1`] = `
       </button>
     </div>
     <div
-      className="emotion-7 emotion-8"
+      className="emotion-5"
       width="440px"
     >
       <div
-        className="emotion-5 emotion-6"
+        className="emotion-4"
       />
     </div>
   </div>
@@ -604,7 +604,7 @@ exports[`Modal Snapshots renders Modal with close icon 1`] = `
 `;
 
 exports[`Modal Snapshots renders Modal with different padding 1`] = `
-.emotion-11 {
+.emotion-7 {
   position: fixed;
   top: 0;
   left: 0;
@@ -629,11 +629,11 @@ exports[`Modal Snapshots renders Modal with different padding 1`] = `
   animation-duration: 0.3s;
 }
 
-.emotion-9 {
+.emotion-6 {
   position: relative;
   width: 440px;
-  -webkit-animation: animation-1htt9yb;
-  animation: animation-1htt9yb;
+  -webkit-animation: animation-221pkp;
+  animation: animation-221pkp;
   -webkit-animation-duration: 150ms;
   animation-duration: 150ms;
   -webkit-animation-timing-function: ease-out;
@@ -643,7 +643,7 @@ exports[`Modal Snapshots renders Modal with different padding 1`] = `
   transform-origin: top center;
 }
 
-.emotion-5 {
+.emotion-4 {
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
@@ -672,7 +672,7 @@ exports[`Modal Snapshots renders Modal with different padding 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -811,7 +811,7 @@ exports[`Modal Snapshots renders Modal with different padding 1`] = `
   fill: transparent;
 }
 
-.emotion-7 {
+.emotion-5 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -822,16 +822,16 @@ exports[`Modal Snapshots renders Modal with different padding 1`] = `
 }
 
 <div
-  className="emotion-11 emotion-12"
+  className="emotion-7 emotion-8"
   onClick={[Function]}
 >
   <div
-    className="emotion-9 emotion-10"
+    className="emotion-6"
     role="dialog"
     width="440px"
   >
     <div
-      className="emotion-3 emotion-4"
+      className="emotion-3"
     >
       <button
         aria-label="Close"
@@ -850,11 +850,11 @@ exports[`Modal Snapshots renders Modal with different padding 1`] = `
       </button>
     </div>
     <div
-      className="emotion-7 emotion-8"
+      className="emotion-5"
       width="440px"
     >
       <div
-        className="emotion-5 emotion-6"
+        className="emotion-4"
       />
     </div>
   </div>
@@ -862,7 +862,7 @@ exports[`Modal Snapshots renders Modal with different padding 1`] = `
 `;
 
 exports[`Modal Snapshots renders Modal with transformOrigin 1`] = `
-.emotion-6 {
+.emotion-3 {
   position: fixed;
   top: 0;
   left: 0;
@@ -887,11 +887,11 @@ exports[`Modal Snapshots renders Modal with transformOrigin 1`] = `
   animation-duration: 0.3s;
 }
 
-.emotion-4 {
+.emotion-2 {
   position: relative;
   width: 440px;
-  -webkit-animation: animation-1htt9yb;
-  animation: animation-1htt9yb;
+  -webkit-animation: animation-221pkp;
+  animation: animation-221pkp;
   -webkit-animation-duration: 150ms;
   animation-duration: 150ms;
   -webkit-animation-timing-function: ease-out;
@@ -909,7 +909,7 @@ exports[`Modal Snapshots renders Modal with transformOrigin 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-2 {
+.emotion-1 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -920,20 +920,20 @@ exports[`Modal Snapshots renders Modal with transformOrigin 1`] = `
 }
 
 <div
-  className="emotion-6 emotion-7"
+  className="emotion-3 emotion-4"
   onClick={[Function]}
 >
   <div
-    className="emotion-4 emotion-5"
+    className="emotion-2"
     role="dialog"
     width="440px"
   >
     <div
-      className="emotion-2 emotion-3"
+      className="emotion-1"
       width="440px"
     >
       <div
-        className="emotion-0 emotion-1"
+        className="emotion-0"
       >
         <span>
           hello world
@@ -945,7 +945,7 @@ exports[`Modal Snapshots renders Modal with transformOrigin 1`] = `
 `;
 
 exports[`Modal Snapshots renders Modal without close icon 1`] = `
-.emotion-6 {
+.emotion-3 {
   position: fixed;
   top: 0;
   left: 0;
@@ -970,11 +970,11 @@ exports[`Modal Snapshots renders Modal without close icon 1`] = `
   animation-duration: 0.3s;
 }
 
-.emotion-4 {
+.emotion-2 {
   position: relative;
   width: 440px;
-  -webkit-animation: animation-1htt9yb;
-  animation: animation-1htt9yb;
+  -webkit-animation: animation-221pkp;
+  animation: animation-221pkp;
   -webkit-animation-duration: 150ms;
   animation-duration: 150ms;
   -webkit-animation-timing-function: ease-out;
@@ -992,7 +992,7 @@ exports[`Modal Snapshots renders Modal without close icon 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-2 {
+.emotion-1 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -1003,20 +1003,20 @@ exports[`Modal Snapshots renders Modal without close icon 1`] = `
 }
 
 <div
-  className="emotion-6 emotion-7"
+  className="emotion-3 emotion-4"
   onClick={[Function]}
 >
   <div
-    className="emotion-4 emotion-5"
+    className="emotion-2"
     role="dialog"
     width="440px"
   >
     <div
-      className="emotion-2 emotion-3"
+      className="emotion-1"
       width="440px"
     >
       <div
-        className="emotion-0 emotion-1"
+        className="emotion-0"
       >
         <span>
           hello world
@@ -1028,7 +1028,7 @@ exports[`Modal Snapshots renders Modal without close icon 1`] = `
 `;
 
 exports[`Modal Snapshots renders as expected 1`] = `
-.emotion-6 {
+.emotion-3 {
   position: fixed;
   top: 0;
   left: 0;
@@ -1053,11 +1053,11 @@ exports[`Modal Snapshots renders as expected 1`] = `
   animation-duration: 0.3s;
 }
 
-.emotion-4 {
+.emotion-2 {
   position: relative;
   width: 440px;
-  -webkit-animation: animation-1htt9yb;
-  animation: animation-1htt9yb;
+  -webkit-animation: animation-221pkp;
+  animation: animation-221pkp;
   -webkit-animation-duration: 150ms;
   animation-duration: 150ms;
   -webkit-animation-timing-function: ease-out;
@@ -1067,7 +1067,7 @@ exports[`Modal Snapshots renders as expected 1`] = `
   transform-origin: top center;
 }
 
-.emotion-2 {
+.emotion-1 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -1086,20 +1086,20 @@ exports[`Modal Snapshots renders as expected 1`] = `
 }
 
 <div
-  className="emotion-6 emotion-7"
+  className="emotion-3 emotion-4"
   onClick={[Function]}
 >
   <div
-    className="emotion-4 emotion-5"
+    className="emotion-2"
     role="dialog"
     width="440px"
   >
     <div
-      className="emotion-2 emotion-3"
+      className="emotion-1"
       width="440px"
     >
       <div
-        className="emotion-0 emotion-1"
+        className="emotion-0"
       />
     </div>
   </div>

--- a/modules/modal/react/spec/__snapshots__/Modal.snapshot.tsx.snap
+++ b/modules/modal/react/spec/__snapshots__/Modal.snapshot.tsx.snap
@@ -51,7 +51,7 @@ exports[`Modal Snapshots renders Modal with a different width 1`] = `
 .emotion-1 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 32px;
@@ -294,7 +294,7 @@ exports[`Modal Snapshots renders Modal with children elements 1`] = `
 .emotion-5 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;
@@ -388,7 +388,7 @@ exports[`Modal Snapshots renders Modal with close icon 1`] = `
 .emotion-5 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 16px;
@@ -814,7 +814,7 @@ exports[`Modal Snapshots renders Modal with different padding 1`] = `
 .emotion-5 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 32px;
@@ -912,7 +912,7 @@ exports[`Modal Snapshots renders Modal with transformOrigin 1`] = `
 .emotion-1 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;
@@ -995,7 +995,7 @@ exports[`Modal Snapshots renders Modal without close icon 1`] = `
 .emotion-1 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;
@@ -1070,7 +1070,7 @@ exports[`Modal Snapshots renders as expected 1`] = `
 .emotion-1 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 16px;

--- a/modules/modal/react/spec/__snapshots__/Modal.snapshot.tsx.snap
+++ b/modules/modal/react/spec/__snapshots__/Modal.snapshot.tsx.snap
@@ -51,7 +51,7 @@ exports[`Modal Snapshots renders Modal with a different width 1`] = `
 .emotion-1 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 32px;
@@ -294,7 +294,7 @@ exports[`Modal Snapshots renders Modal with children elements 1`] = `
 .emotion-5 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;
@@ -388,7 +388,7 @@ exports[`Modal Snapshots renders Modal with close icon 1`] = `
 .emotion-5 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 16px;
@@ -814,7 +814,7 @@ exports[`Modal Snapshots renders Modal with different padding 1`] = `
 .emotion-5 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 32px;
@@ -912,7 +912,7 @@ exports[`Modal Snapshots renders Modal with transformOrigin 1`] = `
 .emotion-1 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;
@@ -995,7 +995,7 @@ exports[`Modal Snapshots renders Modal without close icon 1`] = `
 .emotion-1 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;
@@ -1070,7 +1070,7 @@ exports[`Modal Snapshots renders as expected 1`] = `
 .emotion-1 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 16px;

--- a/modules/modal/react/spec/__snapshots__/Modal.snapshot.tsx.snap
+++ b/modules/modal/react/spec/__snapshots__/Modal.snapshot.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Modal Snapshots renders Modal with a different width 1`] = `
-.emotion-3 {
+.emotion-6 {
   position: fixed;
   top: 0;
   left: 0;
@@ -34,11 +34,11 @@ exports[`Modal Snapshots renders Modal with a different width 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-2 {
+.emotion-4 {
   position: relative;
   width: 800px;
-  -webkit-animation: animation-221pkp;
-  animation: animation-221pkp;
+  -webkit-animation: animation-1htt9yb;
+  animation: animation-1htt9yb;
   -webkit-animation-duration: 150ms;
   animation-duration: 150ms;
   -webkit-animation-timing-function: ease-out;
@@ -48,7 +48,7 @@ exports[`Modal Snapshots renders Modal with a different width 1`] = `
   transform-origin: top center;
 }
 
-.emotion-1 {
+.emotion-2 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -59,20 +59,20 @@ exports[`Modal Snapshots renders Modal with a different width 1`] = `
 }
 
 <div
-  className="emotion-3 emotion-4"
+  className="emotion-6 emotion-7"
   onClick={[Function]}
 >
   <div
-    className="emotion-2"
+    className="emotion-4 emotion-5"
     role="dialog"
     width="800px"
   >
     <div
-      className="emotion-1"
+      className="emotion-2 emotion-3"
       width="800px"
     >
       <div
-        className="emotion-0"
+        className="emotion-0 emotion-1"
       >
         <span>
           hello world
@@ -84,7 +84,7 @@ exports[`Modal Snapshots renders Modal with a different width 1`] = `
 `;
 
 exports[`Modal Snapshots renders Modal with children elements 1`] = `
-.emotion-7 {
+.emotion-11 {
   position: fixed;
   top: 0;
   left: 0;
@@ -109,11 +109,11 @@ exports[`Modal Snapshots renders Modal with children elements 1`] = `
   animation-duration: 0.3s;
 }
 
-.emotion-6 {
+.emotion-9 {
   position: relative;
   width: 440px;
-  -webkit-animation: animation-221pkp;
-  animation: animation-221pkp;
+  -webkit-animation: animation-1htt9yb;
+  animation: animation-1htt9yb;
   -webkit-animation-duration: 150ms;
   animation-duration: 150ms;
   -webkit-animation-timing-function: ease-out;
@@ -123,7 +123,7 @@ exports[`Modal Snapshots renders Modal with children elements 1`] = `
   transform-origin: top center;
 }
 
-.emotion-4 {
+.emotion-5 {
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
@@ -291,7 +291,7 @@ exports[`Modal Snapshots renders Modal with children elements 1`] = `
   fill: transparent;
 }
 
-.emotion-5 {
+.emotion-7 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -302,16 +302,16 @@ exports[`Modal Snapshots renders Modal with children elements 1`] = `
 }
 
 <div
-  className="emotion-7 emotion-8"
+  className="emotion-11 emotion-12"
   onClick={[Function]}
 >
   <div
-    className="emotion-6"
+    className="emotion-9 emotion-10"
     role="dialog"
     width="440px"
   >
     <div
-      className="emotion-3"
+      className="emotion-3 emotion-4"
     >
       <button
         aria-label="Close"
@@ -330,11 +330,11 @@ exports[`Modal Snapshots renders Modal with children elements 1`] = `
       </button>
     </div>
     <div
-      className="emotion-5"
+      className="emotion-7 emotion-8"
       width="440px"
     >
       <div
-        className="emotion-4"
+        className="emotion-5 emotion-6"
       >
         <span>
           hello world
@@ -346,7 +346,7 @@ exports[`Modal Snapshots renders Modal with children elements 1`] = `
 `;
 
 exports[`Modal Snapshots renders Modal with close icon 1`] = `
-.emotion-7 {
+.emotion-11 {
   position: fixed;
   top: 0;
   left: 0;
@@ -371,11 +371,11 @@ exports[`Modal Snapshots renders Modal with close icon 1`] = `
   animation-duration: 0.3s;
 }
 
-.emotion-6 {
+.emotion-9 {
   position: relative;
   width: 440px;
-  -webkit-animation: animation-221pkp;
-  animation: animation-221pkp;
+  -webkit-animation: animation-1htt9yb;
+  animation: animation-1htt9yb;
   -webkit-animation-duration: 150ms;
   animation-duration: 150ms;
   -webkit-animation-timing-function: ease-out;
@@ -385,7 +385,7 @@ exports[`Modal Snapshots renders Modal with close icon 1`] = `
   transform-origin: top center;
 }
 
-.emotion-5 {
+.emotion-7 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -395,7 +395,7 @@ exports[`Modal Snapshots renders Modal with close icon 1`] = `
   width: 440px;
 }
 
-.emotion-4 {
+.emotion-5 {
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
@@ -564,16 +564,16 @@ exports[`Modal Snapshots renders Modal with close icon 1`] = `
 }
 
 <div
-  className="emotion-7 emotion-8"
+  className="emotion-11 emotion-12"
   onClick={[Function]}
 >
   <div
-    className="emotion-6"
+    className="emotion-9 emotion-10"
     role="dialog"
     width="440px"
   >
     <div
-      className="emotion-3"
+      className="emotion-3 emotion-4"
     >
       <button
         aria-label="Close"
@@ -592,11 +592,11 @@ exports[`Modal Snapshots renders Modal with close icon 1`] = `
       </button>
     </div>
     <div
-      className="emotion-5"
+      className="emotion-7 emotion-8"
       width="440px"
     >
       <div
-        className="emotion-4"
+        className="emotion-5 emotion-6"
       />
     </div>
   </div>
@@ -604,7 +604,7 @@ exports[`Modal Snapshots renders Modal with close icon 1`] = `
 `;
 
 exports[`Modal Snapshots renders Modal with different padding 1`] = `
-.emotion-7 {
+.emotion-11 {
   position: fixed;
   top: 0;
   left: 0;
@@ -629,11 +629,11 @@ exports[`Modal Snapshots renders Modal with different padding 1`] = `
   animation-duration: 0.3s;
 }
 
-.emotion-6 {
+.emotion-9 {
   position: relative;
   width: 440px;
-  -webkit-animation: animation-221pkp;
-  animation: animation-221pkp;
+  -webkit-animation: animation-1htt9yb;
+  animation: animation-1htt9yb;
   -webkit-animation-duration: 150ms;
   animation-duration: 150ms;
   -webkit-animation-timing-function: ease-out;
@@ -643,7 +643,7 @@ exports[`Modal Snapshots renders Modal with different padding 1`] = `
   transform-origin: top center;
 }
 
-.emotion-4 {
+.emotion-5 {
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
@@ -811,7 +811,7 @@ exports[`Modal Snapshots renders Modal with different padding 1`] = `
   fill: transparent;
 }
 
-.emotion-5 {
+.emotion-7 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -822,16 +822,16 @@ exports[`Modal Snapshots renders Modal with different padding 1`] = `
 }
 
 <div
-  className="emotion-7 emotion-8"
+  className="emotion-11 emotion-12"
   onClick={[Function]}
 >
   <div
-    className="emotion-6"
+    className="emotion-9 emotion-10"
     role="dialog"
     width="440px"
   >
     <div
-      className="emotion-3"
+      className="emotion-3 emotion-4"
     >
       <button
         aria-label="Close"
@@ -850,11 +850,11 @@ exports[`Modal Snapshots renders Modal with different padding 1`] = `
       </button>
     </div>
     <div
-      className="emotion-5"
+      className="emotion-7 emotion-8"
       width="440px"
     >
       <div
-        className="emotion-4"
+        className="emotion-5 emotion-6"
       />
     </div>
   </div>
@@ -862,7 +862,7 @@ exports[`Modal Snapshots renders Modal with different padding 1`] = `
 `;
 
 exports[`Modal Snapshots renders Modal with transformOrigin 1`] = `
-.emotion-3 {
+.emotion-6 {
   position: fixed;
   top: 0;
   left: 0;
@@ -887,11 +887,11 @@ exports[`Modal Snapshots renders Modal with transformOrigin 1`] = `
   animation-duration: 0.3s;
 }
 
-.emotion-2 {
+.emotion-4 {
   position: relative;
   width: 440px;
-  -webkit-animation: animation-221pkp;
-  animation: animation-221pkp;
+  -webkit-animation: animation-1htt9yb;
+  animation: animation-1htt9yb;
   -webkit-animation-duration: 150ms;
   animation-duration: 150ms;
   -webkit-animation-timing-function: ease-out;
@@ -909,7 +909,7 @@ exports[`Modal Snapshots renders Modal with transformOrigin 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-1 {
+.emotion-2 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -920,20 +920,20 @@ exports[`Modal Snapshots renders Modal with transformOrigin 1`] = `
 }
 
 <div
-  className="emotion-3 emotion-4"
+  className="emotion-6 emotion-7"
   onClick={[Function]}
 >
   <div
-    className="emotion-2"
+    className="emotion-4 emotion-5"
     role="dialog"
     width="440px"
   >
     <div
-      className="emotion-1"
+      className="emotion-2 emotion-3"
       width="440px"
     >
       <div
-        className="emotion-0"
+        className="emotion-0 emotion-1"
       >
         <span>
           hello world
@@ -945,7 +945,7 @@ exports[`Modal Snapshots renders Modal with transformOrigin 1`] = `
 `;
 
 exports[`Modal Snapshots renders Modal without close icon 1`] = `
-.emotion-3 {
+.emotion-6 {
   position: fixed;
   top: 0;
   left: 0;
@@ -970,11 +970,11 @@ exports[`Modal Snapshots renders Modal without close icon 1`] = `
   animation-duration: 0.3s;
 }
 
-.emotion-2 {
+.emotion-4 {
   position: relative;
   width: 440px;
-  -webkit-animation: animation-221pkp;
-  animation: animation-221pkp;
+  -webkit-animation: animation-1htt9yb;
+  animation: animation-1htt9yb;
   -webkit-animation-duration: 150ms;
   animation-duration: 150ms;
   -webkit-animation-timing-function: ease-out;
@@ -992,7 +992,7 @@ exports[`Modal Snapshots renders Modal without close icon 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-1 {
+.emotion-2 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -1003,20 +1003,20 @@ exports[`Modal Snapshots renders Modal without close icon 1`] = `
 }
 
 <div
-  className="emotion-3 emotion-4"
+  className="emotion-6 emotion-7"
   onClick={[Function]}
 >
   <div
-    className="emotion-2"
+    className="emotion-4 emotion-5"
     role="dialog"
     width="440px"
   >
     <div
-      className="emotion-1"
+      className="emotion-2 emotion-3"
       width="440px"
     >
       <div
-        className="emotion-0"
+        className="emotion-0 emotion-1"
       >
         <span>
           hello world
@@ -1028,7 +1028,7 @@ exports[`Modal Snapshots renders Modal without close icon 1`] = `
 `;
 
 exports[`Modal Snapshots renders as expected 1`] = `
-.emotion-3 {
+.emotion-6 {
   position: fixed;
   top: 0;
   left: 0;
@@ -1053,11 +1053,11 @@ exports[`Modal Snapshots renders as expected 1`] = `
   animation-duration: 0.3s;
 }
 
-.emotion-2 {
+.emotion-4 {
   position: relative;
   width: 440px;
-  -webkit-animation: animation-221pkp;
-  animation: animation-221pkp;
+  -webkit-animation: animation-1htt9yb;
+  animation: animation-1htt9yb;
   -webkit-animation-duration: 150ms;
   animation-duration: 150ms;
   -webkit-animation-timing-function: ease-out;
@@ -1067,7 +1067,7 @@ exports[`Modal Snapshots renders as expected 1`] = `
   transform-origin: top center;
 }
 
-.emotion-1 {
+.emotion-2 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -1086,20 +1086,20 @@ exports[`Modal Snapshots renders as expected 1`] = `
 }
 
 <div
-  className="emotion-3 emotion-4"
+  className="emotion-6 emotion-7"
   onClick={[Function]}
 >
   <div
-    className="emotion-2"
+    className="emotion-4 emotion-5"
     role="dialog"
     width="440px"
   >
     <div
-      className="emotion-1"
+      className="emotion-2 emotion-3"
       width="440px"
     >
       <div
-        className="emotion-0"
+        className="emotion-0 emotion-1"
       />
     </div>
   </div>

--- a/modules/popup/react/spec/__snapshots__/Popup.snapshot.tsx.snap
+++ b/modules/popup/react/spec/__snapshots__/Popup.snapshot.tsx.snap
@@ -25,7 +25,7 @@ exports[`Popup Snapshots renders Popup with a smaller close icon 1`] = `
 .emotion-1 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;
@@ -234,7 +234,7 @@ exports[`Popup Snapshots renders Popup with children elements 1`] = `
 .emotion-6 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;
@@ -294,7 +294,7 @@ exports[`Popup Snapshots renders Popup with close icon 1`] = `
 .emotion-6 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 16px;
@@ -686,7 +686,7 @@ exports[`Popup Snapshots renders Popup with different padding 1`] = `
 .emotion-6 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 32px;
@@ -750,7 +750,7 @@ exports[`Popup Snapshots renders Popup with transformOrigin 1`] = `
 .emotion-1 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;
@@ -799,7 +799,7 @@ exports[`Popup Snapshots renders Popup without close icon 1`] = `
 .emotion-1 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;
@@ -840,7 +840,7 @@ exports[`Popup Snapshots renders as expected 1`] = `
 .emotion-1 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 16px;

--- a/modules/popup/react/spec/__snapshots__/Popup.snapshot.tsx.snap
+++ b/modules/popup/react/spec/__snapshots__/Popup.snapshot.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Popup Snapshots renders Popup with a smaller close icon 1`] = `
-.emotion-4 {
+.emotion-2 {
   position: relative;
   -webkit-animation: animation-1htt9yb;
   animation: animation-1htt9yb;
@@ -22,7 +22,7 @@ exports[`Popup Snapshots renders Popup with a smaller close icon 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-2 {
+.emotion-1 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -32,14 +32,14 @@ exports[`Popup Snapshots renders Popup with a smaller close icon 1`] = `
 }
 
 <div
-  className="emotion-4 emotion-5"
+  className="emotion-2 emotion-3"
   role="dialog"
 >
   <div
-    className="emotion-2 emotion-3"
+    className="emotion-1"
   >
     <div
-      className="emotion-0 emotion-1"
+      className="emotion-0"
     >
       <span>
         hello world
@@ -50,7 +50,7 @@ exports[`Popup Snapshots renders Popup with a smaller close icon 1`] = `
 `;
 
 exports[`Popup Snapshots renders Popup with children elements 1`] = `
-.emotion-9 {
+.emotion-7 {
   position: relative;
   -webkit-animation: animation-1htt9yb;
   animation: animation-1htt9yb;
@@ -92,7 +92,7 @@ exports[`Popup Snapshots renders Popup with children elements 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -231,7 +231,7 @@ exports[`Popup Snapshots renders Popup with children elements 1`] = `
   fill: transparent;
 }
 
-.emotion-7 {
+.emotion-6 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -241,7 +241,7 @@ exports[`Popup Snapshots renders Popup with children elements 1`] = `
 }
 
 <div
-  className="emotion-9 emotion-10"
+  className="emotion-7 emotion-8"
   role="dialog"
 >
   <div
@@ -264,10 +264,10 @@ exports[`Popup Snapshots renders Popup with children elements 1`] = `
     </button>
   </div>
   <div
-    className="emotion-7 emotion-8"
+    className="emotion-6"
   >
     <div
-      className="emotion-5 emotion-6"
+      className="emotion-5"
     >
       <span>
         hello world
@@ -278,7 +278,7 @@ exports[`Popup Snapshots renders Popup with children elements 1`] = `
 `;
 
 exports[`Popup Snapshots renders Popup with close icon 1`] = `
-.emotion-9 {
+.emotion-7 {
   position: relative;
   -webkit-animation: animation-1htt9yb;
   animation: animation-1htt9yb;
@@ -291,7 +291,7 @@ exports[`Popup Snapshots renders Popup with close icon 1`] = `
   transform-origin: top center;
 }
 
-.emotion-7 {
+.emotion-6 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -329,7 +329,7 @@ exports[`Popup Snapshots renders Popup with close icon 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -469,7 +469,7 @@ exports[`Popup Snapshots renders Popup with close icon 1`] = `
 }
 
 <div
-  className="emotion-9 emotion-10"
+  className="emotion-7 emotion-8"
   role="dialog"
 >
   <div
@@ -492,17 +492,17 @@ exports[`Popup Snapshots renders Popup with close icon 1`] = `
     </button>
   </div>
   <div
-    className="emotion-7 emotion-8"
+    className="emotion-6"
   >
     <div
-      className="emotion-5 emotion-6"
+      className="emotion-5"
     />
   </div>
 </div>
 `;
 
 exports[`Popup Snapshots renders Popup with different padding 1`] = `
-.emotion-9 {
+.emotion-7 {
   position: relative;
   -webkit-animation: animation-1htt9yb;
   animation: animation-1htt9yb;
@@ -544,7 +544,7 @@ exports[`Popup Snapshots renders Popup with different padding 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -683,7 +683,7 @@ exports[`Popup Snapshots renders Popup with different padding 1`] = `
   fill: transparent;
 }
 
-.emotion-7 {
+.emotion-6 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -693,7 +693,7 @@ exports[`Popup Snapshots renders Popup with different padding 1`] = `
 }
 
 <div
-  className="emotion-9 emotion-10"
+  className="emotion-7 emotion-8"
   role="dialog"
 >
   <div
@@ -716,17 +716,17 @@ exports[`Popup Snapshots renders Popup with different padding 1`] = `
     </button>
   </div>
   <div
-    className="emotion-7 emotion-8"
+    className="emotion-6"
   >
     <div
-      className="emotion-5 emotion-6"
+      className="emotion-5"
     />
   </div>
 </div>
 `;
 
 exports[`Popup Snapshots renders Popup with transformOrigin 1`] = `
-.emotion-4 {
+.emotion-2 {
   position: relative;
   -webkit-animation: animation-1htt9yb;
   animation: animation-1htt9yb;
@@ -747,7 +747,7 @@ exports[`Popup Snapshots renders Popup with transformOrigin 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-2 {
+.emotion-1 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -757,14 +757,14 @@ exports[`Popup Snapshots renders Popup with transformOrigin 1`] = `
 }
 
 <div
-  className="emotion-4 emotion-5"
+  className="emotion-2 emotion-3"
   role="dialog"
 >
   <div
-    className="emotion-2 emotion-3"
+    className="emotion-1"
   >
     <div
-      className="emotion-0 emotion-1"
+      className="emotion-0"
     >
       <span>
         hello world
@@ -775,7 +775,7 @@ exports[`Popup Snapshots renders Popup with transformOrigin 1`] = `
 `;
 
 exports[`Popup Snapshots renders Popup without close icon 1`] = `
-.emotion-4 {
+.emotion-2 {
   position: relative;
   -webkit-animation: animation-1htt9yb;
   animation: animation-1htt9yb;
@@ -796,7 +796,7 @@ exports[`Popup Snapshots renders Popup without close icon 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-2 {
+.emotion-1 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -806,14 +806,14 @@ exports[`Popup Snapshots renders Popup without close icon 1`] = `
 }
 
 <div
-  className="emotion-4 emotion-5"
+  className="emotion-2 emotion-3"
   role="dialog"
 >
   <div
-    className="emotion-2 emotion-3"
+    className="emotion-1"
   >
     <div
-      className="emotion-0 emotion-1"
+      className="emotion-0"
     >
       <span>
         hello world
@@ -824,7 +824,7 @@ exports[`Popup Snapshots renders Popup without close icon 1`] = `
 `;
 
 exports[`Popup Snapshots renders as expected 1`] = `
-.emotion-4 {
+.emotion-2 {
   position: relative;
   -webkit-animation: animation-1htt9yb;
   animation: animation-1htt9yb;
@@ -837,7 +837,7 @@ exports[`Popup Snapshots renders as expected 1`] = `
   transform-origin: top center;
 }
 
-.emotion-2 {
+.emotion-1 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -855,14 +855,14 @@ exports[`Popup Snapshots renders as expected 1`] = `
 }
 
 <div
-  className="emotion-4 emotion-5"
+  className="emotion-2 emotion-3"
   role="dialog"
 >
   <div
-    className="emotion-2 emotion-3"
+    className="emotion-1"
   >
     <div
-      className="emotion-0 emotion-1"
+      className="emotion-0"
     />
   </div>
 </div>

--- a/modules/popup/react/spec/__snapshots__/Popup.snapshot.tsx.snap
+++ b/modules/popup/react/spec/__snapshots__/Popup.snapshot.tsx.snap
@@ -25,7 +25,7 @@ exports[`Popup Snapshots renders Popup with a smaller close icon 1`] = `
 .emotion-1 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;
@@ -234,7 +234,7 @@ exports[`Popup Snapshots renders Popup with children elements 1`] = `
 .emotion-6 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;
@@ -294,7 +294,7 @@ exports[`Popup Snapshots renders Popup with close icon 1`] = `
 .emotion-6 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 16px;
@@ -686,7 +686,7 @@ exports[`Popup Snapshots renders Popup with different padding 1`] = `
 .emotion-6 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 32px;
@@ -750,7 +750,7 @@ exports[`Popup Snapshots renders Popup with transformOrigin 1`] = `
 .emotion-1 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;
@@ -799,7 +799,7 @@ exports[`Popup Snapshots renders Popup without close icon 1`] = `
 .emotion-1 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 0px;
@@ -840,7 +840,7 @@ exports[`Popup Snapshots renders as expected 1`] = `
 .emotion-1 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 16px;

--- a/modules/popup/react/spec/__snapshots__/Popup.snapshot.tsx.snap
+++ b/modules/popup/react/spec/__snapshots__/Popup.snapshot.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Popup Snapshots renders Popup with a smaller close icon 1`] = `
-.emotion-2 {
+.emotion-4 {
   position: relative;
   -webkit-animation: animation-1htt9yb;
   animation: animation-1htt9yb;
@@ -22,7 +22,7 @@ exports[`Popup Snapshots renders Popup with a smaller close icon 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-1 {
+.emotion-2 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -32,14 +32,14 @@ exports[`Popup Snapshots renders Popup with a smaller close icon 1`] = `
 }
 
 <div
-  className="emotion-2 emotion-3"
+  className="emotion-4 emotion-5"
   role="dialog"
 >
   <div
-    className="emotion-1"
+    className="emotion-2 emotion-3"
   >
     <div
-      className="emotion-0"
+      className="emotion-0 emotion-1"
     >
       <span>
         hello world
@@ -50,7 +50,7 @@ exports[`Popup Snapshots renders Popup with a smaller close icon 1`] = `
 `;
 
 exports[`Popup Snapshots renders Popup with children elements 1`] = `
-.emotion-7 {
+.emotion-9 {
   position: relative;
   -webkit-animation: animation-1htt9yb;
   animation: animation-1htt9yb;
@@ -231,7 +231,7 @@ exports[`Popup Snapshots renders Popup with children elements 1`] = `
   fill: transparent;
 }
 
-.emotion-6 {
+.emotion-7 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -241,7 +241,7 @@ exports[`Popup Snapshots renders Popup with children elements 1`] = `
 }
 
 <div
-  className="emotion-7 emotion-8"
+  className="emotion-9 emotion-10"
   role="dialog"
 >
   <div
@@ -264,10 +264,10 @@ exports[`Popup Snapshots renders Popup with children elements 1`] = `
     </button>
   </div>
   <div
-    className="emotion-6"
+    className="emotion-7 emotion-8"
   >
     <div
-      className="emotion-5"
+      className="emotion-5 emotion-6"
     >
       <span>
         hello world
@@ -278,7 +278,7 @@ exports[`Popup Snapshots renders Popup with children elements 1`] = `
 `;
 
 exports[`Popup Snapshots renders Popup with close icon 1`] = `
-.emotion-7 {
+.emotion-9 {
   position: relative;
   -webkit-animation: animation-1htt9yb;
   animation: animation-1htt9yb;
@@ -291,7 +291,7 @@ exports[`Popup Snapshots renders Popup with close icon 1`] = `
   transform-origin: top center;
 }
 
-.emotion-6 {
+.emotion-7 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -469,7 +469,7 @@ exports[`Popup Snapshots renders Popup with close icon 1`] = `
 }
 
 <div
-  className="emotion-7 emotion-8"
+  className="emotion-9 emotion-10"
   role="dialog"
 >
   <div
@@ -492,17 +492,17 @@ exports[`Popup Snapshots renders Popup with close icon 1`] = `
     </button>
   </div>
   <div
-    className="emotion-6"
+    className="emotion-7 emotion-8"
   >
     <div
-      className="emotion-5"
+      className="emotion-5 emotion-6"
     />
   </div>
 </div>
 `;
 
 exports[`Popup Snapshots renders Popup with different padding 1`] = `
-.emotion-7 {
+.emotion-9 {
   position: relative;
   -webkit-animation: animation-1htt9yb;
   animation: animation-1htt9yb;
@@ -683,7 +683,7 @@ exports[`Popup Snapshots renders Popup with different padding 1`] = `
   fill: transparent;
 }
 
-.emotion-6 {
+.emotion-7 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -693,7 +693,7 @@ exports[`Popup Snapshots renders Popup with different padding 1`] = `
 }
 
 <div
-  className="emotion-7 emotion-8"
+  className="emotion-9 emotion-10"
   role="dialog"
 >
   <div
@@ -716,17 +716,17 @@ exports[`Popup Snapshots renders Popup with different padding 1`] = `
     </button>
   </div>
   <div
-    className="emotion-6"
+    className="emotion-7 emotion-8"
   >
     <div
-      className="emotion-5"
+      className="emotion-5 emotion-6"
     />
   </div>
 </div>
 `;
 
 exports[`Popup Snapshots renders Popup with transformOrigin 1`] = `
-.emotion-2 {
+.emotion-4 {
   position: relative;
   -webkit-animation: animation-1htt9yb;
   animation: animation-1htt9yb;
@@ -747,7 +747,7 @@ exports[`Popup Snapshots renders Popup with transformOrigin 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-1 {
+.emotion-2 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -757,14 +757,14 @@ exports[`Popup Snapshots renders Popup with transformOrigin 1`] = `
 }
 
 <div
-  className="emotion-2 emotion-3"
+  className="emotion-4 emotion-5"
   role="dialog"
 >
   <div
-    className="emotion-1"
+    className="emotion-2 emotion-3"
   >
     <div
-      className="emotion-0"
+      className="emotion-0 emotion-1"
     >
       <span>
         hello world
@@ -775,7 +775,7 @@ exports[`Popup Snapshots renders Popup with transformOrigin 1`] = `
 `;
 
 exports[`Popup Snapshots renders Popup without close icon 1`] = `
-.emotion-2 {
+.emotion-4 {
   position: relative;
   -webkit-animation: animation-1htt9yb;
   animation: animation-1htt9yb;
@@ -796,7 +796,7 @@ exports[`Popup Snapshots renders Popup without close icon 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-1 {
+.emotion-2 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -806,14 +806,14 @@ exports[`Popup Snapshots renders Popup without close icon 1`] = `
 }
 
 <div
-  className="emotion-2 emotion-3"
+  className="emotion-4 emotion-5"
   role="dialog"
 >
   <div
-    className="emotion-1"
+    className="emotion-2 emotion-3"
   >
     <div
-      className="emotion-0"
+      className="emotion-0 emotion-1"
     >
       <span>
         hello world
@@ -824,7 +824,7 @@ exports[`Popup Snapshots renders Popup without close icon 1`] = `
 `;
 
 exports[`Popup Snapshots renders as expected 1`] = `
-.emotion-2 {
+.emotion-4 {
   position: relative;
   -webkit-animation: animation-1htt9yb;
   animation: animation-1htt9yb;
@@ -837,7 +837,7 @@ exports[`Popup Snapshots renders as expected 1`] = `
   transform-origin: top center;
 }
 
-.emotion-1 {
+.emotion-2 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -855,14 +855,14 @@ exports[`Popup Snapshots renders as expected 1`] = `
 }
 
 <div
-  className="emotion-2 emotion-3"
+  className="emotion-4 emotion-5"
   role="dialog"
 >
   <div
-    className="emotion-1"
+    className="emotion-2 emotion-3"
   >
     <div
-      className="emotion-0"
+      className="emotion-0 emotion-1"
     />
   </div>
 </div>

--- a/modules/radio/css/lib/radio.scss
+++ b/modules/radio/css/lib/radio.scss
@@ -1,14 +1,14 @@
 .wdc-form-radio {
   @include wdc-form-selection-control();
 
-  input+label::before {
-    border-radius: 100%;
+  input + label::before {
+    border-radius: $wdc-border-radius-circle;
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cg%3E%3Ccircle fill='%23FFFFFF' cx='12' cy='12' r='4'%3E%3C/circle%3E%3C/g%3E%3C/svg%3E");
     background-position: center center;
     background-size: $wdc-spacing-m;
   }
 
-  input:checked+label::before {
+  input:checked + label::before {
     background-size: $wdc-spacing-m;
   }
 }

--- a/modules/radio/react/lib/Radio.tsx
+++ b/modules/radio/react/lib/Radio.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import styled from 'react-emotion';
 import {focusRing} from '@workday/canvas-kit-react-common';
 import canvas, {
+  borderRadius,
   colors,
   inputColors,
   spacingNumbers as spacing,
@@ -44,7 +45,7 @@ const RadioInputWrapper = styled('div')<Pick<RadioProps, 'disabled'>>(
   {
     height: radioHeight,
     '&::after': {
-      borderRadius: '100%',
+      borderRadius: borderRadius.circle,
       boxShadow: '0 0 0 0 ' + colors.soap200,
       content: '""',
       display: 'inline-block',

--- a/modules/radio/react/lib/RadioGroup.tsx
+++ b/modules/radio/react/lib/RadioGroup.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styled from 'react-emotion';
 import Radio, {RadioProps} from './Radio';
-import {spacing, inputColors, colors} from '@workday/canvas-kit-react-core';
+import {borderRadius, spacing, inputColors, colors} from '@workday/canvas-kit-react-core';
 import {ErrorType, GrowthBehavior} from '@workday/canvas-kit-react-common';
 
 export interface RadioGroupProps extends GrowthBehavior {
@@ -48,7 +48,7 @@ const Container = styled('div')<Pick<RadioGroupProps, 'error' | 'grow'>>(
       return {};
     }
     return {
-      borderRadius: 4,
+      borderRadius: borderRadius.m,
       transition: '100ms box-shadow',
       boxShadow: errorBorderColor
         ? `inset 0 0 0 1px ${errorBorderColor}, inset 0 0 0 3px ${errorRingColor}`

--- a/modules/radio/react/spec/__snapshots__/Radio.snapshot.tsx.snap
+++ b/modules/radio/react/spec/__snapshots__/Radio.snapshot.tsx.snap
@@ -19,7 +19,7 @@ exports[`Radio Snapshots renders as expected 1`] = `
 }
 
 .emotion-6::after {
-  border-radius: 100%;
+  border-radius: 999px;
   box-shadow: 0 0 0 0 #f0f1f2;
   content: "";
   display: inline-block;
@@ -242,7 +242,7 @@ exports[`Radio Snapshots renders as expected 2`] = `
 }
 
 .emotion-6::after {
-  border-radius: 100%;
+  border-radius: 999px;
   box-shadow: 0 0 0 0 #f0f1f2;
   content: "";
   display: inline-block;
@@ -358,7 +358,7 @@ exports[`Radio Snapshots renders as expected 3`] = `
 }
 
 .emotion-6::after {
-  border-radius: 100%;
+  border-radius: 999px;
   box-shadow: 0 0 0 0 #f0f1f2;
   content: "";
   display: inline-block;
@@ -525,7 +525,7 @@ exports[`Radio Snapshots renders as expected 4`] = `
 }
 
 .emotion-6::after {
-  border-radius: 100%;
+  border-radius: 999px;
   box-shadow: 0 0 0 0 #f0f1f2;
   content: "";
   display: inline-block;
@@ -697,7 +697,7 @@ exports[`Radio Snapshots renders radio group with alert as expected 1`] = `
 }
 
 .emotion-6::after {
-  border-radius: 100%;
+  border-radius: 999px;
   box-shadow: 0 0 0 0 #f0f1f2;
   content: "";
   display: inline-block;
@@ -1022,7 +1022,7 @@ exports[`Radio Snapshots renders radio group with error as expected 1`] = `
 }
 
 .emotion-6::after {
-  border-radius: 100%;
+  border-radius: 999px;
   box-shadow: 0 0 0 0 #f0f1f2;
   content: "";
   display: inline-block;

--- a/modules/select/react/lib/Select.tsx
+++ b/modules/select/react/lib/Select.tsx
@@ -1,7 +1,14 @@
 import * as React from 'react';
 import styled from 'react-emotion';
 import {GrowthBehavior, ErrorType, errorRing} from '@workday/canvas-kit-react-common';
-import {colors, inputColors, spacingNumbers, type, spacing} from '@workday/canvas-kit-react-core';
+import {
+  colors,
+  borderRadius,
+  inputColors,
+  spacingNumbers,
+  type,
+  spacing,
+} from '@workday/canvas-kit-react-core';
 import {caretDownSmallIcon} from '@workday/canvas-system-icons-web';
 import {SystemIcon} from '@workday/canvas-kit-react-icon';
 import SelectOption from './SelectOption';
@@ -23,7 +30,7 @@ const SelectContainer = styled('select')<SelectProps>(
     border: `1px solid ${inputColors.border}`,
     display: 'block',
     backgroundColor: inputColors.background,
-    borderRadius: 4,
+    borderRadius: borderRadius.m,
     boxSizing: 'border-box',
     height: spacing.xl,
     minWidth: 280,

--- a/modules/side-panel/react/spec/__snapshots__/SidePanel.snapshot.tsx.snap
+++ b/modules/side-panel/react/spec/__snapshots__/SidePanel.snapshot.tsx.snap
@@ -445,7 +445,7 @@ exports[`SidePanel Snapshots renders a toggle button 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -819,7 +819,7 @@ exports[`SidePanel Snapshots renders side panel on the right with correct toggle
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -1044,7 +1044,7 @@ exports[`SidePanel Snapshots renders side panel on the right with correct toggle
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;

--- a/modules/status-indicator/react/lib/StatusIndicator.tsx
+++ b/modules/status-indicator/react/lib/StatusIndicator.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {SystemIcon} from '@workday/canvas-kit-react-icon';
 import {CanvasSystemIcon} from '@workday/design-assets-types';
 import {GenericStyle} from '@workday/canvas-kit-react-common';
-import {colors, type, spacing} from '@workday/canvas-kit-react-core';
+import {borderRadius, colors, type, spacing} from '@workday/canvas-kit-react-core';
 import {CSSObject} from 'create-emotion';
 import styled from 'react-emotion';
 
@@ -39,7 +39,7 @@ export const statusIndicatorStyles: StatusIndicatorGenericStyle = {
     maxWidth: 150,
     height: spacing.s,
     padding: `1px ${spacing.xxxs}`,
-    borderRadius: 2,
+    borderRadius: borderRadius.s,
     boxSizing: 'border-box',
   },
   variants: {

--- a/modules/switch/react/lib/Switch.tsx
+++ b/modules/switch/react/lib/Switch.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styled from 'react-emotion';
-import { ErrorType, focusRing, mouseFocusBehavior } from '@workday/canvas-kit-react-common';
-import { borderRadius, colors, inputColors, depth, spacing } from '@workday/canvas-kit-react-core';
+import {ErrorType, focusRing, mouseFocusBehavior} from '@workday/canvas-kit-react-common';
+import {borderRadius, colors, inputColors, depth, spacing} from '@workday/canvas-kit-react-core';
 
 export interface SwitchProps extends React.InputHTMLAttributes<HTMLInputElement> {
   checked: boolean;
@@ -32,7 +32,7 @@ const SwitchInput = styled('input')<SwitchProps>(
     width: switchTapArea,
     margin: 0,
     marginLeft: spacing.xxxs,
-    borderRadius: 999,
+    borderRadius: borderRadius.circle,
     opacity: 0,
     '&:focus, &:active': {
       outline: 'none',
@@ -49,10 +49,10 @@ const SwitchInput = styled('input')<SwitchProps>(
       },
     }),
   },
-  ({ disabled }) => ({
+  ({disabled}) => ({
     cursor: disabled ? 'not-allowed' : 'pointer',
   }),
-  ({ error }) => {
+  ({error}) => {
     let errorRingColor;
     let errorRingBorderColor = 'transparent';
 
@@ -106,12 +106,12 @@ const SwitchBackground = styled('div')<Pick<SwitchProps, 'checked' | 'disabled'>
     padding: '0px 2px',
     transition: 'background-color 200ms ease',
   },
-  ({ checked, disabled }) => ({
+  ({checked, disabled}) => ({
     backgroundColor: disabled ? colors.soap400 : checked ? colors.blueberry500 : colors.licorice200,
   })
 );
 
-const SwitchCircle = styled('div')<Pick<SwitchProps, 'checked'>>(({ checked }) => ({
+const SwitchCircle = styled('div')<Pick<SwitchProps, 'checked'>>(({checked}) => ({
   width: circleSize,
   height: circleSize,
   borderRadius: borderRadius.circle,
@@ -129,7 +129,7 @@ export default class Switch extends React.Component<SwitchProps> {
 
   public render() {
     // TODO: Standardize on prop spread location (see #150)
-    const { checked, disabled, id, inputRef, onChange, value, ...elemProps } = this.props;
+    const {checked, disabled, id, inputRef, onChange, value, ...elemProps} = this.props;
 
     return (
       <SwitchContainer>

--- a/modules/switch/react/lib/Switch.tsx
+++ b/modules/switch/react/lib/Switch.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styled from 'react-emotion';
-import {ErrorType, focusRing, mouseFocusBehavior} from '@workday/canvas-kit-react-common';
-import {colors, inputColors, depth, spacing} from '@workday/canvas-kit-react-core';
+import { ErrorType, focusRing, mouseFocusBehavior } from '@workday/canvas-kit-react-common';
+import { borderRadius, colors, inputColors, depth, spacing } from '@workday/canvas-kit-react-core';
 
 export interface SwitchProps extends React.InputHTMLAttributes<HTMLInputElement> {
   checked: boolean;
@@ -49,10 +49,10 @@ const SwitchInput = styled('input')<SwitchProps>(
       },
     }),
   },
-  ({disabled}) => ({
+  ({ disabled }) => ({
     cursor: disabled ? 'not-allowed' : 'pointer',
   }),
-  ({error}) => {
+  ({ error }) => {
     let errorRingColor;
     let errorRingBorderColor = 'transparent';
 
@@ -102,19 +102,19 @@ const SwitchBackground = styled('div')<Pick<SwitchProps, 'checked' | 'disabled'>
     marginTop: spacing.xxs,
     width: switchWidth,
     height: switchHeight,
-    borderRadius: 999,
+    borderRadius: borderRadius.circle,
     padding: '0px 2px',
     transition: 'background-color 200ms ease',
   },
-  ({checked, disabled}) => ({
+  ({ checked, disabled }) => ({
     backgroundColor: disabled ? colors.soap400 : checked ? colors.blueberry500 : colors.licorice200,
   })
 );
 
-const SwitchCircle = styled('div')<Pick<SwitchProps, 'checked'>>(({checked}) => ({
+const SwitchCircle = styled('div')<Pick<SwitchProps, 'checked'>>(({ checked }) => ({
   width: circleSize,
   height: circleSize,
-  borderRadius: 999,
+  borderRadius: borderRadius.circle,
   ...depth[1],
   backgroundColor: colors.frenchVanilla100,
   transform: checked ? `translateX(${translateLength})` : 'translateX(0)',
@@ -129,7 +129,7 @@ export default class Switch extends React.Component<SwitchProps> {
 
   public render() {
     // TODO: Standardize on prop spread location (see #150)
-    const {checked, disabled, id, inputRef, onChange, value, ...elemProps} = this.props;
+    const { checked, disabled, id, inputRef, onChange, value, ...elemProps } = this.props;
 
     return (
       <SwitchContainer>

--- a/modules/switch/react/spec/__snapshots__/Switch.snapshot.tsx.snap
+++ b/modules/switch/react/spec/__snapshots__/Switch.snapshot.tsx.snap
@@ -59,7 +59,7 @@ exports[`Switch Snapshots renders a switch with custom prop 1`] = `
   margin-top: 8px;
   width: 32px;
   height: 16px;
-  border-radius: 999px;
+  border-radius: 100%;
   padding: 0px 2px;
   -webkit-transition: background-color 200ms ease;
   transition: background-color 200ms ease;
@@ -69,7 +69,7 @@ exports[`Switch Snapshots renders a switch with custom prop 1`] = `
 .emotion-2 {
   width: 12px;
   height: 12px;
-  border-radius: 999px;
+  border-radius: 100%;
   box-shadow: 0px 2px 4px 0 rgba(0,0,0,0.08);
   background-color: #ffffff;
   -webkit-transform: translateX(16px);
@@ -168,7 +168,7 @@ exports[`Switch Snapshots renders as expected 1`] = `
   margin-top: 8px;
   width: 32px;
   height: 16px;
-  border-radius: 999px;
+  border-radius: 100%;
   padding: 0px 2px;
   -webkit-transition: background-color 200ms ease;
   transition: background-color 200ms ease;
@@ -178,7 +178,7 @@ exports[`Switch Snapshots renders as expected 1`] = `
 .emotion-2 {
   width: 12px;
   height: 12px;
-  border-radius: 999px;
+  border-radius: 100%;
   box-shadow: 0px 2px 4px 0 rgba(0,0,0,0.08);
   background-color: #ffffff;
   -webkit-transform: translateX(0);
@@ -223,7 +223,7 @@ exports[`Switch Snapshots renders switch disabled checked 1`] = `
 .emotion-2 {
   width: 12px;
   height: 12px;
-  border-radius: 999px;
+  border-radius: 100%;
   box-shadow: 0px 2px 4px 0 rgba(0,0,0,0.08);
   background-color: #ffffff;
   -webkit-transform: translateX(16px);
@@ -287,7 +287,7 @@ exports[`Switch Snapshots renders switch disabled checked 1`] = `
   margin-top: 8px;
   width: 32px;
   height: 16px;
-  border-radius: 999px;
+  border-radius: 100%;
   padding: 0px 2px;
   -webkit-transition: background-color 200ms ease;
   transition: background-color 200ms ease;
@@ -329,7 +329,7 @@ exports[`Switch Snapshots renders switch disabled unchecked 1`] = `
 .emotion-2 {
   width: 12px;
   height: 12px;
-  border-radius: 999px;
+  border-radius: 100%;
   box-shadow: 0px 2px 4px 0 rgba(0,0,0,0.08);
   background-color: #ffffff;
   -webkit-transform: translateX(0);
@@ -393,7 +393,7 @@ exports[`Switch Snapshots renders switch disabled unchecked 1`] = `
   margin-top: 8px;
   width: 32px;
   height: 16px;
-  border-radius: 999px;
+  border-radius: 100%;
   padding: 0px 2px;
   -webkit-transition: background-color 200ms ease;
   transition: background-color 200ms ease;
@@ -484,7 +484,7 @@ exports[`Switch Snapshots renders switch on 1`] = `
   margin-top: 8px;
   width: 32px;
   height: 16px;
-  border-radius: 999px;
+  border-radius: 100%;
   padding: 0px 2px;
   -webkit-transition: background-color 200ms ease;
   transition: background-color 200ms ease;
@@ -494,7 +494,7 @@ exports[`Switch Snapshots renders switch on 1`] = `
 .emotion-2 {
   width: 12px;
   height: 12px;
-  border-radius: 999px;
+  border-radius: 100%;
   box-shadow: 0px 2px 4px 0 rgba(0,0,0,0.08);
   background-color: #ffffff;
   -webkit-transform: translateX(16px);
@@ -588,7 +588,7 @@ exports[`Switch Snapshots renders switch with id 1`] = `
   margin-top: 8px;
   width: 32px;
   height: 16px;
-  border-radius: 999px;
+  border-radius: 100%;
   padding: 0px 2px;
   -webkit-transition: background-color 200ms ease;
   transition: background-color 200ms ease;
@@ -598,7 +598,7 @@ exports[`Switch Snapshots renders switch with id 1`] = `
 .emotion-2 {
   width: 12px;
   height: 12px;
-  border-radius: 999px;
+  border-radius: 100%;
   box-shadow: 0px 2px 4px 0 rgba(0,0,0,0.08);
   background-color: #ffffff;
   -webkit-transform: translateX(16px);
@@ -696,7 +696,7 @@ exports[`Switch Snapshots renders switch with name and value 1`] = `
   margin-top: 8px;
   width: 32px;
   height: 16px;
-  border-radius: 999px;
+  border-radius: 100%;
   padding: 0px 2px;
   -webkit-transition: background-color 200ms ease;
   transition: background-color 200ms ease;
@@ -706,7 +706,7 @@ exports[`Switch Snapshots renders switch with name and value 1`] = `
 .emotion-2 {
   width: 12px;
   height: 12px;
-  border-radius: 999px;
+  border-radius: 100%;
   box-shadow: 0px 2px 4px 0 rgba(0,0,0,0.08);
   background-color: #ffffff;
   -webkit-transform: translateX(16px);

--- a/modules/switch/react/spec/__snapshots__/Switch.snapshot.tsx.snap
+++ b/modules/switch/react/spec/__snapshots__/Switch.snapshot.tsx.snap
@@ -59,7 +59,7 @@ exports[`Switch Snapshots renders a switch with custom prop 1`] = `
   margin-top: 8px;
   width: 32px;
   height: 16px;
-  border-radius: 100%;
+  border-radius: 999px;
   padding: 0px 2px;
   -webkit-transition: background-color 200ms ease;
   transition: background-color 200ms ease;
@@ -69,7 +69,7 @@ exports[`Switch Snapshots renders a switch with custom prop 1`] = `
 .emotion-2 {
   width: 12px;
   height: 12px;
-  border-radius: 100%;
+  border-radius: 999px;
   box-shadow: 0px 2px 4px 0 rgba(0,0,0,0.08);
   background-color: #ffffff;
   -webkit-transform: translateX(16px);
@@ -168,7 +168,7 @@ exports[`Switch Snapshots renders as expected 1`] = `
   margin-top: 8px;
   width: 32px;
   height: 16px;
-  border-radius: 100%;
+  border-radius: 999px;
   padding: 0px 2px;
   -webkit-transition: background-color 200ms ease;
   transition: background-color 200ms ease;
@@ -178,7 +178,7 @@ exports[`Switch Snapshots renders as expected 1`] = `
 .emotion-2 {
   width: 12px;
   height: 12px;
-  border-radius: 100%;
+  border-radius: 999px;
   box-shadow: 0px 2px 4px 0 rgba(0,0,0,0.08);
   background-color: #ffffff;
   -webkit-transform: translateX(0);
@@ -223,7 +223,7 @@ exports[`Switch Snapshots renders switch disabled checked 1`] = `
 .emotion-2 {
   width: 12px;
   height: 12px;
-  border-radius: 100%;
+  border-radius: 999px;
   box-shadow: 0px 2px 4px 0 rgba(0,0,0,0.08);
   background-color: #ffffff;
   -webkit-transform: translateX(16px);
@@ -287,7 +287,7 @@ exports[`Switch Snapshots renders switch disabled checked 1`] = `
   margin-top: 8px;
   width: 32px;
   height: 16px;
-  border-radius: 100%;
+  border-radius: 999px;
   padding: 0px 2px;
   -webkit-transition: background-color 200ms ease;
   transition: background-color 200ms ease;
@@ -329,7 +329,7 @@ exports[`Switch Snapshots renders switch disabled unchecked 1`] = `
 .emotion-2 {
   width: 12px;
   height: 12px;
-  border-radius: 100%;
+  border-radius: 999px;
   box-shadow: 0px 2px 4px 0 rgba(0,0,0,0.08);
   background-color: #ffffff;
   -webkit-transform: translateX(0);
@@ -393,7 +393,7 @@ exports[`Switch Snapshots renders switch disabled unchecked 1`] = `
   margin-top: 8px;
   width: 32px;
   height: 16px;
-  border-radius: 100%;
+  border-radius: 999px;
   padding: 0px 2px;
   -webkit-transition: background-color 200ms ease;
   transition: background-color 200ms ease;
@@ -484,7 +484,7 @@ exports[`Switch Snapshots renders switch on 1`] = `
   margin-top: 8px;
   width: 32px;
   height: 16px;
-  border-radius: 100%;
+  border-radius: 999px;
   padding: 0px 2px;
   -webkit-transition: background-color 200ms ease;
   transition: background-color 200ms ease;
@@ -494,7 +494,7 @@ exports[`Switch Snapshots renders switch on 1`] = `
 .emotion-2 {
   width: 12px;
   height: 12px;
-  border-radius: 100%;
+  border-radius: 999px;
   box-shadow: 0px 2px 4px 0 rgba(0,0,0,0.08);
   background-color: #ffffff;
   -webkit-transform: translateX(16px);
@@ -588,7 +588,7 @@ exports[`Switch Snapshots renders switch with id 1`] = `
   margin-top: 8px;
   width: 32px;
   height: 16px;
-  border-radius: 100%;
+  border-radius: 999px;
   padding: 0px 2px;
   -webkit-transition: background-color 200ms ease;
   transition: background-color 200ms ease;
@@ -598,7 +598,7 @@ exports[`Switch Snapshots renders switch with id 1`] = `
 .emotion-2 {
   width: 12px;
   height: 12px;
-  border-radius: 100%;
+  border-radius: 999px;
   box-shadow: 0px 2px 4px 0 rgba(0,0,0,0.08);
   background-color: #ffffff;
   -webkit-transform: translateX(16px);
@@ -696,7 +696,7 @@ exports[`Switch Snapshots renders switch with name and value 1`] = `
   margin-top: 8px;
   width: 32px;
   height: 16px;
-  border-radius: 100%;
+  border-radius: 999px;
   padding: 0px 2px;
   -webkit-transition: background-color 200ms ease;
   transition: background-color 200ms ease;
@@ -706,7 +706,7 @@ exports[`Switch Snapshots renders switch with name and value 1`] = `
 .emotion-2 {
   width: 12px;
   height: 12px;
-  border-radius: 100%;
+  border-radius: 999px;
   box-shadow: 0px 2px 4px 0 rgba(0,0,0,0.08);
   background-color: #ffffff;
   -webkit-transform: translateX(16px);

--- a/modules/text-area/react/lib/TextArea.tsx
+++ b/modules/text-area/react/lib/TextArea.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styled from 'react-emotion';
 import {GrowthBehavior, ErrorType, errorRing} from '@workday/canvas-kit-react-common';
-import {inputColors, spacingNumbers, type} from '@workday/canvas-kit-react-core';
+import {borderRadius, inputColors, spacingNumbers, type} from '@workday/canvas-kit-react-core';
 
 export interface TextAreaProps
   extends GrowthBehavior,
@@ -29,7 +29,7 @@ const TextAreaContainer = styled('textarea')<TextAreaProps>(
     border: `1px solid ${inputColors.border}`,
     display: 'block',
     backgroundColor: inputColors.background,
-    borderRadius: 4,
+    borderRadius: borderRadius.m,
     boxSizing: 'border-box',
     minHeight: 64,
     minWidth: 280,

--- a/modules/text-input/react/lib/TextInput.tsx
+++ b/modules/text-input/react/lib/TextInput.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import styled from 'react-emotion';
-import {GrowthBehavior, ErrorType, errorRing} from '@workday/canvas-kit-react-common';
-import {inputColors, spacingNumbers, type} from '@workday/canvas-kit-react-core';
+import { GrowthBehavior, ErrorType, errorRing } from '@workday/canvas-kit-react-common';
+import { borderRadius, inputColors, spacingNumbers, type } from '@workday/canvas-kit-react-core';
 
 export interface TextInputProps
   extends GrowthBehavior,
-    React.InputHTMLAttributes<HTMLInputElement> {
+  React.InputHTMLAttributes<HTMLInputElement> {
   disabled?: boolean;
   error?: ErrorType;
   inputRef?: React.Ref<HTMLInputElement>;
@@ -22,7 +22,7 @@ const Input = styled('input')<TextInputProps>(
     border: `1px solid ${inputColors.border}`,
     display: 'block',
     backgroundColor: inputColors.background,
-    borderRadius: 4,
+    borderRadius: borderRadius.m,
     boxSizing: 'border-box',
     height: 40,
     minWidth: 280,
@@ -48,10 +48,10 @@ const Input = styled('input')<TextInputProps>(
       },
     },
   },
-  ({error}) => ({
+  ({ error }) => ({
     ...errorRing(error),
   }),
-  ({grow}) =>
+  ({ grow }) =>
     grow && {
       width: '100%',
     }
@@ -66,7 +66,7 @@ export default class TextInput extends React.Component<TextInputProps> {
 
   render() {
     // TODO: Standardize on prop spread location (see #150)
-    const {grow, inputRef, error, ...inputProps} = this.props;
+    const { grow, inputRef, error, ...inputProps } = this.props;
 
     return <Input innerRef={inputRef} grow={grow} error={error} {...inputProps} />;
   }

--- a/modules/toast/react/spec/__snapshots__/Toast.snapshot.tsx.snap
+++ b/modules/toast/react/spec/__snapshots__/Toast.snapshot.tsx.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Toast Snapshots renders as expected 1`] = `
-.emotion-10 {
+.emotion-8 {
   position: relative;
   width: 360px;
-  -webkit-animation: animation-1htt9yb;
-  animation: animation-1htt9yb;
+  -webkit-animation: animation-221pkp;
+  animation: animation-221pkp;
   -webkit-animation-duration: 150ms;
   animation-duration: 150ms;
   -webkit-animation-timing-function: ease-out;
@@ -15,7 +15,7 @@ exports[`Toast Snapshots renders as expected 1`] = `
   transform-origin: top center;
 }
 
-.emotion-8 {
+.emotion-7 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -91,16 +91,16 @@ exports[`Toast Snapshots renders as expected 1`] = `
 }
 
 <div
-  className="emotion-10 emotion-11"
+  className="emotion-8"
   role="dialog"
   width={360}
 >
   <div
-    className="emotion-8 emotion-9"
+    className="emotion-7"
     width={360}
   >
     <div
-      className="emotion-6 emotion-7"
+      className="emotion-6"
     >
       <div
         className="emotion-4 emotion-5"
@@ -125,11 +125,11 @@ exports[`Toast Snapshots renders as expected 1`] = `
 `;
 
 exports[`Toast Snapshots renders with a close button 1`] = `
-.emotion-15 {
+.emotion-12 {
   position: relative;
   width: 360px;
-  -webkit-animation: animation-1htt9yb;
-  animation: animation-1htt9yb;
+  -webkit-animation: animation-221pkp;
+  animation: animation-221pkp;
   -webkit-animation-duration: 150ms;
   animation-duration: 150ms;
   -webkit-animation-timing-function: ease-out;
@@ -139,7 +139,7 @@ exports[`Toast Snapshots renders with a close button 1`] = `
   transform-origin: top center;
 }
 
-.emotion-13 {
+.emotion-11 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -149,7 +149,7 @@ exports[`Toast Snapshots renders with a close button 1`] = `
   width: 360px;
 }
 
-.emotion-11 {
+.emotion-10 {
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
@@ -157,7 +157,7 @@ exports[`Toast Snapshots renders with a close button 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-6 {
+.emotion-5 {
   display: inline-block;
   margin-right: 16px;
   -webkit-align-self: start;
@@ -165,35 +165,35 @@ exports[`Toast Snapshots renders with a close button 1`] = `
   align-self: start;
 }
 
-.emotion-6 svg {
+.emotion-5 svg {
   display: block;
 }
 
-.emotion-6 .wd-icon-fill {
+.emotion-5 .wd-icon-fill {
   fill: #43c463;
 }
 
-.emotion-6:hover .wd-icon-fill {
+.emotion-5:hover .wd-icon-fill {
   fill: #43c463;
 }
 
-.emotion-6 .wd-icon-accent {
+.emotion-5 .wd-icon-accent {
   fill: #43c463;
 }
 
-.emotion-6:hover .wd-icon-accent {
+.emotion-5:hover .wd-icon-accent {
   fill: #43c463;
 }
 
-.emotion-6 .wd-icon-background {
+.emotion-5 .wd-icon-background {
   fill: transparent;
 }
 
-.emotion-6:hover .wd-icon-background {
+.emotion-5:hover .wd-icon-background {
   fill: transparent;
 }
 
-.emotion-7 {
+.emotion-6 {
   word-break: break-word;
   word-wrap: break-word;
 }
@@ -219,7 +219,7 @@ exports[`Toast Snapshots renders with a close button 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -363,7 +363,7 @@ exports[`Toast Snapshots renders with a close button 1`] = `
   fill: transparent;
 }
 
-.emotion-9 {
+.emotion-8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -381,12 +381,12 @@ exports[`Toast Snapshots renders with a close button 1`] = `
 }
 
 <div
-  className="emotion-15 emotion-16"
+  className="emotion-12"
   role="dialog"
   width={360}
 >
   <div
-    className="emotion-3 emotion-4"
+    className="emotion-3"
   >
     <button
       aria-label="Close"
@@ -405,18 +405,18 @@ exports[`Toast Snapshots renders with a close button 1`] = `
     </button>
   </div>
   <div
-    className="emotion-13 emotion-14"
+    className="emotion-11"
     width={360}
   >
     <div
-      className="emotion-11 emotion-12"
+      className="emotion-10"
     >
       <div
-        className="emotion-9 emotion-10"
+        className="emotion-8 emotion-9"
         onClose={[MockFunction]}
       >
         <span
-          className="emotion-5 emotion-6"
+          className="emotion-4 emotion-5"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"24\\" height=\\"24\\" class=\\"wd-icon-check wd-icon\\" focusable=\\"false\\" role=\\"presentation\\" viewBox=\\"0 0 24 24\\"><g fill-rule=\\"evenodd\\" class=\\"wd-icon-container\\"><path d=\\"M8.657 15.85l10.26-10.26a.49.49 0 0 1 .703.01l.7.7a.495.495 0 0 1 .01.704L9.005 18.33a.488.488 0 0 1-.692.002L8.3 18.32l-4.946-4.946a.495.495 0 0 1 .003-.711l.7-.7a.507.507 0 0 1 .711-.004l3.889 3.89z\\" class=\\"wd-icon-fill\\"/></g></svg>",
@@ -424,7 +424,7 @@ exports[`Toast Snapshots renders with a close button 1`] = `
           }
         />
         <div
-          className="emotion-7 emotion-8"
+          className="emotion-6 emotion-7"
         >
           Your data has been updated.
         </div>
@@ -435,11 +435,11 @@ exports[`Toast Snapshots renders with a close button 1`] = `
 `;
 
 exports[`Toast Snapshots renders with an action link 1`] = `
-.emotion-17 {
+.emotion-14 {
   position: relative;
   width: 360px;
-  -webkit-animation: animation-1htt9yb;
-  animation: animation-1htt9yb;
+  -webkit-animation: animation-221pkp;
+  animation: animation-221pkp;
   -webkit-animation-duration: 150ms;
   animation-duration: 150ms;
   -webkit-animation-timing-function: ease-out;
@@ -449,7 +449,7 @@ exports[`Toast Snapshots renders with an action link 1`] = `
   transform-origin: top center;
 }
 
-.emotion-15 {
+.emotion-13 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -459,7 +459,7 @@ exports[`Toast Snapshots renders with an action link 1`] = `
   width: 360px;
 }
 
-.emotion-13 {
+.emotion-12 {
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
@@ -467,7 +467,7 @@ exports[`Toast Snapshots renders with an action link 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-6 {
+.emotion-5 {
   display: inline-block;
   margin-right: 16px;
   -webkit-align-self: start;
@@ -475,35 +475,35 @@ exports[`Toast Snapshots renders with an action link 1`] = `
   align-self: start;
 }
 
-.emotion-6 svg {
+.emotion-5 svg {
   display: block;
 }
 
-.emotion-6 .wd-icon-fill {
+.emotion-5 .wd-icon-fill {
   fill: #43c463;
 }
 
-.emotion-6:hover .wd-icon-fill {
+.emotion-5:hover .wd-icon-fill {
   fill: #43c463;
 }
 
-.emotion-6 .wd-icon-accent {
+.emotion-5 .wd-icon-accent {
   fill: #43c463;
 }
 
-.emotion-6:hover .wd-icon-accent {
+.emotion-5:hover .wd-icon-accent {
   fill: #43c463;
 }
 
-.emotion-6 .wd-icon-background {
+.emotion-5 .wd-icon-background {
   fill: transparent;
 }
 
-.emotion-6:hover .wd-icon-background {
+.emotion-5:hover .wd-icon-background {
   fill: transparent;
 }
 
-.emotion-9 {
+.emotion-8 {
   word-break: break-word;
   word-wrap: break-word;
 }
@@ -529,7 +529,7 @@ exports[`Toast Snapshots renders with an action link 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -673,7 +673,7 @@ exports[`Toast Snapshots renders with an action link 1`] = `
   fill: transparent;
 }
 
-.emotion-11 {
+.emotion-10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -690,7 +690,7 @@ exports[`Toast Snapshots renders with an action link 1`] = `
   margin-right: 24px;
 }
 
-.emotion-7 {
+.emotion-6 {
   display: block;
   border: none;
   padding: 0;
@@ -705,14 +705,14 @@ exports[`Toast Snapshots renders with an action link 1`] = `
   cursor: pointer;
 }
 
-.emotion-7:hover,
-.emotion-7:active {
+.emotion-6:hover,
+.emotion-6:active {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0875e1;
 }
 
-.emotion-7:focus {
+.emotion-6:focus {
   background: #d7eafc;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -720,12 +720,12 @@ exports[`Toast Snapshots renders with an action link 1`] = `
 }
 
 <div
-  className="emotion-17 emotion-18"
+  className="emotion-14"
   role="dialog"
   width={360}
 >
   <div
-    className="emotion-3 emotion-4"
+    className="emotion-3"
   >
     <button
       aria-label="Close"
@@ -744,18 +744,18 @@ exports[`Toast Snapshots renders with an action link 1`] = `
     </button>
   </div>
   <div
-    className="emotion-15 emotion-16"
+    className="emotion-13"
     width={360}
   >
     <div
-      className="emotion-13 emotion-14"
+      className="emotion-12"
     >
       <div
-        className="emotion-11 emotion-12"
+        className="emotion-10 emotion-11"
         onClose={[MockFunction]}
       >
         <span
-          className="emotion-5 emotion-6"
+          className="emotion-4 emotion-5"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"24\\" height=\\"24\\" class=\\"wd-icon-check wd-icon\\" focusable=\\"false\\" role=\\"presentation\\" viewBox=\\"0 0 24 24\\"><g fill-rule=\\"evenodd\\" class=\\"wd-icon-container\\"><path d=\\"M8.657 15.85l10.26-10.26a.49.49 0 0 1 .703.01l.7.7a.495.495 0 0 1 .01.704L9.005 18.33a.488.488 0 0 1-.692.002L8.3 18.32l-4.946-4.946a.495.495 0 0 1 .003-.711l.7-.7a.507.507 0 0 1 .711-.004l3.889 3.89z\\" class=\\"wd-icon-fill\\"/></g></svg>",
@@ -763,11 +763,11 @@ exports[`Toast Snapshots renders with an action link 1`] = `
           }
         />
         <div
-          className="emotion-9 emotion-10"
+          className="emotion-8 emotion-9"
         >
           Process failed.
           <button
-            className="emotion-7 emotion-8"
+            className="emotion-6 emotion-7"
             onClick={[MockFunction]}
           >
             View More
@@ -780,11 +780,11 @@ exports[`Toast Snapshots renders with an action link 1`] = `
 `;
 
 exports[`Toast Snapshots renders with an icon 1`] = `
-.emotion-15 {
+.emotion-12 {
   position: relative;
   width: 360px;
-  -webkit-animation: animation-1htt9yb;
-  animation: animation-1htt9yb;
+  -webkit-animation: animation-221pkp;
+  animation: animation-221pkp;
   -webkit-animation-duration: 150ms;
   animation-duration: 150ms;
   -webkit-animation-timing-function: ease-out;
@@ -794,7 +794,7 @@ exports[`Toast Snapshots renders with an icon 1`] = `
   transform-origin: top center;
 }
 
-.emotion-13 {
+.emotion-11 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -804,7 +804,7 @@ exports[`Toast Snapshots renders with an icon 1`] = `
   width: 360px;
 }
 
-.emotion-11 {
+.emotion-10 {
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
@@ -812,7 +812,7 @@ exports[`Toast Snapshots renders with an icon 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-6 {
+.emotion-5 {
   display: inline-block;
   margin-right: 16px;
   -webkit-align-self: start;
@@ -820,35 +820,35 @@ exports[`Toast Snapshots renders with an icon 1`] = `
   align-self: start;
 }
 
-.emotion-6 svg {
+.emotion-5 svg {
   display: block;
 }
 
-.emotion-6 .wd-icon-fill {
+.emotion-5 .wd-icon-fill {
   fill: #43c463;
 }
 
-.emotion-6:hover .wd-icon-fill {
+.emotion-5:hover .wd-icon-fill {
   fill: #43c463;
 }
 
-.emotion-6 .wd-icon-accent {
+.emotion-5 .wd-icon-accent {
   fill: #43c463;
 }
 
-.emotion-6:hover .wd-icon-accent {
+.emotion-5:hover .wd-icon-accent {
   fill: #43c463;
 }
 
-.emotion-6 .wd-icon-background {
+.emotion-5 .wd-icon-background {
   fill: transparent;
 }
 
-.emotion-6:hover .wd-icon-background {
+.emotion-5:hover .wd-icon-background {
   fill: transparent;
 }
 
-.emotion-7 {
+.emotion-6 {
   word-break: break-word;
   word-wrap: break-word;
 }
@@ -874,7 +874,7 @@ exports[`Toast Snapshots renders with an icon 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   font-size: 13px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: 1px solid transparent;
   box-shadow: none;
   position: relative;
@@ -1018,7 +1018,7 @@ exports[`Toast Snapshots renders with an icon 1`] = `
   fill: transparent;
 }
 
-.emotion-9 {
+.emotion-8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1036,12 +1036,12 @@ exports[`Toast Snapshots renders with an icon 1`] = `
 }
 
 <div
-  className="emotion-15 emotion-16"
+  className="emotion-12"
   role="dialog"
   width={360}
 >
   <div
-    className="emotion-3 emotion-4"
+    className="emotion-3"
   >
     <button
       aria-label="Close"
@@ -1060,18 +1060,18 @@ exports[`Toast Snapshots renders with an icon 1`] = `
     </button>
   </div>
   <div
-    className="emotion-13 emotion-14"
+    className="emotion-11"
     width={360}
   >
     <div
-      className="emotion-11 emotion-12"
+      className="emotion-10"
     >
       <div
-        className="emotion-9 emotion-10"
+        className="emotion-8 emotion-9"
         onClose={[MockFunction]}
       >
         <span
-          className="emotion-5 emotion-6"
+          className="emotion-4 emotion-5"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"24\\" height=\\"24\\" class=\\"wd-icon-check wd-icon\\" focusable=\\"false\\" role=\\"presentation\\" viewBox=\\"0 0 24 24\\"><g fill-rule=\\"evenodd\\" class=\\"wd-icon-container\\"><path d=\\"M8.657 15.85l10.26-10.26a.49.49 0 0 1 .703.01l.7.7a.495.495 0 0 1 .01.704L9.005 18.33a.488.488 0 0 1-.692.002L8.3 18.32l-4.946-4.946a.495.495 0 0 1 .003-.711l.7-.7a.507.507 0 0 1 .711-.004l3.889 3.89z\\" class=\\"wd-icon-fill\\"/></g></svg>",
@@ -1079,7 +1079,7 @@ exports[`Toast Snapshots renders with an icon 1`] = `
           }
         />
         <div
-          className="emotion-7 emotion-8"
+          className="emotion-6 emotion-7"
         >
           Success
         </div>

--- a/modules/toast/react/spec/__snapshots__/Toast.snapshot.tsx.snap
+++ b/modules/toast/react/spec/__snapshots__/Toast.snapshot.tsx.snap
@@ -18,7 +18,7 @@ exports[`Toast Snapshots renders as expected 1`] = `
 .emotion-7 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 16px;
@@ -142,7 +142,7 @@ exports[`Toast Snapshots renders with a close button 1`] = `
 .emotion-11 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 16px;
@@ -452,7 +452,7 @@ exports[`Toast Snapshots renders with an action link 1`] = `
 .emotion-13 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 16px;
@@ -797,7 +797,7 @@ exports[`Toast Snapshots renders with an icon 1`] = `
 .emotion-11 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 16px;

--- a/modules/toast/react/spec/__snapshots__/Toast.snapshot.tsx.snap
+++ b/modules/toast/react/spec/__snapshots__/Toast.snapshot.tsx.snap
@@ -18,7 +18,7 @@ exports[`Toast Snapshots renders as expected 1`] = `
 .emotion-7 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 16px;
@@ -142,7 +142,7 @@ exports[`Toast Snapshots renders with a close button 1`] = `
 .emotion-11 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 16px;
@@ -452,7 +452,7 @@ exports[`Toast Snapshots renders with an action link 1`] = `
 .emotion-13 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 16px;
@@ -797,7 +797,7 @@ exports[`Toast Snapshots renders with an icon 1`] = `
 .emotion-11 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
-  border-radius: 3px;
+  border-radius: 4px;
   box-sizing: border-box;
   box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
   padding: 16px;

--- a/modules/toast/react/spec/__snapshots__/Toast.snapshot.tsx.snap
+++ b/modules/toast/react/spec/__snapshots__/Toast.snapshot.tsx.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Toast Snapshots renders as expected 1`] = `
-.emotion-8 {
+.emotion-10 {
   position: relative;
   width: 360px;
-  -webkit-animation: animation-221pkp;
-  animation: animation-221pkp;
+  -webkit-animation: animation-1htt9yb;
+  animation: animation-1htt9yb;
   -webkit-animation-duration: 150ms;
   animation-duration: 150ms;
   -webkit-animation-timing-function: ease-out;
@@ -15,7 +15,7 @@ exports[`Toast Snapshots renders as expected 1`] = `
   transform-origin: top center;
 }
 
-.emotion-7 {
+.emotion-8 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -91,16 +91,16 @@ exports[`Toast Snapshots renders as expected 1`] = `
 }
 
 <div
-  className="emotion-8"
+  className="emotion-10 emotion-11"
   role="dialog"
   width={360}
 >
   <div
-    className="emotion-7"
+    className="emotion-8 emotion-9"
     width={360}
   >
     <div
-      className="emotion-6"
+      className="emotion-6 emotion-7"
     >
       <div
         className="emotion-4 emotion-5"
@@ -125,321 +125,11 @@ exports[`Toast Snapshots renders as expected 1`] = `
 `;
 
 exports[`Toast Snapshots renders with a close button 1`] = `
-.emotion-12 {
+.emotion-15 {
   position: relative;
   width: 360px;
-  -webkit-animation: animation-221pkp;
-  animation: animation-221pkp;
-  -webkit-animation-duration: 150ms;
-  animation-duration: 150ms;
-  -webkit-animation-timing-function: ease-out;
-  animation-timing-function: ease-out;
-  -webkit-transform-origin: top center;
-  -ms-transform-origin: top center;
-  transform-origin: top center;
-}
-
-.emotion-11 {
-  background-color: #ffffff;
-  border: 1px solid #ced3d9;
-  border-radius: 8px;
-  box-sizing: border-box;
-  box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
-  padding: 16px;
-  width: 360px;
-}
-
-.emotion-10 {
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 400;
-  color: #494949;
-  font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
-}
-
-.emotion-5 {
-  display: inline-block;
-  margin-right: 16px;
-  -webkit-align-self: start;
-  -ms-flex-item-align: start;
-  align-self: start;
-}
-
-.emotion-5 svg {
-  display: block;
-}
-
-.emotion-5 .wd-icon-fill {
-  fill: #43c463;
-}
-
-.emotion-5:hover .wd-icon-fill {
-  fill: #43c463;
-}
-
-.emotion-5 .wd-icon-accent {
-  fill: #43c463;
-}
-
-.emotion-5:hover .wd-icon-accent {
-  fill: #43c463;
-}
-
-.emotion-5 .wd-icon-background {
-  fill: transparent;
-}
-
-.emotion-5:hover .wd-icon-background {
-  fill: transparent;
-}
-
-.emotion-6 {
-  word-break: break-word;
-  word-wrap: break-word;
-}
-
-.emotion-3 {
-  position: absolute;
-  right: 10px;
-  top: 10px;
-}
-
-.emotion-1 {
-  box-sizing: border-box;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  font-size: 13px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  position: relative;
-  cursor: pointer;
-  outline: none;
-  -webkit-transition: all 120ms linear;
-  transition: all 120ms linear;
-  border-width: 0px;
-  background-color: transparent;
-  margin: -6px;
-  width: 32px;
-  height: 32px;
-}
-
-.emotion-1:hover:active {
-  -webkit-transition-duration: 40ms;
-  transition-duration: 40ms;
-}
-
-.emotion-1:disabled,
-.emotion-1:disabled:active {
-  cursor: default;
-  box-shadow: none;
-}
-
-.emotion-1 .wd-icon {
-  display: inline-block;
-  vertical-align: middle;
-}
-
-.emotion-1 span .wd-icon-fill,
-.emotion-1 span .wd-icon-accent {
-  -webkit-transition: fill 120ms ease-in;
-  transition: fill 120ms ease-in;
-  fill: #7b858f;
-}
-
-.emotion-1:focus {
-  background-color: transparent;
-}
-
-.emotion-1:focus span .wd-icon-fill,
-.emotion-1:focus span .wd-icon-accent {
-  fill: #7b858f;
-}
-
-.emotion-1:hover:focus {
-  background-color: transparent;
-}
-
-.emotion-1:active,
-.emotion-1:focus:active,
-.emotion-1:hover:active {
-  background-color: transparent;
-  border-color: transparent;
-}
-
-.emotion-1:active span .wd-icon-fill,
-.emotion-1:focus:active span .wd-icon-fill,
-.emotion-1:hover:active span .wd-icon-fill,
-.emotion-1:active span .wd-icon-accent,
-.emotion-1:focus:active span .wd-icon-accent,
-.emotion-1:hover:active span .wd-icon-accent {
-  fill: #333d47;
-}
-
-.emotion-1:hover {
-  background-color: transparent;
-}
-
-.emotion-1:hover span .wd-icon-fill,
-.emotion-1:hover span .wd-icon-accent {
-  fill: #333d47;
-}
-
-.emotion-1:disabled,
-.emotion-1:active:disabled,
-.emotion-1:focus:disabled,
-.emotion-1:hover:disabled {
-  background-color: transparent;
-}
-
-.emotion-1:disabled span .wd-icon-fill,
-.emotion-1:active:disabled span .wd-icon-fill,
-.emotion-1:focus:disabled span .wd-icon-fill,
-.emotion-1:hover:disabled span .wd-icon-fill,
-.emotion-1:disabled span .wd-icon-accent,
-.emotion-1:active:disabled span .wd-icon-accent,
-.emotion-1:focus:disabled span .wd-icon-accent,
-.emotion-1:hover:disabled span .wd-icon-accent {
-  fill: #b9c0c7;
-}
-
-.emotion-1:not([disabled]):focus {
-  -webkit-animation: animation-os2b9x 100ms;
-  animation: animation-os2b9x 100ms;
-  box-shadow: 0 0 0 0px #ffffff,0 0 0 2px #0875e1;
-}
-
-.emotion-1:not([disabled]):active {
-  border-color: transparent;
-  -webkit-animation: animation-os2b9x 100ms;
-  animation: animation-os2b9x 100ms;
-  box-shadow: 0 0 0 0px #ffffff,0 0 0 2px #0875e1;
-}
-
-.emotion-1 span svg {
-  width: 20px;
-  height: 20px;
-}
-
-.emotion-0 {
-  display: inline-block;
-}
-
-.emotion-0 svg {
-  display: block;
-}
-
-.emotion-0 .wd-icon-fill {
-  fill: #7b858f;
-}
-
-.emotion-0:hover .wd-icon-fill {
-  fill: #333d47;
-}
-
-.emotion-0 .wd-icon-accent {
-  fill: #7b858f;
-}
-
-.emotion-0:hover .wd-icon-accent {
-  fill: #333d47;
-}
-
-.emotion-0 .wd-icon-background {
-  fill: transparent;
-}
-
-.emotion-0:hover .wd-icon-background {
-  fill: transparent;
-}
-
-.emotion-8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-size: 13px;
-  line-height: 20px;
-  font-weight: 400;
-  color: #494949;
-  font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
-  margin-right: 24px;
-}
-
-<div
-  className="emotion-12"
-  role="dialog"
-  width={360}
->
-  <div
-    className="emotion-3"
-  >
-    <button
-      aria-label="Close"
-      className="emotion-1 emotion-2"
-      onClick={[MockFunction]}
-      title="Close"
-    >
-      <span
-        className="emotion-0"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"24\\" height=\\"24\\" class=\\"wd-icon-x wd-icon\\" focusable=\\"false\\" role=\\"presentation\\" viewBox=\\"0 0 24 24\\"><g fill-rule=\\"evenodd\\" class=\\"wd-icon-container\\"><path d=\\"M5.996 4.582a.5.5 0 0 0-.717-.003l-.7.7a.504.504 0 0 0 .003.717L10.586 12l-6.004 6.004a.5.5 0 0 0-.003.717l.7.7c.197.197.514.2.717-.003L12 13.414l6.004 6.004a.5.5 0 0 0 .717.003l.7-.7a.504.504 0 0 0-.003-.717L13.414 12l6.004-6.004a.5.5 0 0 0 .003-.717l-.7-.7a.504.504 0 0 0-.717.003L12 10.586 5.996 4.582z\\" class=\\"wd-icon-fill\\"/></g></svg>",
-          }
-        }
-      />
-    </button>
-  </div>
-  <div
-    className="emotion-11"
-    width={360}
-  >
-    <div
-      className="emotion-10"
-    >
-      <div
-        className="emotion-8 emotion-9"
-        onClose={[MockFunction]}
-      >
-        <span
-          className="emotion-4 emotion-5"
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"24\\" height=\\"24\\" class=\\"wd-icon-check wd-icon\\" focusable=\\"false\\" role=\\"presentation\\" viewBox=\\"0 0 24 24\\"><g fill-rule=\\"evenodd\\" class=\\"wd-icon-container\\"><path d=\\"M8.657 15.85l10.26-10.26a.49.49 0 0 1 .703.01l.7.7a.495.495 0 0 1 .01.704L9.005 18.33a.488.488 0 0 1-.692.002L8.3 18.32l-4.946-4.946a.495.495 0 0 1 .003-.711l.7-.7a.507.507 0 0 1 .711-.004l3.889 3.89z\\" class=\\"wd-icon-fill\\"/></g></svg>",
-            }
-          }
-        />
-        <div
-          className="emotion-6 emotion-7"
-        >
-          Your data has been updated.
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Toast Snapshots renders with an action link 1`] = `
-.emotion-14 {
-  position: relative;
-  width: 360px;
-  -webkit-animation: animation-221pkp;
-  animation: animation-221pkp;
+  -webkit-animation: animation-1htt9yb;
+  animation: animation-1htt9yb;
   -webkit-animation-duration: 150ms;
   animation-duration: 150ms;
   -webkit-animation-timing-function: ease-out;
@@ -459,7 +149,7 @@ exports[`Toast Snapshots renders with an action link 1`] = `
   width: 360px;
 }
 
-.emotion-12 {
+.emotion-11 {
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
@@ -467,7 +157,7 @@ exports[`Toast Snapshots renders with an action link 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-5 {
+.emotion-6 {
   display: inline-block;
   margin-right: 16px;
   -webkit-align-self: start;
@@ -475,35 +165,35 @@ exports[`Toast Snapshots renders with an action link 1`] = `
   align-self: start;
 }
 
-.emotion-5 svg {
+.emotion-6 svg {
   display: block;
 }
 
-.emotion-5 .wd-icon-fill {
+.emotion-6 .wd-icon-fill {
   fill: #43c463;
 }
 
-.emotion-5:hover .wd-icon-fill {
+.emotion-6:hover .wd-icon-fill {
   fill: #43c463;
 }
 
-.emotion-5 .wd-icon-accent {
+.emotion-6 .wd-icon-accent {
   fill: #43c463;
 }
 
-.emotion-5:hover .wd-icon-accent {
+.emotion-6:hover .wd-icon-accent {
   fill: #43c463;
 }
 
-.emotion-5 .wd-icon-background {
+.emotion-6 .wd-icon-background {
   fill: transparent;
 }
 
-.emotion-5:hover .wd-icon-background {
+.emotion-6:hover .wd-icon-background {
   fill: transparent;
 }
 
-.emotion-8 {
+.emotion-7 {
   word-break: break-word;
   word-wrap: break-word;
 }
@@ -673,7 +363,7 @@ exports[`Toast Snapshots renders with an action link 1`] = `
   fill: transparent;
 }
 
-.emotion-10 {
+.emotion-9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -690,7 +380,317 @@ exports[`Toast Snapshots renders with an action link 1`] = `
   margin-right: 24px;
 }
 
+<div
+  className="emotion-15 emotion-16"
+  role="dialog"
+  width={360}
+>
+  <div
+    className="emotion-3 emotion-4"
+  >
+    <button
+      aria-label="Close"
+      className="emotion-1 emotion-2"
+      onClick={[MockFunction]}
+      title="Close"
+    >
+      <span
+        className="emotion-0"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"24\\" height=\\"24\\" class=\\"wd-icon-x wd-icon\\" focusable=\\"false\\" role=\\"presentation\\" viewBox=\\"0 0 24 24\\"><g fill-rule=\\"evenodd\\" class=\\"wd-icon-container\\"><path d=\\"M5.996 4.582a.5.5 0 0 0-.717-.003l-.7.7a.504.504 0 0 0 .003.717L10.586 12l-6.004 6.004a.5.5 0 0 0-.003.717l.7.7c.197.197.514.2.717-.003L12 13.414l6.004 6.004a.5.5 0 0 0 .717.003l.7-.7a.504.504 0 0 0-.003-.717L13.414 12l6.004-6.004a.5.5 0 0 0 .003-.717l-.7-.7a.504.504 0 0 0-.717.003L12 10.586 5.996 4.582z\\" class=\\"wd-icon-fill\\"/></g></svg>",
+          }
+        }
+      />
+    </button>
+  </div>
+  <div
+    className="emotion-13 emotion-14"
+    width={360}
+  >
+    <div
+      className="emotion-11 emotion-12"
+    >
+      <div
+        className="emotion-9 emotion-10"
+        onClose={[MockFunction]}
+      >
+        <span
+          className="emotion-5 emotion-6"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"24\\" height=\\"24\\" class=\\"wd-icon-check wd-icon\\" focusable=\\"false\\" role=\\"presentation\\" viewBox=\\"0 0 24 24\\"><g fill-rule=\\"evenodd\\" class=\\"wd-icon-container\\"><path d=\\"M8.657 15.85l10.26-10.26a.49.49 0 0 1 .703.01l.7.7a.495.495 0 0 1 .01.704L9.005 18.33a.488.488 0 0 1-.692.002L8.3 18.32l-4.946-4.946a.495.495 0 0 1 .003-.711l.7-.7a.507.507 0 0 1 .711-.004l3.889 3.89z\\" class=\\"wd-icon-fill\\"/></g></svg>",
+            }
+          }
+        />
+        <div
+          className="emotion-7 emotion-8"
+        >
+          Your data has been updated.
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Toast Snapshots renders with an action link 1`] = `
+.emotion-17 {
+  position: relative;
+  width: 360px;
+  -webkit-animation: animation-1htt9yb;
+  animation: animation-1htt9yb;
+  -webkit-animation-duration: 150ms;
+  animation-duration: 150ms;
+  -webkit-animation-timing-function: ease-out;
+  animation-timing-function: ease-out;
+  -webkit-transform-origin: top center;
+  -ms-transform-origin: top center;
+  transform-origin: top center;
+}
+
+.emotion-15 {
+  background-color: #ffffff;
+  border: 1px solid #ced3d9;
+  border-radius: 8px;
+  box-sizing: border-box;
+  box-shadow: 0px 4px 8px 0 rgba(0,0,0,0.1);
+  padding: 16px;
+  width: 360px;
+}
+
+.emotion-13 {
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
+  color: #494949;
+  font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
+}
+
 .emotion-6 {
+  display: inline-block;
+  margin-right: 16px;
+  -webkit-align-self: start;
+  -ms-flex-item-align: start;
+  align-self: start;
+}
+
+.emotion-6 svg {
+  display: block;
+}
+
+.emotion-6 .wd-icon-fill {
+  fill: #43c463;
+}
+
+.emotion-6:hover .wd-icon-fill {
+  fill: #43c463;
+}
+
+.emotion-6 .wd-icon-accent {
+  fill: #43c463;
+}
+
+.emotion-6:hover .wd-icon-accent {
+  fill: #43c463;
+}
+
+.emotion-6 .wd-icon-background {
+  fill: transparent;
+}
+
+.emotion-6:hover .wd-icon-background {
+  fill: transparent;
+}
+
+.emotion-9 {
+  word-break: break-word;
+  word-wrap: break-word;
+}
+
+.emotion-3 {
+  position: absolute;
+  right: 10px;
+  top: 10px;
+}
+
+.emotion-1 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-size: 13px;
+  border-radius: 50%;
+  border: 1px solid transparent;
+  box-shadow: none;
+  position: relative;
+  cursor: pointer;
+  outline: none;
+  -webkit-transition: all 120ms linear;
+  transition: all 120ms linear;
+  border-width: 0px;
+  background-color: transparent;
+  margin: -6px;
+  width: 32px;
+  height: 32px;
+}
+
+.emotion-1:hover:active {
+  -webkit-transition-duration: 40ms;
+  transition-duration: 40ms;
+}
+
+.emotion-1:disabled,
+.emotion-1:disabled:active {
+  cursor: default;
+  box-shadow: none;
+}
+
+.emotion-1 .wd-icon {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.emotion-1 span .wd-icon-fill,
+.emotion-1 span .wd-icon-accent {
+  -webkit-transition: fill 120ms ease-in;
+  transition: fill 120ms ease-in;
+  fill: #7b858f;
+}
+
+.emotion-1:focus {
+  background-color: transparent;
+}
+
+.emotion-1:focus span .wd-icon-fill,
+.emotion-1:focus span .wd-icon-accent {
+  fill: #7b858f;
+}
+
+.emotion-1:hover:focus {
+  background-color: transparent;
+}
+
+.emotion-1:active,
+.emotion-1:focus:active,
+.emotion-1:hover:active {
+  background-color: transparent;
+  border-color: transparent;
+}
+
+.emotion-1:active span .wd-icon-fill,
+.emotion-1:focus:active span .wd-icon-fill,
+.emotion-1:hover:active span .wd-icon-fill,
+.emotion-1:active span .wd-icon-accent,
+.emotion-1:focus:active span .wd-icon-accent,
+.emotion-1:hover:active span .wd-icon-accent {
+  fill: #333d47;
+}
+
+.emotion-1:hover {
+  background-color: transparent;
+}
+
+.emotion-1:hover span .wd-icon-fill,
+.emotion-1:hover span .wd-icon-accent {
+  fill: #333d47;
+}
+
+.emotion-1:disabled,
+.emotion-1:active:disabled,
+.emotion-1:focus:disabled,
+.emotion-1:hover:disabled {
+  background-color: transparent;
+}
+
+.emotion-1:disabled span .wd-icon-fill,
+.emotion-1:active:disabled span .wd-icon-fill,
+.emotion-1:focus:disabled span .wd-icon-fill,
+.emotion-1:hover:disabled span .wd-icon-fill,
+.emotion-1:disabled span .wd-icon-accent,
+.emotion-1:active:disabled span .wd-icon-accent,
+.emotion-1:focus:disabled span .wd-icon-accent,
+.emotion-1:hover:disabled span .wd-icon-accent {
+  fill: #b9c0c7;
+}
+
+.emotion-1:not([disabled]):focus {
+  -webkit-animation: animation-os2b9x 100ms;
+  animation: animation-os2b9x 100ms;
+  box-shadow: 0 0 0 0px #ffffff,0 0 0 2px #0875e1;
+}
+
+.emotion-1:not([disabled]):active {
+  border-color: transparent;
+  -webkit-animation: animation-os2b9x 100ms;
+  animation: animation-os2b9x 100ms;
+  box-shadow: 0 0 0 0px #ffffff,0 0 0 2px #0875e1;
+}
+
+.emotion-1 span svg {
+  width: 20px;
+  height: 20px;
+}
+
+.emotion-0 {
+  display: inline-block;
+}
+
+.emotion-0 svg {
+  display: block;
+}
+
+.emotion-0 .wd-icon-fill {
+  fill: #7b858f;
+}
+
+.emotion-0:hover .wd-icon-fill {
+  fill: #333d47;
+}
+
+.emotion-0 .wd-icon-accent {
+  fill: #7b858f;
+}
+
+.emotion-0:hover .wd-icon-accent {
+  fill: #333d47;
+}
+
+.emotion-0 .wd-icon-background {
+  fill: transparent;
+}
+
+.emotion-0:hover .wd-icon-background {
+  fill: transparent;
+}
+
+.emotion-11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-size: 13px;
+  line-height: 20px;
+  font-weight: 400;
+  color: #494949;
+  font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
+  margin-right: 24px;
+}
+
+.emotion-7 {
   display: block;
   border: none;
   padding: 0;
@@ -705,14 +705,14 @@ exports[`Toast Snapshots renders with an action link 1`] = `
   cursor: pointer;
 }
 
-.emotion-6:hover,
-.emotion-6:active {
+.emotion-7:hover,
+.emotion-7:active {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0875e1;
 }
 
-.emotion-6:focus {
+.emotion-7:focus {
   background: #d7eafc;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -720,12 +720,12 @@ exports[`Toast Snapshots renders with an action link 1`] = `
 }
 
 <div
-  className="emotion-14"
+  className="emotion-17 emotion-18"
   role="dialog"
   width={360}
 >
   <div
-    className="emotion-3"
+    className="emotion-3 emotion-4"
   >
     <button
       aria-label="Close"
@@ -744,18 +744,18 @@ exports[`Toast Snapshots renders with an action link 1`] = `
     </button>
   </div>
   <div
-    className="emotion-13"
+    className="emotion-15 emotion-16"
     width={360}
   >
     <div
-      className="emotion-12"
+      className="emotion-13 emotion-14"
     >
       <div
-        className="emotion-10 emotion-11"
+        className="emotion-11 emotion-12"
         onClose={[MockFunction]}
       >
         <span
-          className="emotion-4 emotion-5"
+          className="emotion-5 emotion-6"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"24\\" height=\\"24\\" class=\\"wd-icon-check wd-icon\\" focusable=\\"false\\" role=\\"presentation\\" viewBox=\\"0 0 24 24\\"><g fill-rule=\\"evenodd\\" class=\\"wd-icon-container\\"><path d=\\"M8.657 15.85l10.26-10.26a.49.49 0 0 1 .703.01l.7.7a.495.495 0 0 1 .01.704L9.005 18.33a.488.488 0 0 1-.692.002L8.3 18.32l-4.946-4.946a.495.495 0 0 1 .003-.711l.7-.7a.507.507 0 0 1 .711-.004l3.889 3.89z\\" class=\\"wd-icon-fill\\"/></g></svg>",
@@ -763,11 +763,11 @@ exports[`Toast Snapshots renders with an action link 1`] = `
           }
         />
         <div
-          className="emotion-8 emotion-9"
+          className="emotion-9 emotion-10"
         >
           Process failed.
           <button
-            className="emotion-6 emotion-7"
+            className="emotion-7 emotion-8"
             onClick={[MockFunction]}
           >
             View More
@@ -780,11 +780,11 @@ exports[`Toast Snapshots renders with an action link 1`] = `
 `;
 
 exports[`Toast Snapshots renders with an icon 1`] = `
-.emotion-12 {
+.emotion-15 {
   position: relative;
   width: 360px;
-  -webkit-animation: animation-221pkp;
-  animation: animation-221pkp;
+  -webkit-animation: animation-1htt9yb;
+  animation: animation-1htt9yb;
   -webkit-animation-duration: 150ms;
   animation-duration: 150ms;
   -webkit-animation-timing-function: ease-out;
@@ -794,7 +794,7 @@ exports[`Toast Snapshots renders with an icon 1`] = `
   transform-origin: top center;
 }
 
-.emotion-11 {
+.emotion-13 {
   background-color: #ffffff;
   border: 1px solid #ced3d9;
   border-radius: 8px;
@@ -804,7 +804,7 @@ exports[`Toast Snapshots renders with an icon 1`] = `
   width: 360px;
 }
 
-.emotion-10 {
+.emotion-11 {
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
@@ -812,7 +812,7 @@ exports[`Toast Snapshots renders with an icon 1`] = `
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
 }
 
-.emotion-5 {
+.emotion-6 {
   display: inline-block;
   margin-right: 16px;
   -webkit-align-self: start;
@@ -820,35 +820,35 @@ exports[`Toast Snapshots renders with an icon 1`] = `
   align-self: start;
 }
 
-.emotion-5 svg {
+.emotion-6 svg {
   display: block;
 }
 
-.emotion-5 .wd-icon-fill {
+.emotion-6 .wd-icon-fill {
   fill: #43c463;
 }
 
-.emotion-5:hover .wd-icon-fill {
+.emotion-6:hover .wd-icon-fill {
   fill: #43c463;
 }
 
-.emotion-5 .wd-icon-accent {
+.emotion-6 .wd-icon-accent {
   fill: #43c463;
 }
 
-.emotion-5:hover .wd-icon-accent {
+.emotion-6:hover .wd-icon-accent {
   fill: #43c463;
 }
 
-.emotion-5 .wd-icon-background {
+.emotion-6 .wd-icon-background {
   fill: transparent;
 }
 
-.emotion-5:hover .wd-icon-background {
+.emotion-6:hover .wd-icon-background {
   fill: transparent;
 }
 
-.emotion-6 {
+.emotion-7 {
   word-break: break-word;
   word-wrap: break-word;
 }
@@ -1018,7 +1018,7 @@ exports[`Toast Snapshots renders with an icon 1`] = `
   fill: transparent;
 }
 
-.emotion-8 {
+.emotion-9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1036,12 +1036,12 @@ exports[`Toast Snapshots renders with an icon 1`] = `
 }
 
 <div
-  className="emotion-12"
+  className="emotion-15 emotion-16"
   role="dialog"
   width={360}
 >
   <div
-    className="emotion-3"
+    className="emotion-3 emotion-4"
   >
     <button
       aria-label="Close"
@@ -1060,18 +1060,18 @@ exports[`Toast Snapshots renders with an icon 1`] = `
     </button>
   </div>
   <div
-    className="emotion-11"
+    className="emotion-13 emotion-14"
     width={360}
   >
     <div
-      className="emotion-10"
+      className="emotion-11 emotion-12"
     >
       <div
-        className="emotion-8 emotion-9"
+        className="emotion-9 emotion-10"
         onClose={[MockFunction]}
       >
         <span
-          className="emotion-4 emotion-5"
+          className="emotion-5 emotion-6"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"24\\" height=\\"24\\" class=\\"wd-icon-check wd-icon\\" focusable=\\"false\\" role=\\"presentation\\" viewBox=\\"0 0 24 24\\"><g fill-rule=\\"evenodd\\" class=\\"wd-icon-container\\"><path d=\\"M8.657 15.85l10.26-10.26a.49.49 0 0 1 .703.01l.7.7a.495.495 0 0 1 .01.704L9.005 18.33a.488.488 0 0 1-.692.002L8.3 18.32l-4.946-4.946a.495.495 0 0 1 .003-.711l.7-.7a.507.507 0 0 1 .711-.004l3.889 3.89z\\" class=\\"wd-icon-fill\\"/></g></svg>",
@@ -1079,7 +1079,7 @@ exports[`Toast Snapshots renders with an icon 1`] = `
           }
         />
         <div
-          className="emotion-6 emotion-7"
+          className="emotion-7 emotion-8"
         >
           Success
         </div>

--- a/modules/tooltip/react/lib/Tooltip.tsx
+++ b/modules/tooltip/react/lib/Tooltip.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import styled from 'react-emotion';
-import {colors, spacing, type} from '@workday/canvas-kit-react-core';
+import {borderRadius, colors, spacing, type} from '@workday/canvas-kit-react-core';
 import {TransformOrigin, getTranslateFromOrigin} from '@workday/canvas-kit-react-common';
 import {keyframes} from 'emotion';
 
@@ -28,7 +28,7 @@ const TooltipContainer = styled('div')<TooltipProps>(
   {
     ...type.body,
     display: 'inline-flex',
-    borderRadius: spacing.xxxs,
+    borderRadius: borderRadius.m,
     padding: spacing.xxs,
     backgroundColor: 'rgba(0,0,0,.85)',
     color: colors.frenchVanilla100,


### PR DESCRIPTION
## Summary

As part of (https://github.com/Workday/canvas-kit/issues/98), we're adding `borderRadius` to `core` in both React and CSS (https://github.com/Workday/canvas-kit/issues/58) and using it everywhere where we're currently theses values.

Closes #98 
Closes #58 

**NOTE**: This is blocked on https://github.com/Workday/canvas-kit/pull/200 being merged

## Visual Breaking Changes

This commit changes the border radius of `card` to `8px` from `3px`. This change affects other components relying on `card`:
- `menu`
- `modal`
- `popup`
- `toast`

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md
- [x] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [x] design approved final implementation
- [x] a11y approved final implementation
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Squash and Merge Message Proposal

feat(core): Add border radius to CSS and React (#204)