### PR TITLE
test: Fix modal specs

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -18,7 +18,7 @@ Cypress.Commands.add('injectAxe', () => {
 
 // Add better logging to cy.tab
 Cypress.Commands.overwrite('tab', (originalFn, subject) => {
-  const prevSubject = cy.$$(subject || cy.state('window').document.activeElement);
+  const prevSubject = cy.$$(subject || (cy as any).state('window').document.activeElement);
 
   const log = Cypress.log({
     $el: prevSubject,

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -34,7 +34,7 @@ Cypress.Commands.overwrite('tab', (originalFn, subject) => {
   return Cypress.Promise.try(() => originalFn(subject))
     .then(value => {
       log.set('$el', value).snapshot();
-      return value;
+      return Cypress.$(value);
     })
     .finally(() => {
       log.end();

--- a/modules/modal/react/lib/ModalContent.tsx
+++ b/modules/modal/react/lib/ModalContent.tsx
@@ -98,12 +98,10 @@ function getFirstElementToFocus(modalEl: HTMLElement): HTMLElement {
 }
 
 const useKeyDownListener = (handleKeydown: EventListenerOrEventListenerObject) => {
-  React.useEffect(() => {
-    const timeout = setTimeout(() => {
-      document.addEventListener('keydown', handleKeydown);
-    }, 50);
+  // `useLayoutEffect` for automation
+  React.useLayoutEffect(() => {
+    document.addEventListener('keydown', handleKeydown);
     return () => {
-      clearTimeout(timeout);
       document.removeEventListener('keydown', handleKeydown);
     };
   }, [handleKeydown]);

--- a/modules/modal/react/lib/ModalContent.tsx
+++ b/modules/modal/react/lib/ModalContent.tsx
@@ -99,8 +99,11 @@ function getFirstElementToFocus(modalEl: HTMLElement): HTMLElement {
 
 const useKeyDownListener = (handleKeydown: EventListenerOrEventListenerObject) => {
   React.useEffect(() => {
-    document.addEventListener('keydown', handleKeydown);
+    const timeout = setTimeout(() => {
+      document.addEventListener('keydown', handleKeydown);
+    }, 50);
     return () => {
+      clearTimeout(timeout);
       document.removeEventListener('keydown', handleKeydown);
     };
   }, [handleKeydown]);


### PR DESCRIPTION
## Summary

Tests are failing on CI, but not locally. I'm making a PR to see what it takes to fix on the CI.

There is some strange issue where the "tab" key is hit before the event listener is added. There are some issues on `cypress-tab-plugin` that causes errors. On investigating, I discovered this issue: https://github.com/Bkucera/cypress-plugin-tab/issues/13
