### PR TITLE
fix: bad quote marks on accessible hide CSS (#343)

### DIFF
--- a/modules/common/css/lib/accessibility.scss
+++ b/modules/common/css/lib/accessibility.scss
@@ -23,14 +23,14 @@
 }
 
 @mixin wdc-accessible-hide() {
-  clip: 'rect(1px, 1px, 1px, 1px)'; // Deprecated but still used by most browsers, clip-path will be taking its place soon.
-  clip-path: 'polygon(0px 0px, 0px 0px, 0px 0px, 0px 0px)';
-  position: 'absolute';
-  overflow: 'hidden';
-  white-space: 'nowrap';
-  height: '1px';
-  width: '1px';
-  margin: '-1px';
+  clip: rect(1px, 1px, 1px, 1px); // Deprecated but still used by most browsers, clip-path will be taking its place soon.
+  clip-path: polygon(0px 0px, 0px 0px, 0px 0px, 0px 0px);
+  position: absolute;
+  overflow: hidden;
+  white-space: nowrap;
+  height: 1px;
+  width: 1px;
+  margin: -1px;
   padding: 0;
   border: 0;
 }

--- a/modules/form-field/css/README.md
+++ b/modules/form-field/css/README.md
@@ -160,7 +160,7 @@ Use `.wdc-form-error`/`.wdc-form-alert` with `.wdc-form-textinput`.
 <div class="wdc-form">
   <div class="wdc-form-field-wrapper wdc-form-field-error">
     <label class="wdc-form-label" for="input">Input Label</label>
-    <div class="wdc-form-field wdc-form-textinput">
+    <div class="wdc-form-field">
       <div class="wdc-form-textinput wdc-form-error">
         <input id="input" type="text" aria-describedby="error-message" aria-invalid="true" />
       </div>

--- a/modules/form-field/css/README.md
+++ b/modules/form-field/css/README.md
@@ -31,15 +31,15 @@ inline icons. Process your SASS through PostCSS once it has been compiled to CSS
 <form class="wdc-form">
   <div class="wdc-form-field-wrapper">
     <label class="wdc-form-label wdc-form-label-required" for="email">Email</label>
-    <div class="wdc-form-field">
-      <input type="text" class="wdc-form-textinput" placeholder="email@address.com" id="email" />
+    <div class="wdc-form-field wdc-form-textinput">
+      <input type="text" placeholder="email@address.com" id="email" />
     </div>
   </div>
 
   <div class="wdc-form-field-wrapper">
     <label class="wdc-form-label wdc-form-label-required" for="password">Password</label>
-    <div class="wdc-form-field">
-      <input type="password" class="wdc-form-textinput" id="password" />
+    <div class="wdc-form-field wdc-form-textinput">
+      <input type="password" id="password" />
     </div>
   </div>
 </form>
@@ -54,10 +54,9 @@ by applying the `.wdc-form-label-position-left` class to `.wdc-form`.
 <div class="wdc-form wdc-form-label-position-left">
   <div class="wdc-form-field-wrapper">
     <label for="textinput" class="wdc-form-label wdc-form-label-required">Input Label</label>
-    <div class="wdc-form-field">
+    <div class="wdc-form-field wdc-form-textinput">
       <input
         type="text"
-        class="wdc-form-textinput"
         placeholder="Here's a placeholder"
         id="textinput"
       />
@@ -79,7 +78,16 @@ If you need to toggle this programmatically (i.e. for mobile responsive), you ca
 
 ## Accessibility
 
+If you need to hide your label visually please still include one and hide using the `.wdc-accessible-hide` class.
+
+```html
+<label for="textinput" class="wdc-form-label wdc-accessible-hide">Label for screenreaders</label>
+<div class="wdc-form-field wdc-form-textinput">
+  <input type="text" id="textinput" />
+</div>
+```
 See [canvas-kit-core](../../core/css#accessibility) for accessibility guidelines.
+
 
 ## Form Controls
 
@@ -91,14 +99,15 @@ Group form labels and fields using `.wdc-form-field`.
 
 Use `.wdc-form-label` on `<label>` elements.
 
-**Required field labels**  
+**Required field labels**
 Labels for required fields should use `.wdc-form-label-required` to add a red asterisk next to the
-label.
+label. You can also add the required attribute to the input to get build in required input behavior.
 
 ```html
 <div class="wdc-form-field-wrapper">
   <label class="wdc-form-label wdc-form-label-required">Required Label</label>
   <label class="wdc-form-label">Input Label</label>
+  <input required />
 </div>
 ```
 
@@ -131,7 +140,7 @@ Error styling is available as both classes and mixins. Using the class is prefer
 Use `.wdc-form-field-error` for errors and `.wdc-form-field-alert` for alerts. Applying error and
 alert styling will display an icon on the right inside the input.
 
-**Messages**  
+**Messages**
 Add messages to errors and alerts by wrapping your message with `.wdc-form-hint-message` or
 `.wdc-form-hint-message`. Using `strong` will bolden text with the respective error/alert color.
 
@@ -151,7 +160,7 @@ Use `.wdc-form-error`/`.wdc-form-alert` with `.wdc-form-textinput`.
 <div class="wdc-form">
   <div class="wdc-form-field-wrapper wdc-form-field-error">
     <label class="wdc-form-label" for="input">Input Label</label>
-    <div class="wdc-form-field">
+    <div class="wdc-form-field wdc-form-textinput">
       <div class="wdc-form-textinput wdc-form-error">
         <input id="input" type="text" aria-describedby="error-message" aria-invalid="true" />
       </div>


### PR DESCRIPTION
Quick bug fix

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [ ] `yarn test` passes
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)
