### PR TITLE
fix(side-panel): Add flexibility for aria attributes

### DIFF
--- a/modules/side-panel/react/lib/SidePanel.tsx
+++ b/modules/side-panel/react/lib/SidePanel.tsx
@@ -19,6 +19,7 @@ export interface SidePanelProps extends React.HTMLAttributes<HTMLDivElement> {
   backgroundColor?: SidePanelBackgroundColor;
   closeNavigationLabel: string;
   openNavigationLabel: string;
+  role?: string;
 }
 
 export interface SidePanelState {
@@ -136,6 +137,7 @@ export default class SidePanel extends React.Component<SidePanelProps, SidePanel
     backgroundColor: SidePanelBackgroundColor.White,
     closeNavigationLabel: 'close navigation',
     openNavigationLabel: 'open navigation',
+    role: 'region',
   };
 
   constructor(props: SidePanelProps) {
@@ -166,13 +168,13 @@ export default class SidePanel extends React.Component<SidePanelProps, SidePanel
       backgroundColor,
       openNavigationLabel,
       closeNavigationLabel,
+      role,
       ...elemProps
     } = this.props;
 
     return (
       <SidePanelContainer
-        role="region"
-        aria-orientation="vertical"
+        role={role}
         padding={padding}
         openDirection={openDirection}
         openWidth={openWidth}

--- a/modules/side-panel/react/lib/SidePanel.tsx
+++ b/modules/side-panel/react/lib/SidePanel.tsx
@@ -19,7 +19,6 @@ export interface SidePanelProps extends React.HTMLAttributes<HTMLDivElement> {
   backgroundColor?: SidePanelBackgroundColor;
   closeNavigationLabel: string;
   openNavigationLabel: string;
-  role?: string;
 }
 
 export interface SidePanelState {
@@ -137,7 +136,6 @@ export default class SidePanel extends React.Component<SidePanelProps, SidePanel
     backgroundColor: SidePanelBackgroundColor.White,
     closeNavigationLabel: 'close navigation',
     openNavigationLabel: 'open navigation',
-    role: 'region',
   };
 
   constructor(props: SidePanelProps) {
@@ -168,13 +166,12 @@ export default class SidePanel extends React.Component<SidePanelProps, SidePanel
       backgroundColor,
       openNavigationLabel,
       closeNavigationLabel,
-      role,
       ...elemProps
     } = this.props;
 
     return (
       <SidePanelContainer
-        role={role}
+        role="region"
         padding={padding}
         openDirection={openDirection}
         openWidth={openWidth}


### PR DESCRIPTION
Fixes: https://github.com/Workday/canvas-kit/issues/320

We were forcing aria attributes so the side panel and it wasn't accessible. We still kept the role as default, but removed `aria-orientation`. The consumer can now pass any other aria attribute if they need to override anything.