### PR TITLE
Ci/fix forks maybe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
       run: yarn cypress run --record
       env:
         # Cypress gathers info about a commit and PR to show in the dashboard. Github Actions isn't officially supported as a CI provider, so we'll help it along
-        TRAVIS: 1 # Pretend to be Travis. More info: https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/util/ci_provider.js
+        TRAVIS: true # Pretend to be Travis. More info: https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/util/ci_provider.js
         TRAVIS_PULL_REQUEST_BRANCH: ${{ github.head_ref }} # Tell Cypress what the PR branch name is
         CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_KEY }}
+        # Tell Cypress how to handle forks: https://github.com/bahmutov/is-fork-pr/blob/master/src/index.js
+        TRAVIS_PULL_REQUEST: ${{ github.event.pull_request.number }}
+        TRAVIS_REPO_SLUG: ${{ github.event.pull_request.base.repo.full_name }}
+        TRAVIS_PULL_REQUEST_SLUG: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,4 @@ jobs:
         # Cypress gathers info about a commit and PR to show in the dashboard. Github Actions isn't officially supported as a CI provider, so we'll help it along
         TRAVIS: true # Pretend to be Travis. More info: https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/util/ci_provider.js
         TRAVIS_PULL_REQUEST_BRANCH: ${{ github.head_ref }} # Tell Cypress what the PR branch name is
-        CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_KEY }}
-        # Tell Cypress how to handle forks: https://github.com/bahmutov/is-fork-pr/blob/master/src/index.js
-        TRAVIS_PULL_REQUEST: ${{ github.event.pull_request.number }}
-        TRAVIS_REPO_SLUG: ${{ github.event.pull_request.base.repo.full_name }}
-        TRAVIS_PULL_REQUEST_SLUG: ${{ github.event.pull_request.head.repo.full_name }}
+        CYPRESS_RECORD_KEY: 3a9347b6-36ab-4a36-823d-709f4078b148


### PR DESCRIPTION
## Summary

CI is hard. Especially with forks. This just hard-codes the Cypress Key until Github can come up with a way to use secrets in forks! 

## Additional References

https://github.community/t5/GitHub-Actions/Make-secrets-available-to-builds-of-forks/m-p/33876/highlight/true#M1691
