### PR TITLE
ci: Update ChromaticQA for better baselines

### DIFF
--- a/.github/workflows/chromaticqa.yml
+++ b/.github/workflows/chromaticqa.yml
@@ -11,10 +11,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-      with:
-        # Use 'head' instead of 'merge': https://docs.chromaticqa.com/setup_ci#pull-request-builds
-        # 'head' is the HEAD of the PR branch. 'merge' is the hidden merge commit created by github
-        ref: refs/pull/${{ github.event.pull_request.number}}/head
     - uses: actions/setup-node@v1
       with:
         node-version: 10.x

--- a/.github/workflows/chromaticqa.yml
+++ b/.github/workflows/chromaticqa.yml
@@ -16,12 +16,7 @@ jobs:
         node-version: 10.x
     - name: Install Packages
       run: yarn install
-    - name: ChromaticQA
-      # Chromatic has a separate Github check that handles changes. We need to exit
-      # zero, otherwise this Github workflow will have to be rerun _after_ a visual review.
-      # This extra step is unnecessary with the Chromatic check we have integrated.
-      # http://docs.chromaticqa.com/setup_ci#command-exit-code
-      run: yarn chromatic --exit-zero-on-changes
-      env:
-        CI: true
-        CHROMATIC_APP_CODE: dlpro96xybh
+    - uses: chromaui/action@releases/v1
+      with:
+        appCode: dlpro96xybh
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chromaticqa.yml
+++ b/.github/workflows/chromaticqa.yml
@@ -24,6 +24,6 @@ jobs:
       run: yarn chromatic --exit-zero-on-changes
       env:
         CI: true
-        CHROMATIC_BRANCH: ${{ event.payload.pull_request.head.ref }}
-        CHROMATIC_SHA: ${{ github.event.payload.pull_request.head.sha }}
+        CHROMATIC_BRANCH: ${{ github.event.pull_request.head.ref }}
+        CHROMATIC_SHA: ${{ github.event.pull_request.head.sha }}
         CHROMATIC_APP_CODE: dlpro96xybh

--- a/.github/workflows/chromaticqa.yml
+++ b/.github/workflows/chromaticqa.yml
@@ -16,7 +16,14 @@ jobs:
         node-version: 10.x
     - name: Install Packages
       run: yarn install
-    - uses: chromaui/action@releases/v1
-      with:
-        appCode: dlpro96xybh
-        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: ChromaticQA
+      # Chromatic has a separate Github check that handles changes. We need to exit
+      # zero, otherwise this Github workflow will have to be rerun _after_ a visual review.
+      # This extra step is unnecessary with the Chromatic check we have integrated.
+      # http://docs.chromaticqa.com/setup_ci#command-exit-code
+      run: yarn chromatic --exit-zero-on-changes
+      env:
+        CI: true
+        CHROMATIC_BRANCH: ${{ event.payload.pull_request.head.ref }}
+        CHROMATIC_SHA: ${{ github.event.payload.pull_request.head.sha }}
+        CHROMATIC_APP_CODE: dlpro96xybh

--- a/modules/button/react/stories/stories.tsx
+++ b/modules/button/react/stories/stories.tsx
@@ -97,7 +97,7 @@ storiesOf('Button', module)
       <Button disabled={true} size={Button.Size.Small} variant={Button.Variant.Primary}>
         Primary
       </Button>
-      <h3>Growing Primary</h3>
+      <h2>Growing Primary</h2>
       <div className={css(buttonContainer)}>
         <Button size={Button.Size.Large} variant={Button.Variant.Primary} grow={true}>
           Primary

--- a/modules/button/react/stories/stories.tsx
+++ b/modules/button/react/stories/stories.tsx
@@ -97,7 +97,7 @@ storiesOf('Button', module)
       <Button disabled={true} size={Button.Size.Small} variant={Button.Variant.Primary}>
         Primary
       </Button>
-      <h2>Growing Primary</h2>
+      <h3>Growing Primary</h3>
       <div className={css(buttonContainer)}>
         <Button size={Button.Size.Large} variant={Button.Variant.Primary} grow={true}>
           Primary

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "rollup-plugin-node-resolve": "^5.1.0",
     "rollup-plugin-terser": "^5.0.0",
     "sass-loader": "^7.0.1",
-    "storybook-chromatic": "^3.0.2",
+    "storybook-chromatic": "^3.0.3",
     "storybook-readme": "^5.0.8",
     "style-loader": "^0.20.3",
     "ts-loader": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6608,6 +6608,15 @@ cross-spawn@^5.0.1:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cross-spawn@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
+  integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
 crypto-browserify@^3.11.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec"
@@ -14048,6 +14057,11 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
+path-key@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.0.tgz#99a10d870a803bdd5ee6f0470e58dfcd2f9a54d3"
+  integrity sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==
+
 path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
@@ -16777,10 +16791,22 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 shell-quote@1.6.1, shell-quote@^1.6.1:
   version "1.6.1"
@@ -17201,16 +17227,17 @@ store2@^2.7.1:
   resolved "https://registry.yarnpkg.com/store2/-/store2-2.7.1.tgz#22070b7dc04748a792fc6912a58ab99d3a21d788"
   integrity sha512-zzzP5ZY6QWumnAFV6kBRbS44pUMcpZBNER5DWUe1HETlaKXqLcCQxbNu6IHaKr1pUsjuhUGBdOy8sWKmMkL6pQ==
 
-storybook-chromatic@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/storybook-chromatic/-/storybook-chromatic-3.0.2.tgz#d21a55421db690fe2ec8bb14ebb626b662390080"
-  integrity sha512-Myhh3EHYosJjsnW0H/sA8FocFC/WIS12wO87nhf7B1sYj1gDiIPzxyuqeBymaXuwEQTPYh3enaWbkglNvEIEig==
+storybook-chromatic@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/storybook-chromatic/-/storybook-chromatic-3.0.3.tgz#abebb31218f46db28592787753322813054a57ba"
+  integrity sha512-/JY0asvRD8V1jrc/3e+gIpPWOeYHpT0MbKXYiZ3LwR8GAD2sI0V+p7U6wG1n50/4UTrz08j2nFG44KHZjeK5nw==
   dependencies:
     "@babel/preset-react" "^7.0.0"
     "@babel/runtime" "^7.6.2"
     "@chromaui/localtunnel" "2.0.1"
     async-retry "^1.1.4"
     babel-plugin-require-context-hook "^1.0.0"
+    cross-spawn "^7.0.1"
     debug "^4.1.1"
     denodeify "^1.2.1"
     dotenv "^8.1.0"
@@ -18750,6 +18777,13 @@ which@1, which@^1.2.10, which@^1.2.14, which@^1.2.9, which@^1.3.0, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
+which@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.1.tgz#f1cf94d07a8e571b6ff006aeb91d0300c47ef0a4"
+  integrity sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==
   dependencies:
     isexe "^2.0.0"
 


### PR DESCRIPTION
According to my conversation with the ChromaticQA team, our baseline issue should be partially addressed by updating to the latest version of `storybook-chromatic`. The team is currently working on a Github action: https://github.com/chromaui/action (currently in beta).

Here's what the baselines now look like:
![Screen Shot 2019-10-16 at 12 55 23 PM](https://user-images.githubusercontent.com/338257/66949747-4ccc9980-f014-11e9-89d9-37081adbfda2.png)

Before:
```
7f607b on master
```

After:
```
 7f607b on chore/update-chromaticqa
```

Before all PRs used the `master` baseline which was a problem where each CI run against a PR potentially rebaselined another PR. Now we're able to send the baseline explicitly. I've tested this against this PR and another PR to make sure the baselines did not interfere with each other and it doesn't look like they do anymore.

## Proposed Squash Message:
```
ci: Update ChromaticQA for better baselines (#269)
```