### PR TITLE
fix(common): Port accessible hide styles from JS to CSS

### DIFF
--- a/modules/common/css/README.md
+++ b/modules/common/css/README.md
@@ -38,4 +38,8 @@ or
 
 ## Forms
 
-`forms` has shared styles for inputs
+`forms` has shared styles for inputs.
+
+## Accessibility
+
+`accessibility` has focus for inputs and method to provide screen reader only content.

--- a/modules/common/css/lib/accessibility.scss
+++ b/modules/common/css/lib/accessibility.scss
@@ -21,3 +21,16 @@
     outline: none;
   }
 }
+
+.wdc-accessible-hide {
+  clip: 'rect(1px, 1px, 1px, 1px)';
+  clip-path: 'polygon(0px 0px, 0px 0px, 0px 0px, 0px 0px)';
+  position: 'absolute';
+  overflow: 'hidden';
+  word-wrap: 'normal';
+  height: '1px';
+  width: '1px';
+  margin: '-1px';
+  padding: 0;
+  border: 0;
+}

--- a/modules/common/css/lib/accessibility.scss
+++ b/modules/common/css/lib/accessibility.scss
@@ -22,7 +22,7 @@
   }
 }
 
-.wdc-accessible-hide {
+@mixin wdc-accessible-hide() {
   clip: 'rect(1px, 1px, 1px, 1px)'; // Deprecated but still used by most browsers, clip-path will be taking its place soon.
   clip-path: 'polygon(0px 0px, 0px 0px, 0px 0px, 0px 0px)';
   position: 'absolute';
@@ -33,4 +33,8 @@
   margin: '-1px';
   padding: 0;
   border: 0;
+}
+
+.wdc-accessible-hide {
+  @include wdc-accessible-hide();
 }

--- a/modules/common/css/lib/accessibility.scss
+++ b/modules/common/css/lib/accessibility.scss
@@ -23,11 +23,11 @@
 }
 
 .wdc-accessible-hide {
-  clip: 'rect(1px, 1px, 1px, 1px)';
+  clip: 'rect(1px, 1px, 1px, 1px)'; // Deprecated but still used by most browsers, clip-path will be taking its place soon.
   clip-path: 'polygon(0px 0px, 0px 0px, 0px 0px, 0px 0px)';
   position: 'absolute';
   overflow: 'hidden';
-  word-wrap: 'normal';
+  white-space: 'nowrap';
   height: '1px';
   width: '1px';
   margin: '-1px';

--- a/modules/common/react/lib/styles/accessibleHide.ts
+++ b/modules/common/react/lib/styles/accessibleHide.ts
@@ -9,7 +9,7 @@ const accessibleHide: CSSObject = {
   clipPath: 'polygon(0px 0px, 0px 0px, 0px 0px, 0px 0px)',
   position: 'absolute',
   overflow: 'hidden',
-  wordWrap: 'normal',
+  whiteSpace: 'nowrap',
   height: '1px',
   width: '1px',
   margin: '-1px',


### PR DESCRIPTION
## Summary

Code to make text screen reader only was added to JS common repo but was not mirrored in the css. This adds a new class to the common css

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] `yarn test` passes
- [x] code has been documented and, if applicable, usage described in README.md
- [x] a11y approved final implementation
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

This PR also changes Change word-wrap: normal to white-space, see:

https://medium.com/@jessebeach/beware-smushed-off-screen-accessible-text-5952a4c2cbfe
