### PR TITLE
feat: Refactor Modal to use useFocusTrap hook

### DIFF
--- a/modules/common/react/index.ts
+++ b/modules/common/react/index.ts
@@ -9,3 +9,4 @@ export * from './lib/parts/_brand-assets';
 export * from './lib/types';
 export * from './lib/genericStyles';
 export * from './lib/Popper';
+export * from './lib/hooks';

--- a/modules/common/react/lib/hooks/index.ts
+++ b/modules/common/react/lib/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './useDocumentListener';
+export * from './useFocusTrap';

--- a/modules/common/react/lib/hooks/useDocumentListener.ts
+++ b/modules/common/react/lib/hooks/useDocumentListener.ts
@@ -1,0 +1,20 @@
+import {useEffect} from 'react';
+
+/**
+ * This hook will add an event listener to the document and automatically remove it.
+ * Document event listeners are useful for global event types like keyboard events
+ * or drag-and-drop
+ * @param event The event to listen to
+ * @param eventHandler The event handler
+ */
+export const useDocumentListener = (
+  event: string,
+  eventHandler: EventListenerOrEventListenerObject
+) => {
+  useEffect(() => {
+    document.addEventListener(event, eventHandler);
+    return () => {
+      document.removeEventListener(event, eventHandler);
+    };
+  }, [eventHandler]);
+};

--- a/modules/common/react/lib/hooks/useFocusTrap.ts
+++ b/modules/common/react/lib/hooks/useFocusTrap.ts
@@ -1,0 +1,60 @@
+import tabTrappingKey from 'focus-trap-js';
+import {useDocumentListener} from './useDocumentListener';
+
+/**
+ * Set a focus trap around a container. Focus is automatically moved to the first focusable
+ * element in the trap and returned when the trap is released. The provided `firstFocusableEl`
+ * Ref or function determines which element that is. If the `firstFocusableEl` is not provided,
+ * the first focusable element will be automatically determined.
+ * @param containerRef A React Ref of the containing element. This must be a Ref object to avoid stale references
+ * @param firstFocusableEl A React Ref or a function returning an HTMLElement
+ */
+export const useFocusTrap = (
+  containerRef: React.RefObject<HTMLElement | null>,
+  firstFocusableEl: React.RefObject<HTMLElement | null> | (() => HTMLElement | null) = () =>
+    containerRef.current && containerRef.current.querySelectorAll<HTMLElement>('button,input')[0]
+) => {
+  const handleKeydown = (event: KeyboardEvent) => {
+    if (containerRef.current) {
+      tabTrappingKey(event, containerRef.current);
+    }
+  };
+
+  useDocumentListener('keydown', handleKeydown);
+  useTransferFocus(containerRef, firstFocusableEl);
+};
+
+import {useEffect} from 'react';
+
+/**
+ * This hook will transfer focus to the `firstFocusableEl` (or an element returned by a function)
+ * on `useEffect` timing. When the owning component is destroyed, focus is returned to where it
+ * was before the effect was called. This is useful for focus trapping where the hook will transfer
+ * focus within the trap and return focus to the original element when the trap is released
+ * @param containerRef
+ * @param firstFocusableEl
+ */
+const useTransferFocus = (
+  containerRef: React.RefObject<HTMLElement | null>,
+  firstFocusableEl: React.RefObject<HTMLElement | null> | (() => HTMLElement | null)
+) => {
+  const initialFocusedEl =
+    document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+  useEffect(() => {
+    if (containerRef.current) {
+      console.log('firstFocusable', firstFocusableEl);
+      const elem =
+        typeof firstFocusableEl === 'function' ? firstFocusableEl() : firstFocusableEl.current;
+      if (!elem) {
+        throw new Error('No focusable element was found inside container');
+      }
+      elem.focus();
+    }
+    return () => {
+      if (initialFocusedEl) {
+        initialFocusedEl.focus();
+      }
+    };
+  }, [containerRef, firstFocusableEl]);
+};


### PR DESCRIPTION
## Summary

Create a place for utility hooks and extract the logic for a focus trap into a hook for use elsewhere in applications

## Checklist

- [x] `yarn test` passes
- [ ] code has been documented and, if applicable, usage described in README.md
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

