### PR TITLE
ci: Create github action for CI and add Cypress to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  unit_test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 10.x
+    - name: Install Packages
+      run: yarn install --production=false
+    - name: Linting
+      run: yarn lint
+    - name: Build
+      run: yarn build
+    - name: Unit tests
+      run: yarn test
+
+  integration_test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 10.x
+    - name: Install Packages
+      run: yarn install --production=false
+    - name: storybook
+      run: yarn start & npx wait-on http://localhost:9001
+    - name: Integration tests
+      run: yarn cypress run --record --key ${{ secrets.CYPRESS_KEY }}
+      env:
+        # Cypress gathers info about a commit and PR to show in the dashboard. Github Actions isn't officially supported as a CI provider, so we'll help it along
+        TRAVIS: 1 # Pretend to be Travis. More info: https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/util/ci_provider.js
+        TRAVIS_PULL_REQUEST_BRANCH: ${{ github.head_ref }} # Tell Cypress what the PR branch name is

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,5 @@
 {
+  "projectId": "odida5",
   "baseUrl": "http://localhost:9001",
   "supportFile": "cypress/support/index.ts"
 }


### PR DESCRIPTION
## Summary

We're evaluating Github Actions. The PR adds common CI tasks already covered by Travis, but also adds Cypress tests and uploads to the Cypress dashboard. Cypress runs can be found here: https://dashboard.cypress.io/#/projects/odida5/runs

## Checklist

- [x] branch has been rebased on the latest master commit

## Additional References

It doesn't look like Github Actions runs if created from a fork. Here is an example of it working inside my fork: https://github.com/NicholasBoll/canvas-kit/pull/1. Screenshot below:

![Screen Shot 2019-10-03 at 3 57 54 PM](https://user-images.githubusercontent.com/338257/66167153-9a99d880-e5f6-11e9-9327-d118ac647a8f.png)
