### PR TITLE
feat(text-area): Add theming support

### DIFF
--- a/modules/form-field/react/stories/stories_TextArea.tsx
+++ b/modules/form-field/react/stories/stories_TextArea.tsx
@@ -3,7 +3,12 @@ import * as React from 'react';
 import {storiesOf} from '@storybook/react';
 import withReadme from 'storybook-readme/with-readme';
 import {StaticStates} from '@workday/canvas-kit-labs-react-core';
-import {controlComponent, ComponentStatesTable, permutateProps} from '../../../../utils/storybook';
+import {
+  controlComponent,
+  ComponentStatesTable,
+  permutateProps,
+  customColorTheme,
+} from '../../../../utils/storybook';
 
 import {TextArea} from '../../../text-area/react';
 import FormField from '../index';
@@ -11,6 +16,56 @@ import README from '../../../text-area/react/README.md';
 
 const hintText = 'Helpful text goes here.';
 const hintId = 'error-desc-id';
+const TextAreaStates = () => (
+  <StaticStates>
+    <ComponentStatesTable
+      rowProps={permutateProps(
+        {
+          value: [{value: 'Input value', label: 'With Value'}, {value: '', label: 'No Value'}],
+          placeholder: [{value: 'Placeholder', label: 'Placeholder'}],
+          error: [
+            {value: undefined, label: ''},
+            {value: TextArea.ErrorType.Alert, label: 'Alert'},
+            {value: TextArea.ErrorType.Error, label: 'Error'},
+          ],
+        },
+        props => {
+          if (props.value === '' && !props.placeholder) {
+            return false;
+          }
+          return true;
+        }
+      )}
+      columnProps={permutateProps(
+        {
+          className: [
+            {label: 'Default', value: ''},
+            {label: 'Hover', value: 'hover'},
+            {label: 'Focus', value: 'focus'},
+            {label: 'Focus Hover', value: 'focus hover'},
+            {label: 'Active', value: 'active'},
+            {label: 'Active Hover', value: 'active hover'},
+          ],
+          disabled: [{label: '', value: false}, {label: 'Disabled', value: true}],
+        },
+        props => {
+          if (props.disabled && !['', 'hover'].includes(props.className)) {
+            return false;
+          }
+          return true;
+        }
+      )}
+    >
+      {props => (
+        <TextArea
+          {...props}
+          style={{minWidth: 60, width: 100}}
+          onChange={() => {}} // eslint-disable-line no-empty-function
+        />
+      )}
+    </ComponentStatesTable>
+  </StaticStates>
+);
 
 storiesOf('Components|Inputs/TextArea/React/Top Label', module)
   .addParameters({component: TextArea})
@@ -161,53 +216,10 @@ storiesOf('Components|Inputs/TextArea/React/Left Label', module)
 storiesOf('Components|Inputs/TextArea/React/Visual Testing', module)
   .addParameters({component: TextArea})
   .addDecorator(withReadme(README))
-  .add('States', () => (
-    <StaticStates>
-      <ComponentStatesTable
-        rowProps={permutateProps(
-          {
-            value: [{value: 'Input value', label: 'With Value'}, {value: '', label: 'No Value'}],
-            placeholder: [{value: 'Placeholder', label: 'Placeholder'}],
-            error: [
-              {value: undefined, label: ''},
-              {value: TextArea.ErrorType.Alert, label: 'Alert'},
-              {value: TextArea.ErrorType.Error, label: 'Error'},
-            ],
-          },
-          props => {
-            if (props.value === '' && !props.placeholder) {
-              return false;
-            }
-            return true;
-          }
-        )}
-        columnProps={permutateProps(
-          {
-            className: [
-              {label: 'Default', value: ''},
-              {label: 'Hover', value: 'hover'},
-              {label: 'Focus', value: 'focus'},
-              {label: 'Focus Hover', value: 'focus hover'},
-              {label: 'Active', value: 'active'},
-              {label: 'Active Hover', value: 'active hover'},
-            ],
-            disabled: [{label: '', value: false}, {label: 'Disabled', value: true}],
-          },
-          props => {
-            if (props.disabled && !['', 'hover'].includes(props.className)) {
-              return false;
-            }
-            return true;
-          }
-        )}
-      >
-        {props => (
-          <TextArea
-            {...props}
-            style={{minWidth: 60, width: 100}}
-            onChange={() => {}} // eslint-disable-line no-empty-function
-          />
-        )}
-      </ComponentStatesTable>
-    </StaticStates>
-  ));
+  .add('States', () => <TextAreaStates />)
+  .addParameters({
+    canvasProviderDecorator: {
+      theme: customColorTheme,
+    },
+  })
+  .add('Theming', () => <TextAreaStates />);

--- a/modules/form-field/react/stories/stories_TextArea.tsx
+++ b/modules/form-field/react/stories/stories_TextArea.tsx
@@ -16,56 +16,6 @@ import README from '../../../text-area/react/README.md';
 
 const hintText = 'Helpful text goes here.';
 const hintId = 'error-desc-id';
-const TextAreaStates = () => (
-  <StaticStates>
-    <ComponentStatesTable
-      rowProps={permutateProps(
-        {
-          value: [{value: 'Input value', label: 'With Value'}, {value: '', label: 'No Value'}],
-          placeholder: [{value: 'Placeholder', label: 'Placeholder'}],
-          error: [
-            {value: undefined, label: ''},
-            {value: TextArea.ErrorType.Alert, label: 'Alert'},
-            {value: TextArea.ErrorType.Error, label: 'Error'},
-          ],
-        },
-        props => {
-          if (props.value === '' && !props.placeholder) {
-            return false;
-          }
-          return true;
-        }
-      )}
-      columnProps={permutateProps(
-        {
-          className: [
-            {label: 'Default', value: ''},
-            {label: 'Hover', value: 'hover'},
-            {label: 'Focus', value: 'focus'},
-            {label: 'Focus Hover', value: 'focus hover'},
-            {label: 'Active', value: 'active'},
-            {label: 'Active Hover', value: 'active hover'},
-          ],
-          disabled: [{label: '', value: false}, {label: 'Disabled', value: true}],
-        },
-        props => {
-          if (props.disabled && !['', 'hover'].includes(props.className)) {
-            return false;
-          }
-          return true;
-        }
-      )}
-    >
-      {props => (
-        <TextArea
-          {...props}
-          style={{minWidth: 60, width: 100}}
-          onChange={() => {}} // eslint-disable-line no-empty-function
-        />
-      )}
-    </ComponentStatesTable>
-  </StaticStates>
-);
 
 storiesOf('Components|Inputs/TextArea/React/Top Label', module)
   .addParameters({component: TextArea})
@@ -212,6 +162,57 @@ storiesOf('Components|Inputs/TextArea/React/Left Label', module)
       {controlComponent(<TextArea placeholder="Placeholder" />)}
     </FormField>
   ));
+
+const TextAreaStates = () => (
+  <StaticStates>
+    <ComponentStatesTable
+      rowProps={permutateProps(
+        {
+          value: [{value: 'Input value', label: 'With Value'}, {value: '', label: 'No Value'}],
+          placeholder: [{value: 'Placeholder', label: 'Placeholder'}],
+          error: [
+            {value: undefined, label: ''},
+            {value: TextArea.ErrorType.Alert, label: 'Alert'},
+            {value: TextArea.ErrorType.Error, label: 'Error'},
+          ],
+        },
+        props => {
+          if (props.value === '' && !props.placeholder) {
+            return false;
+          }
+          return true;
+        }
+      )}
+      columnProps={permutateProps(
+        {
+          className: [
+            {label: 'Default', value: ''},
+            {label: 'Hover', value: 'hover'},
+            {label: 'Focus', value: 'focus'},
+            {label: 'Focus Hover', value: 'focus hover'},
+            {label: 'Active', value: 'active'},
+            {label: 'Active Hover', value: 'active hover'},
+          ],
+          disabled: [{label: '', value: false}, {label: 'Disabled', value: true}],
+        },
+        props => {
+          if (props.disabled && !['', 'hover'].includes(props.className)) {
+            return false;
+          }
+          return true;
+        }
+      )}
+    >
+      {props => (
+        <TextArea
+          {...props}
+          style={{minWidth: 60, width: 100}}
+          onChange={() => {}} // eslint-disable-line no-empty-function
+        />
+      )}
+    </ComponentStatesTable>
+  </StaticStates>
+);
 
 storiesOf('Components|Inputs/TextArea/React/Visual Testing', module)
   .addParameters({component: TextArea})

--- a/modules/text-area/react/lib/TextArea.tsx
+++ b/modules/text-area/react/lib/TextArea.tsx
@@ -52,7 +52,7 @@ export enum TextAreaResizeDirection {
 }
 
 const TextAreaContainer = styled('textarea')<TextAreaProps>(
-  {
+  ({theme, error}) => ({
     ...type.body,
     border: `1px solid ${inputColors.border}`,
     display: 'block',
@@ -74,8 +74,8 @@ const TextAreaContainer = styled('textarea')<TextAreaProps>(
       borderColor: inputColors.hoverBorder,
     },
     '&:focus:not([disabled])': {
-      borderColor: inputColors.focusBorder,
-      boxShadow: `inset 0 0 0 1px ${inputColors.focusBorder}`,
+      borderColor: theme.palette.common.focusOutline,
+      boxShadow: `inset 0 0 0 1px ${theme.palette.common.focusOutline}`,
       outline: 'none',
     },
     '&:disabled': {
@@ -86,10 +86,9 @@ const TextAreaContainer = styled('textarea')<TextAreaProps>(
         color: inputColors.disabled.text,
       },
     },
-  },
-  ({error}) => ({
-    ...errorRing(error),
+    ...errorRing(error, theme),
   }),
+
   ({resize, grow}) => ({
     width: grow ? '100%' : undefined,
     resize: grow ? TextAreaResizeDirection.Vertical : resize,


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
We're adding theming to our inputs. The consumer must wrap their components in a CanvasProvider and then they can pass their custom theme to any child components through the theme prop.
## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md