### PR TITLE
docs: Fix broken link on  ComboBox Readme

### DIFF
--- a/modules/_labs/combobox/react/README.md
+++ b/modules/_labs/combobox/react/README.md
@@ -24,8 +24,8 @@ See here for
 
 ```tsx
 import {MenuItem} from '@workday/canvas-kit-labs-react-menu';
-import {TextInput} from '@workday/canvas-kit-labs-react-text-input';
-import {FormField} from '@workday/canvas-kit-labs-react-form-field';
+import {TextInput} from '@workday/canvas-kit-react-text-input';
+import {FormField} from '@workday/canvas-kit-react-form-field';
 
 const autocompleteCallback = event => console.log('Adjust menu items here')
 

--- a/modules/_labs/combobox/react/README.md
+++ b/modules/_labs/combobox/react/README.md
@@ -4,7 +4,7 @@
   <img src="https://img.shields.io/badge/UNSTABLE-alpha-orange" alt="UNSTABLE: Alpha" />
 </a>  This component is work in progress and currently in pre-release.
 
-For a full suite of examples, have a look at the [Combobox Stories](./stories.tsx).
+For a full suite of examples, have a look at the [Combobox Stories](./stories/stories.tsx).
 
 ## Installation
 
@@ -14,8 +14,8 @@ yarn add @workday/canvas-kit-labs-react-combobox
 
 ## Accessibility
 
-This module uses the ARIA 1.0 Combobox spec.
-The newer ARIA 1.1 spec does not have full browser/screenreader support yet.
+This module uses the ARIA 1.0 Combobox spec. The newer ARIA 1.1 spec does not have full
+browser/screenreader support yet.
 
 See here for
 [differences between ARIA 1.0 and 1.1](https://www.levelaccess.com/differences-aria-1-0-1-1-changes-rolecombobox/)
@@ -23,7 +23,6 @@ See here for
 ## Usage
 
 ```tsx
-import {SearchBar} from '@workday/canvas-kit-labs-react-header';
 import {MenuItem} from '@workday/canvas-kit-labs-react-menu';
 import {TextInput} from '@workday/canvas-kit-labs-react-text-input';
 import {FormField} from '@workday/canvas-kit-labs-react-form-field';

--- a/modules/_labs/combobox/react/README.md
+++ b/modules/_labs/combobox/react/README.md
@@ -34,8 +34,8 @@ const autocompleteCallback = event => console.log('Adjust menu items here')
   <Combobox
     autocompleteItems={[<MenuItem>Item 1</MenuItem>]}
     onChange={autocompleteCallback}
-    onFocus={action(`Focus`)}
-    onBlur={action(`Blur`)}
+    onFocus={() => { console.log('focus') }}
+    onBlur={(} => { console.log('blur') }
   />
     <TextInput placeholder="Autocomplete" autoFocus={true} />
   </Combobox>

--- a/modules/_labs/combobox/react/README.md
+++ b/modules/_labs/combobox/react/README.md
@@ -23,20 +23,20 @@ See here for
 ## Usage
 
 ```tsx
+import {Combobox} from '@workday/canvas-kit-labs-react-combobox';
 import {MenuItem} from '@workday/canvas-kit-labs-react-menu';
 import {TextInput} from '@workday/canvas-kit-react-text-input';
 import {FormField} from '@workday/canvas-kit-react-form-field';
 
 const autocompleteCallback = event => console.log('Adjust menu items here')
 
-
 <FormField id='id-123' label='Example'>
   <Combobox
     autocompleteItems={[<MenuItem>Item 1</MenuItem>]}
     onChange={autocompleteCallback}
     onFocus={() => { console.log('focus') }}
-    onBlur={(} => { console.log('blur') }
-  />
+    onBlur={() => { console.log('blur') }}
+  >
     <TextInput placeholder="Autocomplete" autoFocus={true} />
   </Combobox>
 </FormField>


### PR DESCRIPTION
## Summary

The stories link on the Readme is pointing to the wrong location for stories

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] code has been documented and, if applicable, usage described in README.md
