### PR TITLE
fix(checkbox): Added an indeterminate checkbox type

### DIFF
--- a/modules/checkbox/react/README.md
+++ b/modules/checkbox/react/README.md
@@ -124,3 +124,12 @@ Default: A uniquely generated id
 | Alert | Yellow outline with alert icon. |
 
 Default: `undefined`
+
+---
+
+#### `indeterminate: boolean`
+
+> Used on a checkbox with nested child checkboxes to denote that some, but not all, child checkboxes
+> are selected.
+
+Default: `false`

--- a/modules/checkbox/react/lib/Checkbox.tsx
+++ b/modules/checkbox/react/lib/Checkbox.tsx
@@ -21,6 +21,7 @@ export interface CheckboxProps extends React.InputHTMLAttributes<HTMLInputElemen
   onChange?: (e: React.SyntheticEvent) => void;
   value?: string;
   error?: ErrorType;
+  indeterminate?: boolean;
 }
 
 const checkboxHeight = 18;
@@ -218,6 +219,12 @@ const CheckboxCheck = styled('div')<Pick<CheckboxProps, 'checked'>>(
   })
 );
 
+const IndeterminateBox = styled('div')({
+  width: '10px',
+  height: '2px',
+  backgroundColor: canvas.colors.frenchVanilla100,
+});
+
 const CheckboxLabel = styled('label')<{disabled?: boolean}>(
   {
     ...canvas.type.body,
@@ -247,6 +254,7 @@ export default class Checkbox extends React.Component<CheckboxProps> {
       onChange,
       value,
       error,
+      indeterminate,
       ...elemProps
     } = this.props;
 
@@ -266,7 +274,11 @@ export default class Checkbox extends React.Component<CheckboxProps> {
           />
           <CheckboxBackground checked={checked} disabled={disabled}>
             <CheckboxCheck checked={checked}>
-              <SystemIcon icon={checkSmallIcon} color={iconColors.inverse} />
+              {indeterminate ? (
+                <IndeterminateBox />
+              ) : (
+                <SystemIcon icon={checkSmallIcon} color={iconColors.inverse} />
+              )}
             </CheckboxCheck>
           </CheckboxBackground>
         </CheckboxInputWrapper>

--- a/modules/form-field/react/stories/stories_Checkbox.tsx
+++ b/modules/form-field/react/stories/stories_Checkbox.tsx
@@ -29,6 +29,11 @@ storiesOf('Form Field/Checkbox/Top Label', module)
       {control(<Checkbox id="1" label="Checkbox option" disabled={true} />)}
     </FormField>
   ))
+  .add('Indeterminate', () => (
+    <FormField label="Label" inputId="my-checkbox-field">
+      {control(<Checkbox id="1" label="Checkbox option" indeterminate={true} />)}
+    </FormField>
+  ))
   .add('Alert', () => (
     <FormField
       label="Label"
@@ -70,6 +75,15 @@ storiesOf('Form Field/Checkbox/Left Label', module)
       labelPosition={FormField.LabelPosition.Left}
     >
       {control(<Checkbox id="1" label="Checkbox option" disabled={true} />)}
+    </FormField>
+  ))
+  .add('Indeterminate', () => (
+    <FormField
+      label="Label"
+      inputId="my-checkbox-field"
+      labelPosition={FormField.LabelPosition.Left}
+    >
+      {control(<Checkbox id="1" label="Checkbox option" indeterminate={true} />)}
     </FormField>
   ))
   .add('Alert', () => (


### PR DESCRIPTION
## Summary

Checkboxes can have an indeterminate state in a nested checkbox context. If the "parent" checkbox has some, but not all, child checkboxes selected, that checkbox is considered indeterminate or otherwise known as "partially selected". 
More information here: https://css-tricks.com/indeterminate-checkboxes/

## Checklist

- [x] `yarn test` passes
- [x] code has been documented and, if applicable, usage described in README.md

## Additional References
![Screen Shot 2019-10-23 at 6 32 51 PM](https://user-images.githubusercontent.com/51688171/67445930-90e70d80-f5c3-11e9-9d39-560fb8caa175.png)

