### PR TITLE
feat(menu): Fix import of React dependency.

### DIFF
--- a/modules/_labs/menu/react/lib/Menu.tsx
+++ b/modules/_labs/menu/react/lib/Menu.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment} from 'react';
+import * as React from 'react';
 import styled from '@emotion/styled';
 import uuid from 'uuid/v4';
 import {MenuItemProps} from './MenuItem';
@@ -112,13 +112,13 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
           {React.Children.map(children, (menuItem: React.ReactElement<MenuItemProps>, index) => {
             const itemId = `${id}-${index}`;
             return (
-              <Fragment key={itemId}>
+              <React.Fragment key={itemId}>
                 {React.cloneElement(menuItem, {
                   onClick: (event: React.MouseEvent) => this.handleClick(event, menuItem.props),
                   id: itemId,
                   isFocused: selectedItemIndex === index,
                 })}
-              </Fragment>
+              </React.Fragment>
             );
           })}
         </List>


### PR DESCRIPTION
fix: Change React dependency import for Menu to fix type declarations for consumers.

<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->


<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary
React was being imported the more ES6-y way, rather than the TypeScript method. This causes some linters and IDEs to not resolve the depedency correctly, and therefore not see the Menu as a valid react component.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] `yarn test` passes

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
