### PR TITLE
ci: Disable git clone depth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
     - ~/.cache
 
 git:
-  depth: 3
+  depth: false
 
 stages:
 - name: pull_request


### PR DESCRIPTION
With `--force-publish` for lerna canary builds, we still need the history to determine the next version to use. This removes the clone depth entirely as discussed.