### PR TITLE
feat(switch): Add theming support

### DIFF
--- a/modules/form-field/react/stories/stories_Switch.tsx
+++ b/modules/form-field/react/stories/stories_Switch.tsx
@@ -6,6 +6,7 @@ import {
   ControlledComponentWrapper,
   ComponentStatesTable,
   permutateProps,
+  customColorTheme,
 } from '../../../../utils/storybook';
 import {StaticStates} from '@workday/canvas-kit-labs-react-core/lib/StaticStates';
 import {Switch} from '../../../switch/react';
@@ -95,54 +96,62 @@ storiesOf('Components|Inputs/Switch/React/Left Label', module)
     </FormField>
   ));
 
+const SwitchStates = () => (
+  <StaticStates>
+    <ComponentStatesTable
+      rowProps={permutateProps(
+        {
+          checked: [{value: true, label: 'Checked'}, {value: false, label: 'Unchecked'}],
+          error: [
+            {value: undefined, label: ''},
+            {value: Switch.ErrorType.Alert, label: 'Alert'},
+            {value: Switch.ErrorType.Error, label: 'Error'},
+          ],
+        },
+        props => {
+          if (props.indeterminate && !props.checked) {
+            return false;
+          }
+          return true;
+        }
+      )}
+      columnProps={permutateProps(
+        {
+          className: [
+            {label: 'Default', value: ''},
+            {label: 'Hover', value: 'hover'},
+            {label: 'Focus', value: 'focus'},
+            {label: 'Focus Hover', value: 'focus hover'},
+            {label: 'Active', value: 'active'},
+            {label: 'Active Hover', value: 'active hover'},
+          ],
+          disabled: [{label: '', value: false}, {label: 'Disabled', value: true}],
+        },
+        props => {
+          if (props.disabled && !['', 'hover'].includes(props.className)) {
+            return false;
+          }
+          return true;
+        }
+      )}
+    >
+      {props => (
+        <Switch
+          {...props}
+          onChange={() => {}} // eslint-disable-line no-empty-function
+        />
+      )}
+    </ComponentStatesTable>
+  </StaticStates>
+);
+
 storiesOf('Components|Inputs/Switch/React/Visual Testing', module)
   .addParameters({component: Switch})
   .addDecorator(withReadme(README))
-  .add('States', () => (
-    <StaticStates>
-      <ComponentStatesTable
-        rowProps={permutateProps(
-          {
-            checked: [{value: true, label: 'Checked'}, {value: false, label: 'Unchecked'}],
-            error: [
-              {value: undefined, label: ''},
-              {value: Switch.ErrorType.Alert, label: 'Alert'},
-              {value: Switch.ErrorType.Error, label: 'Error'},
-            ],
-          },
-          props => {
-            if (props.indeterminate && !props.checked) {
-              return false;
-            }
-            return true;
-          }
-        )}
-        columnProps={permutateProps(
-          {
-            className: [
-              {label: 'Default', value: ''},
-              {label: 'Hover', value: 'hover'},
-              {label: 'Focus', value: 'focus'},
-              {label: 'Focus Hover', value: 'focus hover'},
-              {label: 'Active', value: 'active'},
-              {label: 'Active Hover', value: 'active hover'},
-            ],
-            disabled: [{label: '', value: false}, {label: 'Disabled', value: true}],
-          },
-          props => {
-            if (props.disabled && !['', 'hover'].includes(props.className)) {
-              return false;
-            }
-            return true;
-          }
-        )}
-      >
-        {props => (
-          <Switch
-            {...props}
-            onChange={() => {}} // eslint-disable-line no-empty-function
-          />
-        )}
-      </ComponentStatesTable>
-    </StaticStates>
-  ));
+  .add('States', () => <SwitchStates />)
+  .addParameters({
+    canvasProviderDecorator: {
+      theme: customColorTheme,
+    },
+  })
+  .add('Theming', () => <SwitchStates />);

--- a/modules/radio/react/lib/Radio.tsx
+++ b/modules/radio/react/lib/Radio.tsx
@@ -113,9 +113,6 @@ const RadioInput = styled('input')<RadioProps>(
     '&:hover ~ div:first-of-type::after': {
       boxShadow: disabled ? undefined : `0 0 0 ${rippleRadius}px ${colors.soap200}`,
     },
-    '&:focus:hover:checked ~ div:first-of-type::after': {
-      ...themedFocusRing(theme, {width: 2, separation: 2, innerColor: colors.soap200}),
-    },
     '&:hover ~ div:first-of-type': {
       backgroundColor: checked
         ? theme.palette.primary.main
@@ -143,10 +140,10 @@ const RadioInput = styled('input')<RadioProps>(
       '&:focus ~ div:first-of-type': {
         ...themedFocusRing(theme, {width: 0}),
         borderWidth: '1px',
-        borderColor: checked ? theme.palette.common.focusOutline : inputColors.border,
+        borderColor: checked ? theme.palette.primary.main : inputColors.border,
       },
-      '&:focus:hover, &:focus:active ~ div:first-of-type': {
-        borderColor: checked ? theme.palette.common.focusOutline : inputColors.hoverBorder,
+      '&:focus:hover ~ div:first-of-type, &:focus:active ~ div:first-of-type': {
+        borderColor: checked ? theme.palette.primary.main : inputColors.hoverBorder,
       },
     }),
   })

--- a/modules/switch/react/lib/Switch.tsx
+++ b/modules/switch/react/lib/Switch.tsx
@@ -121,13 +121,17 @@ const SwitchBackground = styled('div')<Pick<SwitchProps, 'checked' | 'disabled'>
     padding: '0px 2px',
     transition: 'background-color 200ms ease',
   },
-  ({checked, disabled, theme}) => ({
-    backgroundColor: disabled
-      ? colors.soap400
-      : checked
-      ? theme.palette.primary.main
-      : colors.licorice200,
-  })
+  ({checked, disabled, theme}) => {
+    if (checked) {
+      return {
+        backgroundColor: disabled ? theme.palette.primary.light : theme.palette.primary.main,
+      };
+    } else {
+      return {
+        backgroundColor: disabled ? colors.soap400 : colors.licorice200,
+      };
+    }
+  }
 );
 
 const SwitchCircle = styled('div')<Pick<SwitchProps, 'checked'>>(({checked}) => ({

--- a/modules/switch/react/lib/Switch.tsx
+++ b/modules/switch/react/lib/Switch.tsx
@@ -1,8 +1,13 @@
 import * as React from 'react';
 import {styled, Themeable} from '@workday/canvas-kit-labs-react-core';
 import uuid from 'uuid/v4';
-import {ErrorType, focusRing, mouseFocusBehavior} from '@workday/canvas-kit-react-common';
-import {borderRadius, colors, inputColors, depth, spacing} from '@workday/canvas-kit-react-core';
+import {
+  ErrorType,
+  themedFocusRing,
+  mouseFocusBehavior,
+  getErrorColors,
+} from '@workday/canvas-kit-react-common';
+import {borderRadius, colors, depth, spacing} from '@workday/canvas-kit-react-core';
 
 export interface SwitchProps extends Themeable, React.InputHTMLAttributes<HTMLInputElement> {
   /**
@@ -58,46 +63,42 @@ const SwitchInput = styled('input')<SwitchProps>(
     marginLeft: spacing.xxxs,
     borderRadius: borderRadius.circle,
     opacity: 0,
+  },
+  ({theme}) => ({
     '&:focus, &:active': {
       outline: 'none',
       '& ~ div:first-of-type': {
-        ...focusRing(2, 2, false),
+        ...themedFocusRing(theme, {separation: 2, animate: false}),
       },
     },
     ...mouseFocusBehavior({
       '&:focus, &:active': {
         '& ~ div:first-of-type': {
-          ...focusRing(0, 0),
+          ...themedFocusRing(theme, {width: 0}),
           animation: 'none',
         },
       },
     }),
-  },
+  }),
   ({disabled}) => ({
     cursor: disabled ? 'not-allowed' : 'pointer',
   }),
-  ({error}) => {
-    let errorRingColor;
-    let errorRingBorderColor = 'transparent';
+  ({error, theme}) => {
+    const errorColors = getErrorColors(error, theme);
 
-    if (error === ErrorType.Error) {
-      errorRingColor = inputColors.error.border;
-    } else if (error === ErrorType.Alert) {
-      errorRingColor = inputColors.warning.border;
-      errorRingBorderColor = colors.cantaloupe600;
-    } else {
-      return;
+    if (errorColors.outer === errorColors.inner) {
+      errorColors.outer = 'transparent';
     }
 
     const styles = {
       '& ~ div:first-of-type': {
         boxShadow: `
           0 0 0 2px ${colors.frenchVanilla100},
-          0 0 0 4px ${errorRingColor},
-          0 0 0 5px ${errorRingBorderColor}`,
+          0 0 0 4px ${errorColors.inner},
+          0 0 0 5px ${errorColors.outer}`,
       },
       '&:focus ~ div:first-of-type': {
-        ...focusRing(2, 2, false),
+        ...themedFocusRing(theme, {separation: 2, animate: false}),
       },
     };
     return {
@@ -108,8 +109,8 @@ const SwitchInput = styled('input')<SwitchProps>(
         '&:focus ~ div:first-of-type, &:active ~ div:first-of-type': {
           boxShadow: `
             0 0 0 2px ${colors.frenchVanilla100},
-            0 0 0 4px ${errorRingColor},
-            0 0 0 5px ${errorRingBorderColor}`,
+            0 0 0 4px ${errorColors.inner},
+            0 0 0 5px ${errorColors.outer}`,
         },
       }),
     };
@@ -130,8 +131,12 @@ const SwitchBackground = styled('div')<Pick<SwitchProps, 'checked' | 'disabled'>
     padding: '0px 2px',
     transition: 'background-color 200ms ease',
   },
-  ({checked, disabled}) => ({
-    backgroundColor: disabled ? colors.soap400 : checked ? colors.blueberry500 : colors.licorice200,
+  ({checked, disabled, theme}) => ({
+    backgroundColor: disabled
+      ? colors.soap400
+      : checked
+      ? theme.palette.primary.main
+      : colors.licorice200,
   })
 );
 

--- a/modules/switch/react/lib/Switch.tsx
+++ b/modules/switch/react/lib/Switch.tsx
@@ -64,22 +64,6 @@ const SwitchInput = styled('input')<SwitchProps>(
     borderRadius: borderRadius.circle,
     opacity: 0,
   },
-  ({theme}) => ({
-    '&:focus, &:active': {
-      outline: 'none',
-      '& ~ div:first-of-type': {
-        ...themedFocusRing(theme, {separation: 2, animate: false}),
-      },
-    },
-    ...mouseFocusBehavior({
-      '&:focus, &:active': {
-        '& ~ div:first-of-type': {
-          ...themedFocusRing(theme, {width: 0}),
-          animation: 'none',
-        },
-      },
-    }),
-  }),
   ({disabled}) => ({
     cursor: disabled ? 'not-allowed' : 'pointer',
   }),
@@ -91,6 +75,12 @@ const SwitchInput = styled('input')<SwitchProps>(
     }
 
     const styles = {
+      '&:focus': {
+        outline: 'none',
+        '& ~ div:first-of-type': {
+          ...themedFocusRing(theme, {separation: 2, animate: false}),
+        },
+      },
       '& ~ div:first-of-type': {
         boxShadow: `
           0 0 0 2px ${colors.frenchVanilla100},


### PR DESCRIPTION
## Summary

We're adding theming to our inputs. The consumer must wrap their components in a `CanvasProvider` and then they can pass their custom theme to any child components through the `theme` prop.

Partially addresses #358 

Blocked on https://github.com/Workday/canvas-kit/pull/457

Notes:
- I noticed we were still using Blueberry 500 for the checked color. This is an old styling and all of our other inputs now use Blueberry 400. The checked background was updated. If you need to force Blueberry 500 for whatever reason, you can wrap the switch with a custom theme
- The checked disabled state was a light gray when it should have been a light blue. This has been updated.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)
