### PR TITLE
refactor(text-input): Remove error icon in CSS

### DIFF
--- a/modules/common/css/lib/errors.scss
+++ b/modules/common/css/lib/errors.scss
@@ -1,32 +1,3 @@
-// Icons
-@svg-load errorIcon url(#{$_wdc-form-icons-path}/wd-icon-exclamation-circle.svg) {
-  .wd-icon-fill {
-    fill: $wdc-color-error;
-  }
-
-  .wd-icon-accent {
-    fill: $wdc-color-error;
-  }
-
-  .wd-icon-background {
-    fill: $wdc-color-french-vanilla-100;
-  }
-}
-
-@svg-load alertIcon url(#{$_wdc-form-icons-path}/wd-icon-exclamation-triangle.svg) {
-  .wd-icon-fill {
-    fill: $wdc-color-alert;
-  }
-
-  .wd-icon-accent {
-    fill: $wdc-color-alert;
-  }
-
-  .wd-icon-background {
-    fill: $wdc-color-french-vanilla-100;
-  }
-}
-
 // Errors and Alerts
 @mixin wdc-form-validation($_type) {
   $_borderColor: $wdc-color-black-pepper-100 !default; // This should not be used, it is necessary for the @if / @else if to.
@@ -115,7 +86,6 @@
       content: '';
       width: 24px;
       height: 24px;
-      background: svg-inline(errorIcon) center no-repeat;
     }
   }
 
@@ -203,7 +173,6 @@
       content: '';
       width: 24px;
       height: 24px;
-      background: svg-inline(alertIcon) center no-repeat;
     }
   }
 

--- a/modules/common/css/lib/errors.scss
+++ b/modules/common/css/lib/errors.scss
@@ -78,15 +78,6 @@
     input {
       @include wdc-form-error;
     }
-
-    &:after {
-      position: absolute;
-      top: $wdc-spacing-xxs;
-      left: $wdc-form-field-min-width - $wdc-spacing-l;
-      content: '';
-      width: 24px;
-      height: 24px;
-    }
   }
 
   .wdc-form-textarea,
@@ -165,14 +156,6 @@
   &.wdc-form-textinput {
     input {
       @include wdc-form-alert;
-    }
-    &:after {
-      position: absolute;
-      top: $wdc-spacing-xxs;
-      left: $wdc-form-field-min-width - $wdc-spacing-l;
-      content: '';
-      width: 24px;
-      height: 24px;
     }
   }
 


### PR DESCRIPTION
We're updating `text-input` React (#218) so this PR is to make sure the CSS matches these changes

### Breaking Visual Changes
- Error and alert icons are not longer displayed inside `text-input` components

### Squash and Merge Message Proposal

refactor(text-input): Remove error icon in CSS (#222)