### PR TITLE
ci: Announce canary builds on slack

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,6 @@ insert_final_newline = true
 trim_trailing_whitespace = false
 
 # 2 space indentation
-[*.{html,css,scss,js,ts,tsx,json,md}]
+[*.{html,css,scss,js,ts,tsx,json,md,yml}]
 indent_style = space
 indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,9 @@ jobs:
       - yarn build
     deploy:
       provider: script
-      script: npm config set //registry.npmjs.org/:_authToken=$NPM_PUBLISH_TOKEN && yarn lerna publish from-package --yes --pre-dist-tag prerelease
+      script:
+			  - npm config set //registry.npmjs.org/:_authToken=$NPM_PUBLISH_TOKEN
+				- yarn lerna publish from-package --yes --pre-dist-tag prerelease
       skip_cleanup: true
       on:
         tags: true
@@ -75,7 +77,12 @@ jobs:
       - CHROMATIC_APP_CODE="m1dh5kc7oj"
     deploy:
       - provider: script
-        script: npm config set //registry.npmjs.org/:_authToken=$NPM_PUBLISH_TOKEN && yarn lerna publish --yes --force-publish="*" --canary --preid next --dist-tag next
+        script:
+          - npm config set //registry.npmjs.org/:_authToken=$NPM_PUBLISH_TOKEN
+          - yarn lerna publish --yes --force-publish="*" --canary --preid next --dist-tag next
+          - git rev-parse --short HEAD | read sha
+          - node utils/get-lerna-version.js | read version
+          - curl -X POST --data-urlencode "payload={\"text\": \"*New canary build published from <https://github.com/Workday/canvas-kit/commit/$sha|merge commit $sha> (v$version)*\n\n\`yarn add @workday/canvas-kit-{module}@$version\`\nor\n\`yarn add @workday/canvas-kit-{module}@next\`\"}" $SLACK_WEBHOOK
         skip_cleanup: true
         on:
           branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,8 +61,8 @@ jobs:
     deploy:
       provider: script
       script:
-			  - npm config set //registry.npmjs.org/:_authToken=$NPM_PUBLISH_TOKEN
-				- yarn lerna publish from-package --yes --pre-dist-tag prerelease
+        - npm config set //registry.npmjs.org/:_authToken=$NPM_PUBLISH_TOKEN
+        - yarn lerna publish from-package --yes --pre-dist-tag prerelease
       skip_cleanup: true
       on:
         tags: true

--- a/utils/get-lerna-version.js
+++ b/utils/get-lerna-version.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const pkg = require(path.resolve(__dirname, '../lerna.json'));
+console.log(pkg.version);


### PR DESCRIPTION
## Summary

Give us a notification in slack when a canary build has been published so we don't have to check the Travis logs

Example format (incorrect version no):

**New canary build published from [merge commit 6ead127](https://github.com/Workday/canvas-kit/commit/6ead127) (v3.3.2)**
`yarn add @workday/canvas-kit-{module}@3.3.2`
or
`yarn add @workday/canvas-kit-{module}@next`