### PR TITLE
ci: Fix canary build null version error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
     - ~/.cache
 
 git:
-  depth: 3
+  depth: 50
 
 stages:
 - name: pull_request
@@ -70,7 +70,7 @@ jobs:
       - yarn chromatic --auto-accept-changes --app-code="dlpro96xybh" # v1
       - yarn chromatic --auto-accept-changes # v2
       - yarn build-storybook
-      - npm config set //registry.npmjs.org/:_authToken=$NPM_PUBLISH_TOKEN && yarn lerna publish --yes --canary --preid next --pre-dist-tag next
+      - npm config set //registry.npmjs.org/:_authToken=$NPM_PUBLISH_TOKEN && yarn lerna publish --yes --canary --preid next --dist-tag next
     env:
       - CHROMATIC_APP_CODE="m1dh5kc7oj"
     deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,16 +70,21 @@ jobs:
       - yarn chromatic --auto-accept-changes --app-code="dlpro96xybh" # v1
       - yarn chromatic --auto-accept-changes # v2
       - yarn build-storybook
-      - npm config set //registry.npmjs.org/:_authToken=$NPM_PUBLISH_TOKEN && yarn lerna publish --yes --canary --preid next --dist-tag next
+      - yarn build
     env:
       - CHROMATIC_APP_CODE="m1dh5kc7oj"
     deploy:
-      provider: pages
-      skip_cleanup: true
-      local_dir: docs
-      github_token: "$GH_STORYBOOK_TOKEN"
-      on:
-        branch: master
+      - provider: script
+        script: npm config set //registry.npmjs.org/:_authToken=$NPM_PUBLISH_TOKEN && yarn lerna publish --yes --canary --preid next --dist-tag next
+        skip_cleanup: true
+        on:
+          tags: true
+      - provider: pages
+        skip_cleanup: true
+        local_dir: docs
+        github_token: "$GH_STORYBOOK_TOKEN"
+        on:
+          branch: master
 
 env:
   global:


### PR DESCRIPTION
## Summary

#443 added support for Canary builds, but it has an issue (see https://github.com/lerna/lerna/issues/1769). When determining the previous version to base the canary version off of, [for some reason Lerna uses `git describe` instead of looking at `lerna.json`](https://github.com/lerna/lerna/issues/1769#issuecomment-522847704). Since Travis performs a shallow git clone (currently at a depth of 3), it only checks out the latest 3 commits. When `git describe` can't find a tag from a previous release within those 3 commits, it returns `null`, which causes Lerna to attempt to use the version `null-next.2+cebbd9c` and subsequently fail.

This PR extends the depth of the Travis repo clone to 50 ([the maximum](https://docs.travis-ci.com/user/customizing-the-build#git-clone-depth)). 

**Note: this means that if we have merged >50 PRs since the last release, the canary build on the next merge to master will fail.** We could set `depth: false`, but that would cause the entire history to be cloned. I figured >50 PRs between releases wouldn't be likely so I stuck with this to preserve some build speed.