### PR TITLE
fix(labs): Update incorrect emotion version in labs core

### DIFF
--- a/modules/_labs/core/react/package.json
+++ b/modules/_labs/core/react/package.json
@@ -37,8 +37,8 @@
     "react": ">= 16.8 < 17"
   },
   "dependencies": {
+    "@emotion/core": "^10.0.21",
     "@workday/canvas-colors-web": "^0.17.12",
-    "@workday/canvas-kit-react-core": "^3.0.0",
-    "emotion": "^9.2.12"
+    "@workday/canvas-kit-react-core": "^3.0.0"
   }
 }


### PR DESCRIPTION
## Summary

Somehow an Emotion 9 dep snuck in (must have been a bad rebase). This fixes it.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [ ] `yarn test` passes
