### PR TITLE
fix: Add missing tilde on SASS imports (#307)

### DIFF
--- a/modules/_canvas-kit-css/README.md
+++ b/modules/_canvas-kit-css/README.md
@@ -4,9 +4,34 @@ The bundle package containing all modules of the Canvas CSS Kit.
 
 ## Usage
 
-Add your `node_modules` directory to your SASS `includePaths`. You will then be able to import
-`index.scss`.
+Canvas Kit CSS uses tilde `~` imports to resolve imports to your project's node_modules directory.
+
+This is done automatically in Webpack's sass-loader.
+
+If you would like to import outside of webpack you have a few options you can pass to the SASS `importer` option.
+
+* If you are using `node_sass` you can try a third part importer such as `node-sass-tilde-importer`
+
+* If you are using `dart_sass` you will need your own custom importer, e.g.:
+
+```ts
+const tildeImporter = (url: string): {file: string} => {
+  if (url[0] === '~') {
+    url = `./node_modules/${url.substr(1)}`;
+  }
+
+  return {file: url};
+}
+```
+
+Troubleshooting:
+
+In some cases your may need to add your `node_modules` directory to your the SASS `includePaths` option.
+
+------------
+
+You will then be able to import any scss file `index.scss`.
 
 ```scss
-@import '@workday/canvas-kit-css/index.scss';
+@import '~@workday/canvas-kit-css/index.scss';
 ```

--- a/modules/core/css/lib/variables/colors.scss
+++ b/modules/core/css/lib/variables/colors.scss
@@ -1,5 +1,5 @@
 // Canvas Kit Colors
-@import '@workday/canvas-colors-web/dist/sass/canvas-colors-hex.scss';
+@import '~@workday/canvas-colors-web/dist/sass/canvas-colors-hex.scss';
 
 $wdc-color-error: $wdc-color-cinnamon-500;
 $wdc-color-error-light: $wdc-color-cinnamon-200;

--- a/modules/core/css/lib/variables/depth.scss
+++ b/modules/core/css/lib/variables/depth.scss
@@ -1,2 +1,2 @@
 // Depth & Shadows
-@import '@workday/canvas-depth-web/dist/sass/canvas-depth.scss';
+@import '~@workday/canvas-depth-web/dist/sass/canvas-depth.scss';


### PR DESCRIPTION


<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

There were two files that were inconsistently importing sass files. This fixes it and clarifies usage in the top level README.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] `yarn test` passes
- [x] code has been documented and, if applicable, usage described in README.md
- [x] design approved final implementation
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
