### PR TITLE
fix(labs): Remove global type from useTheme hook

### DIFF
--- a/modules/_labs/core/react/lib/theming/README.md
+++ b/modules/_labs/core/react/lib/theming/README.md
@@ -200,17 +200,6 @@ example of this is an app with many small React trees.
 Simply set your theme on the window object like so:
 
 ```tsx
-// If using typescript, you will need to declare this on the window object
-declare global {
-  interface Window {
-    workday: {
-      canvas: {
-        theme?: CanvasTheme;
-      };
-    };
-  }
-}
-
 const theme: PartialCanvasTheme = {
   palette: {
     primary: {

--- a/modules/_labs/core/react/lib/theming/useTheme.ts
+++ b/modules/_labs/core/react/lib/theming/useTheme.ts
@@ -3,16 +3,6 @@ import {ThemeContext} from '@emotion/core';
 import {CanvasTheme} from './types';
 import {defaultCanvasTheme} from './theme';
 
-declare global {
-  interface Window {
-    workday: {
-      canvas: {
-        theme?: CanvasTheme;
-      };
-    };
-  }
-}
-
 /**
  * Hook function to get the correct theme object.
  * @param {Object=} theme - The theme object returned from the emotion ThemeContext
@@ -40,7 +30,9 @@ export function useTheme(theme?: Object): CanvasTheme {
     // Context not supported or invalid (probably called from within a class component)
   }
 
+  // @ts-ignore
   if (window.workday && window.workday.canvas && window.workday.canvas.theme) {
+    // @ts-ignore
     return window.workday.canvas.theme;
   }
 


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The global type declaration overrides an internal Workday window object. We are going to remove the type declaration but should also rethink where the fallback should be for an internal use case of `useTheme` (or if we should even include it here?)

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [ ] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
