### PR TITLE
fix(text-input): Update type of inputRef

### DIFF
--- a/modules/text-input/react/lib/TextInput.tsx
+++ b/modules/text-input/react/lib/TextInput.tsx
@@ -7,7 +7,7 @@ export interface TextInputProps
   extends GrowthBehavior,
     React.InputHTMLAttributes<HTMLInputElement> {
   error?: ErrorType;
-  inputRef?: React.RefObject<HTMLInputElement>;
+  inputRef?: React.Ref<HTMLInputElement>;
 }
 
 const Input = styled('input')<Pick<TextInputProps, 'error' | 'grow'>>(


### PR DESCRIPTION
Typing the ref as `React.Ref` instead of `React.RefObject` allows the prop to also accept [callback refs](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs).

Example use:
[![Edit fancy-sea-ryh19](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/fancy-sea-ryh19?fontsize=14&hidenavigation=1&theme=dark)