### PR TITLE
ci: Add check for missing or unused dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ jobs:
   - stage: pull_request
     script:
       - yarn lint
+      - yarn depcheck
       - yarn test
       - yarn chromatic --exit-zero-on-changes --app-code="dlpro96xybh" # v1 for cross-browser
       - yarn chromatic --exit-zero-on-changes # v2 for visual review features and Storybook hosting

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ jobs:
   - stage: pull_request
     script:
       - yarn lint
-			- yarn checkdeps
+      - yarn checkdeps
       - yarn test
       - yarn chromatic --exit-zero-on-changes --app-code="dlpro96xybh" # v1 for cross-browser
       - yarn chromatic --exit-zero-on-changes # v2 for visual review features and Storybook hosting

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ jobs:
   - stage: pull_request
     script:
       - yarn lint
+			- yarn checkdeps
       - yarn test
       - yarn chromatic --exit-zero-on-changes --app-code="dlpro96xybh" # v1 for cross-browser
       - yarn chromatic --exit-zero-on-changes # v2 for visual review features and Storybook hosting

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ jobs:
   - stage: pull_request
     script:
       - yarn lint
-      - yarn depcheck
       - yarn test
       - yarn chromatic --exit-zero-on-changes --app-code="dlpro96xybh" # v1 for cross-browser
       - yarn chromatic --exit-zero-on-changes # v2 for visual review features and Storybook hosting

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ jobs:
   - stage: pull_request
     script:
       - yarn lint
-      - yarn checkdeps
+      - yarn depcheck
       - yarn test
       - yarn chromatic --exit-zero-on-changes --app-code="dlpro96xybh" # v1 for cross-browser
       - yarn chromatic --exit-zero-on-changes # v2 for visual review features and Storybook hosting

--- a/modules/_canvas-kit-react/package.json
+++ b/modules/_canvas-kit-react/package.json
@@ -47,7 +47,6 @@
     "@workday/canvas-kit-react-common": "^3.3.0",
     "@workday/canvas-kit-react-cookie-banner": "^3.3.0",
     "@workday/canvas-kit-react-core": "^3.2.0",
-    "@workday/canvas-kit-react-fonts": "^3.2.0",
     "@workday/canvas-kit-react-form-field": "^3.3.2",
     "@workday/canvas-kit-react-icon": "^3.3.0",
     "@workday/canvas-kit-react-layout": "^3.3.0",

--- a/modules/_canvas-kit-react/package.json
+++ b/modules/_canvas-kit-react/package.json
@@ -23,7 +23,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/_labs/combobox/react/package.json
+++ b/modules/_labs/combobox/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/_labs/combobox/react/spec/Combobox.spec.tsx
+++ b/modules/_labs/combobox/react/spec/Combobox.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Combobox from '../lib/Combobox';
-import {MenuItem} from '../../../menu/react/index';
+import {MenuItem} from '../../../menu/react';
 import {TextInput} from '../../../../text-input/react';
 import {render, fireEvent} from '@testing-library/react';
 

--- a/modules/_labs/combobox/react/stories/stories.tsx
+++ b/modules/_labs/combobox/react/stories/stories.tsx
@@ -6,9 +6,9 @@ import {action} from '@storybook/addon-actions';
 import {withKnobs} from '@storybook/addon-knobs';
 
 import Combobox, {ComboboxProps} from '../index';
-import FormField from '../../../../form-field/react/index';
-import {MenuItem} from '../../../menu/react/index';
-import {TextInput} from '../../../../text-input/react/index';
+import FormField from '../../../../form-field/react';
+import {MenuItem} from '../../../menu/react';
+import {TextInput} from '../../../../text-input/react';
 import README from '../README.md';
 
 class Autocomplete extends React.Component<

--- a/modules/_labs/core/react/package.json
+++ b/modules/_labs/core/react/package.json
@@ -48,8 +48,6 @@
     "rtl-css-js": "^1.13.1"
   },
   "devDependencies": {
-    "@workday/canvas-kit-react-button": "^3.3.0",
-    "@workday/canvas-kit-react-card": "^3.3.0",
     "@workday/canvas-system-icons-web": "^1.0.20"
   }
 }

--- a/modules/_labs/core/react/package.json
+++ b/modules/_labs/core/react/package.json
@@ -23,7 +23,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/_labs/core/react/package.json
+++ b/modules/_labs/core/react/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@emotion/core": "^10.0.21",
+    "@emotion/styled": "^10.0.17",
     "@workday/canvas-colors-web": "^0.17.13",
     "@workday/canvas-kit-react-core": "^3.2.0",
     "chroma-js": "^2.1.0",
@@ -46,6 +47,8 @@
     "rtl-css-js": "^1.13.1"
   },
   "devDependencies": {
-    "@workday/canvas-kit-react-button": "^3.3.0"
+    "@workday/canvas-kit-react-button": "^3.3.0",
+    "@workday/canvas-kit-react-card": "^3.3.0",
+    "@workday/canvas-system-icons-web": "^1.0.20"
   }
 }

--- a/modules/_labs/core/react/stories/stories_direction.tsx
+++ b/modules/_labs/core/react/stories/stories_direction.tsx
@@ -7,8 +7,8 @@ import README from '../lib/theming/README.md';
 
 import {CanvasProvider, createCanvasTheme, ContentDirection} from '../index';
 import {rewind30Icon, fastForward15Icon, mediaPauseIcon} from '@workday/canvas-system-icons-web';
-import {IconButton, IconButtonProps} from '@workday/canvas-kit-react-button';
-import {Card} from '@workday/canvas-kit-react-card';
+import {IconButton, IconButtonProps} from '../../../../button/react';
+import {Card} from '../../../../card/react';
 
 const commonIconButtonProps: Pick<IconButtonProps, 'aria-label' | 'title' | 'icon'> = {
   'aria-label': 'Activity Stream',

--- a/modules/_labs/core/react/stories/stories_direction.tsx
+++ b/modules/_labs/core/react/stories/stories_direction.tsx
@@ -3,17 +3,12 @@ import * as React from 'react';
 import {storiesOf} from '@storybook/react';
 import withReadme from 'storybook-readme/with-readme';
 
-import {IconButton, IconButtonProps} from '@workday/canvas-kit-react-button';
-
 import README from '../lib/theming/README.md';
 
-import {
-  CanvasProvider,
-  createCanvasTheme,
-  ContentDirection,
-} from '@workday/canvas-kit-labs-react-core';
+import {CanvasProvider, createCanvasTheme, ContentDirection} from '../index';
 import {rewind30Icon, fastForward15Icon, mediaPauseIcon} from '@workday/canvas-system-icons-web';
-import {Card} from '@workday/canvas-kit-react';
+import {IconButton, IconButtonProps} from '@workday/canvas-kit-react-button';
+import {Card} from '@workday/canvas-kit-react-card';
 
 const commonIconButtonProps: Pick<IconButtonProps, 'aria-label' | 'title' | 'icon'> = {
   'aria-label': 'Activity Stream',

--- a/modules/_labs/drawer/react/lib/DrawerHeader.tsx
+++ b/modules/_labs/drawer/react/lib/DrawerHeader.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import styled from '@emotion/styled';
-import {typeColors} from '@workday/canvas-colors-web';
-import {colors, spacing, H4, CanvasColor} from '@workday/canvas-kit-react-core';
+import {colors, spacing, H4, CanvasColor, typeColors} from '@workday/canvas-kit-react-core';
 import {IconButton, IconButtonVariant, IconButtonProps} from '@workday/canvas-kit-react-button';
 import {xIcon} from '@workday/canvas-system-icons-web';
 

--- a/modules/_labs/drawer/react/package.json
+++ b/modules/_labs/drawer/react/package.json
@@ -23,7 +23,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/_labs/drawer/react/package.json
+++ b/modules/_labs/drawer/react/package.json
@@ -37,7 +37,8 @@
     "@emotion/core": "^10.0.21",
     "@emotion/styled": "^10.0.17",
     "@workday/canvas-kit-react-button": "^3.3.0",
-    "@workday/canvas-kit-react-core": "^3.2.0"
+    "@workday/canvas-kit-react-core": "^3.2.0",
+    "@workday/canvas-system-icons-web": "^1.0.20"
   },
   "peerDependencies": {
     "react": ">= 16.8 < 17"

--- a/modules/_labs/header/react/package.json
+++ b/modules/_labs/header/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/_labs/header/react/package.json
+++ b/modules/_labs/header/react/package.json
@@ -42,6 +42,7 @@
     "@emotion/core": "^10.0.21",
     "@emotion/styled": "^10.0.17",
     "@workday/canvas-kit-labs-react-combobox": "^3.3.2",
+    "@workday/canvas-kit-labs-react-menu": "^3.3.0",
     "@workday/canvas-kit-react-button": "^3.3.0",
     "@workday/canvas-kit-react-common": "^3.3.0",
     "@workday/canvas-kit-react-core": "^3.2.0",
@@ -51,8 +52,5 @@
     "@workday/canvas-system-icons-web": "^1.0.20",
     "chroma-js": "^2.1.0",
     "uuid": "^3.3.3"
-  },
-  "devDependencies": {
-    "@workday/canvas-kit-labs-react-menu": "^3.3.0"
   }
 }

--- a/modules/_labs/header/react/package.json
+++ b/modules/_labs/header/react/package.json
@@ -52,7 +52,6 @@
     "uuid": "^3.3.3"
   },
   "devDependencies": {
-    "@workday/canvas-kit-labs-react-menu": "^3.3.0",
-    "@workday/canvas-kit-react-avatar": "^3.3.0"
+    "@workday/canvas-kit-labs-react-menu": "^3.3.0"
   }
 }

--- a/modules/_labs/header/react/stories/stories.tsx
+++ b/modules/_labs/header/react/stories/stories.tsx
@@ -10,10 +10,10 @@ import chroma from 'chroma-js';
 
 import {notificationsIcon, inboxIcon} from '@workday/canvas-system-icons-web';
 
-import {AvatarButton} from '../../../../avatar/react/index';
-import {colors, spacing} from '../../../../core/react/index';
-import {Button, IconButton} from '../../../../button/react/index';
-import {MenuItem} from '../../../menu/react/index';
+import {AvatarButton} from '../../../../avatar/react';
+import {colors, spacing} from '../../../../core/react';
+import {Button, IconButton} from '../../../../button/react';
+import {MenuItem} from '../../../menu/react';
 import {
   GlobalHeader,
   Header,

--- a/modules/_labs/menu/react/package.json
+++ b/modules/_labs/menu/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/_labs/menu/react/package.json
+++ b/modules/_labs/menu/react/package.json
@@ -37,8 +37,7 @@
   ],
   "devDependencies": {
     "@material-ui/core": "^3.9.2",
-    "@workday/canvas-system-icons-web": "^1.0.20",
-    "@workday/canvas-kit-react-button": "^3.3.0"
+    "@workday/canvas-system-icons-web": "^1.0.20"
   },
   "dependencies": {
     "@emotion/core": "^10.0.21",

--- a/modules/_labs/menu/react/package.json
+++ b/modules/_labs/menu/react/package.json
@@ -37,12 +37,13 @@
   "devDependencies": {
     "@material-ui/core": "^3.9.2",
     "@workday/canvas-system-icons-web": "^1.0.20",
-    "react-transition-group": "^2.5.0"
+    "@workday/canvas-kit-react-button": "^3.3.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.21",
     "@emotion/styled": "^10.0.17",
     "@types/uuid": "^3.4.4",
+    "@workday/canvas-kit-labs-react-core": "^3.3.0",
     "@workday/canvas-kit-react-card": "^3.3.0",
     "@workday/canvas-kit-react-common": "^3.3.0",
     "@workday/canvas-kit-react-core": "^3.2.0",

--- a/modules/_labs/menu/react/stories/stories.tsx
+++ b/modules/_labs/menu/react/stories/stories.tsx
@@ -7,7 +7,7 @@ import uuid from 'uuid/v4';
 import {setupIcon, uploadCloudIcon, userIcon, extLinkIcon} from '@workday/canvas-system-icons-web';
 import Popper from '@material-ui/core/Popper';
 import ClickAwayListener from '@material-ui/core/ClickAwayListener';
-import {Button, ButtonProps} from '@workday/canvas-kit-react-button';
+import {Button, ButtonProps} from '../../../../button/react';
 
 import Menu from '../lib/Menu';
 import MenuItem, {MenuItemProps} from '../lib/MenuItem';

--- a/modules/action-bar/react/package.json
+++ b/modules/action-bar/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/action-bar/react/package.json
+++ b/modules/action-bar/react/package.json
@@ -41,8 +41,5 @@
     "@emotion/core": "^10.0.21",
     "@emotion/styled": "^10.0.17",
     "@workday/canvas-kit-react-core": "^3.2.0"
-  },
-  "devDependencies": {
-    "@workday/canvas-kit-react-button": "^3.3.0"
   }
 }

--- a/modules/action-bar/react/stories/stories.tsx
+++ b/modules/action-bar/react/stories/stories.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import {storiesOf} from '@storybook/react';
 import withReadme from 'storybook-readme/with-readme';
 
-import {Button} from '../../../button/react/index';
+import {Button} from '../../../button/react';
 import {ActionBar} from '../index';
 import README from '../README.md';
 

--- a/modules/avatar/react/package.json
+++ b/modules/avatar/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/banner/react/package.json
+++ b/modules/banner/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/banner/react/package.json
+++ b/modules/banner/react/package.json
@@ -38,8 +38,6 @@
     "react": ">= 16.8 < 17"
   },
   "dependencies": {
-    "@emotion/core": "^10.0.21",
-    "@emotion/styled": "^10.0.17",
     "@workday/canvas-kit-labs-react-core": "^3.3.0",
     "@workday/canvas-kit-react-common": "^3.3.0",
     "@workday/canvas-kit-react-core": "^3.2.0",

--- a/modules/button/react/package.json
+++ b/modules/button/react/package.json
@@ -42,6 +42,7 @@
     "@emotion/core": "^10.0.21",
     "@emotion/is-prop-valid": "^0.8.2",
     "@emotion/styled": "^10.0.17",
+    "@workday/canvas-kit-labs-react-core": "^3.3.0",
     "@workday/canvas-kit-react-common": "^3.3.0",
     "@workday/canvas-kit-react-core": "^3.2.0",
     "@workday/canvas-kit-react-icon": "^3.3.0",

--- a/modules/button/react/package.json
+++ b/modules/button/react/package.json
@@ -25,7 +25,8 @@
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:babel": "babel --no-babelrc --plugins babel-plugin-emotion dist --out-dir dist",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --sequential build:es6 build:babel build:cjs"
+    "build": "npm-run-all --sequential build:es6 build:babel build:cjs",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/card/react/package.json
+++ b/modules/card/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/card/react/stories/stories.mdx
+++ b/modules/card/react/stories/stories.mdx
@@ -1,6 +1,6 @@
 import {Meta, Story, Preview, Props} from '@storybook/addon-docs/blocks';
 
-import {spacing} from '../../../core/react/index';
+import {spacing} from '../../../core/react';
 import README from '../README.md';
 import Card from '../index';
 

--- a/modules/checkbox/react/package.json
+++ b/modules/checkbox/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/checkbox/react/package.json
+++ b/modules/checkbox/react/package.json
@@ -38,8 +38,6 @@
     "react": ">= 16.8 < 17"
   },
   "dependencies": {
-    "@emotion/core": "^10.0.21",
-    "@emotion/styled": "^10.0.17",
     "@workday/canvas-kit-labs-react-core": "^3.3.0",
     "@workday/canvas-kit-react-common": "^3.3.0",
     "@workday/canvas-kit-react-core": "^3.2.0",

--- a/modules/color-picker/react/package.json
+++ b/modules/color-picker/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/color-picker/react/package.json
+++ b/modules/color-picker/react/package.json
@@ -44,6 +44,9 @@
     "@workday/canvas-kit-react-text-input": "^3.3.2",
     "@workday/canvas-system-icons-web": "^1.0.20"
   },
+  "devDependencies": {
+    "@workday/canvas-kit-react-form-field": "^3.3.0"
+  },
   "peerDependencies": {
     "react": ">= 16.8 < 17"
   }

--- a/modules/color-picker/react/package.json
+++ b/modules/color-picker/react/package.json
@@ -45,9 +45,6 @@
     "@workday/canvas-kit-react-text-input": "^3.3.2",
     "@workday/canvas-system-icons-web": "^1.0.20"
   },
-  "devDependencies": {
-    "@workday/canvas-kit-react-form-field": "^3.3.0"
-  },
   "peerDependencies": {
     "react": ">= 16.8 < 17"
   }

--- a/modules/common/react/package.json
+++ b/modules/common/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/common/react/package.json
+++ b/modules/common/react/package.json
@@ -39,7 +39,6 @@
   },
   "dependencies": {
     "@emotion/core": "^10.0.21",
-    "@emotion/styled": "^10.0.17",
     "@workday/canvas-kit-react-core": "^3.2.0",
     "lodash": "^4.17.14",
     "popper.js": "^1.15.0"

--- a/modules/common/react/spec/colorUtils.spec.tsx
+++ b/modules/common/react/spec/colorUtils.spec.tsx
@@ -1,5 +1,5 @@
 import {colors} from '@workday/canvas-kit-react-core';
-import {pickForegroundColor} from '@workday/canvas-kit-react-common';
+import {pickForegroundColor} from '../index';
 
 describe('Color Utils methods', () => {
   describe('pickForegroundColor', () => {

--- a/modules/common/react/stories/stories.tsx
+++ b/modules/common/react/stories/stories.tsx
@@ -3,8 +3,8 @@ import * as React from 'react';
 import {storiesOf} from '@storybook/react';
 import withReadme from 'storybook-readme/with-readme';
 
-import {Button} from '../../../button/react/index';
-import {Popup} from '../../../popup/react/index';
+import {Button} from '../../../button/react';
+import {Popup} from '../../../popup/react';
 import {Popper} from '../index';
 import README from '../README.md';
 

--- a/modules/cookie-banner/react/package.json
+++ b/modules/cookie-banner/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/cookie-banner/react/stories/stories.tsx
+++ b/modules/cookie-banner/react/stories/stories.tsx
@@ -7,8 +7,8 @@ import withReadme from 'storybook-readme/with-readme';
 import {action} from '@storybook/addon-actions';
 import styled from '@emotion/styled';
 
-import {Button} from '../../../button/react/index';
-import {type} from '../../../core/react/index';
+import {Button} from '../../../button/react';
+import {type} from '../../../core/react';
 import CookieBanner from '../index';
 import README from '../README.md';
 

--- a/modules/core/react/package.json
+++ b/modules/core/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/fonts/react/package.json
+++ b/modules/fonts/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/form-field/react/package.json
+++ b/modules/form-field/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/form-field/react/package.json
+++ b/modules/form-field/react/package.json
@@ -44,11 +44,5 @@
     "@workday/canvas-kit-react-common": "^3.3.0",
     "@workday/canvas-kit-react-core": "^3.2.0",
     "uuid": "^3.3.3"
-  },
-  "devDependencies": {
-    "@workday/canvas-kit-react-checkbox": "^3.3.2",
-    "@workday/canvas-kit-react-radio": "^3.3.2",
-    "@workday/canvas-kit-react-select": "^3.3.2",
-    "@workday/canvas-kit-react-text-input": "^3.3.2"
   }
 }

--- a/modules/form-field/react/stories/stories_Checkbox.tsx
+++ b/modules/form-field/react/stories/stories_Checkbox.tsx
@@ -9,7 +9,7 @@ import {
   permutateProps,
 } from '../../../../utils/storybook';
 
-import {Checkbox} from '../../../checkbox/react/index';
+import {Checkbox} from '../../../checkbox/react';
 import FormField from '../index';
 import README from '../../../checkbox/react/README.md';
 

--- a/modules/form-field/react/stories/stories_ColorInput.tsx
+++ b/modules/form-field/react/stories/stories_ColorInput.tsx
@@ -5,7 +5,7 @@ import withReadme from 'storybook-readme/with-readme';
 import {StaticStates} from '@workday/canvas-kit-labs-react-core';
 import {controlComponent, ComponentStatesTable, permutateProps} from '../../../../utils/storybook';
 
-import {ColorInput} from '../../../color-picker/react/index';
+import {ColorInput} from '../../../color-picker/react';
 import FormField from '../index';
 import README from '../../../color-picker/react/README.md';
 

--- a/modules/form-field/react/stories/stories_ColorPreview.tsx
+++ b/modules/form-field/react/stories/stories_ColorPreview.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import {storiesOf} from '@storybook/react';
 import withReadme from 'storybook-readme/with-readme';
 
-import {ColorPreview} from '../../../color-picker/react/index';
+import {ColorPreview} from '../../../color-picker/react';
 import FormField from '../index';
 import README from '../../../color-picker/react/README.md';
 

--- a/modules/form-field/react/stories/stories_Radio.tsx
+++ b/modules/form-field/react/stories/stories_Radio.tsx
@@ -4,7 +4,7 @@ import {storiesOf} from '@storybook/react';
 import withReadme from 'storybook-readme/with-readme';
 import {ControlledComponentWrapper} from '../../../../utils/storybook';
 
-import {Radio, RadioGroup} from '../../../radio/react/index';
+import {Radio, RadioGroup} from '../../../radio/react';
 import FormField from '../index';
 import README from '../../../radio/react/README.md';
 

--- a/modules/form-field/react/stories/stories_Select.tsx
+++ b/modules/form-field/react/stories/stories_Select.tsx
@@ -6,7 +6,7 @@ import {controlComponent} from '../../../../utils/storybook';
 
 import FormField from '..';
 import README from '../../../select/react/README.md';
-import {Select, SelectOption} from '../../../select/react/index';
+import {Select, SelectOption} from '../../../select/react';
 
 const hintText = 'Helpful text goes here.';
 const hintId = 'error-desc-id';

--- a/modules/form-field/react/stories/stories_Select.tsx
+++ b/modules/form-field/react/stories/stories_Select.tsx
@@ -6,7 +6,7 @@ import {controlComponent} from '../../../../utils/storybook';
 
 import FormField from '..';
 import README from '../../../select/react/README.md';
-import {Select, SelectOption} from '@workday/canvas-kit-react-select';
+import {Select, SelectOption} from '../../../select/react/index';
 
 const hintText = 'Helpful text goes here.';
 const hintId = 'error-desc-id';

--- a/modules/form-field/react/stories/stories_Switch.tsx
+++ b/modules/form-field/react/stories/stories_Switch.tsx
@@ -8,7 +8,7 @@ import {
   permutateProps,
 } from '../../../../utils/storybook';
 import {StaticStates} from '@workday/canvas-kit-labs-react-core/lib/StaticStates';
-import {Switch} from '../../../switch/react/index';
+import {Switch} from '../../../switch/react';
 import FormField from '../index';
 import README from '../../../switch/react/README.md';
 

--- a/modules/form-field/react/stories/stories_TextArea.tsx
+++ b/modules/form-field/react/stories/stories_TextArea.tsx
@@ -5,7 +5,7 @@ import withReadme from 'storybook-readme/with-readme';
 import {StaticStates} from '@workday/canvas-kit-labs-react-core';
 import {controlComponent, ComponentStatesTable, permutateProps} from '../../../../utils/storybook';
 
-import {TextArea} from '../../../text-area/react/index';
+import {TextArea} from '../../../text-area/react';
 import FormField from '../index';
 import README from '../../../text-area/react/README.md';
 

--- a/modules/form-field/react/stories/stories_TextInput.tsx
+++ b/modules/form-field/react/stories/stories_TextInput.tsx
@@ -5,7 +5,7 @@ import withReadme from 'storybook-readme/with-readme';
 import {StaticStates} from '@workday/canvas-kit-labs-react-core';
 import {controlComponent, ComponentStatesTable, permutateProps} from '../../../../utils/storybook';
 
-import {TextInput} from '../../../text-input/react/index';
+import {TextInput} from '../../../text-input/react';
 import FormField from '../index';
 import README from '../../../text-input/react/README.md';
 

--- a/modules/icon/css/stories.tsx
+++ b/modules/icon/css/stories.tsx
@@ -4,7 +4,7 @@ import {Component} from 'react';
 import {storiesOf} from '@storybook/react';
 import withReadme from 'storybook-readme/with-readme';
 import README from './README.md';
-import {colors} from '../../core/react/index';
+import {colors} from '../../core/react';
 // @ts-ignore
 import initializeIcons from './lib/canvas-kit-css-icon';
 import './index.scss';

--- a/modules/icon/react/package.json
+++ b/modules/icon/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/icon/react/stories/stories.tsx
+++ b/modules/icon/react/stories/stories.tsx
@@ -7,7 +7,7 @@ import {benefitsIcon} from '@workday/canvas-applet-icons-web';
 import {activityStreamIcon} from '@workday/canvas-system-icons-web';
 import {CanvasGraphic, CanvasIconTypes} from '@workday/design-assets-types';
 
-import {colors} from '../../../core/react/index';
+import {colors} from '../../../core/react';
 import {AccentIcon, AppletIcon, SystemIcon, SystemIconCircle, Graphic} from '../index';
 import README from '../README.md';
 

--- a/modules/layout/react/package.json
+++ b/modules/layout/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/layout/react/stories/stories.tsx
+++ b/modules/layout/react/stories/stories.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import {storiesOf} from '@storybook/react';
 import withReadme from 'storybook-readme/with-readme';
 
-import {Card} from '../../../card/react/index';
+import {Card} from '../../../card/react';
 import Layout from '../index';
 import README from '../README.md';
 

--- a/modules/loading-animation/react/package.json
+++ b/modules/loading-animation/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/modal/react/package.json
+++ b/modules/modal/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/modal/react/package.json
+++ b/modules/modal/react/package.json
@@ -37,9 +37,11 @@
   "dependencies": {
     "@emotion/core": "^10.0.21",
     "@emotion/styled": "^10.0.17",
-    "@workday/canvas-kit-react-common": "^3.3.0",
     "@workday/canvas-kit-react-popup": "^3.3.0",
     "focus-trap-js": "1.0.8"
+  },
+  "devDependencies": {
+    "@workday/canvas-kit-react-button": "^3.3.0"
   },
   "peerDependencies": {
     "react": ">= 16.8 < 17"

--- a/modules/modal/react/package.json
+++ b/modules/modal/react/package.json
@@ -41,9 +41,6 @@
     "@workday/canvas-kit-react-popup": "^3.3.0",
     "focus-trap-js": "1.0.8"
   },
-  "devDependencies": {
-    "@workday/canvas-kit-react-button": "^3.3.0"
-  },
   "peerDependencies": {
     "react": ">= 16.8 < 17"
   }

--- a/modules/modal/react/stories/stories.tsx
+++ b/modules/modal/react/stories/stories.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import {storiesOf} from '@storybook/react';
 import withReadme from 'storybook-readme/with-readme';
 
-import {Button} from '@workday/canvas-kit-react-button';
+import {Button} from '../../../button/react';
 import Modal, {useModal} from '..';
 import README from '../README.md';
 

--- a/modules/page-header/react/package.json
+++ b/modules/page-header/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/page-header/react/package.json
+++ b/modules/page-header/react/package.json
@@ -41,9 +41,7 @@
     "@emotion/core": "^10.0.21",
     "@emotion/styled": "^10.0.17",
     "@workday/canvas-kit-react-button": "^3.3.0",
-    "@workday/canvas-kit-react-common": "^3.3.0",
-    "@workday/canvas-kit-react-core": "^3.2.0",
-    "@workday/canvas-kit-react-icon": "^3.3.0"
+    "@workday/canvas-kit-react-core": "^3.2.0"
   },
   "devDependencies": {
     "@workday/canvas-system-icons-web": "^1.0.20"

--- a/modules/popup/react/package.json
+++ b/modules/popup/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/popup/react/package.json
+++ b/modules/popup/react/package.json
@@ -34,9 +34,6 @@
     "workday",
     "popup"
   ],
-  "devDependencies": {
-    "@material-ui/core": "^3.9.2"
-  },
   "dependencies": {
     "@emotion/core": "^10.0.21",
     "@emotion/styled": "^10.0.17",

--- a/modules/radio/react/package.json
+++ b/modules/radio/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/radio/react/package.json
+++ b/modules/radio/react/package.json
@@ -43,8 +43,5 @@
     "@workday/canvas-kit-react-common": "^3.3.0",
     "@workday/canvas-kit-react-core": "^3.2.0",
     "uuid": "^3.3.3"
-  },
-  "devDependencies": {
-    "@workday/canvas-kit-react-form-field": "^3.3.0"
   }
 }

--- a/modules/radio/react/package.json
+++ b/modules/radio/react/package.json
@@ -38,11 +38,12 @@
     "react": ">= 16.8 < 17"
   },
   "dependencies": {
-    "@emotion/core": "^10.0.21",
-    "@emotion/styled": "^10.0.17",
     "@workday/canvas-kit-labs-react-core": "^3.3.0",
     "@workday/canvas-kit-react-common": "^3.3.0",
     "@workday/canvas-kit-react-core": "^3.2.0",
     "uuid": "^3.3.3"
+  },
+  "devDependencies": {
+    "@workday/canvas-kit-react-form-field": "^3.3.0"
   }
 }

--- a/modules/radio/react/spec/Radio.spec.tsx
+++ b/modules/radio/react/spec/Radio.spec.tsx
@@ -3,7 +3,7 @@ import {mount} from 'enzyme';
 import Radio from '../lib/Radio';
 import ReactDOMServer from 'react-dom/server';
 import {axe} from 'jest-axe';
-import FormField from '@workday/canvas-kit-react-form-field';
+import FormField from '../../../form-field/react';
 
 describe('Radio Input', () => {
   const cb = jest.fn();

--- a/modules/select/react/package.json
+++ b/modules/select/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/select/react/package.json
+++ b/modules/select/react/package.json
@@ -38,8 +38,6 @@
     "react": ">= 16.8 < 17"
   },
   "dependencies": {
-    "@emotion/core": "^10.0.21",
-    "@emotion/styled": "^10.0.17",
     "@workday/canvas-kit-labs-react-core": "^3.3.0",
     "@workday/canvas-kit-react-common": "^3.3.0",
     "@workday/canvas-kit-react-core": "^3.2.0",

--- a/modules/side-panel/react/package.json
+++ b/modules/side-panel/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/side-panel/react/package.json
+++ b/modules/side-panel/react/package.json
@@ -40,6 +40,7 @@
     "@workday/canvas-kit-react-button": "^3.3.0",
     "@workday/canvas-kit-react-core": "^3.2.0",
     "@workday/canvas-system-icons-web": "^1.0.20",
+    "@workday/design-assets-types": "^0.2.4",
     "lodash": "^4.17.14"
   },
   "peerDependencies": {

--- a/modules/side-panel/react/stories/stories.tsx
+++ b/modules/side-panel/react/stories/stories.tsx
@@ -10,10 +10,10 @@ import {select, number} from '@storybook/addon-knobs';
 
 import {colors, type} from '@workday/canvas-kit-react-core';
 import README from '../README.md';
-import {SystemIcon} from '../../../icon/react/index';
-import {Header} from '../../../_labs/header/react/index';
-import {Button, IconButton} from '../../../button/react/index';
-import {AvatarButton} from '../../../avatar/react/index';
+import {SystemIcon} from '../../../icon/react';
+import {Header} from '../../../_labs/header/react';
+import {Button, IconButton} from '../../../button/react';
+import {AvatarButton} from '../../../avatar/react';
 import SidePanel from '../index';
 
 interface SidePanelState {

--- a/modules/side-panel/react/stories/stories.tsx
+++ b/modules/side-panel/react/stories/stories.tsx
@@ -10,10 +10,10 @@ import {select, number} from '@storybook/addon-knobs';
 
 import {colors, type} from '@workday/canvas-kit-react-core';
 import README from '../README.md';
-import {SystemIcon} from '@workday/canvas-kit-react-icon';
-import {Header} from '@workday/canvas-kit-labs-react-header';
-import {Button, IconButton} from '@workday/canvas-kit-react-button';
-import {AvatarButton} from '@workday/canvas-kit-react-avatar';
+import {SystemIcon} from '../../../icon/react/index';
+import {Header} from '../../../_labs/header/react/index';
+import {Button, IconButton} from '../../../button/react/index';
+import {AvatarButton} from '../../../avatar/react/index';
 import SidePanel from '../index';
 
 interface SidePanelState {

--- a/modules/skeleton/react/package.json
+++ b/modules/skeleton/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/status-indicator/react/package.json
+++ b/modules/status-indicator/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/status-indicator/react/package.json
+++ b/modules/status-indicator/react/package.json
@@ -44,5 +44,8 @@
     "@workday/canvas-kit-react-core": "^3.2.0",
     "@workday/canvas-kit-react-icon": "^3.3.0",
     "@workday/design-assets-types": "^0.2.4"
+  },
+  "devDependencies": {
+    "@workday/canvas-system-icons-web": "^1.0.20"
   }
 }

--- a/modules/switch/react/package.json
+++ b/modules/switch/react/package.json
@@ -23,7 +23,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/switch/react/package.json
+++ b/modules/switch/react/package.json
@@ -37,10 +37,9 @@
     "react": ">= 16.8 < 17"
   },
   "dependencies": {
-    "@emotion/core": "^10.0.21",
-    "@emotion/styled": "^10.0.17",
     "@workday/canvas-kit-labs-react-core": "^3.3.0",
     "@workday/canvas-kit-react-common": "^3.3.0",
-    "@workday/canvas-kit-react-core": "^3.2.0"
+    "@workday/canvas-kit-react-core": "^3.2.0",
+    "uuid": "^3.3.3"
   }
 }

--- a/modules/table/react/package.json
+++ b/modules/table/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/text-area/react/package.json
+++ b/modules/text-area/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/text-area/react/package.json
+++ b/modules/text-area/react/package.json
@@ -38,8 +38,6 @@
     "react": ">= 16.8 < 17"
   },
   "dependencies": {
-    "@emotion/core": "^10.0.21",
-    "@emotion/styled": "^10.0.17",
     "@workday/canvas-kit-labs-react-core": "^3.3.0",
     "@workday/canvas-kit-react-common": "^3.3.0",
     "@workday/canvas-kit-react-core": "^3.2.0"

--- a/modules/text-input/react/package.json
+++ b/modules/text-input/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/toast/react/package.json
+++ b/modules/toast/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/toast/react/stories/stories.tsx
+++ b/modules/toast/react/stories/stories.tsx
@@ -4,7 +4,7 @@ import {storiesOf} from '@storybook/react';
 import {exclamationCircleIcon} from '@workday/canvas-system-icons-web';
 import withReadme from 'storybook-readme/with-readme';
 
-import {colors} from '../../../core/react/index';
+import {colors} from '../../../core/react';
 import Toast from '../index';
 import README from '../README.md';
 

--- a/modules/tooltip/react/package.json
+++ b/modules/tooltip/react/package.json
@@ -24,7 +24,8 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/modules/tooltip/react/package.json
+++ b/modules/tooltip/react/package.json
@@ -42,5 +42,9 @@
     "@emotion/styled": "^10.0.17",
     "@workday/canvas-kit-react-common": "^3.3.0",
     "@workday/canvas-kit-react-core": "^3.2.0"
+  },
+  "devDependencies": {
+    "@material-ui/core": "^3.9.2",
+    "@workday/canvas-system-icons-web": "^1.0.20"
   }
 }

--- a/modules/tooltip/react/stories/stories.tsx
+++ b/modules/tooltip/react/stories/stories.tsx
@@ -5,7 +5,7 @@ import withReadme from 'storybook-readme/with-readme';
 import Popper from '@material-ui/core/Popper';
 import {xIcon} from '@workday/canvas-system-icons-web';
 
-import {IconButton} from '../../../button/react/index';
+import {IconButton} from '../../../button/react';
 import Tooltip from '../index';
 import README from '../README.md';
 

--- a/package.json
+++ b/package.json
@@ -136,7 +136,8 @@
     "test": "TZ=UTC jest",
     "bump": "lerna version",
     "cypress:open": "cypress open",
-    "cypress:run": "cypress run"
+    "cypress:run": "cypress run",
+    "depcheck": "./utils/check-dependencies-exist.js"
   },
   "config": {
     "commitizen": {
@@ -161,5 +162,8 @@
   "workspaces": [
     "modules/**"
   ],
-  "browserslist": "> 5%, last 2 firefox versions, last 2 chrome versions, last 2 safari versions, last 2 edge versions, ie 11"
+  "browserslist": "> 5%, last 2 firefox versions, last 2 chrome versions, last 2 safari versions, last 2 edge versions, ie 11",
+  "dependencies": {
+    "depcheck": "^0.9.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -122,6 +122,8 @@
     "start": "node --max-old-space-size=2048 node_modules/.bin/start-storybook -p 9001 -c .storybook",
     "watch": "TSC_NONPOLLING_WATCHER=1 lerna run watch --parallel --stream",
     "clean": "lerna run clean",
+    "depcheck": "lerna run depcheck",
+    "prebuild": "yarn depcheck",
     "build": "lerna run build",
     "build:rebuild": "lerna run build:rebuild",
     "create-module": "./utils/create-component/createComponent.js",
@@ -136,8 +138,7 @@
     "test": "TZ=UTC jest",
     "bump": "lerna version",
     "cypress:open": "cypress open",
-    "cypress:run": "cypress run",
-    "depcheck": "lerna run depcheck"
+    "cypress:run": "cypress run"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "cypress-pipe": "^1.5.0",
     "cypress-plugin-tab": "^1.0.3",
     "cz-conventional-changelog": "^2.1.0",
+    "depcheck": "^0.9.2",
     "emoji-js": "^3.4.1",
     "emotion-theming": "^10.0.10",
     "enzyme": "^3.6.0",
@@ -163,8 +164,5 @@
   "workspaces": [
     "modules/**"
   ],
-  "browserslist": "> 5%, last 2 firefox versions, last 2 chrome versions, last 2 safari versions, last 2 edge versions, ie 11",
-  "dependencies": {
-    "depcheck": "^0.9.2"
-  }
+  "browserslist": "> 5%, last 2 firefox versions, last 2 chrome versions, last 2 safari versions, last 2 edge versions, ie 11"
 }

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "bump": "lerna version",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
-    "depcheck": "./utils/check-dependencies-exist.js"
+    "depcheck": "lerna run depcheck"
   },
   "config": {
     "commitizen": {

--- a/utils/check-dependencies-exist.js
+++ b/utils/check-dependencies-exist.js
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const glob = require('glob');
+const colors = require('colors');
+const depCheck = require('depcheck');
+
+const depCheckOptions = {
+  ignoreMatches: [
+    '@testing-library/react',
+    '@storybook/react',
+    'storybook-readme',
+    '@storybook/addon-actions',
+    '@storybook/addon-knobs',
+    'enzyme',
+    'react-dom',
+    'jest-axe',
+    'jest-emotion',
+  ],
+};
+
+const labelMap = {
+  dependencies: {
+    label: 'unused dependency',
+    color: colors.yellow,
+  },
+  devDependencies: {
+    label: 'unused devDependency',
+    color: colors.yellow,
+  },
+  missing: {
+    label: 'missing dependency',
+    color: colors.red,
+  },
+  invalidFiles: {
+    label: 'error',
+    color: colors.red,
+  },
+  invalidDirs: {
+    label: 'error',
+    color: colors.red,
+  },
+};
+
+function formatErrorMessage(errors) {
+  return (
+    `${errors.file}\n` +
+    Object.keys(errors)
+      .map(key => {
+        if (key === 'file') return;
+
+        if (errors[key].constructor === Object) {
+          return Object.keys(errors[key])
+            .map(pkg =>
+              errors[key][pkg]
+                .map(
+                  errorFile =>
+                    `${labelMap[key].color(labelMap[key].label.padEnd(20))}  ${colors.cyan(
+                      pkg
+                    )}  ${colors.dim(errorFile)}`
+                )
+                .join('\n')
+            )
+            .join('\n');
+        } else {
+          return errors[key]
+            .map(
+              error =>
+                `${labelMap[key].color(labelMap[key].label.padEnd(20))}  ${colors.cyan(error)}`
+            )
+            .join('\n');
+        }
+      })
+      .join('\n')
+  );
+}
+
+const searchPath = `${path.resolve(__dirname)}/../modules/**/react`;
+
+glob(searchPath, undefined, function(er, modules) {
+  if (er) {
+    console.error('Could not find any modules/**/react/ folders');
+    return;
+  }
+
+  console.log(`\nChecking dependencies in ${colors.dim(searchPath)}...\n`);
+
+  const checks = [];
+
+  for (let reactModule of modules) {
+    checks.push(
+      new Promise((resolve, reject) => {
+        depCheck(reactModule, depCheckOptions, unused => {
+          const result = {
+            file: reactModule + '/package.json',
+          };
+
+          Object.keys(unused)
+            .filter(key => {
+              if (key === 'using') {
+                return false;
+              }
+              if (unused[key].constructor === Object) {
+                return Object.keys(unused[key]).length;
+              } else {
+                return unused[key].length;
+              }
+            })
+            .forEach(key => (result[key] = unused[key]));
+
+          resolve(result);
+          resolve(null);
+        });
+      })
+    );
+  }
+
+  Promise.all(checks)
+    .then(values => {
+      const realErrors = values.filter(v => Object.keys(v).length > 1); // Exclude when file is the only key
+      realErrors.forEach(errors => {
+        console.log(formatErrorMessage(errors) + '\n');
+      });
+      if (realErrors.length) {
+        process.exit(1);
+      }
+    })
+    .catch(error => {
+      console.error(error);
+    });
+});

--- a/utils/check-dependencies-exist.js
+++ b/utils/check-dependencies-exist.js
@@ -50,6 +50,21 @@ function formatErrorMessage(errors) {
         if (key === 'file') return;
 
         if (errors[key].constructor === Object) {
+          if (key.startsWith('invalid')) {
+            return Object.keys(errors[key])
+              .map(file => {
+                const line = errors[key][file].line;
+                const column = errors[key][file].column;
+                const message = errors[key][file].formatted;
+
+                return (
+                  labelMap[key].color(labelMap[key].label.padEnd(20)) +
+                  colors.dim(`  ${line}:${column}  `) +
+                  message
+                );
+              })
+              .join('\n');
+          }
           return Object.keys(errors[key])
             .map(pkg =>
               errors[key][pkg]

--- a/utils/create-component/templates/react/packageJson.js
+++ b/utils/create-component/templates/react/packageJson.js
@@ -26,7 +26,8 @@ module.exports = (name, moduleName, description, unstable) => `
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6"
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../${unstable ? '../' : ''}utils/check-dependencies-exist.js"
   },
   "keywords": [
     "canvas",

--- a/yarn.lock
+++ b/yarn.lock
@@ -598,6 +598,11 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.5.tgz#cbf45321619ac12d83363fcf9c94bb67fa646d71"
   integrity sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==
 
+"@babel/parser@^7.7.7":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.4.tgz#d1dbe64691d60358a974295fa53da074dd2ce8e8"
+  integrity sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==
+
 "@babel/plugin-proposal-async-generator-functions@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz#b289b306669dce4ad20b0252889a15768c9d417e"
@@ -4440,6 +4445,11 @@
   resolved "https://registry.yarnpkg.com/@types/chroma-js/-/chroma-js-1.4.3.tgz#4456e5cb46885a4952324e55a4b6d4064904790c"
   integrity sha512-m33zg9cRLtuaUSzlbMrr7iLIKNzrD4+M6Unt5+9mCu4BhR5NwnRjVKblINCwzcBXooukIgld8DtEncP8qpvbNg==
 
+"@types/color-name@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
+  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
 "@types/cypress-axe@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@types/cypress-axe/-/cypress-axe-0.4.0.tgz#670bc90f9f0000c97c6111ebdd55c6268456f28f"
@@ -5321,6 +5331,11 @@ ansi-regex@^4.0.0, ansi-regex@^4.1.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
+ansi-regex@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
+  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -5332,6 +5347,14 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
+
+ansi-styles@^4.0.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
+  integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
+  dependencies:
+    "@types/color-name" "^1.1.1"
+    color-convert "^2.0.1"
 
 ansi-to-html@^0.6.11:
   version "0.6.12"
@@ -6739,7 +6762,7 @@ builtin-modules@^1.1.1:
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
   integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
 
-builtin-modules@^3.1.0:
+builtin-modules@^3.0.0, builtin-modules@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.1.0.tgz#aad97c15131eb76b65b50ef208e7584cd76a7484"
   integrity sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==
@@ -7233,6 +7256,15 @@ cliui@^5.0.0:
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
 
+cliui@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
+  integrity sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^6.2.0"
+
 clone-deep@^0.2.4:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-0.2.4.tgz#4e73dd09e9fb971cc38670c5dced9c1896481cc6"
@@ -7305,12 +7337,19 @@ color-convert@^1.9.0, color-convert@^1.9.1:
   dependencies:
     color-name "1.1.3"
 
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@^1.0.0:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
@@ -8365,6 +8404,11 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
+de-indent@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
+  integrity sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=
+
 debounce@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
@@ -8539,6 +8583,29 @@ denodeify@^1.2.1:
   resolved "https://registry.yarnpkg.com/denodeify/-/denodeify-1.2.1.tgz#3a36287f5034e699e7577901052c2e6c94251631"
   integrity sha1-OjYof1A05pnnV3kBBSwubJQlFjE=
 
+depcheck@^0.9.2:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/depcheck/-/depcheck-0.9.2.tgz#9e3198b44a527836914c61ba5395479c62ecbaf4"
+  integrity sha512-w5f+lSZqLJJkk58s44eOd0Vor7hLZot4PlFL0y2JsIX5LuHQ2eAjHlDVeGBD4Mj6ZQSKakvKWRRCcPlvrdU2Sg==
+  dependencies:
+    "@babel/parser" "^7.7.7"
+    "@babel/traverse" "^7.7.4"
+    builtin-modules "^3.0.0"
+    camelcase "^5.3.1"
+    cosmiconfig "^5.2.1"
+    debug "^4.1.1"
+    deps-regex "^0.1.4"
+    js-yaml "^3.4.2"
+    lodash "^4.17.15"
+    minimatch "^3.0.2"
+    node-sass-tilde-importer "^1.0.2"
+    please-upgrade-node "^3.2.0"
+    require-package-name "^2.0.1"
+    resolve "^1.14.1"
+    vue-template-compiler "^2.6.11"
+    walkdir "^0.4.1"
+    yargs "^15.0.2"
+
 depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
@@ -8548,6 +8615,11 @@ deprecation@^2.0.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
+
+deps-regex@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/deps-regex/-/deps-regex-0.1.4.tgz#518667b7691460a5e7e0a341be76eb7ce8090184"
+  integrity sha1-UYZnt2kUYKXn4KNBvnbrfOgJAYQ=
 
 des.js@^1.0.0:
   version "1.0.0"
@@ -10052,7 +10124,7 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
-find-up@^4.0.0:
+find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
@@ -10951,7 +11023,7 @@ hastscript@^5.0.0:
     property-information "^5.0.1"
     space-separated-tokens "^1.0.0"
 
-he@1.2.x:
+he@1.2.x, he@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
@@ -12983,7 +13055,7 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@^3.13.1:
+js-yaml@^3.13.1, js-yaml@^3.4.2:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -14724,6 +14796,13 @@ node-releases@^1.1.42:
   dependencies:
     semver "^6.3.0"
 
+node-sass-tilde-importer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/node-sass-tilde-importer/-/node-sass-tilde-importer-1.0.2.tgz#1a15105c153f648323b4347693fdb0f331bad1ce"
+  integrity sha512-Swcmr38Y7uB78itQeBm3mThjxBy9/Ah/ykPIaURY/L6Nec9AyRoL/jJ7ECfMR+oZeCTVQNxVMu/aHU+TLRVbdg==
+  dependencies:
+    find-parent-dir "^0.3.0"
+
 node-sass@^4.12.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.12.0.tgz#0914f531932380114a30cc5fa4fa63233a25f017"
@@ -15696,6 +15775,13 @@ please-upgrade-node@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz#ed320051dfcc5024fae696712c8288993595e8ac"
   integrity sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==
+  dependencies:
+    semver-compare "^1.0.0"
+
+please-upgrade-node@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
+  integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
   dependencies:
     semver-compare "^1.0.0"
 
@@ -17876,6 +17962,11 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
+require-package-name@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/require-package-name/-/require-package-name-2.0.1.tgz#c11e97276b65b8e2923f75dabf5fb2ef0c3841b9"
+  integrity sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk=
+
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -17967,6 +18058,13 @@ resolve@^1.10.1, resolve@^1.11.1:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
   integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.14.1:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.0.tgz#1b7ca96073ebb52e741ffd799f6b39ea462c67f5"
+  integrity sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==
   dependencies:
     path-parse "^1.0.6"
 
@@ -19104,6 +19202,15 @@ string-width@^4.1.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^5.2.0"
 
+string-width@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
+  integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.0"
+
 string.prototype.matchall@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-3.0.1.tgz#5a9e0b64bcbeb336aa4814820237c2006985646d"
@@ -19185,6 +19292,13 @@ strip-ansi@^4.0.0:
   integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
+  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
+  dependencies:
+    ansi-regex "^5.0.0"
 
 strip-bom@3.0.0, strip-bom@^3.0.0:
   version "3.0.0"
@@ -20364,6 +20478,14 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.0.tgz#bd76d6a23323e2ca8ffa12028dc04559c75f9019"
   integrity sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==
 
+vue-template-compiler@^2.6.11:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.6.11.tgz#c04704ef8f498b153130018993e56309d4698080"
+  integrity sha512-KIq15bvQDrcCjpGjrAhx4mUlyyHfdmTaoNfeoATHLAiWB+MU3cx4lOzMwrnUh9cCxy0Lt1T11hAFY6TQgroUAA==
+  dependencies:
+    de-indent "^1.0.2"
+    he "^1.1.0"
+
 vuex@^3.1.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/vuex/-/vuex-3.1.2.tgz#a2863f4005aa73f2587e55c3fadf3f01f69c7d4d"
@@ -20389,6 +20511,11 @@ wait-for-expect@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.3.0.tgz#65241ce355425f907f5d127bdb5e72c412ff830c"
   integrity sha512-8fJU7jiA96HfGPt+P/UilelSAZfhMBJ52YhKzlmZQvKEZU2EcD1GQ0yqGB6liLdHjYtYAoGVigYwdxr5rktvzA==
+
+walkdir@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/walkdir/-/walkdir-0.4.1.tgz#dc119f83f4421df52e3061e514228a2db20afa39"
+  integrity sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ==
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"
@@ -20915,6 +21042,15 @@ wrap-ansi@^5.1.0:
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
 
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -21059,6 +21195,14 @@ yargs-parser@^13.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^16.1.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-16.1.0.tgz#73747d53ae187e7b8dbe333f95714c76ea00ecf1"
+  integrity sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.0.tgz#275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a"
@@ -21117,6 +21261,23 @@ yargs@^13.3.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.1"
+
+yargs@^15.0.2:
+  version "15.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.1.0.tgz#e111381f5830e863a89550bd4b136bb6a5f37219"
+  integrity sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^16.1.0"
 
 yargs@^7.0.0:
   version "7.1.0"


### PR DESCRIPTION
## Summary

This is a different take on https://github.com/Workday/canvas-kit/pull/293 using [depcheck](https://github.com/depcheck/depcheck).

Closes https://github.com/Workday/canvas-kit/issues/324

We occasionally don't catch missing dependencies in our package.json files. Due to how the mono repo works we do not notice this locally and we end up publishing packages that come with a `Module not found` error. This adds a utility script to check for missing and unused dependencies. I've added it as a script in our travis config so that it will run for PRs.

Note: I could not the scss checking to resolve properly so it thought all of our deps were unused. I think it may be something to do with the `~` imports. Will need to play with it a bit more.

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
![image](https://user-images.githubusercontent.com/908478/73486116-4e1e9980-4359-11ea-9ba6-44977508cf69.png)

