### PR TITLE
chore: Use proper prettier file in configs

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,12 +1,12 @@
 module.exports = {
-  "arrowParens": "avoid",
-  "bracketSpacing": false,
-  "jsxBracketSameLine": false,
-  "printWidth": 100,
-  "proseWrap": "always",
-  "semi": true,
-  "singleQuote": true,
-  "tabWidth": 2,
-  "trailingComma": "es5",
-  "useTabs": false
-}
+  arrowParens: 'avoid',
+  bracketSpacing: false,
+  jsxBracketSameLine: false,
+  printWidth: 100,
+  proseWrap: 'always',
+  semi: true,
+  singleQuote: true,
+  tabWidth: 2,
+  trailingComma: 'es5',
+  useTabs: false,
+};

--- a/COMPONENT_STATUS.md
+++ b/COMPONENT_STATUS.md
@@ -23,44 +23,44 @@ part of Canvas.
 
 | Component                                      |       React        |        CSS         |                                    Guidelines                                     |
 | ---------------------------------------------- | :----------------: | :----------------: | :-------------------------------------------------------------------------------: |
-| **Buttons**                                    ||||
+| **Buttons**                                    |                    |                    |                                                                                   |
 | [Button - Standard](modules/button)            | :white_check_mark: | :white_check_mark: |       [:blue_book:](https://design.workday.com/components/buttons/buttons)        |
 | [Button - Drop Down](modules/button)           | :white_check_mark: | :white_check_mark: |       [:blue_book:](https://design.workday.com/components/buttons/buttons)        |
 | [Button - Icon](modules/button)                | :white_check_mark: | :white_check_mark: |     [:blue_book:](https://design.workday.com/components/buttons/icon-buttons)     |
 | [Button - Text](modules/button)                | :white_check_mark: |     :clock330:     |     [:blue_book:](https://design.workday.com/components/buttons/text-buttons)     |
-| [Action Bar](modules/action-bar)               | :white_check_mark: | :white_check_mark: |      [:blue_book:](https://design.workday.com/components/buttons/action-bar)      |  
-| **Containers**                                 ||||
+| [Action Bar](modules/action-bar)               | :white_check_mark: | :white_check_mark: |      [:blue_book:](https://design.workday.com/components/buttons/action-bar)      |
+| **Containers**                                 |                    |                    |                                                                                   |
 | [Card](modules/card)                           | :white_check_mark: | :white_check_mark: |       [:blue_book:](https://design.workday.com/components/containers/cards)       |
 | Tabs                                           |                    |                    |                                                                                   |
 | [Table](modules/table)                         | :white_check_mark: | :white_check_mark: |      [:blue_book:](https://design.workday.com/components/containers/tables)       |
-| **Form Elements**                              ||||
-| [Form Field](modules/form-field)               | :white_check_mark: | :white_check_mark: ||
+| **Form Elements**                              |                    |                    |                                                                                   |
+| [Form Field](modules/form-field)               | :white_check_mark: | :white_check_mark: |                                                                                   |
 | [Checkbox](modules/checkbox)                   | :white_check_mark: | :white_check_mark: |   [:blue_book:](https://design.workday.com/components/form-elements/checkboxes)   |
 | [Color Input]([modules/color-picker)           | :white_check_mark: |                    |  [:blue_book:](https://design.workday.com/components/form-elements/color-input)   |
-| Date Input                                     |                    |                    ||
+| Date Input                                     |                    |                    |                                                                                   |
 | [Drop Down Select](modules/select)             | :white_check_mark: | :white_check_mark: |                                                                                   |
-| Numeric Input                                  |                    |                    ||
+| Numeric Input                                  |                    |                    |                                                                                   |
 | [Radio Button](modules/radio)                  | :white_check_mark: | :white_check_mark: | [:blue_book:](https://design.workday.com/components/form-elements/radio-buttons)  |
 | [TextArea](modules/text-area)                  | :white_check_mark: | :white_check_mark: |   [:blue_book:](https://design.workday.com/components/form-elements/text-area)    |
 | [Text Input](modules/text-input)               | :white_check_mark: | :white_check_mark: |   [:blue_book:](https://design.workday.com/components/form-elements/text-input)   |
-| [Switch](modules/switch)                       | :white_check_mark: |||
-| Slider                                         |                    |                    ||
-| **Indicators**                                 ||||
+| [Switch](modules/switch)                       | :white_check_mark: |                    |                                                                                   |
+| Slider                                         |                    |                    |                                                                                   |
+| **Indicators**                                 |                    |                    |                                                                                   |
 | [Banners](modules/banner)                      | :white_check_mark: | :white_check_mark: |      [:blue_book:](https://design.workday.com/components/indicators/banners)      |
 | [Loading Animation](modules/loading-animation) | :white_check_mark: | :white_check_mark: | [:blue_book:](https://design.workday.com/components/indicators/loading-animation) |
 | [Skeleton Loader](modules/skeleton)            | :white_check_mark: |                    |  [:blue_book:](https://design.workday.com/components/indicators/skeleton-loader)  |
-| Progress Bar                                   |                    |                    ||
+| Progress Bar                                   |                    |                    |                                                                                   |
 | [Status Indicator](modules/status-indicator)   | :white_check_mark: |                    | [:blue_book:](https://design.workday.com/components/indicators/status-indicators) |
-| **Navigation**                                 ||||
+| **Navigation**                                 |                    |                    |                                                                                   |
 | [Header](modules/_labs/header)                 |    :microscope:    |                    |      [:blue_book:](https://design.workday.com/components/navigation/headers)      |
 | [Page Header](modules/page-header)             | :white_check_mark: | :white_check_mark: |    [:blue_book:](https://design.workday.com/components/navigation/page-header)    |
-| [Side Panel](modules/side-panel)               | :white_check_mark: |||
-| **Popups**                                     ||||
-| [Cookie Banner](modules/cookie-banner)         | :white_check_mark: |                    ||
-| [Modal](modules/modal)                         | :white_check_mark: | :white_check_mark: ||
+| [Side Panel](modules/side-panel)               | :white_check_mark: |                    |                                                                                   |
+| **Popups**                                     |                    |                    |                                                                                   |
+| [Cookie Banner](modules/cookie-banner)         | :white_check_mark: |                    |                                                                                   |
+| [Modal](modules/modal)                         | :white_check_mark: | :white_check_mark: |                                                                                   |
 | [Toast](modules/toast)                         | :white_check_mark: |                    |        [:blue_book:](https://design.workday.com/components/popups/toasts)         |
 | [Tooltip](modules/tooltip)                     | :white_check_mark: | :white_check_mark: |       [:blue_book:](https://design.workday.com/components/popups/tooltips)        |
-| [Menu](modules/_labs/menu)                     |    :microscope:    | :white_check_mark: |         [:blue_book:](https://design.workday.com/components/popups/menus)         |  
-| [Pop Up](modules/popup)                        | :white_check_mark: | :white_check_mark: ||
-| **Miscellaneous**                              ||||
+| [Menu](modules/_labs/menu)                     |    :microscope:    | :white_check_mark: |         [:blue_book:](https://design.workday.com/components/popups/menus)         |
+| [Pop Up](modules/popup)                        | :white_check_mark: | :white_check_mark: |                                                                                   |
+| **Miscellaneous**                              |                    |                    |                                                                                   |
 | [Avatar](modules/avatar)                       | :white_check_mark: |                    |                                                                                   |

--- a/eslintrc.js
+++ b/eslintrc.js
@@ -1,4 +1,4 @@
-const prettierConfig = require('./.prettierrc');
+const prettierConfig = require('./.prettierrc.js');
 
 module.exports = {
   env: {

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,5 @@
 {
-  "packages": [
-    "modules/**"
-  ],
+  "packages": ["modules/**"],
   "version": "3.1.1",
   "npmClient": "yarn",
   "useWorkspaces": true,

--- a/modules/_canvas-kit-css/README.md
+++ b/modules/_canvas-kit-css/README.md
@@ -8,11 +8,12 @@ Canvas Kit CSS uses tilde `~` imports to resolve imports to your project's node_
 
 This is done automatically in Webpack's sass-loader.
 
-If you would like to import outside of webpack you have a few options you can pass to the SASS `importer` option.
+If you would like to import outside of webpack you have a few options you can pass to the SASS
+`importer` option.
 
-* If you are using `node_sass` you can try a third part importer such as `node-sass-tilde-importer`
+- If you are using `node_sass` you can try a third part importer such as `node-sass-tilde-importer`
 
-* If you are using `dart_sass` you will need your own custom importer, e.g.:
+- If you are using `dart_sass` you will need your own custom importer, e.g.:
 
 ```ts
 const tildeImporter = (url: string): {file: string} => {
@@ -21,14 +22,15 @@ const tildeImporter = (url: string): {file: string} => {
   }
 
   return {file: url};
-}
+};
 ```
 
 Troubleshooting:
 
-In some cases your may need to add your `node_modules` directory to your the SASS `includePaths` option.
+In some cases your may need to add your `node_modules` directory to your the SASS `includePaths`
+option.
 
-------------
+---
 
 You will then be able to import any scss file `index.scss`.
 

--- a/modules/_canvas-kit-react/README.md
+++ b/modules/_canvas-kit-react/README.md
@@ -4,5 +4,5 @@ The bundle package containing all modules of the Canvas Kit React.
 
 > Note: By default, no fonts are included with Canvas Kit modules. To use official Canvas Kit fonts,
 > install and import the `@workday/canvas-kit-react-fonts` module in addition to
-> `@workday/canvas-kit-react`. By installing `@workday/canvas-kit-react-fonts` you are opting in to 
+> `@workday/canvas-kit-react`. By installing `@workday/canvas-kit-react-fonts` you are opting in to
 > using the Workday CDN.

--- a/modules/_labs/combobox/react/README.md
+++ b/modules/_labs/combobox/react/README.md
@@ -4,8 +4,8 @@
   <img src="https://img.shields.io/badge/UNSTABLE-alpha-orange" alt="UNSTABLE: Alpha" />
 </a>  This component is work in progress and currently in pre-release.
 
-A specialized input wrapper that adds an autocomplete list.
-Based on W3 spec for [List Autocomplete with Manual Selection](https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html)
+A specialized input wrapper that adds an autocomplete list. Based on W3 spec for
+[List Autocomplete with Manual Selection](https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html)
 
 For a full suite of examples, have a look at the [Combobox Stories](./stories.tsx).
 
@@ -88,7 +88,8 @@ Default: `'Reset Search Input'`
 
 #### `onChange: React.ChangeEventHandler<HTMLInputElement>`
 
-> Callback to listen when the TextInput changes. This is usually used to update the autocomplete items.
+> Callback to listen when the TextInput changes. This is usually used to update the autocomplete
+> items.
 
 ---
 

--- a/modules/_labs/combobox/react/tsconfig.json
+++ b/modules/_labs/combobox/react/tsconfig.json
@@ -1,10 +1,4 @@
 {
   "extends": "../../../../tsconfig.json",
-  "exclude": [
-    "node_modules",
-    "ts-tmp",
-    "dist",
-    "spec",
-    "stories"
-  ]
+  "exclude": ["node_modules", "ts-tmp", "dist", "spec", "stories"]
 }

--- a/modules/_labs/drawer/react/tsconfig.cjs.json
+++ b/modules/_labs/drawer/react/tsconfig.cjs.json
@@ -1,4 +1,3 @@
-
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {

--- a/modules/_labs/drawer/react/tsconfig.es6.json
+++ b/modules/_labs/drawer/react/tsconfig.es6.json
@@ -1,4 +1,3 @@
-
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {

--- a/modules/_labs/drawer/react/tsconfig.json
+++ b/modules/_labs/drawer/react/tsconfig.json
@@ -1,4 +1,3 @@
-
 {
   "extends": "../../../../tsconfig.json",
   "exclude": ["node_modules", "ts-tmp", "dist", "spec", "stories"]

--- a/modules/_labs/header/react/README.md
+++ b/modules/_labs/header/react/README.md
@@ -164,7 +164,8 @@ Default: `DubLogoTitle` (for "Dub" variants) or `WorkdayLogoTitle` (for "Full" v
 
 > Indicates whether the children in the header should be collapsed.
 >
-> - The `nav` element collapses into a hamburger icon menu. Any `IconButton` or `SystemIcon` will also collapse.
+> - The `nav` element collapses into a hamburger icon menu. Any `IconButton` or `SystemIcon` will
+>   also collapse.
 
 ---
 
@@ -181,7 +182,6 @@ Default: `DubLogoTitle` (for "Dub" variants) or `WorkdayLogoTitle` (for "Full" v
 #### `leftSlot: React.ReactElement`
 
 > A React element for the left of the header, this is typically a search bar component
-
 
 # Global Header
 
@@ -373,11 +373,11 @@ A component that contains a search bar with autocomplete functionality.
 import {SearchBar} from '@workday/canvas-kit-labs-react-header';
 import {MenuItem} from '@workday/canvas-kit-labs-react-menu';
 
-const handleInputChange = event => console.log('Adjust menu items here')
+const handleInputChange = event => console.log('Adjust menu items here');
 const handleSearchSubmit = event => {
   const query = (event.target as HTMLFormElement).getElementsByTagName('input')[0].value;
-  console.log("Submitted query: ", query)
-}
+  console.log('Submitted query: ', query);
+};
 
 <SearchBar
   autocompleteItems={[<MenuItem>Item 1</MenuItem>]}
@@ -387,7 +387,7 @@ const handleSearchSubmit = event => {
   grow={true}
   searchTheme={SearchBar.Theme.Dark}
   onSubmit={handleSearchSubmit}
-/>
+/>;
 ```
 
 ## Static Properties
@@ -412,7 +412,8 @@ const handleSearchSubmit = event => {
 
 #### `onInputChange: React.ChangeEventHandler<HTMLInputElement>`
 
-> Callback to listen when the TextInput changes. This is usually used to update the autocomplete items.
+> Callback to listen when the TextInput changes. This is usually used to update the autocomplete
+> items.
 
 ---
 
@@ -424,14 +425,14 @@ const handleSearchSubmit = event => {
 
 #### `searchTheme?: SearchTheme | SearchThemeAttributes`
 
-> The theme of the header the search input is being rendered in.
-> There are 3 build in themes, but the styles are customizable via SearchThemeAttributes.
+> The theme of the header the search input is being rendered in. There are 3 build in themes, but
+> the styles are customizable via SearchThemeAttributes.
 
-| Theme       | Description                                                                                               |
-| ----------- | --------------------------------------------------------------------------------------------------------- |
-| Light       | White background with dark-colored text, blue focus ring.                                                 |
-| Dark        | Dark semi transparent background with white text. Inverts on focus.                                       |
-| Transparent | Transparent background (intended for light-colored header) with dark text. Also used in collapsed state.  |
+| Theme       | Description                                                                                              |
+| ----------- | -------------------------------------------------------------------------------------------------------- |
+| Light       | White background with dark-colored text, blue focus ring.                                                |
+| Dark        | Dark semi transparent background with white text. Inverts on focus.                                      |
+| Transparent | Transparent background (intended for light-colored header) with dark text. Also used in collapsed state. |
 
 Default: `SearchTheme.Light`
 

--- a/modules/checkbox/react/README.md
+++ b/modules/checkbox/react/README.md
@@ -37,7 +37,8 @@ import Checkbox from '@workday/canvas-kit-react-checkbox';
 import FormField from '@workday/canvas-kit-react-form-field';
 
 <FormField label="My Field" inputId="my-checkbox-field">
-  <Checkbox disabled={false} checked={checked} onChange={this.handleCheck} id="my-checkbox-field" />;
+  <Checkbox disabled={false} checked={checked} onChange={this.handleCheck} id="my-checkbox-field" />
+  ;
 </FormField>;
 ```
 

--- a/modules/form-field/css/README.md
+++ b/modules/form-field/css/README.md
@@ -55,11 +55,7 @@ by applying the `.wdc-form-label-position-left` class to `.wdc-form`.
   <div class="wdc-form-field-wrapper">
     <label for="textinput" class="wdc-form-label wdc-form-label-required">Input Label</label>
     <div class="wdc-form-field wdc-form-textinput">
-      <input
-        type="text"
-        placeholder="Here's a placeholder"
-        id="textinput"
-      />
+      <input type="text" placeholder="Here's a placeholder" id="textinput" />
     </div>
   </div>
 </div>
@@ -78,7 +74,8 @@ If you need to toggle this programmatically (i.e. for mobile responsive), you ca
 
 ## Accessibility
 
-If you need to hide your label visually please still include one and hide using the `.wdc-accessible-hide` class.
+If you need to hide your label visually please still include one and hide using the
+`.wdc-accessible-hide` class.
 
 ```html
 <label for="textinput" class="wdc-form-label wdc-accessible-hide">Label for screenreaders</label>
@@ -86,8 +83,8 @@ If you need to hide your label visually please still include one and hide using 
   <input type="text" id="textinput" />
 </div>
 ```
-See [canvas-kit-core](../../core/css#accessibility) for accessibility guidelines.
 
+See [canvas-kit-core](../../core/css#accessibility) for accessibility guidelines.
 
 ## Form Controls
 
@@ -99,9 +96,9 @@ Group form labels and fields using `.wdc-form-field`.
 
 Use `.wdc-form-label` on `<label>` elements.
 
-**Required field labels**
-Labels for required fields should use `.wdc-form-label-required` to add a red asterisk next to the
-label. You can also add the required attribute to the input to get build in required input behavior.
+**Required field labels** Labels for required fields should use `.wdc-form-label-required` to add a
+red asterisk next to the label. You can also add the required attribute to the input to get build in
+required input behavior.
 
 ```html
 <div class="wdc-form-field-wrapper">
@@ -140,9 +137,9 @@ Error styling is available as both classes and mixins. Using the class is prefer
 Use `.wdc-form-field-error` for errors and `.wdc-form-field-alert` for alerts. Applying error and
 alert styling will display an icon on the right inside the input.
 
-**Messages**
-Add messages to errors and alerts by wrapping your message with `.wdc-form-hint-message` or
-`.wdc-form-hint-message`. Using `strong` will bolden text with the respective error/alert color.
+**Messages** Add messages to errors and alerts by wrapping your message with
+`.wdc-form-hint-message` or `.wdc-form-hint-message`. Using `strong` will bolden text with the
+respective error/alert color.
 
 Place the message element after the form controls.
 

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "commitmsg": "commitlint --edit $HUSKY_GIT_PARAMS",
     "build-storybook": "build-storybook -c .storybook -o docs",
     "lint": "node utils/check-lockfile-links.js && node utils/check-mismatched-dependencies.js && eslint -c ./eslintrc.js --ext=jsx,ts,tsx .",
-    "format:prettier": "prettier --config=./.prettierrc --ignore-path=./.prettierignore \"**/*.{js,jsx,json,ts,tsx,md}\" --write",
+    "format:prettier": "prettier --config=./.prettierrc.js --ignore-path=./.prettierignore \"**/*.{js,jsx,json,ts,tsx,md}\" --write",
     "format": "yarn lint --fix",
     "test": "TZ=UTC jest",
     "bump": "lerna version",

--- a/wallaby.js
+++ b/wallaby.js
@@ -32,11 +32,10 @@ module.exports = wallaby => {
       jestConfig.setupFilesAfterEnv = [`${w.projectCacheDir}/jest/setupTests.js`];
 
       // Tell Jest how to resolve symlinked modules. Without this, Jest will look at source TS files and not at Wallaby's compiled & instrumented files
-      jestConfig.moduleNameMapper = {
+      (jestConfig.moduleNameMapper = {
         '@workday/canvas-kit-react-(.*)': '<rootDir>/modules/$1/react',
-      },
-
-      w.testFramework.configure(jestConfig);
+      }),
+        w.testFramework.configure(jestConfig);
     },
   };
 };


### PR DESCRIPTION
The `format:pretty` command would fail because we were pointing to a `.prettierrc` file but we actually store the prettier configurations in `.prettierrc.js`. I also updated the file path in the `eslintrc.js`.
I then ran the command to update any files that needed formatting.