### PR TITLE
docs: Update incorrect story category for deprecated CSS buttons

### DIFF
--- a/modules/button/css/stories.tsx
+++ b/modules/button/css/stories.tsx
@@ -175,7 +175,7 @@ storiesOf('Components|Buttons/Button/CSS/Text', module)
     </div>
   ));
 
-storiesOf('CSS/Button/Deprecated', module)
+storiesOf('Components|Buttons/Button/CSS/Deprecated', module)
   .addDecorator(withReadme(README))
   .add('Primary', () => (
     <div className="story">


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

This updates the IA for `Buttons/Button/CSS/Depracated`. It currently is in the `Others` category on storybook.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md
- [x] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [x] design approved final implementation
- [x] a11y approved final implementation
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
