### PR TITLE
feat(checkbox): Add theming support

### DIFF
--- a/modules/_labs/core/react/lib/theming/useTheme.ts
+++ b/modules/_labs/core/react/lib/theming/useTheme.ts
@@ -23,7 +23,7 @@ export function useTheme(theme?: Object): CanvasTheme {
 
   try {
     const context = React.useContext(ThemeContext);
-    if (context) {
+    if (context && Object.entries(context).length !== 0) {
       return context as CanvasTheme;
     }
   } catch (e) {

--- a/modules/checkbox/react/lib/Checkbox.tsx
+++ b/modules/checkbox/react/lib/Checkbox.tsx
@@ -107,8 +107,10 @@ const CheckboxInput = styled('input')<CheckboxProps>(
     },
 
     // States
-    '&:not(:checked):not(:disabled):not(:focus):hover ~ div:first-of-type': {
-      borderColor: inputColors.hoverBorder,
+    '&:not(:checked):not(:disabled):not(:focus):hover, &:not(:checked):not(:disabled):active': {
+      '~ div:first-of-type': {
+        borderColor: inputColors.hoverBorder,
+      },
     },
     '&:checked ~ div:first-of-type': {
       borderColor: theme.palette.primary.main,
@@ -140,7 +142,7 @@ const CheckboxInput = styled('input')<CheckboxProps>(
     },
     ...mouseFocusBehavior({
       '&:focus ~ div:first-of-type': {
-        border: `1px solid ${inputColors.border}`,
+        border: `1px solid ${inputColors.hoverBorder}`,
         boxShadow: 'none',
         '& span': {
           marginLeft: '-6px',
@@ -193,8 +195,10 @@ const CheckboxInput = styled('input')<CheckboxProps>(
         border: `1px solid ${errorRingColor}`,
         boxShadow: `0 0 0 1px ${errorRingColor}, 0 0 0 2px ${errorRingBorderColor}`,
       },
-      '&:not(:checked):not(:disabled):not(:focus):hover ~ div:first-of-type': {
-        borderColor: errorRingColor,
+      '&:not(:checked):not(:disabled):not(:focus):hover, &:not(:checked):not(:disabled):active': {
+        '~ div:first-of-type': {
+          borderColor: errorRingColor,
+        },
       },
       '&:checked ~ div:first-of-type': {
         borderColor: theme.palette.primary.main,

--- a/modules/checkbox/react/lib/Checkbox.tsx
+++ b/modules/checkbox/react/lib/Checkbox.tsx
@@ -1,11 +1,6 @@
 import * as React from 'react';
 import {styled, Themeable} from '@workday/canvas-kit-labs-react-core';
-import {
-  ErrorType,
-  focusRing,
-  themedFocusRing,
-  mouseFocusBehavior,
-} from '@workday/canvas-kit-react-common';
+import {ErrorType, themedFocusRing, mouseFocusBehavior} from '@workday/canvas-kit-react-common';
 import canvas, {
   borderRadius,
   colors,

--- a/modules/checkbox/react/lib/Checkbox.tsx
+++ b/modules/checkbox/react/lib/Checkbox.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import {styled, Themeable} from '@workday/canvas-kit-labs-react-core';
-import {ErrorType, focusRing, mouseFocusBehavior} from '@workday/canvas-kit-react-common';
+import {
+  ErrorType,
+  focusRing,
+  themedFocusRing,
+  mouseFocusBehavior,
+} from '@workday/canvas-kit-react-common';
 import canvas, {
   borderRadius,
   colors,
@@ -128,7 +133,7 @@ const CheckboxInput = styled('input')<CheckboxProps>(
       boxShadow: 'none',
     },
     '&:checked:focus ~ div:first-of-type': {
-      ...focusRing(2, 2, false),
+      ...themedFocusRing(theme, {width: 2, separation: 2, animate: false}),
       '& span': {
         marginLeft: '-7px',
       },

--- a/modules/checkbox/react/lib/Checkbox.tsx
+++ b/modules/checkbox/react/lib/Checkbox.tsx
@@ -87,7 +87,7 @@ const CheckboxInputWrapper = styled('div')<Pick<CheckboxProps, 'disabled'>>({
  * and was easier to use than a component selector in this case.
  */
 const CheckboxInput = styled('input')<CheckboxProps>(
-  {
+  ({theme}) => ({
     borderRadius: borderRadius.s,
     width: checkboxTapArea,
     height: checkboxTapArea,
@@ -106,16 +106,16 @@ const CheckboxInput = styled('input')<CheckboxProps>(
       borderColor: inputColors.hoverBorder,
     },
     '&:checked ~ div:first-of-type': {
-      borderColor: colors.blueberry400,
-      backgroundColor: colors.blueberry400,
+      borderColor: theme.palette.primary.main,
+      backgroundColor: theme.palette.primary.main,
     },
     '&:disabled ~ div:first-of-type': {
       borderColor: inputColors.disabled.border,
       backgroundColor: inputColors.disabled.background,
     },
     '&:disabled:checked ~ div:first-of-type': {
-      borderColor: colors.blueberry200,
-      backgroundColor: colors.blueberry200,
+      borderColor: theme.palette.primary.light,
+      backgroundColor: theme.palette.primary.light,
     },
 
     // Focus
@@ -123,7 +123,7 @@ const CheckboxInput = styled('input')<CheckboxProps>(
       outline: 'none',
     },
     '&:focus ~ div:first-of-type': {
-      borderColor: colors.blueberry400,
+      borderColor: theme.palette.primary.main,
       borderWidth: '2px',
       boxShadow: 'none',
     },
@@ -142,14 +142,14 @@ const CheckboxInput = styled('input')<CheckboxProps>(
         },
       },
       '&:checked ~ div:first-of-type': {
-        borderColor: colors.blueberry400,
+        borderColor: theme.palette.primary.main,
       },
       '&:disabled:checked ~ div:first-of-type': {
-        borderColor: colors.blueberry200,
-        backgroundColor: colors.blueberry200,
+        borderColor: theme.palette.primary.light,
+        backgroundColor: theme.palette.primary.light,
       },
     }),
-  },
+  }),
 
   // Ripple
   {
@@ -170,15 +170,15 @@ const CheckboxInput = styled('input')<CheckboxProps>(
       boxShadow: disabled ? undefined : `0 0 0 ${rippleRadius}px ${colors.soap200}`,
     },
   }),
-  ({error}) => {
+  ({theme, error}) => {
     let errorRingColor;
     let errorRingBorderColor = 'transparent';
 
     if (error === ErrorType.Error) {
-      errorRingColor = inputColors.error.border;
+      errorRingColor = theme.palette.error.main;
     } else if (error === ErrorType.Alert) {
-      errorRingColor = inputColors.warning.border;
-      errorRingBorderColor = colors.cantaloupe600;
+      errorRingColor = theme.palette.alert.main;
+      errorRingBorderColor = theme.palette.alert.darkest;
     } else {
       return;
     }
@@ -192,7 +192,7 @@ const CheckboxInput = styled('input')<CheckboxProps>(
         borderColor: errorRingColor,
       },
       '&:checked ~ div:first-of-type': {
-        borderColor: colors.blueberry400,
+        borderColor: theme.palette.primary.main,
         boxShadow: `
             0 0 0 2px ${colors.frenchVanilla100},
             0 0 0 4px ${errorRingColor},

--- a/modules/common/react/index.ts
+++ b/modules/common/react/index.ts
@@ -1,4 +1,4 @@
-export {default as focusRing} from './lib/styles/focusRing';
+export {default as focusRing, themedFocusRing} from './lib/styles/focusRing';
 export {default as errorRing} from './lib/styles/errorRing';
 export {default as accessibleHide} from './lib/styles/accessibleHide';
 export {default as hideMouseFocus, mouseFocusBehavior} from './lib/styles/hideMouseFocus';

--- a/modules/common/react/lib/styles/focusRing.ts
+++ b/modules/common/react/lib/styles/focusRing.ts
@@ -1,5 +1,6 @@
 import {keyframes, CSSObject} from '@emotion/core';
 import canvas from '@workday/canvas-kit-react-core';
+import {CanvasTheme} from '@workday/canvas-kit-labs-react-core';
 import memoize from 'lodash/memoize';
 
 type FocusRingParams = {
@@ -43,12 +44,12 @@ export const memoizedFocusRing = memoize(calculateFocusRing, (...args) => JSON.s
 
 /**
  * A utility to create a canvas style focus ring around your widget.
- * By default, this mixin will create a 1px focus ring tightly wrapped
- * to the widget (no whitespace).
+ * By default, this mixin will create a 2px focus ring tightly wrapped
+ * to the container (no whitespace).
  *
  * @param ringWidth        Allows the user to specify the thickness in px of the focus ring.
  * @param separationWidth  Allows the user to define the width in px of the whitespace
- *                         that there should be between the widget and the focus ring.
+ *                         that there should be between the component and the focus ring.
  * @param animate          Set property to false to opt out of the standard grow out of the middle animation
  * @param inset            Determines whether or not the focus ring is inset
  * @param innerShadowColor Allows the user to specify the inner shadow color
@@ -79,4 +80,51 @@ export default function focusRing(
   }
 
   return calculateFocusRing(argsToPass);
+}
+
+interface ThemedFocusRingOptions {
+  width?: number;
+  separation?: number;
+  animate?: boolean;
+  inset?: boolean;
+  innerColor?: string;
+  outerColor?: string;
+  memoize?: boolean;
+}
+
+/**
+ * A utility to create a canvas style focus ring around your widget.
+ * By default, this mixin will create a 2px focus ring tightly wrapped
+ * to the container (no whitespace).
+ *
+ * @returns {CSSObject} the css object for the focus ring style
+ */
+export function themedFocusRing(
+  theme: CanvasTheme,
+  options: ThemedFocusRingOptions = {}
+): CSSObject {
+  const {
+    width = 2,
+    separation = 0,
+    animate = true,
+    inset = false,
+    innerColor = canvas.colors.frenchVanilla100,
+    outerColor = theme.palette.common.focusOutline,
+    memoize = true,
+  } = options;
+
+  const args: FocusRingParams = {
+    ringWidth: width,
+    separationWidth: separation,
+    innerShadowColor: innerColor,
+    outerShadowColor: outerColor,
+    animate,
+    inset,
+  };
+
+  if (memoize) {
+    return memoizedFocusRing(args);
+  }
+
+  return calculateFocusRing(args);
 }

--- a/modules/form-field/react/stories/stories_Checkbox.tsx
+++ b/modules/form-field/react/stories/stories_Checkbox.tsx
@@ -7,6 +7,7 @@ import {
   ControlledComponentWrapper,
   ComponentStatesTable,
   permutateProps,
+  customColorTheme,
 } from '../../../../utils/storybook';
 
 import {Checkbox} from '../../../checkbox/react';
@@ -175,7 +176,7 @@ storiesOf('Components|Inputs/Checkbox/React/Visual Testing', module)
   .add('States', () => <CheckboxStates />)
   .addParameters({
     canvasProviderDecorator: {
-      showCustomThemePalette: true,
+      theme: customColorTheme,
     },
   })
   .add('Theming', () => <CheckboxStates />);

--- a/modules/form-field/react/stories/stories_Checkbox.tsx
+++ b/modules/form-field/react/stories/stories_Checkbox.tsx
@@ -118,56 +118,64 @@ storiesOf('Components|Inputs/Checkbox/React/Left Label', module)
     </FormField>
   ));
 
+const CheckboxStates = () => (
+  <StaticStates>
+    <ComponentStatesTable
+      rowProps={permutateProps(
+        {
+          checked: [{value: true, label: 'Checked'}, {value: false, label: 'Unchecked'}],
+          indeterminate: [{value: true, label: 'Indeterminate'}, {value: false, label: ''}],
+          error: [
+            {value: undefined, label: ''},
+            {value: Checkbox.ErrorType.Alert, label: 'Alert'},
+            {value: Checkbox.ErrorType.Error, label: 'Error'},
+          ],
+        },
+        props => {
+          if (props.indeterminate && !props.checked) {
+            return false;
+          }
+          return true;
+        }
+      )}
+      columnProps={permutateProps(
+        {
+          className: [
+            {label: 'Default', value: ''},
+            {label: 'Hover', value: 'hover'},
+            {label: 'Focus', value: 'focus'},
+            {label: 'Focus Hover', value: 'focus hover'},
+            {label: 'Active', value: 'active'},
+            {label: 'Active Hover', value: 'active hover'},
+          ],
+          disabled: [{label: '', value: false}, {label: 'Disabled', value: true}],
+        },
+        props => {
+          if (props.disabled && !['', 'hover'].includes(props.className)) {
+            return false;
+          }
+          return true;
+        }
+      )}
+    >
+      {props => (
+        <Checkbox
+          {...props}
+          onChange={() => {}} // eslint-disable-line no-empty-function
+          label="Checkbox"
+        />
+      )}
+    </ComponentStatesTable>
+  </StaticStates>
+);
+
 storiesOf('Components|Inputs/Checkbox/React/Visual Testing', module)
   .addParameters({component: Checkbox})
   .addDecorator(withReadme(README))
-  .add('States', () => (
-    <StaticStates>
-      <ComponentStatesTable
-        rowProps={permutateProps(
-          {
-            checked: [{value: true, label: 'Checked'}, {value: false, label: 'Unchecked'}],
-            indeterminate: [{value: true, label: 'Indeterminate'}, {value: false, label: ''}],
-            error: [
-              {value: undefined, label: ''},
-              {value: Checkbox.ErrorType.Alert, label: 'Alert'},
-              {value: Checkbox.ErrorType.Error, label: 'Error'},
-            ],
-          },
-          props => {
-            if (props.indeterminate && !props.checked) {
-              return false;
-            }
-            return true;
-          }
-        )}
-        columnProps={permutateProps(
-          {
-            className: [
-              {label: 'Default', value: ''},
-              {label: 'Hover', value: 'hover'},
-              {label: 'Focus', value: 'focus'},
-              {label: 'Focus Hover', value: 'focus hover'},
-              {label: 'Active', value: 'active'},
-              {label: 'Active Hover', value: 'active hover'},
-            ],
-            disabled: [{label: '', value: false}, {label: 'Disabled', value: true}],
-          },
-          props => {
-            if (props.disabled && !['', 'hover'].includes(props.className)) {
-              return false;
-            }
-            return true;
-          }
-        )}
-      >
-        {props => (
-          <Checkbox
-            {...props}
-            onChange={() => {}} // eslint-disable-line no-empty-function
-            label="Checkbox"
-          />
-        )}
-      </ComponentStatesTable>
-    </StaticStates>
-  ));
+  .add('States', () => <CheckboxStates />)
+  .addParameters({
+    canvasProviderDecorator: {
+      showCustomThemePalette: true,
+    },
+  })
+  .add('Theming', () => <CheckboxStates />);


### PR DESCRIPTION
## Summary

We're adding theming to our inputs. The consumer must wrap their components in a `CanvasProvider` and then they can pass their custom theme to any child components through the `theme` prop.

Partially addresses #358 

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)
