### PR TITLE
fix: Remove hard coded strings for alert and error and added new props

### DIFF
--- a/modules/form-field/react/lib/FormField.tsx
+++ b/modules/form-field/react/lib/FormField.tsx
@@ -51,13 +51,13 @@ export interface FormFieldProps
    */
   children: React.ReactNode;
   /**
-   * The Label for the error messages. This props is only added for translation, otherwise it shouldn't change
-   * @default Error
+   * The label for the error message hint text if `hintText` and `error` are defined. This prop should only be used for translating the default string 'Error'.
+   * @default 'Error'
    */
   errorLabel?: string;
   /**
-   * The Label for the error messages. This props is only added for translation, otherwise it shouldn't change
-   * @default Alert
+   * The label for the alert message hint text if `hintText` and `error` are defined. This prop should only be used for translating the default string 'Alert'.
+   * @default 'Alert'
    */
   alertLabel?: string;
 }

--- a/modules/form-field/react/lib/FormField.tsx
+++ b/modules/form-field/react/lib/FormField.tsx
@@ -20,6 +20,8 @@ export interface FormFieldProps
   required?: boolean;
   useFieldset: boolean;
   children: React.ReactNode;
+  errorLabel?: string;
+  alertLabel?: string;
 }
 
 export interface FormFieldErrorBehavior {
@@ -85,6 +87,8 @@ export default class FormField extends React.Component<FormFieldProps> {
   static defaultProps = {
     labelPosition: FormField.LabelPosition.Top,
     useFieldset: false,
+    alertLabel: 'Alert',
+    errorLabel: 'Error',
   };
 
   private inputId: string = this.props.inputId || uuid();
@@ -127,6 +131,8 @@ export default class FormField extends React.Component<FormFieldProps> {
       hintText,
       hintId,
       inputId,
+      errorLabel,
+      alertLabel,
       grow,
       children,
       useFieldset,
@@ -155,7 +161,7 @@ export default class FormField extends React.Component<FormFieldProps> {
         <FormFieldInputContainer grow={grow} labelPosition={labelPosition}>
           {React.Children.map(children, this.renderChildren)}
           {hintText && (
-            <Hint error={error} id={hintId}>
+            <Hint errorLabel={errorLabel} alertLabel={alertLabel} error={error} id={hintId}>
               {hintText}
             </Hint>
           )}

--- a/modules/form-field/react/lib/FormField.tsx
+++ b/modules/form-field/react/lib/FormField.tsx
@@ -20,7 +20,15 @@ export interface FormFieldProps
   required?: boolean;
   useFieldset: boolean;
   children: React.ReactNode;
+  /**
+   * The Label for the error messages. This props is only added for translation, otherwise it shouldn't change
+   * @default Error
+   */
   errorLabel?: string;
+  /**
+   * The Label for the error messages. This props is only added for translation, otherwise it shouldn't change
+   * @default Alert
+   */
   alertLabel?: string;
 }
 

--- a/modules/form-field/react/lib/Hint.tsx
+++ b/modules/form-field/react/lib/Hint.tsx
@@ -43,7 +43,7 @@ export default class Hint extends React.Component<HintProps> {
 
     return (
       <Message {...this.props}>
-        {typeof error !== 'undefined' && <Label>{hintLabel && `${hintLabel}: `}</Label>}
+        {typeof error !== 'undefined' && hintLabel && <Label>{hintLabel}: </Label>}
         {children}
       </Message>
     );

--- a/modules/form-field/react/lib/Hint.tsx
+++ b/modules/form-field/react/lib/Hint.tsx
@@ -5,7 +5,15 @@ import {spacing, type} from '@workday/canvas-kit-react-core';
 
 export interface HintProps extends Themeable, React.HTMLAttributes<HTMLParagraphElement> {
   error?: ErrorType;
+  /**
+   * The Label for the error messages. This props is only added for translation, otherwise it shouldn't change
+   * @default Error
+   */
   errorLabel?: string;
+  /**
+   * The Label for the error messages. This props is only added for translation, otherwise it shouldn't change
+   * @default Alert
+   */
   alertLabel?: string;
 }
 

--- a/modules/form-field/react/lib/Hint.tsx
+++ b/modules/form-field/react/lib/Hint.tsx
@@ -9,13 +9,13 @@ export interface HintProps extends Themeable, React.HTMLAttributes<HTMLParagraph
    */
   error?: ErrorType;
   /**
-   * The Label for the error messages. This props is only added for translation, otherwise it shouldn't change
-   * @default Error
+   * The label for the error message hint text if `hintText` and `error` are defined. This prop should only be used for translating the default string 'Error'.
+   * @default 'Error'
    */
   errorLabel?: string;
   /**
-   * The Label for the error messages. This props is only added for translation, otherwise it shouldn't change
-   * @default Alert
+   * The label for the alert message hint text if `hintText` and `error` are defined. This prop should only be used for translating the default string 'Alert'.
+   * @default 'Alert'
    */
   alertLabel?: string;
 }

--- a/modules/form-field/react/lib/Hint.tsx
+++ b/modules/form-field/react/lib/Hint.tsx
@@ -5,6 +5,8 @@ import {spacing, type} from '@workday/canvas-kit-react-core';
 
 export interface HintProps extends Themeable, React.HTMLAttributes<HTMLParagraphElement> {
   error?: ErrorType;
+  errorLabel?: string;
+  alertLabel?: string;
 }
 
 const Label = styled('span')(type.body2, type.variant.label);
@@ -13,24 +15,27 @@ const Message = styled('p')(type.body2, {width: '100%', margin: `${spacing.xxs} 
 
 export default class Hint extends React.Component<HintProps> {
   static ErrorType = ErrorType;
-
+  static defaultProps = {
+    errorLabel: 'Error',
+    alertLabel: 'Alert',
+  };
   public render() {
-    const {children, error} = this.props;
+    const {children, error, errorLabel, alertLabel} = this.props;
 
-    let errorLabel: string | undefined;
+    let hintLabel: string | undefined;
     switch (error) {
       case Hint.ErrorType.Error:
-        errorLabel = 'Error';
+        hintLabel = errorLabel;
         break;
       case Hint.ErrorType.Alert:
-        errorLabel = 'Alert';
+        hintLabel = alertLabel;
         break;
       default:
     }
 
     return (
       <Message {...this.props}>
-        {typeof error !== 'undefined' && <Label>{errorLabel && `${errorLabel}: `}</Label>}
+        {typeof error !== 'undefined' && <Label>{hintLabel && `${hintLabel}: `}</Label>}
         {children}
       </Message>
     );

--- a/modules/form-field/react/spec/Hint.spec.tsx
+++ b/modules/form-field/react/spec/Hint.spec.tsx
@@ -1,28 +1,24 @@
 import * as React from 'react';
-import {shallow, mount} from 'enzyme';
+import {render} from '@testing-library/react';
 import Hint from '../lib/Hint';
 
 describe('Hint', () => {
-  test('Error label is set', () => {
-    const component = shallow(<Hint error={Hint.ErrorType.Error} />);
-
-    expect(component.render().text()).toEqual(expect.stringContaining('Error:'));
-
-    component.unmount();
+  describe('when rendered with an ErrorType', () => {
+    it('should render an error label when error type is Error', async () => {
+      const {getByTestId} = render(<Hint data-testid="hintError" error={Hint.ErrorType.Error} />);
+      expect(getByTestId('hintError').children[0].textContent).toEqual('Error: ');
+    });
+    it('should render an alert label when error type is Alert', async () => {
+      const {getByTestId} = render(<Hint data-testid="hintError" error={Hint.ErrorType.Alert} />);
+      expect(getByTestId('hintError').children[0].textContent).toEqual('Alert: ');
+    });
   });
-
-  test('Alert label is set', () => {
-    const component = shallow(<Hint error={Hint.ErrorType.Alert} />);
-
-    expect(component.render().text()).toEqual(expect.stringContaining('Alert:'));
-
-    component.unmount();
-  });
-
-  test('Hint should spread extra props', () => {
-    const component = mount(<Hint data-propspread="test" />);
-    const container = component.at(0).getDOMNode();
-    expect(container.getAttribute('data-propspread')).toBe('test');
-    component.unmount();
+  describe('when rendered with a custom Error string', () => {
+    it('should render a custom label for type Error', async () => {
+      const {getByTestId} = render(
+        <Hint errorLabel={'Hay un Error'} data-testid="hintError" error={Hint.ErrorType.Error} />
+      );
+      expect(getByTestId('hintError').children[0].textContent).toEqual('Hay un Error: ');
+    });
   });
 });

--- a/modules/form-field/react/spec/Hint.spec.tsx
+++ b/modules/form-field/react/spec/Hint.spec.tsx
@@ -6,17 +6,17 @@ describe('Hint', () => {
   describe('when rendered with an ErrorType', () => {
     it('should render an error label when error type is Error', async () => {
       const {getByText} = render(<Hint error={Hint.ErrorType.Error} />);
-      expect(getByText('Error:').innerHTML).toEqual('Error: ');
+      expect(getByText('Error:')).toBeDefined();
     });
     it('should render an alert label when error type is Alert', async () => {
       const {getByText} = render(<Hint error={Hint.ErrorType.Alert} />);
-      expect(getByText('Alert:').innerHTML).toEqual('Alert: ');
+      expect(getByText('Alert:')).toBeDefined();
     });
   });
   describe('when rendered with a custom Error string', () => {
     it('should render a custom label for type Error', async () => {
       const {getByText} = render(<Hint errorLabel={'Hay un error'} error={Hint.ErrorType.Error} />);
-      expect(getByText('Hay un error:').innerHTML).toEqual('Hay un error: ');
+      expect(getByText('Hay un error:')).toBeDefined();
     });
   });
 });

--- a/modules/form-field/react/spec/Hint.spec.tsx
+++ b/modules/form-field/react/spec/Hint.spec.tsx
@@ -5,20 +5,18 @@ import Hint from '../lib/Hint';
 describe('Hint', () => {
   describe('when rendered with an ErrorType', () => {
     it('should render an error label when error type is Error', async () => {
-      const {getByTestId} = render(<Hint data-testid="hintError" error={Hint.ErrorType.Error} />);
-      expect(getByTestId('hintError').children[0].textContent).toEqual('Error: ');
+      const {getByText} = render(<Hint error={Hint.ErrorType.Error} />);
+      expect(getByText('Error:').innerHTML).toEqual('Error: ');
     });
     it('should render an alert label when error type is Alert', async () => {
-      const {getByTestId} = render(<Hint data-testid="hintError" error={Hint.ErrorType.Alert} />);
-      expect(getByTestId('hintError').children[0].textContent).toEqual('Alert: ');
+      const {getByText} = render(<Hint error={Hint.ErrorType.Alert} />);
+      expect(getByText('Alert:').innerHTML).toEqual('Alert: ');
     });
   });
   describe('when rendered with a custom Error string', () => {
     it('should render a custom label for type Error', async () => {
-      const {getByTestId} = render(
-        <Hint errorLabel={'Hay un Error'} data-testid="hintError" error={Hint.ErrorType.Error} />
-      );
-      expect(getByTestId('hintError').children[0].textContent).toEqual('Hay un Error: ');
+      const {getByText} = render(<Hint errorLabel={'Hay un error'} error={Hint.ErrorType.Error} />);
+      expect(getByText('Hay un error:').innerHTML).toEqual('Hay un error: ');
     });
   });
 });


### PR DESCRIPTION
Fixes: https://github.com/Workday/canvas-kit/issues/385
With the translation efforts, we forgot to update the `error` and `alert` labels for the error messages. We also had to add a prop to `FormField` to allow customization.