### PR TITLE
fix: Card, Popup and Modal cleanup

### DIFF
--- a/modules/card/css/README.md
+++ b/modules/card/css/README.md
@@ -1,7 +1,7 @@
 # Canvas Kit Card
 
 A card is a flexible and extensible content container that includes options for positioning. The
-card content includes classes for header and body.
+card content includes classes for heading and body.
 
 ## Installation
 
@@ -33,7 +33,7 @@ Card sizes follow the 12 column grid system. To adjust sizes append the size mod
 ```html
 <div class="wdc-card-container">
   <div class="wdc-card-4">
-    <h3 class="wdc-card-header">
+    <h3 class="wdc-card-heading">
       Card Header
     </h3>
     <div class="wdc-card-body">
@@ -41,7 +41,7 @@ Card sizes follow the 12 column grid system. To adjust sizes append the size mod
     </div>
   </div>
   <div class="wdc-card-4">
-    <h3 class="wdc-card-header">
+    <h3 class="wdc-card-heading">
       Card Header
     </h3>
     <div class="wdc-card-body">
@@ -49,7 +49,7 @@ Card sizes follow the 12 column grid system. To adjust sizes append the size mod
     </div>
   </div>
   <div class="wdc-card-4">
-    <h3 class="wdc-card-header">
+    <h3 class="wdc-card-heading">
       Card Header
     </h3>
     <div class="wdc-card-body">
@@ -68,7 +68,7 @@ Card padding may be removed by add the `.wdc-card-no-padding` modifier.
 ```html
 <div class="wdc-card-container">
   <div class="wdc-card-6 wdc-card-no-padding">
-    <h3 class="wdc-card-header">
+    <h3 class="wdc-card-heading">
       Card Header
     </h3>
     <div class="wdc-card-body">
@@ -76,7 +76,7 @@ Card padding may be removed by add the `.wdc-card-no-padding` modifier.
     </div>
   </div>
   <div class="wdc-card-6">
-    <h3 class="wdc-card-header">
+    <h3 class="wdc-card-heading">
       Card Header
     </h3>
     <div class="wdc-card-body">
@@ -95,7 +95,7 @@ Card positioning can be changed by adding a modifier to the container class,
 ```html
 <div class="wdc-card-container wdc-card-container-space-around">
   <div class="wdc-card-2">
-    <h3 class="wdc-card-header">
+    <h3 class="wdc-card-heading">
       Card Header
     </h3>
     <div class="wdc-card-body">
@@ -116,11 +116,11 @@ to set a custom depth for your card.
 ```html
 <div class="wdc-card-container">
   <div class="wdc-card wdc-depth-3">
-    <h3 class="wdc-card-header">Card Header</h3>
+    <h3 class="wdc-card-heading">Card Header</h3>
     <div class="wdc-card-body">.wdc-depth-3</div>
   </div>
   <div class="wdc-card-3 wdc-depth-4">
-    <h3 class="wdc-card-header">Card Header</h3>
+    <h3 class="wdc-card-heading">Card Header</h3>
     <div class="wdc-card-body">.wdc-depth-4</div>
   </div>
 </div>

--- a/modules/card/css/lib/card.scss
+++ b/modules/card/css/lib/card.scss
@@ -22,12 +22,14 @@ $_wdc-container-positions: 'start' flex-start, 'end' flex-end, 'center' center,
   background-color: $wdc-color-french-vanilla-100;
   box-sizing: border-box;
 
-  .wdc-card-header {
+  &-heading,
+  &-header,
+  &-title {
     @include wdc-type-h3();
     margin-bottom: $wdc-spacing-m;
   }
 
-  .wdc-card-body {
+  &-body {
     @include wdc-type-body();
   }
 }

--- a/modules/card/css/lib/card.scss
+++ b/modules/card/css/lib/card.scss
@@ -27,6 +27,7 @@ $_wdc-container-positions: 'start' flex-start, 'end' flex-end, 'center' center,
   &-title {
     @include wdc-type-h3();
     margin-bottom: $wdc-spacing-m;
+    margin-top: 0;
   }
 
   &-body {

--- a/modules/card/css/stories.tsx
+++ b/modules/card/css/stories.tsx
@@ -11,56 +11,56 @@ storiesOf('CSS/Card', module)
       <h2>Default</h2>
       <section>
         <div className="wdc-card">
-          <h3 className="wdc-card-header">Card Header</h3>
+          <h3 className="wdc-card-heading">Card Header</h3>
           <div className="wdc-card-body">.wdc-card</div>
         </div>
         <div className="wdc-card-container">
           <div className="wdc-card-3">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-3</div>
           </div>
           <div className="wdc-card-3">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-3</div>
           </div>
           <div className="wdc-card-6">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-6</div>
           </div>
           <div className="wdc-card-4">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-4</div>
           </div>
           <div className="wdc-card-4">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-4</div>
           </div>
           <div className="wdc-card-4">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-4</div>
           </div>
           <div className="wdc-card-3">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-3</div>
           </div>
           <div className="wdc-card-3">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-3</div>
           </div>
           <div className="wdc-card-3">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-3</div>
           </div>
           <div className="wdc-card-3">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-3</div>
           </div>
           <div className="wdc-card-6">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-6</div>
           </div>
           <div className="wdc-card-6">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-6</div>
           </div>
         </div>
@@ -71,71 +71,71 @@ storiesOf('CSS/Card', module)
       <section>
         <div className="wdc-card-container wdc-card-container-around">
           <div className="wdc-card-3">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-container-around</div>
           </div>
           <div className="wdc-card-3">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-container-around</div>
           </div>
           <div className="wdc-card-3">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-container-around</div>
           </div>
         </div>
         <div className="wdc-card-container wdc-card-container-between">
           <div className="wdc-card-3">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-container-between</div>
           </div>
           <div className="wdc-card-3">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-container-between</div>
           </div>
           <div className="wdc-card-3">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-container-between</div>
           </div>
         </div>
         <div className="wdc-card-container wdc-card-container-center">
           <div className="wdc-card-3">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-container-center</div>
           </div>
           <div className="wdc-card-3">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-container-center</div>
           </div>
           <div className="wdc-card-3">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-container-center</div>
           </div>
         </div>
         <div className="wdc-card-container wdc-card-container-end">
           <div className="wdc-card-3">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-container-end</div>
           </div>
           <div className="wdc-card-3">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-container-end</div>
           </div>
           <div className="wdc-card-3">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-container-end</div>
           </div>
         </div>
         <div className="wdc-card-container wdc-card-container-start">
           <div className="wdc-card-3">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-container-start</div>
           </div>
           <div className="wdc-card-3">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-container-start</div>
           </div>
           <div className="wdc-card-3">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-container-start</div>
           </div>
         </div>
@@ -146,11 +146,11 @@ storiesOf('CSS/Card', module)
       <section>
         <div className="wdc-card-container">
           <div className="wdc-card-6 wdc-card-no-padding">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-6.wdc-card-no-padding</div>
           </div>
           <div className="wdc-card-6 wdc-card-no-padding">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-card-6</div>
           </div>
         </div>
@@ -161,19 +161,19 @@ storiesOf('CSS/Card', module)
       <section>
         <div className="wdc-card-container">
           <div className="wdc-card-3 wdc-depth-1">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-depth-1</div>
           </div>
           <div className="wdc-card-3 wdc-depth-2">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-depth-2</div>
           </div>
           <div className="wdc-card-3 wdc-depth-3">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-depth-3</div>
           </div>
           <div className="wdc-card-3 wdc-depth-4">
-            <h3 className="wdc-card-header">Card Header</h3>
+            <h3 className="wdc-card-heading">Card Header</h3>
             <div className="wdc-card-body">.wdc-depth-4</div>
           </div>
         </div>

--- a/modules/card/react/lib/Card.tsx
+++ b/modules/card/react/lib/Card.tsx
@@ -57,6 +57,7 @@ const Box = styled('div')<CardProps>(
 
 const Header = styled('h3')(type.h3, {
   marginBottom: spacing.m,
+  marginTop: 0,
 });
 
 const Body = styled('div')(type.body);

--- a/modules/card/react/spec/__snapshots__/Card.snapshot.tsx.snap
+++ b/modules/card/react/spec/__snapshots__/Card.snapshot.tsx.snap
@@ -54,6 +54,7 @@ exports[`Card Snapshots renders a card with heading 1`] = `
   color: #333333;
   font-family: "Roboto","Helvetica Neue","Helvetica",Arial,sans-serif;
   margin-bottom: 24px;
+  margin-top: 0;
 }
 
 <div

--- a/modules/modal/css/README.md
+++ b/modules/modal/css/README.md
@@ -24,13 +24,13 @@ Add your `node_modules` directory to your SASS `includePaths`. You will then be 
 ## Usage
 
 Use `.wdc-modal-bg` to create the background overlay and `.wdc-modal` to create the modal itself.
-The title and body content can be styled using `.wdc-modal-title` and `.wdc-modal-body`,
+The title and body content can be styled using `.wdc-modal-heading` and `.wdc-modal-body`,
 respectively.
 
 ```html
 <div class="wdc-modal-bg">
   <div class="wdc-modal" role="dialog" aria-labelledby="modal-heading">
-    <div class="wdc-modal-title" id="modal-heading">Modal Title</div>
+    <div class="wdc-modal-heading" id="modal-heading">Modal Title</div>
     <div class="wdc-modal-body">Modal content</div>
   </div>
 </div>
@@ -46,7 +46,7 @@ respectively.
         <i class="wdc-icon" data-icon="x" data-category="system" />
       </button>
     </div>
-    <div class="wdc-modal-title" id="modal-heading">Modal Title</div>
+    <div class="wdc-modal-heading" id="modal-heading">Modal Title</div>
     <div class="wdc-modal-body">Modal content</div>
   </div>
 </div>
@@ -59,7 +59,7 @@ or `wdc-modal-no-padding` to set the padding to `0`.
 
 ```html
 <div class="wdc-modal wdc-modal-no-padding" role="dialog" aria-labelledby="modal-heading">
-  <div class="wdc-modal-title" id="modal-heading">Modal Title</div>
+  <div class="wdc-modal-heading" id="modal-heading">Modal Title</div>
   <div class="wdc-modal-body">Modal content</div>
 </div>
 ```

--- a/modules/modal/css/stories.tsx
+++ b/modules/modal/css/stories.tsx
@@ -48,7 +48,7 @@ class ModalWrapper extends React.Component<{}, ModalWrapperState> {
                   <i className="wdc-icon" data-icon="x" data-category="system" />
                 </button>
               </div>
-              <h3 className="wdc-modal-title" id="modal-heading">
+              <h3 className="wdc-modal-heading" id="modal-heading">
                 Delete Item
               </h3>
               <div style={{marginBottom: '24px'}} className="wdc-modal-body">

--- a/modules/modal/react/lib/Modal.tsx
+++ b/modules/modal/react/lib/Modal.tsx
@@ -66,7 +66,7 @@ const Container = styled('div')({
 
 const transformOrigin = {
   horizontal: 'center',
-  vertical: 'top',
+  vertical: 'bottom',
 } as const;
 
 function onInitialFocus(
@@ -161,6 +161,7 @@ export default class Modal extends React.Component<ModalProps> {
       firstFocusRef: firstFocusableRef,
       ...elemProps
     } = this.props;
+    
     return (
       open && (
         <FocusTrap

--- a/modules/popup/css/README.md
+++ b/modules/popup/css/README.md
@@ -24,11 +24,11 @@ Add your `node_modules` directory to your SASS `includePaths`. You will then be 
 ## Usage
 
 Use `.wdc-popup` to create a popup. The title and body content can be styled using
-`.wdc-popup-title` and `.wdc-popup-body`, respectively.
+`.wdc-popup-heading` and `.wdc-popup-body`, respectively.
 
 ```html
 <div class="wdc-popup" role="dialog" aria-labelledby="popup-heading">
-  <div class="wdc-popup-title" id="popup-heading">Popup Title</div>
+  <div class="wdc-popup-heading" id="popup-heading">Popup Title</div>
   <div class="wdc-popup-body">Popup content</div>
 </div>
 ```
@@ -42,7 +42,7 @@ Use `.wdc-popup` to create a popup. The title and body content can be styled usi
       <i class="wdc-icon" data-icon="x" data-category="system" />
     </button>
   </div>
-  <div class="wdc-popup-title" id="popup-heading">Popup Title</div>
+  <div class="wdc-popup-heading" id="popup-heading">Popup Title</div>
   <div class="wdc-popup-body">Popup content</div>
 </div>
 ```
@@ -54,7 +54,7 @@ or `wdc-popup-no-padding` to set the padding to `0`.
 
 ```html
 <div class="wdc-popup wdc-popup-no-padding" role="dialog" aria-labelledby="popup-heading">
-  <div class="wdc-popup-title" id="popup-heading">Popup Title</div>
+  <div class="wdc-popup-heading" id="popup-heading">Popup Title</div>
   <div class="wdc-popup-body">Popup content</div>
 </div>
 ```
@@ -81,7 +81,7 @@ it.
   role="dialog"
   aria-labelledby="popup-heading"
 >
-  <div class="wdc-popup-title" id="popup-heading">Popup Title</div>
+  <div class="wdc-popup-heading" id="popup-heading">Popup Title</div>
   <div class="wdc-popup-body">Popup content</div>
 </div>
 ```

--- a/modules/popup/css/lib/popup.scss
+++ b/modules/popup/css/lib/popup.scss
@@ -17,15 +17,6 @@
     right: $wdc-spacing-xs;
     top: $wdc-spacing-xs;
   }
-
-  &-title {
-    @include wdc-type-h3();
-    margin-bottom: $wdc-spacing-m;
-  }
-
-  &-body {
-    @include wdc-type-body();
-  }
 }
 
 .wdc-popup {

--- a/modules/popup/css/stories.tsx
+++ b/modules/popup/css/stories.tsx
@@ -53,7 +53,7 @@ class PopupWrapper extends React.Component<{}, PopupWrapperState> {
                 <i className="wdc-icon" data-icon="x" data-category="system" />
               </button>
             </div>
-            <h3 className="wdc-popup-title" id="popup-heading">
+            <h3 className="wdc-popup-heading" id="popup-heading">
               Delete Item
             </h3>
             <div style={{marginBottom: '24px'}} className="wdc-popup-body">

--- a/modules/popup/react/lib/Popup.tsx
+++ b/modules/popup/react/lib/Popup.tsx
@@ -15,7 +15,7 @@ export enum PopupPadding {
   l = '32px',
 }
 
-export interface PopupProps {
+export interface PopupProps extends React.HTMLAttributes<HTMLDivElement> {
   padding: PopupPadding;
   transformOrigin: TransformOrigin;
   closeIconSize: IconButtonSize;


### PR DESCRIPTION
## Summary

I found a few issues with Cards, Popups and Modals. The heading margin issue was noted in our recent design review.
- All of their headings where the same, but named different things. Now we support `*-heading`, `*-header`, and `*-title` to be flexible.
- Card headings had the browser default margin top which was adding extra space to popups and modals as well
- `PopupProps` were missing their div attribute interface extension

### Breaking Visual Changes:
- Margin top on card headers removed which changes the height of the card. Could cause reflow issues

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [ ] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)
