### PR TITLE
fix(labs): Fix theming implementation

### DIFF
--- a/modules/_labs/core/react/index.ts
+++ b/modules/_labs/core/react/index.ts
@@ -1,23 +1,8 @@
 import type from './lib/type';
 import space from './lib/space';
 import CanvasProvider from './lib/CanvasProvider';
-import {breakpoints, CanvasBreakpoints, BreakpointKey} from './lib/theming/breakpoints';
-import createCanvasTheme from './lib/theming/createCanvasTheme';
-import styled from './lib/theming/styled';
-import useTheme from './lib/theming/useTheme';
 
 export default type;
-export {
-  breakpoints,
-  type,
-  space,
-  BreakpointKey,
-  CanvasBreakpoints,
-  CanvasProvider,
-  createCanvasTheme,
-  styled,
-  useTheme,
-};
+export {type, space, CanvasProvider};
 export * from './lib/type';
-export * from './lib/theming/types';
-export * from './lib/theming/theme';
+export * from './lib/theming';

--- a/modules/_labs/core/react/lib/CanvasProvider.tsx
+++ b/modules/_labs/core/react/lib/CanvasProvider.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
+import {ThemeProvider} from 'emotion-theming';
 import {InputProvider} from '@workday/canvas-kit-react-core';
 import {CanvasTheme} from './theming/types';
-import {ThemeProvider, defaultCanvasTheme} from './theming/theme';
+import {defaultCanvasTheme} from './theming/theme';
 
 export interface CanvasProviderProps {
   theme: CanvasTheme;
@@ -16,7 +17,7 @@ export default class CanvasProvider extends React.Component<CanvasProviderProps>
     const {children, theme} = this.props;
 
     return (
-      <ThemeProvider value={theme}>
+      <ThemeProvider theme={theme}>
         <InputProvider>{children}</InputProvider>
       </ThemeProvider>
     );

--- a/modules/_labs/core/react/lib/theming/README.md
+++ b/modules/_labs/core/react/lib/theming/README.md
@@ -5,13 +5,7 @@ Canvas Kit Core contains wrappers and types to enabling theming of Canvas compon
 ## Installation
 
 ```sh
-yarn add @workday/canvas-kit-react
-```
-
-or
-
-```sh
-yarn add @workday/canvas-kit-react-core
+yarn add @workday/canvas-kit-labs-react-core
 ```
 
 ## Usage
@@ -23,7 +17,7 @@ our Canvas Components.
 
 ```tsx
 import * as React from 'react';
-import {CanvasProvider} from '@workday/canvas-kit-react';
+import {CanvasProvider} from '@workday/canvas-kit-labs-react-core';
 
 <CanvasProvider>{/* All your components containing any Canvas components */}</CanvasProvider>;
 ```
@@ -127,7 +121,7 @@ import {
   CanvasProvider,
   PartialCanvasTheme,
   createCanvasTheme,
-} from '@workday/canvas-kit-react-core';
+} from '@workday/canvas-kit-labs-react-core';
 
 const theme: PartialCanvasTheme = {
   palette: {
@@ -152,7 +146,7 @@ inner theme will override the outer theme.
 ```tsx
 import * as React from 'react';
 import {ThemeProvider} from 'emotion-theming';
-import {CanvasProvider, CanvasTheme} from '@workday/canvas-kit-react';
+import {CanvasProvider, CanvasTheme} from '@workday/canvas-kit-labs-react-core';
 import {Switch} from '@workday/canvas-kit-react-switch';
 
 const theme: PartialCanvasTheme = {

--- a/modules/_labs/core/react/lib/theming/README.md
+++ b/modules/_labs/core/react/lib/theming/README.md
@@ -5,13 +5,13 @@ Canvas Kit Core contains wrappers and types to enabling theming of Canvas compon
 ## Installation
 
 ```sh
-yarn add @workday/canvas-kit-labs-react-core
+yarn add @workday/canvas-kit-react
 ```
 
 or
 
 ```sh
-yarn add @workday/canvas-kit-labs-react-core
+yarn add @workday/canvas-kit-react-core
 ```
 
 ## Usage
@@ -23,7 +23,7 @@ our Canvas Components.
 
 ```tsx
 import * as React from 'react';
-import {CanvasProvider} from '@workday/canvas-kit-labs-react-core';
+import {CanvasProvider} from '@workday/canvas-kit-react';
 
 <CanvasProvider>{/* All your components containing any Canvas components */}</CanvasProvider>;
 ```
@@ -127,7 +127,7 @@ import {
   CanvasProvider,
   PartialCanvasTheme,
   createCanvasTheme,
-} from '@workday/canvas-kit-labs-react-core';
+} from '@workday/canvas-kit-react-core';
 
 const theme: PartialCanvasTheme = {
   palette: {
@@ -146,12 +146,13 @@ const theme: PartialCanvasTheme = {
 
 It is possible to set a theme for a specific component or set of components within your React tree.
 This is generally discouraged for consistency reasons, but may be required in some contexts (a green
-`Switch` component for example). To do this, you must use the `ThemeProvider` component. The inner
-theme will override the outer theme.
+`Switch` component for example). To do this, you must use Emotion's `ThemeProvider` component. The
+inner theme will override the outer theme.
 
 ```tsx
 import * as React from 'react';
-import {CanvasProvider, CanvasTheme, ThemeProvider} from '@workday/canvas-kit-labs-react-core';
+import {ThemeProvider} from 'emotion-theming';
+import {CanvasProvider, CanvasTheme} from '@workday/canvas-kit-react';
 import {Switch} from '@workday/canvas-kit-react-switch';
 
 const theme: PartialCanvasTheme = {
@@ -164,7 +165,7 @@ const theme: PartialCanvasTheme = {
 
 <CanvasProvider>
   {/* All your components containing any Canvas components */}
-  <ThemeProvider value={createCanvasTheme(theme)}>
+  <ThemeProvider theme={createCanvasTheme(theme)}>
     <Switch checked={true} />
   </ThemeProvider>
 </CanvasProvider>;

--- a/modules/_labs/core/react/lib/theming/createCanvasTheme.ts
+++ b/modules/_labs/core/react/lib/theming/createCanvasTheme.ts
@@ -93,5 +93,5 @@ export default function createCanvasTheme(partialTheme: PartialCanvasTheme): Can
     breakpoints,
   };
 
-  return merge({...defaultCanvasTheme}, mergable) as CanvasTheme;
+  return merge({}, defaultCanvasTheme, mergable) as CanvasTheme;
 }

--- a/modules/_labs/core/react/lib/theming/createCanvasTheme.ts
+++ b/modules/_labs/core/react/lib/theming/createCanvasTheme.ts
@@ -81,7 +81,7 @@ export default function createCanvasTheme(partialTheme: PartialCanvasTheme): Can
   const {palette = {}, breakpoints = {}} = partialTheme;
   const {primary, alert, error, success, neutral, common = {}} = palette;
 
-  const mergable: PartialCanvasTheme = {
+  const mergeable: PartialCanvasTheme = {
     palette: {
       common,
       primary: fillPalette(primary),
@@ -93,5 +93,5 @@ export default function createCanvasTheme(partialTheme: PartialCanvasTheme): Can
     breakpoints,
   };
 
-  return merge({}, defaultCanvasTheme, mergable) as CanvasTheme;
+  return merge({}, defaultCanvasTheme, mergeable) as CanvasTheme;
 }

--- a/modules/_labs/core/react/lib/theming/createCanvasTheme.ts
+++ b/modules/_labs/core/react/lib/theming/createCanvasTheme.ts
@@ -77,7 +77,7 @@ function fillPalette(palette?: PartialCanvasThemePalette): CanvasThemePalette | 
   };
 }
 
-export default function createCanvasTheme(partialTheme: PartialCanvasTheme): CanvasTheme {
+export function createCanvasTheme(partialTheme: PartialCanvasTheme): CanvasTheme {
   const {palette = {}, breakpoints = {}} = partialTheme;
   const {primary, alert, error, success, neutral, common = {}} = palette;
 

--- a/modules/_labs/core/react/lib/theming/createCanvasTheme.ts
+++ b/modules/_labs/core/react/lib/theming/createCanvasTheme.ts
@@ -93,5 +93,5 @@ export default function createCanvasTheme(partialTheme: PartialCanvasTheme): Can
     breakpoints,
   };
 
-  return merge(defaultCanvasTheme, mergable) as CanvasTheme;
+  return merge({...defaultCanvasTheme}, mergable) as CanvasTheme;
 }

--- a/modules/_labs/core/react/lib/theming/index.ts
+++ b/modules/_labs/core/react/lib/theming/index.ts
@@ -1,0 +1,6 @@
+export * from './breakpoints';
+export * from './createCanvasTheme';
+export {default as styled} from './styled';
+export * from './types';
+export * from './theme';
+export * from './useTheme';

--- a/modules/_labs/core/react/lib/theming/styled.ts
+++ b/modules/_labs/core/react/lib/theming/styled.ts
@@ -1,6 +1,5 @@
 import {default as emotionStyled, CreateStyled, Interpolation} from '@emotion/styled';
-import {CanvasTheme} from './types';
-import useTheme from './useTheme';
+import {CanvasTheme, useTheme} from './';
 
 // Pulled from https://github.com/emotion-js/emotion/blob/master/packages/styled-base/src/utils.js#L6 (not exported)
 type Interpolations = Array<any>;

--- a/modules/_labs/core/react/lib/theming/theme.ts
+++ b/modules/_labs/core/react/lib/theming/theme.ts
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import colors from '@workday/canvas-colors-web';
 import {CanvasTheme} from './types';
 import {breakpoints, up, down, between, only} from './breakpoints';
@@ -57,6 +56,3 @@ export const defaultCanvasTheme: CanvasTheme = {
     only,
   },
 };
-
-export const ThemeContext = React.createContext(defaultCanvasTheme);
-export const ThemeProvider = ThemeContext.Provider;

--- a/modules/_labs/core/react/lib/theming/useTheme.ts
+++ b/modules/_labs/core/react/lib/theming/useTheme.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import {ThemeContext} from '@emotion/core';
 import {CanvasTheme} from './types';
-import {ThemeContext, defaultCanvasTheme} from './theme';
+import {defaultCanvasTheme} from './theme';
 
 declare global {
   interface Window {

--- a/modules/_labs/core/react/lib/theming/useTheme.ts
+++ b/modules/_labs/core/react/lib/theming/useTheme.ts
@@ -26,7 +26,7 @@ declare global {
  * ThemeProvider or context exists.
  * Tracked on https://github.com/emotion-js/emotion/issues/1193.
  */
-export default function useTheme(theme?: Object): CanvasTheme {
+export function useTheme(theme?: Object): CanvasTheme {
   if (theme && Object.entries(theme).length !== 0) {
     return theme as CanvasTheme;
   }

--- a/modules/_labs/core/react/spec/breakpoints.spec.tsx
+++ b/modules/_labs/core/react/spec/breakpoints.spec.tsx
@@ -1,4 +1,4 @@
-import {BreakpointKey, up, down, between, only} from '../lib/theming/breakpoints';
+import {BreakpointKey, up, down, between, only} from '../lib/theming';
 
 describe('Breakpoints', () => {
   test('up function works with enum', () => {

--- a/modules/_labs/core/react/spec/createCanvasTheme.spec.tsx
+++ b/modules/_labs/core/react/spec/createCanvasTheme.spec.tsx
@@ -1,5 +1,6 @@
 import {defaultCanvasTheme} from '../lib/theming/theme';
 import createCanvasTheme from '../lib/theming/createCanvasTheme';
+import lodash from 'lodash';
 
 describe('useTheme', () => {
   test('calling without any input provides the default theme', () => {
@@ -50,5 +51,19 @@ describe('useTheme', () => {
     };
 
     expect(theme).toEqual(expected);
+  });
+
+  test('custom theme should not override defaultCanvasTheme when merged', () => {
+    const input = {
+      palette: {
+        primary: {
+          main: 'orange',
+        },
+      },
+    };
+    const original = lodash.cloneDeep(defaultCanvasTheme);
+    createCanvasTheme(input);
+
+    expect(original).toEqual(defaultCanvasTheme);
   });
 });

--- a/modules/_labs/core/react/spec/createCanvasTheme.spec.tsx
+++ b/modules/_labs/core/react/spec/createCanvasTheme.spec.tsx
@@ -1,5 +1,4 @@
-import {defaultCanvasTheme} from '../lib/theming/theme';
-import createCanvasTheme from '../lib/theming/createCanvasTheme';
+import {defaultCanvasTheme, createCanvasTheme} from '../lib/theming';
 import lodash from 'lodash';
 
 describe('useTheme', () => {

--- a/modules/_labs/core/react/spec/useTheme.spec.tsx
+++ b/modules/_labs/core/react/spec/useTheme.spec.tsx
@@ -30,7 +30,7 @@ describe('useTheme', () => {
     expect(theme).toBe(customTheme);
   });
 
-  test('with context available, calling useTheme within a component should return context theme', () => {
+  test('with no window context available, calling useTheme within a component should return context theme', () => {
     const container = mount(
       <CanvasProvider theme={customTheme}>
         <Component />

--- a/modules/_labs/core/react/spec/useTheme.spec.tsx
+++ b/modules/_labs/core/react/spec/useTheme.spec.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import {mount} from 'enzyme';
 import CanvasProvider from '../lib/CanvasProvider';
-import {defaultCanvasTheme} from '../lib/theming/theme';
-import createCanvasTheme from '../lib/theming/createCanvasTheme';
-import useTheme from '../lib/theming/useTheme';
+import {defaultCanvasTheme, createCanvasTheme, useTheme} from '../lib/theming';
 
 describe('useTheme', () => {
   const customTheme = createCanvasTheme({

--- a/modules/_labs/core/react/stories/stories_theme.tsx
+++ b/modules/_labs/core/react/stories/stories_theme.tsx
@@ -4,8 +4,8 @@ import {jsx} from '@emotion/core';
 import styled from '@emotion/styled';
 import {storiesOf} from '@storybook/react';
 import withReadme from 'storybook-readme/with-readme';
-
-import {CanvasTheme, CanvasThemePalette, useTheme} from '../index';
+import useTheme from '../lib/theming/useTheme';
+import {CanvasTheme, CanvasThemePalette} from '../lib/theming/types';
 import README from '../lib/theming/README.md';
 import {H1, colors, type, spacing, borderRadius} from '@workday/canvas-kit-react-core';
 

--- a/modules/_labs/core/react/stories/stories_theme.tsx
+++ b/modules/_labs/core/react/stories/stories_theme.tsx
@@ -5,9 +5,13 @@ import styled from '@emotion/styled';
 import {storiesOf} from '@storybook/react';
 import withReadme from 'storybook-readme/with-readme';
 import CanvasProvider from '../lib/CanvasProvider';
-import createCanvasTheme from '../lib/theming/createCanvasTheme';
-import useTheme from '../lib/theming/useTheme';
-import {CanvasTheme, CanvasThemePalette, Themeable} from '../lib/theming/types';
+import {
+  CanvasTheme,
+  CanvasThemePalette,
+  Themeable,
+  createCanvasTheme,
+  useTheme,
+} from '../lib/theming';
 import README from '../lib/theming/README.md';
 import {H1, colors, type, spacing, borderRadius} from '@workday/canvas-kit-react-core';
 

--- a/modules/_labs/core/react/stories/stories_theme.tsx
+++ b/modules/_labs/core/react/stories/stories_theme.tsx
@@ -4,8 +4,10 @@ import {jsx} from '@emotion/core';
 import styled from '@emotion/styled';
 import {storiesOf} from '@storybook/react';
 import withReadme from 'storybook-readme/with-readme';
+import CanvasProvider from '../lib/CanvasProvider';
+import createCanvasTheme from '../lib/theming/createCanvasTheme';
 import useTheme from '../lib/theming/useTheme';
-import {CanvasTheme, CanvasThemePalette} from '../lib/theming/types';
+import {CanvasTheme, CanvasThemePalette, Themeable} from '../lib/theming/types';
 import README from '../lib/theming/README.md';
 import {H1, colors, type, spacing, borderRadius} from '@workday/canvas-kit-react-core';
 
@@ -54,6 +56,22 @@ const PaletteTitle = styled(Swatch)(
   })
 );
 
+const customTheme = createCanvasTheme({
+  palette: {
+    primary: {
+      main: colors.greenApple400,
+    },
+  },
+});
+const ThemedComponent = styled('h1')<Themeable>(({theme}) => ({
+  ...type.h3,
+  background: theme.palette.primary.main,
+  color: theme.palette.primary.contrast,
+  borderRadius: borderRadius.m,
+  padding: spacing.xs,
+  display: 'inline-block',
+}));
+
 const createSwatch = (name: string, color: string, contrast: string, Component = Swatch) => {
   return (
     <Component bg={color} contrast={contrast} key={`${name}-${color}`}>
@@ -90,6 +108,11 @@ const ThemeDemo = (props: any) => {
           );
         })}
       </Palettes>
+      <hr style={{margin: '80px 0'}} />
+      <H1>Custom Theme</H1>
+      <CanvasProvider theme={customTheme}>
+        <ThemedComponent>Themed Component</ThemedComponent>
+      </CanvasProvider>
     </div>
   );
 };


### PR DESCRIPTION
## Summary

There were two issues with #272:

- During review, we switched from using `deepmerge` to `lodash/merge`. I didn't realize at the time that `lodash/merge` mutates the object it's returning, so we were updating the `defaultCanvasTheme` unintentionally
- I tried using our own `ThemeProvider` to mitigate an issue with `@storybook/addon-knobs`. After realizing this wasn't causing the problem with the addon, I left it as is. However, there is an issue with this in conjunction with our custom `styled` function and how React hooks work. Since we expect `theme` to be passed to `useTheme` through `styled` from Emotion (since we can't use `useContext` within class components), we _do_ need to use Emotion's `ThemeContext`. This is because Emotion is calling our interpolations and passing the theme through (using their context, without the option to override). If we ever move to functional components exclusively in the future, we can change this to use a custom context. Otherwise our current approach with a wrapping `styled` function will not work with a custom context. 

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md
