### PR TITLE
ci: Pull canary version from lerna publish logs instead of lerna.json

### DIFF
--- a/utils/publish-canary.js
+++ b/utils/publish-canary.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 'use strict';
 
-const path = require('path');
 const request = require('request');
 const {promisify} = require('util');
 const cmd = promisify(require('node-cmd').get);
@@ -10,21 +9,27 @@ const [
   SLACK_WEBHOOK,
   TRAVIS_BUILD_URL = 'https://travis-ci.org/Workday/canvas-kit/branches',
 ] = process.argv.slice(2);
+const pkgRegex = /Successfully published:\n((.|\n)*)lerna success published (\d*) packages/gm;
+const versionRegex = /@workday\/[a-z-]*@(\d*.\d*.\d*-next.\d*\+\w*)/gm;
+const data = {};
 
-// Use the following if we ever want to list the packages/count
-// const regex = /Successfully published:\n((.|\n)*)lerna success published (\d*) packages/gm;
-// const match = regex.exec(output);
-// data.packages = match[1]
-//   .replace(/\n|\r/g, '')
-//   .split(' - ')
-//   .filter(pkg => pkg.length);
-// data.count = match[3];
+cmd('pwd')
+  .then(output => {
+    console.log(output);
 
-cmd('yarn lerna publish --yes --force-publish="*" --canary --preid next --dist-tag next')
-  .then(output => cmd('git rev-parse --short HEAD'))
+    data.packages = pkgRegex
+      .exec(lerna)[1]
+      .replace(/\n|\r/g, '')
+      .split(' - ')
+      .filter(pkg => pkg.length);
+
+    if (data.packages.length) {
+      data.version = versionRegex.exec(data.packages[0])[1];
+    }
+
+    return cmd('git rev-parse --short HEAD');
+  })
   .then(sha => {
-    const version = require(path.resolve(__dirname, '../lerna.json')).version;
-
     request.post(
       SLACK_WEBHOOK,
       {
@@ -33,11 +38,11 @@ cmd('yarn lerna publish --yes --force-publish="*" --canary --preid next --dist-t
             {
               fallback: 'Plain-text summary of the attachment.',
               color: '#2eb886',
-              author_name: `New canary build published (v${version})`,
+              author_name: `New canary build published (v${data.version})`,
               author_link: TRAVIS_BUILD_URL,
               title: `Merge commit ${sha}`,
               title_link: `https://github.com/Workday/canvas-kit/commit/${sha}`,
-              text: `\`yarn add @workday/canvas-kit-{module}@${version}\`\nor\n\`yarn add @workday/canvas-kit-{module}@next\`\n`,
+              text: `\`yarn add @workday/canvas-kit-{module}@${data.version}\`\nor\n\`yarn add @workday/canvas-kit-{module}@next\`\n`,
               ts: Date.now(),
             },
           ],


### PR DESCRIPTION
I was under the impression that `lerna publish --canary` would update the `lerna.json` file, but it does not. The check for the version was looking in `lerna.json`, so we were getting an old version. This updates the logic to pull the version from the logs of the `lerna publish` command.