### PR TITLE
fix(header): Allow elements to flex correctly in IE11

### DIFF
--- a/modules/_labs/header/react/lib/Header.tsx
+++ b/modules/_labs/header/react/lib/Header.tsx
@@ -98,7 +98,7 @@ const BrandLink = styled('a')({
   },
 });
 
-const navStyle = ({themeColor, leftSlot}: Pick<HeaderProps, 'themeColor' | 'leftSlot'>) => {
+const navStyle = ({themeColor}: Pick<HeaderProps, 'themeColor'>) => {
   const theme = themes[themeColor];
 
   return css({
@@ -107,7 +107,7 @@ const navStyle = ({themeColor, leftSlot}: Pick<HeaderProps, 'themeColor' | 'left
       flex: `1 0 auto`, // Instead of just flex-grow: 1 for IE11, see https://github.com/philipwalton/flexbugs#flexbug-1
       justifyContent: 'center',
       height: 'inherit',
-      marginLeft: leftSlot ? spacing.xl : 0,
+      marginLeft: spacing.xl,
 
       '& ul': {
         color: theme.linkColor,
@@ -179,9 +179,7 @@ const navStyle = ({themeColor, leftSlot}: Pick<HeaderProps, 'themeColor' | 'left
   });
 };
 
-const ChildrenSlot = styled('div')<
-  Pick<HeaderProps, 'centeredNav' | 'themeColor' | 'isCollapsed' | 'leftSlot'>
->(
+const ChildrenSlot = styled('div')<Pick<HeaderProps, 'centeredNav' | 'themeColor' | 'isCollapsed'>>(
   {
     marginRight: spacing.m,
     // TODO: remove this when we get real icon buttons
@@ -391,7 +389,6 @@ export default class Header extends React.Component<HeaderProps, {}> {
           themeColor={themeColor}
           centeredNav={shouldCenteredNav}
           isCollapsed={isCollapsed}
-          leftSlot={leftSlot}
         >
           {isCollapsed ? (
             // Screen size is smaller than our largest breakpoint so turn nav into a hamburger

--- a/modules/_labs/header/react/lib/Header.tsx
+++ b/modules/_labs/header/react/lib/Header.tsx
@@ -180,7 +180,7 @@ const navStyle = ({themeColor, leftSlot}: Pick<HeaderProps, 'themeColor' | 'left
 };
 
 const ChildrenSlot = styled('div')<
-  Pick<HeaderProps, 'centeredNav' | 'themeColor' | 'isCollapsed' | 'leftslot'>
+  Pick<HeaderProps, 'centeredNav' | 'themeColor' | 'isCollapsed' | 'leftSlot'>
 >(
   {
     marginRight: spacing.m,

--- a/modules/_labs/header/react/lib/Header.tsx
+++ b/modules/_labs/header/react/lib/Header.tsx
@@ -67,7 +67,6 @@ const HeaderShell = styled('div')<Pick<HeaderProps, 'variant' | 'themeColor'>>(
     WebkitFontSmoothing: 'antialiased',
     MozOsxFontSmoothing: 'grayscale',
     position: 'relative',
-    overflow: 'hidden',
   },
   ({variant, themeColor}) => ({
     // Only the variant Full has a large header, all the other one (Dub, Global) have a small header height
@@ -99,7 +98,7 @@ const BrandLink = styled('a')({
   },
 });
 
-const navStyle = ({themeColor}: Pick<HeaderProps, 'themeColor'>) => {
+const navStyle = ({themeColor, leftSlot}: Pick<HeaderProps, 'themeColor' | 'leftSlot'>) => {
   const theme = themes[themeColor];
 
   return css({
@@ -108,7 +107,7 @@ const navStyle = ({themeColor}: Pick<HeaderProps, 'themeColor'>) => {
       flex: `1 0 auto`, // Instead of just flex-grow: 1 for IE11, see https://github.com/philipwalton/flexbugs#flexbug-1
       justifyContent: 'center',
       height: 'inherit',
-      marginLeft: spacing.xl,
+      marginLeft: leftSlot ? spacing.xl : 0,
 
       '& ul': {
         color: theme.linkColor,
@@ -180,7 +179,9 @@ const navStyle = ({themeColor}: Pick<HeaderProps, 'themeColor'>) => {
   });
 };
 
-const ChildrenSlot = styled('div')<Pick<HeaderProps, 'centeredNav' | 'themeColor' | 'isCollapsed'>>(
+const ChildrenSlot = styled('div')<
+  Pick<HeaderProps, 'centeredNav' | 'themeColor' | 'isCollapsed' | 'leftslot'>
+>(
   {
     marginRight: spacing.m,
     // TODO: remove this when we get real icon buttons
@@ -390,6 +391,7 @@ export default class Header extends React.Component<HeaderProps, {}> {
           themeColor={themeColor}
           centeredNav={shouldCenteredNav}
           isCollapsed={isCollapsed}
+          leftSlot={leftSlot}
         >
           {isCollapsed ? (
             // Screen size is smaller than our largest breakpoint so turn nav into a hamburger

--- a/modules/_labs/header/react/lib/Header.tsx
+++ b/modules/_labs/header/react/lib/Header.tsx
@@ -67,6 +67,7 @@ const HeaderShell = styled('div')<Pick<HeaderProps, 'variant' | 'themeColor'>>(
     WebkitFontSmoothing: 'antialiased',
     MozOsxFontSmoothing: 'grayscale',
     position: 'relative',
+    overflow: 'hidden',
   },
   ({variant, themeColor}) => ({
     // Only the variant Full has a large header, all the other one (Dub, Global) have a small header height
@@ -82,7 +83,7 @@ const BrandSlot = styled('div')(
     height: '100%',
   },
   (props: {grow?: boolean}) => ({
-    flexGrow: props.grow ? 1 : 'unset',
+    flex: props.grow ? `1 0 auto` : 'unset',
   })
 );
 
@@ -104,7 +105,7 @@ const navStyle = ({themeColor}: Pick<HeaderProps, 'themeColor'>) => {
   return css({
     nav: {
       display: 'flex',
-      flexGrow: 1,
+      flex: `1 0 auto`, // Instead of just flex-grow: 1 for IE11, see https://github.com/philipwalton/flexbugs#flexbug-1
       justifyContent: 'center',
       height: 'inherit',
       marginLeft: spacing.xl,
@@ -201,7 +202,7 @@ const ChildrenSlot = styled('div')<Pick<HeaderProps, 'centeredNav' | 'themeColor
     '> *:last-child': {
       marginRight: isCollapsed ? '' : 0,
     },
-    flexGrow: !isCollapsed && centeredNav ? 1 : 'unset',
+    flex: !isCollapsed && centeredNav ? `1 0 auto` : 'unset',
   }),
   navStyle
 );

--- a/modules/_labs/header/react/lib/parts/SearchBar.tsx
+++ b/modules/_labs/header/react/lib/parts/SearchBar.tsx
@@ -103,17 +103,19 @@ function getInputColors(theme: SearchThemeAttributes, isFocused?: boolean) {
 
 const formCollapsedBackground = colors.frenchVanilla100;
 
-const maxWidth = '480px';
+const maxWidth = 480;
+const minWidth = 120;
 
 const SearchForm = styled('form')<
   Pick<SearchBarProps, 'isCollapsed' | 'rightAlign' | 'grow'> & Pick<SearchBarState, 'showForm'>
 >(
   {
     position: 'relative',
-    flex: `1 0 auto`, // Instead of just flex-grow: 1 for IE11, see https://github.com/philipwalton/flexbugs#flexbug-1
+    flex: `1 1 auto`, // Instead of just flex-grow: 1 for IE11, see https://github.com/philipwalton/flexbugs#flexbug-1
     display: 'flex',
     alignItems: 'center',
     marginLeft: spacing.m,
+    minWidth: minWidth,
   },
   ({isCollapsed, showForm, rightAlign, grow}) => {
     const collapseStyles: CSSObject = isCollapsed
@@ -230,7 +232,7 @@ const SearchInput = styled(TextInput)<
       }
     : {
         maxWidth: grow ? '100%' : maxWidth,
-        minWidth: '120px',
+        minWidth: minWidth,
         paddingLeft: spacingNumbers.xl + spacingNumbers.xxs,
         paddingRight: spacing.xl,
         backgroundColor: inputColors.background,

--- a/modules/_labs/header/react/lib/parts/SearchBar.tsx
+++ b/modules/_labs/header/react/lib/parts/SearchBar.tsx
@@ -105,6 +105,7 @@ const formCollapsedBackground = colors.frenchVanilla100;
 
 const maxWidth = 480;
 const minWidth = 120;
+const height = 44;
 
 const SearchForm = styled('form')<
   Pick<SearchBarProps, 'isCollapsed' | 'rightAlign' | 'grow'> & Pick<SearchBarState, 'showForm'>
@@ -148,7 +149,8 @@ const SearchContainer = styled('div')({
   position: `relative`,
   width: `100%`,
   textAlign: 'left',
-  minHeight: spacingNumbers.xl + spacingNumbers.xxxs,
+  minHeight: height,
+  height: height, // Needed to keep IE11 vertically centered
 });
 
 const SearchCombobox = styled(Combobox)({
@@ -208,6 +210,7 @@ const SearchField = styled(FormField)<
   return {
     display: (isCollapsed && showForm) || !isCollapsed ? 'inline-block' : 'none',
     width: '100%',
+    height: height,
     maxWidth: isCollapsed || grow ? '100%' : maxWidth,
     marginBottom: spacingNumbers.zero,
     '> div': {
@@ -245,7 +248,7 @@ const SearchInput = styled(TextInput)<
     WebkitAppearance: 'none',
     transition: 'background-color 120ms, color 120ms, box-shadow 200ms, border-color 200ms',
     zIndex: 2,
-    height: 44,
+    height: height,
     paddingTop: spacing.xs,
     paddingBottom: spacing.xs,
     width: '100%',

--- a/modules/_labs/header/react/lib/parts/SearchBar.tsx
+++ b/modules/_labs/header/react/lib/parts/SearchBar.tsx
@@ -110,10 +110,9 @@ const SearchForm = styled('form')<
 >(
   {
     position: 'relative',
-    flexGrow: 1,
+    flex: `1 0 auto`, // Instead of just flex-grow: 1 for IE11, see https://github.com/philipwalton/flexbugs#flexbug-1
     display: 'flex',
     alignItems: 'center',
-    width: '100%',
     marginLeft: spacing.m,
   },
   ({isCollapsed, showForm, rightAlign, grow}) => {

--- a/modules/_labs/header/react/lib/parts/WorkdayLogoTitle.tsx
+++ b/modules/_labs/header/react/lib/parts/WorkdayLogoTitle.tsx
@@ -32,8 +32,9 @@ const Lockup = styled('div')<WorkdayLogoTitleProps>(
     alignItems: 'center',
     justifyContent: 'center',
   },
-  ({variant}) => ({
+  ({variant, title}) => ({
     height: variant === HeaderVariant.Global ? HeaderHeight.Small : HeaderHeight.Large,
+    paddingRight: title ? 0 : spacing.xl,
   })
 );
 

--- a/modules/_labs/header/react/lib/parts/WorkdayLogoTitle.tsx
+++ b/modules/_labs/header/react/lib/parts/WorkdayLogoTitle.tsx
@@ -32,9 +32,8 @@ const Lockup = styled('div')<WorkdayLogoTitleProps>(
     alignItems: 'center',
     justifyContent: 'center',
   },
-  ({variant, title}) => ({
+  ({variant}) => ({
     height: variant === HeaderVariant.Global ? HeaderHeight.Small : HeaderHeight.Large,
-    paddingRight: title ? 0 : spacing.xl,
   })
 );
 

--- a/modules/_labs/header/react/stories/stories.tsx
+++ b/modules/_labs/header/react/stories/stories.tsx
@@ -363,6 +363,32 @@ storiesOf('Labs|Header/React', module)
         </Header>
       </div>
       <br />
+      <div css={containerStyle}>
+        <Header
+          variant={Header.Variant.Dub}
+          title="Centered Menu Without Search"
+          themeColor={Header.Theme.White}
+          centeredNav={true}
+          brandUrl="#"
+          isCollapsed={boolean('isCollapsed', false)}
+        >
+          {nav}
+          <IconButton
+            variant={IconButton.Variant.Circle}
+            icon={notificationsIcon}
+            title="Notifications"
+            aria-label="Notifications"
+          />
+          <IconButton
+            variant={IconButton.Variant.Circle}
+            icon={inboxIcon}
+            title="Inbox"
+            aria-label="Inbox"
+          />
+          <Button variant={Button.Variant.Primary}>Logout</Button>
+        </Header>
+      </div>
+      <br />
       <div css={[containerStyle, backgroundStyle]}>
         <Header
           variant={Header.Variant.Dub}

--- a/modules/button/react/lib/ButtonStyles.ts
+++ b/modules/button/react/lib/ButtonStyles.ts
@@ -311,6 +311,7 @@ export const iconButtonStyles: ButtonGenericStyle = {
   variants: {
     sizes: {
       [ButtonSize.Small]: {
+        minWidth: canvas.spacing.l, // min-width is set so buttons don't collapse in IE11
         width: canvas.spacing.l,
         height: canvas.spacing.l,
         'span svg': {
@@ -319,6 +320,7 @@ export const iconButtonStyles: ButtonGenericStyle = {
         },
       },
       [ButtonSize.Medium]: {
+        minWidth: canvas.spacing.xl,
         width: canvas.spacing.xl,
         height: canvas.spacing.xl,
       },
@@ -326,12 +328,14 @@ export const iconButtonStyles: ButtonGenericStyle = {
     types: {
       [IconButtonVariant.Square]: {
         borderRadius: borderRadius.m,
+        minWidth: canvas.spacing.l,
         width: canvas.spacing.l,
         height: canvas.spacing.l,
         ...getIconButtonStateStyle(IconButtonVariant.Square),
       },
       [IconButtonVariant.SquareFilled]: {
         borderRadius: borderRadius.m,
+        minWidth: canvas.spacing.l,
         width: canvas.spacing.l,
         height: canvas.spacing.l,
         ...getIconButtonStateStyle(IconButtonVariant.SquareFilled),


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

An alternative solution from the one proposed in #422

This fixes #420, a bug where the slot containing the nav and icon buttons were getting squished. This was because the slot containing the nav and icons shrunk past the default content size. In addition, icon buttons weren't sized properly in IE11, they need a min-width set, otherwise they collapse.

**Before**:
<img width="1110" alt="Screen Shot 2020-01-26 at 12 11 51 PM" src="https://user-images.githubusercontent.com/14299381/73141105-15b74c80-4035-11ea-8695-3bebc509b53a.png">

[Flexbugs](https://github.com/philipwalton/flexbugs#flexbug-1) describes this bug: "Minimum content sizing of flex items not honored" in IE11.

> The flexbox spec defines an initial flex-shrink value of 1 but says items should not shrink below their default minimum content size. You can usually get this same behavior by setting a flex-shrink value of 0 (instead of the default 1) and a flex-basis value of auto. That will cause the flex item to be at least as big as its width or height (if declared) or its default content size.

By setting a min-width in the `Search` component and `flex: 1 0 auto` in the header (so it respects content sizing), the everything flexes properly in IE11 now.

This PR also adds: 
* a `min-width` equal to the `width` of an `IconButton` so it doesn't collapse if the container gets too small. 
* an `overflow: hidden` to the header shell so stuff doesn't leak out of the header, but I think it's debatable if this needs to be there or is considered a breaking change. @vibdev what do you think?
* an example to the story that shows a dub header without the search bar that #422 added
* a fix for vertical centering by fixing height values in the `Search` component

**After:**
<img width="1351" alt="Screen Shot 2020-01-27 at 4 57 01 AM" src="https://user-images.githubusercontent.com/14299381/73176528-82782880-40c1-11ea-924e-a949452bbbe7.png">

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [ ] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
