### PR TITLE
fix(side-panel): Change width of children container when closed

### DIFF
--- a/modules/side-panel/react/lib/SidePanel.tsx
+++ b/modules/side-panel/react/lib/SidePanel.tsx
@@ -91,13 +91,13 @@ const SidePanelContainer = styled('div')<
   })
 );
 
-const ChildrenContainer = styled('div')<Pick<SidePanelProps, 'openWidth'>>(
+const ChildrenContainer = styled('div')<Pick<SidePanelProps, 'openWidth' | 'open'>>(
   {
     transition: 'none',
     zIndex: 1, // show above SidePanelFooter when screen is small vertically
   },
-  ({openWidth}) => ({
-    width: openWidth,
+  ({open, openWidth}) => ({
+    width: open ? openWidth : closedWidth,
   })
 );
 
@@ -180,7 +180,7 @@ export default class SidePanel extends React.Component<SidePanelProps, SidePanel
         open={open}
         {...elemProps}
       >
-        <ChildrenContainer openWidth={openWidth}>
+        <ChildrenContainer open={open} openWidth={openWidth}>
           {header && open ? <Header>{header}</Header> : null}
           {this.props.children}
         </ChildrenContainer>


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Fixes: https://github.com/Workday/canvas-kit/issues/303
