### PR TITLE
ci: Exit 0 on ChromaticQA changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ jobs:
 
   - stage: master
     script:
-      - yarn chromatic --auto-accept-changes
+      - yarn chromatic --auto-accept-changes --exit-zero-on-changess
       - yarn build-storybook
     env:
       - CHROMATIC_APP_CODE="dlpro96xybh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
     script:
       - yarn lint
       - yarn test
-      - yarn chromatic
+      - yarn chromatic --exit-zero-on-changes
       - yarn start & npx wait-on http://localhost:9001
       - yarn cypress run --record
       - kill $(jobs -p) || true
@@ -62,7 +62,7 @@ jobs:
 
   - stage: master
     script:
-      - yarn chromatic --auto-accept-changes --exit-zero-on-changess
+      - yarn chromatic --auto-accept-changes
       - yarn build-storybook
     env:
       - CHROMATIC_APP_CODE="dlpro96xybh"


### PR DESCRIPTION
## Summary

By default the ChromaticQA CLI doesn't exit a `0` on changes. We use the Github integration, so we want to exit `0` even with changes so the TravisCI check passes. Chromatic then adds an additional check that is attached to approvals.