### PR TITLE
feat(button): Utilize InputProvider for mouse input focus

### DIFF
--- a/modules/button/react/lib/utils.ts
+++ b/modules/button/react/lib/utils.ts
@@ -1,5 +1,5 @@
 import {CSSObject} from '@emotion/core';
-import {focusRing} from '@workday/canvas-kit-react-common';
+import {focusRing, mouseFocusBehavior} from '@workday/canvas-kit-react-common';
 import {
   ButtonSize,
   DeprecatedButtonVariant,
@@ -130,7 +130,7 @@ export function getButtonStateStyle(variant: AllButtonVariants): CSSObject {
     return {};
   }
 
-  return {
+  const baseStyles = {
     backgroundColor: buttonColors.background,
     borderColor: buttonColors.border,
     color: buttonColors.text,
@@ -145,31 +145,9 @@ export function getButtonStateStyle(variant: AllButtonVariants): CSSObject {
         color: buttonColors.labelData,
       },
     }),
-    ':focus': {
-      backgroundColor: buttonColors.focusBackground,
-      borderColor: buttonColors.focusBorder,
-      color: buttonColors.focusText,
-      ...(buttonColors.labelDataFocus && {
-        ['.' + ButtonStyles.labelDataBaseStyles.classname]: {color: buttonColors.labelDataFocus},
-      }),
-      ...(buttonColors.labelIconFocus && {
-        'span .wd-icon-fill, span .wd-icon-accent': {fill: buttonColors.labelIconFocus},
-      }),
-    },
-    ':hover:focus': {
-      backgroundColor: buttonColors.hoverBackground,
-    },
-    ':active, :focus:active, :hover:active': {
-      backgroundColor: buttonColors.activeBackground,
-      borderColor: buttonColors.activeBorder,
-      color: buttonColors.activeText,
-      ...(buttonColors.labelDataActive && {
-        ['.' + ButtonStyles.labelDataBaseStyles.classname]: {color: buttonColors.labelDataActive},
-      }),
-      ...(buttonColors.labelIconActive && {
-        'span .wd-icon-fill, span .wd-icon-accent': {fill: buttonColors.labelIconActive},
-      }),
-    },
+  };
+
+  const hoverStyles = {
     ':hover': {
       backgroundColor: buttonColors.hoverBackground,
       borderColor: buttonColors.hoverBorder,
@@ -184,6 +162,40 @@ export function getButtonStateStyle(variant: AllButtonVariants): CSSObject {
         'span .wd-icon-fill, span .wd-icon-accent': {fill: buttonColors.labelIconHover},
       }),
     },
+  };
+
+  const activeStyles = {
+    ':active, :focus:active, :hover:active': {
+      backgroundColor: buttonColors.activeBackground,
+      borderColor: buttonColors.activeBorder,
+      color: buttonColors.activeText,
+      ...(buttonColors.labelDataActive && {
+        ['.' + ButtonStyles.labelDataBaseStyles.classname]: {color: buttonColors.labelDataActive},
+      }),
+      ...(buttonColors.labelIconActive && {
+        'span .wd-icon-fill, span .wd-icon-accent': {fill: buttonColors.labelIconActive},
+      }),
+    },
+  };
+
+  return {
+    ...baseStyles,
+    ':focus': {
+      backgroundColor: buttonColors.focusBackground,
+      borderColor: buttonColors.focusBorder,
+      color: buttonColors.focusText,
+      ...(buttonColors.labelDataFocus && {
+        ['.' + ButtonStyles.labelDataBaseStyles.classname]: {color: buttonColors.labelDataFocus},
+      }),
+      ...(buttonColors.labelIconFocus && {
+        'span .wd-icon-fill, span .wd-icon-accent': {fill: buttonColors.labelIconFocus},
+      }),
+    },
+    ':hover:focus': {
+      backgroundColor: buttonColors.hoverBackground,
+    },
+    ...activeStyles,
+    ...hoverStyles,
     ':disabled, :active:disabled, :focus:disabled, :hover:disabled': {
       backgroundColor: buttonColors.disabledBackground,
       borderColor: buttonColors.disabledBorder,
@@ -205,5 +217,15 @@ export function getButtonStateStyle(variant: AllButtonVariants): CSSObject {
         ...getButtonFocusRing(variant),
       },
     },
+    ...mouseFocusBehavior({
+      '&:focus': {
+        ...baseStyles,
+        outline: 'none',
+        boxShadow: 'none',
+        animation: 'none',
+        ...hoverStyles,
+        ...activeStyles,
+      },
+    }),
   };
 }


### PR DESCRIPTION
## Summary

It does what it says! This takes advantage of `InputProvider` to hide the focus styling when using a mouse and showing it when keyboard navigation begins. This is added to all buttons (including the deprecated ones).

Depends on #276. Blocked until that is merged.

## Checklist

- [x] branch has been rebased on the latest master commit
- [x] `yarn test` passes
- [x] design approved final implementation
- [x] a11y approved final implementation
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)