### PR TITLE
ci: Use node script for publishing canary versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,7 @@ jobs:
       - yarn build
     deploy:
       provider: script
-      script:
-        - npm config set //registry.npmjs.org/:_authToken=$NPM_PUBLISH_TOKEN
-        - yarn lerna publish from-package --yes --pre-dist-tag prerelease
+      script: npm config set //registry.npmjs.org/:_authToken=$NPM_PUBLISH_TOKEN && yarn lerna publish from-package --yes --pre-dist-tag prerelease
       skip_cleanup: true
       on:
         tags: true
@@ -77,12 +75,7 @@ jobs:
       - CHROMATIC_APP_CODE="m1dh5kc7oj"
     deploy:
       - provider: script
-        script:
-          - npm config set //registry.npmjs.org/:_authToken=$NPM_PUBLISH_TOKEN
-          - yarn lerna publish --yes --force-publish="*" --canary --preid next --dist-tag next
-          - git rev-parse --short HEAD | read sha
-          - node utils/get-lerna-version.js | read version
-          - curl -X POST --data-urlencode "payload={\"text\": \"*New canary build published from <https://github.com/Workday/canvas-kit/commit/$sha|merge commit $sha> (v$version)*\n\n\`yarn add @workday/canvas-kit-{module}@$version\`\nor\n\`yarn add @workday/canvas-kit-{module}@next\`\"}" $SLACK_WEBHOOK
+        script: npm config set //registry.npmjs.org/:_authToken=$NPM_PUBLISH_TOKEN && node utils/publish-canary.js $SLACK_WEBHOOK $TRAVIS_BUILD_WEB_URL
         skip_cleanup: true
         on:
           branch: master

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "react-dom": "^16.8.6",
     "react-scripts": "^3.2.0",
     "react-test-renderer": "^16.5.2",
+    "request": "^2.88.2",
     "rimraf": "^2.6.3",
     "rollup": "^1.16.2",
     "rollup-plugin-commonjs": "^10.0.0",

--- a/utils/get-lerna-version.js
+++ b/utils/get-lerna-version.js
@@ -1,6 +1,0 @@
-#!/usr/bin/env node
-'use strict';
-
-const path = require('path');
-const pkg = require(path.resolve(__dirname, '../lerna.json'));
-console.log(pkg.version);

--- a/utils/publish-canary.js
+++ b/utils/publish-canary.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const request = require('request');
+const {promisify} = require('util');
+const cmd = promisify(require('node-cmd').get);
+
+const [
+  SLACK_WEBHOOK,
+  TRAVIS_BUILD_URL = 'https://travis-ci.org/Workday/canvas-kit/branches',
+] = process.argv.slice(2);
+
+// Use the following if we ever want to list the packages/count
+// const regex = /Successfully published:\n((.|\n)*)lerna success published (\d*) packages/gm;
+// const match = regex.exec(output);
+// data.packages = match[1]
+//   .replace(/\n|\r/g, '')
+//   .split(' - ')
+//   .filter(pkg => pkg.length);
+// data.count = match[3];
+
+cmd('yarn lerna publish --yes --force-publish="*" --canary --preid next --dist-tag next')
+  .then(output => cmd('git rev-parse --short HEAD'))
+  .then(sha => {
+    const version = require(path.resolve(__dirname, '../lerna.json')).version;
+
+    request.post(
+      SLACK_WEBHOOK,
+      {
+        json: {
+          attachments: [
+            {
+              fallback: 'Plain-text summary of the attachment.',
+              color: '#2eb886',
+              author_name: `New canary build published (v${version})`,
+              author_link: TRAVIS_BUILD_URL,
+              title: `Merge commit ${sha}`,
+              title_link: `https://github.com/Workday/canvas-kit/commit/${sha}`,
+              text: `\`yarn add @workday/canvas-kit-{module}@${version}\`\nor\n\`yarn add @workday/canvas-kit-{module}@next\`\n`,
+              ts: Date.now(),
+            },
+          ],
+        },
+      },
+      (error, response, body) => {
+        if (error) throw error;
+      }
+    );
+  })
+  .catch(err => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10871,7 +10871,7 @@ har-schema@^2.0.0:
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
   integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
 
-har-validator@~5.1.0:
+har-validator@~5.1.0, har-validator@~5.1.3:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.3.tgz#1ef89ebd3e4996557675eed9893110dc350fa080"
   integrity sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==
@@ -17926,6 +17926,32 @@ request@2.88.0, "request@>=2.76.0 <3.0.0", request@^2.87.0, request@^2.88.0:
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
+request@^2.88.2:
+  version "2.88.2"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
+  integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    har-validator "~5.1.3"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
+    performance-now "^2.1.0"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.5.0"
+    tunnel-agent "^0.6.0"
+    uuid "^3.3.2"
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -19770,7 +19796,7 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
-tough-cookie@^2.3.3, tough-cookie@^2.3.4, tough-cookie@^2.5.0:
+tough-cookie@^2.3.3, tough-cookie@^2.3.4, tough-cookie@^2.5.0, tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
   integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==


### PR DESCRIPTION
I broke the canary build in #458. I guess Travis doesn't like deploy scripts to be multiple lines.

Since this was going to be a very convoluted line if I kept it as shell scripts, I decided to convert this deploy step into a node script. This makes use of Slack's attachments API for nicer formatting.

Hopefully this fixes the build 🤞 