### PR TITLE
chore: Update Cypress/Storybook integration to use cypress-storybook

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,11 +1,8 @@
-import {configure, addDecorator, addParameters, forceReRender} from '@storybook/react';
+import {configure, addDecorator, addParameters} from '@storybook/react';
 import {DocsPage, DocsContainer} from '@storybook/addon-docs/blocks';
 import {withKnobs} from '@storybook/addon-knobs/react';
 import {create} from '@storybook/theming';
-import addons from '@storybook/addons';
-import Events from '@storybook/core-events';
-import {toId} from '@storybook/router';
-import ReactDOM from 'react-dom';
+import 'cypress-storybook/react';
 
 import {commonColors, typeColors, fontFamily} from '../modules/core/react';
 import {CanvasProviderDecorator, FontsDecorator} from '../utils/storybook';
@@ -78,18 +75,3 @@ addParameters({
 });
 
 configure(loadStories, module);
-
-function setCurrentStory(categorization, story) {
-  clearCurrentStory();
-  addons.getChannel().emit(Events.SET_CURRENT_STORY, {
-    storyId: toId(categorization, story),
-  });
-  forceReRender();
-}
-
-function clearCurrentStory() {
-  var root = document.querySelector('#root');
-  ReactDOM.unmountComponentAtNode(root);
-}
-
-window.setCurrentStory = setCurrentStory;

--- a/cypress/helpers/stories.ts
+++ b/cypress/helpers/stories.ts
@@ -1,18 +1,3 @@
-declare global {
-  interface Window {
-    /**
-     * Load a story. This will invoke the storybook router,
-     * unmount a previous story, mount the current story and force a rerender
-     * This should be in a `beforeEach` block to force a fresh new story
-     * @param categorization Categorization information found in the `.add` function - usually used for menu navigation
-     * @param story The specific story example in the `.add` function
-     * @example
-     * setCurrentStory('Button', 'Primary')
-     */
-    setCurrentStory(categorization: string, story: string);
-  }
-}
-
 /**
  * Load a story. This will invoke the storybook router,
  * unmount a previous story, mount the current story and force a rerender
@@ -23,24 +8,7 @@ declare global {
  * h.stories.load('Button', 'Primary')
  */
 export function load(categorization: string, story: string) {
-  const log = Cypress.log({
-    name: 'Load',
-    message: [categorization, story],
-    $el: Cypress.$('#root'),
-  });
-  log.snapshot('before');
-
-  cy.window({log: false}).then(win => {
-    const now = performance.now();
-    win.setCurrentStory(categorization.replace(/[|/]/g, '-').toLowerCase(), story.toLowerCase());
-    log.set('consoleProps', () => ({
-      categorization,
-      story,
-      renderTime: performance.now() - now,
-    }));
-    log.snapshot('after');
-    log.end();
-  });
+  return cy.loadStory(categorization, story);
 }
 
 /**
@@ -48,7 +16,7 @@ export function load(categorization: string, story: string) {
  * To load a story, use h.stories.load(storyName, variant)
  */
 export function visit() {
-  cy.visit('iframe.html');
+  cy.visitStorybook();
   cy.injectAxe();
   cy.configureAxe({
     rules: [

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -1,5 +1,6 @@
 import 'cypress-pipe';
 import 'cypress-plugin-tab';
 import 'cypress-axe';
+import 'cypress-storybook/cypress';
 
 import './commands';

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "cypress-axe": "^0.5.1",
     "cypress-pipe": "^1.5.0",
     "cypress-plugin-tab": "^1.0.3",
+    "cypress-storybook": "^0.0.1",
     "cz-conventional-changelog": "^2.1.0",
     "depcheck": "^0.9.2",
     "emoji-js": "^3.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8306,6 +8306,11 @@ cypress-plugin-tab@^1.0.3:
   dependencies:
     ally.js "^1.4.1"
 
+cypress-storybook@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/cypress-storybook/-/cypress-storybook-0.0.1.tgz#7d4ef220fd91d51444b1e9d4b24128c2f299d091"
+  integrity sha512-Ge28gvq/66kxhbkCbrKWUk/+5kBqFj7ayl63BYMVmn7JFXBLjodbWaq1OsRAhaaWkBJ3y/j48fV7PNOg+tlKug==
+
 cypress@^3.4.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-3.4.1.tgz#ca2e4e9864679da686c6a6189603efd409664c30"
@@ -17380,7 +17385,7 @@ react-textarea-autosize@^7.1.0:
     "@babel/runtime" "^7.1.2"
     prop-types "^15.6.0"
 
-react-transition-group@^2.2.1, react-transition-group@^2.5.0:
+react-transition-group@^2.2.1:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
   integrity sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==


### PR DESCRIPTION
## Summary

Other people could use our Storybook helpers in Cypress. Why not make it an open source library and dogfood it?

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

https://github.com/NicholasBoll/cypress-storybook
