### PR TITLE
ci: Force publish all modules for canary builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
     - ~/.cache
 
 git:
-  depth: 50
+  depth: 3
 
 stages:
 - name: pull_request
@@ -75,7 +75,7 @@ jobs:
       - CHROMATIC_APP_CODE="m1dh5kc7oj"
     deploy:
       - provider: script
-        script: npm config set //registry.npmjs.org/:_authToken=$NPM_PUBLISH_TOKEN && yarn lerna publish --yes --canary --preid next --dist-tag next
+        script: npm config set //registry.npmjs.org/:_authToken=$NPM_PUBLISH_TOKEN && yarn lerna publish --yes --force-publish="*" --canary --preid next --dist-tag next
         skip_cleanup: true
         on:
           branch: master


### PR DESCRIPTION
## Summary

After struggling to get the version checks to work properly with `lerna publish --canary` and discussing how we'd like to publish canary modules, we've decided to force publish everything rather than only doing canary builds of the modules that have changed since the last release. This PR utilizes the `--force-publish` flag to accomplish this.