### PR TITLE
fix: Lower is-prop-valid dep into components that need it

### DIFF
--- a/modules/avatar/react/package.json
+++ b/modules/avatar/react/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@emotion/core": "^10.0.21",
+    "@emotion/is-prop-valid": "^0.8.2",
     "@emotion/styled": "^10.0.17",
     "@workday/canvas-kit-react-common": "^3.0.0",
     "@workday/canvas-kit-react-core": "^3.0.0",

--- a/modules/button/react/package.json
+++ b/modules/button/react/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@emotion/core": "^10.0.21",
+    "@emotion/is-prop-valid": "^0.8.2",
     "@emotion/styled": "^10.0.17",
     "@workday/canvas-kit-react-common": "^3.0.0",
     "@workday/canvas-kit-react-core": "^3.0.0",

--- a/modules/icon/react/package.json
+++ b/modules/icon/react/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@emotion/core": "^10.0.21",
+    "@emotion/is-prop-valid": "^0.8.2",
     "@emotion/styled": "^10.0.17",
     "@workday/canvas-kit-react-common": "^3.0.0",
     "@workday/canvas-kit-react-core": "^3.0.0",

--- a/modules/layout/react/package.json
+++ b/modules/layout/react/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@emotion/core": "^10.0.21",
+    "@emotion/is-prop-valid": "^0.8.2",
     "@emotion/styled": "^10.0.17",
     "@workday/canvas-kit-react-common": "^3.0.0",
     "@workday/canvas-kit-react-core": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@commitlint/cli": "^8.1.0",
     "@commitlint/config-conventional": "^8.1.0",
     "@cypress/webpack-preprocessor": "^4.1.0",
-    "@emotion/is-prop-valid": "^0.8.2",
     "@storybook/addon-actions": "^5.0.11",
     "@storybook/addon-knobs": "^5.0.11",
     "@storybook/addon-options": "^5.0.11",


### PR DESCRIPTION
## Summary

The `@emotion/is-prop-valid` dependency was mistakenly added to the workspace package.json rather than the components' that explicitly need it. This causes "Module not found" errors when using the reference outside of the Canvas Kit repo. This PR removes the workspace dep (it's not needed there), and adds it to the components that use `isValidProp`.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] `yarn test` passes