### PR TITLE
fix: Increase storybook test timeout

### DIFF
--- a/cypress/integration/storybook.spec.ts
+++ b/cypress/integration/storybook.spec.ts
@@ -8,7 +8,7 @@ describe('Storybook', () => {
     cy.get('iframe#storybook-preview-iframe')
       .pipe(
         getIframeBody,
-        {timeout: 10000}
+        {timeout: 20000}
       )
       .should('contain', 'Workday Canvas Kit');
   });


### PR DESCRIPTION
TravisCI runs slow. This test sometimes takes a loooong time