### PR TITLE
fix(skeleton): Remove z-index

### DIFF
--- a/modules/skeleton/react/lib/skeleton.tsx
+++ b/modules/skeleton/react/lib/skeleton.tsx
@@ -28,7 +28,6 @@ const SkeletonAnimator = styled('div')<{diagonal: number; topPosition: number; w
       height: diagonal,
       top: topPosition,
       position: 'absolute',
-      zIndex: 999,
     };
   }
 );

--- a/modules/skeleton/react/spec/__snapshots__/skeleton.snapshot.tsx.snap
+++ b/modules/skeleton/react/spec/__snapshots__/skeleton.snapshot.tsx.snap
@@ -18,7 +18,6 @@ exports[`Skeleton Single Span 1`] = `
   height: 10px;
   top: -5px;
   position: absolute;
-  z-index: 999;
 }
 
 <div


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes #253 

Currently the Skeleton clobbers the z-index of most elements on the page sitting at 999, this was leftover from a previous implementation that is no longer valid. Unlike what #253 specifies this PR removes the z-index altogether. It was just left in there by mistake.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [ ] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
