### PR TITLE
fix(layout): Remove spacing prop from DOM

### DIFF
--- a/modules/layout/react/lib/Column.tsx
+++ b/modules/layout/react/lib/Column.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import styled from 'react-emotion';
+import isPropValid from '@emotion/is-prop-valid';
 
 export interface ColumnProps {
   /**
@@ -20,7 +21,9 @@ export interface ColumnProps {
   width?: number | string;
 }
 
-const ColumnContainer = styled('div')<ColumnProps>(
+const ColumnContainer = styled('div', {
+  shouldForwardProp: prop => isPropValid(prop) && prop !== 'spacing',
+})<ColumnProps>(
   {
     '&:first-child': {
       paddingLeft: 0,

--- a/modules/layout/react/lib/Layout.tsx
+++ b/modules/layout/react/lib/Layout.tsx
@@ -3,6 +3,7 @@ import styled from 'react-emotion';
 import {GenericStyle} from '@workday/canvas-kit-react-common';
 import Column, {ColumnProps} from './Column';
 import canvas, {spacingNumbers} from '@workday/canvas-kit-react-core';
+import isPropValid from '@emotion/is-prop-valid';
 
 export interface LayoutProps {
   /**
@@ -32,7 +33,9 @@ const LayoutStyles: GenericStyle = {
   },
 };
 
-const LayoutContainer = styled('div')<LayoutProps>(
+const LayoutContainer = styled('div', {
+  shouldForwardProp: prop => isPropValid(prop) && prop !== 'spacing',
+})<LayoutProps>(
   LayoutStyles.styles,
   ({gutter}) => {
     if (gutter === 0) {


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This will prevent `spacing` from being rendered in the dom.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
