### PR TITLE
ci: Add canary build script on master commit/merge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,7 @@ jobs:
       - yarn chromatic --auto-accept-changes --app-code="dlpro96xybh" # v1
       - yarn chromatic --auto-accept-changes # v2
       - yarn build-storybook
+      - npm config set //registry.npmjs.org/:_authToken=$NPM_PUBLISH_TOKEN && yarn lerna publish --yes --canary --preid next --pre-dist-tag next
     env:
       - CHROMATIC_APP_CODE="m1dh5kc7oj"
     deploy:


### PR DESCRIPTION
## Summary

To ensure consumers can test out hot fixes as soon as possible, we would like to introduce Canary builds for each merge to master. This will make every PR available immediately after its merged rather than waiting for our ~2 week release cycle. Hopefully this will also reduce the number of ad hoc releases we need to do.

### Version Format:

Rather than using tags to indicate the version like we do for release (because this would tag every commit on master), we will tie canary builds to commit SHAs using lerna's [`--canary`](https://github.com/lerna/lerna/tree/master/commands/publish#--canary) flag
- The default behavior is `3.3.3-alpha.7+eddbcc7` (where `7` is the index of the commit from the last release (`3.3.2`)). 
- We can configure `alpha` here, but nothing else. I recommend we use `next` instead (e.g. `3.3.3-next.7+eddbcc7`).
- This means we will have 3 different npm [dist-tags](https://docs.npmjs.com/cli/dist-tag): `latest` (latest stable version), `prerelease` (alpha/beta versions), `next` (canary builds)
