### PR TITLE
ci: Run canary publish on master commit instead of tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ jobs:
         script: npm config set //registry.npmjs.org/:_authToken=$NPM_PUBLISH_TOKEN && yarn lerna publish --yes --canary --preid next --dist-tag next
         skip_cleanup: true
         on:
-          tags: true
+          branch: master
       - provider: pages
         skip_cleanup: true
         local_dir: docs


### PR DESCRIPTION
In #444 I accidentally instructed Travis to run on tag instead of on commit to the master branch. This should get the canary publish running.