### PR TITLE
test(button): Add static state tables for all Button components

### DIFF
--- a/modules/button/react/lib/ButtonBase.tsx
+++ b/modules/button/react/lib/ButtonBase.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import styled from '@emotion/styled';
+import {styled} from '@workday/canvas-kit-labs-react-core';
 import isPropValid from '@emotion/is-prop-valid';
 import {
   ButtonSize,

--- a/modules/button/react/lib/DropdownButton.tsx
+++ b/modules/button/react/lib/DropdownButton.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {ButtonBaseLabel, ButtonLabelIcon} from './ButtonBase';
 import {getButtonStyle, getButtonSize} from './utils';
-import styled from '@emotion/styled';
+import {styled} from '@workday/canvas-kit-labs-react-core';
 import isPropValid from '@emotion/is-prop-valid';
 import {BaseButtonProps} from './Button';
 import {dropdownButtonStyles} from './ButtonStyles';

--- a/modules/button/react/lib/TextButton.tsx
+++ b/modules/button/react/lib/TextButton.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {ButtonBaseLabel, ButtonLabelIcon} from './ButtonBase';
 import {getButtonStyle} from './utils';
-import styled from '@emotion/styled';
+import {styled} from '@workday/canvas-kit-labs-react-core';
 import isPropValid from '@emotion/is-prop-valid';
 import {ButtonSize, IconPosition, TextButtonVariant} from './types';
 import {BaseButtonProps} from './Button';

--- a/modules/button/react/stories/stories_iconButton.tsx
+++ b/modules/button/react/stories/stories_iconButton.tsx
@@ -3,8 +3,6 @@
 import {jsx, CSSObject} from '@emotion/core';
 import * as React from 'react';
 import {storiesOf} from '@storybook/react';
-import {StaticStates} from '@workday/canvas-kit-labs-react-core/lib/StaticStates';
-import {ComponentStatesTable, permutateProps} from '../../../../utils/storybook';
 import withReadme from 'storybook-readme/with-readme';
 
 import {
@@ -346,71 +344,6 @@ storiesOf('Components|Buttons/Button/React/Icon Button', module)
         <ToggleIconButtonWrapper variant={IconButton.Variant.InverseFilled} />
       </div>
     </div>
-  ));
-
-storiesOf('Components|Buttons/Button/React/Icon Button/Visual', module)
-  .addParameters({component: IconButton})
-  .addDecorator(withReadme(README))
-  .add('States', () => (
-    <React.Fragment>
-      {[false, true].map(toggled => (
-        <div>
-          <h3>Toggled {toggled ? 'On' : 'Off'}</h3>
-          <StaticStates>
-            <ComponentStatesTable
-              rowProps={permutateProps({
-                variant: [
-                  {value: IconButton.Variant.Inverse, label: 'Inverse'},
-                  {value: IconButton.Variant.InverseFilled, label: 'Inverse Filled'},
-                  {value: IconButton.Variant.Plain, label: 'Plain'},
-                  {value: IconButton.Variant.Circle, label: 'Circle'},
-                  {value: IconButton.Variant.CircleFilled, label: 'Circle Filled'},
-                  {value: IconButton.Variant.Square, label: 'Square'},
-                  {value: IconButton.Variant.SquareFilled, label: 'Square Filled'},
-                ],
-              })}
-              columnProps={permutateProps(
-                {
-                  className: [
-                    {label: 'Default', value: ''},
-                    {label: 'Hover', value: 'hover'},
-                    {label: 'Focus', value: 'focus'},
-                    {label: 'Focus Hover', value: 'focus hover'},
-                    {label: 'Active', value: 'active'},
-                    {label: 'Active Hover', value: 'active hover'},
-                  ],
-                  disabled: [{label: '', value: false}, {label: 'Disabled', value: true}],
-                },
-                props => {
-                  if (props.disabled && !['', 'hover'].includes(props.className)) {
-                    return false;
-                  }
-                  return true;
-                }
-              )}
-            >
-              {props => (
-                <div
-                  css={
-                    props.variant === 'inverse' || props.variant === 'inverseFilled'
-                      ? blueBackground
-                      : iconButtonLayout
-                  }
-                >
-                  <IconButton
-                    toggled={toggled}
-                    icon={activityStreamIcon}
-                    aria-label="Activity Stream"
-                    {...props}
-                    onChange={() => {}} // eslint-disable-line no-empty-function
-                  />
-                </div>
-              )}
-            </ComponentStatesTable>
-          </StaticStates>
-        </div>
-      ))}
-    </React.Fragment>
   ));
 
 storiesOf('Components|Buttons/Button/React/Icon Button Toggle Group', module)

--- a/modules/button/react/stories/stories_visualTesting.tsx
+++ b/modules/button/react/stories/stories_visualTesting.tsx
@@ -1,26 +1,29 @@
 /// <reference path="../../../../typings.d.ts" />
 /** @jsx jsx */
 import {jsx, CSSObject} from '@emotion/core';
+import * as React from 'react';
 import {storiesOf} from '@storybook/react';
 import {StaticStates} from '@workday/canvas-kit-labs-react-core';
 import {ComponentStatesTable, permutateProps} from '../../../../utils/storybook';
 import {playCircleIcon} from '@workday/canvas-system-icons-web';
-import {Button, DropdownButton, TextButton} from '../index';
+import {Button, DropdownButton, TextButton, IconButton} from '../index';
 
-const blueBackground: CSSObject = {
+const buttonLayout: CSSObject = {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  flexWrap: 'wrap',
-  backgroundColor: '#0875e1',
-  margin: '0 10px',
-  padding: '12px',
-  maxWidth: 'max-content',
-  borderRadius: '3px',
-  button: {
-    margin: '12px',
-  },
 };
+
+const blueBackground: CSSObject = {
+  ...buttonLayout,
+  backgroundColor: '#0875e1',
+  padding: '12px',
+  borderRadius: '4px',
+};
+
+const Container = props => (
+  <div css={props.blue ? blueBackground : buttonLayout}>{props.children}</div>
+);
 
 const ButtonStates = () => (
   <StaticStates>
@@ -68,13 +71,11 @@ const ButtonStates = () => (
         }
       )}
     >
-      {props => {
-        const button = <Button {...props}>Test</Button>;
-        if (props.variant === Button.Variant.OutlineInverse) {
-          return <div css={blueBackground}>{button}</div>;
-        }
-        return button;
-      }}
+      {props => (
+        <Container blue={props.variant === Button.Variant.OutlineInverse}>
+          <Button {...props}>Test</Button>
+        </Container>
+      )}
     </ComponentStatesTable>
   </StaticStates>
 );
@@ -125,7 +126,11 @@ const DropdownButtonStates = () => (
         }
       )}
     >
-      {props => <DropdownButton {...props}>Test</DropdownButton>}
+      {props => (
+        <Container>
+          <DropdownButton {...props}>Test</DropdownButton>
+        </Container>
+      )}
     </ComponentStatesTable>
   </StaticStates>
 );
@@ -173,17 +178,77 @@ const TextButtonStates = () => (
         }
       )}
     >
-      {props => {
-        const button = <TextButton {...props}>Test</TextButton>;
-        if (
-          [TextButton.Variant.Inverse, TextButton.Variant.InverseAllCaps].includes(props.variant)
-        ) {
-          return <div css={blueBackground}>{button}</div>;
-        }
-        return button;
-      }}
+      {props => (
+        <Container
+          blue={[TextButton.Variant.Inverse, TextButton.Variant.InverseAllCaps].includes(
+            props.variant
+          )}
+        >
+          <TextButton {...props}>Test</TextButton>
+        </Container>
+      )}
     </ComponentStatesTable>
   </StaticStates>
+);
+
+const IconButtonStates = () => (
+  <React.Fragment>
+    {[false, true].map(toggled => (
+      <div>
+        <h3>Toggled {toggled ? 'On' : 'Off'}</h3>
+        <StaticStates>
+          <ComponentStatesTable
+            rowProps={permutateProps({
+              variant: [
+                {value: IconButton.Variant.Inverse, label: 'Inverse'},
+                {value: IconButton.Variant.InverseFilled, label: 'Inverse Filled'},
+                {value: IconButton.Variant.Plain, label: 'Plain'},
+                {value: IconButton.Variant.Circle, label: 'Circle'},
+                {value: IconButton.Variant.CircleFilled, label: 'Circle Filled'},
+                {value: IconButton.Variant.Square, label: 'Square'},
+                {value: IconButton.Variant.SquareFilled, label: 'Square Filled'},
+              ],
+            })}
+            columnProps={permutateProps(
+              {
+                className: [
+                  {label: 'Default', value: ''},
+                  {label: 'Hover', value: 'hover'},
+                  {label: 'Focus', value: 'focus'},
+                  {label: 'Focus Hover', value: 'focus hover'},
+                  {label: 'Active', value: 'active'},
+                  {label: 'Active Hover', value: 'active hover'},
+                ],
+                disabled: [{label: '', value: false}, {label: 'Disabled', value: true}],
+              },
+              props => {
+                if (props.disabled && !['', 'hover'].includes(props.className)) {
+                  return false;
+                }
+                return true;
+              }
+            )}
+          >
+            {props => (
+              <Container
+                blue={[IconButton.Variant.Inverse, IconButton.Variant.InverseFilled].includes(
+                  props.variant
+                )}
+              >
+                <IconButton
+                  toggled={toggled}
+                  icon={playCircleIcon}
+                  aria-label="Play"
+                  {...props}
+                  onChange={() => {}} // eslint-disable-line no-empty-function
+                />
+              </Container>
+            )}
+          </ComponentStatesTable>
+        </StaticStates>
+      </div>
+    ))}
+  </React.Fragment>
 );
 
 storiesOf('Components|Buttons/Button/React/Visual Testing/Button', module)
@@ -197,3 +262,7 @@ storiesOf('Components|Buttons/Button/React/Visual Testing/Dropdown', module)
 storiesOf('Components|Buttons/Button/React/Visual Testing/Text', module)
   .addParameters({component: TextButton})
   .add('States', () => <TextButtonStates />);
+
+storiesOf('Components|Buttons/Button/React/Visual Testing/Icon Button', module)
+  .addParameters({component: IconButton})
+  .add('States', () => <IconButtonStates />);

--- a/modules/button/react/stories/stories_visualTesting.tsx
+++ b/modules/button/react/stories/stories_visualTesting.tsx
@@ -48,6 +48,15 @@ const ButtonStates = () => (
           dataLabel: [{value: undefined, label: ''}, {value: '1:23', label: 'w/ Data Label'}],
         },
         props => {
+          if (props.size === Button.Size.Small && (props.icon || props.dataLabel)) {
+            return false;
+          }
+          if (props.variant === Button.Variant.Highlight && !props.icon) {
+            return false;
+          }
+          if (props.variant === Button.Variant.Delete && (props.icon || props.dataLabel)) {
+            return false;
+          }
           return true;
         }
       )}
@@ -83,29 +92,16 @@ const ButtonStates = () => (
 const DropdownButtonStates = () => (
   <StaticStates>
     <ComponentStatesTable
-      rowProps={permutateProps(
-        {
-          variant: [
-            {value: DropdownButton.Variant.Primary, label: 'Primary'},
-            {value: DropdownButton.Variant.Secondary, label: 'Secondary'},
-            {value: DropdownButton.Variant.Highlight, label: 'Highlight'},
-            {value: DropdownButton.Variant.OutlinePrimary, label: 'Outline Primary'},
-            {value: DropdownButton.Variant.OutlineSecondary, label: 'Outline Secondary'},
-            {value: DropdownButton.Variant.OutlineInverse, label: 'Outline Inverse'},
-            {value: DropdownButton.Variant.Delete, label: 'Delete'},
-          ],
-          size: [
-            {value: DropdownButton.Size.Small, label: 'Small'},
-            {value: DropdownButton.Size.Medium, label: 'Medium'},
-            {value: DropdownButton.Size.Large, label: 'Large'},
-          ],
-          icon: [{value: undefined, label: ''}, {value: playCircleIcon, label: 'w/ Icon'}],
-          dataLabel: [{value: undefined, label: ''}, {value: '1:23', label: 'w/ Data Label'}],
-        },
-        props => {
-          return true;
-        }
-      )}
+      rowProps={permutateProps({
+        variant: [
+          {value: DropdownButton.Variant.Primary, label: 'Primary'},
+          {value: DropdownButton.Variant.Secondary, label: 'Secondary'},
+        ],
+        size: [
+          {value: DropdownButton.Size.Medium, label: 'Medium'},
+          {value: DropdownButton.Size.Large, label: 'Large'},
+        ],
+      })}
       columnProps={permutateProps(
         {
           className: [
@@ -148,11 +144,9 @@ const TextButtonStates = () => (
           ],
           size: [
             {value: TextButton.Size.Small, label: 'Small'},
-            {value: TextButton.Size.Medium, label: 'Medium'},
             {value: TextButton.Size.Large, label: 'Large'},
           ],
           icon: [{value: undefined, label: ''}, {value: playCircleIcon, label: 'w/ Icon'}],
-          dataLabel: [{value: undefined, label: ''}, {value: '1:23', label: 'w/ Data Label'}],
         },
         props => {
           return true;

--- a/modules/button/react/stories/stories_visualTesting.tsx
+++ b/modules/button/react/stories/stories_visualTesting.tsx
@@ -21,7 +21,7 @@ const blueBackground: CSSObject = {
   borderRadius: '4px',
 };
 
-const Container = props => (
+const Container = (props: any) => (
   <div css={props.blue ? blueBackground : buttonLayout}>{props.children}</div>
 );
 

--- a/modules/button/react/stories/stories_visualTesting.tsx
+++ b/modules/button/react/stories/stories_visualTesting.tsx
@@ -252,17 +252,37 @@ const IconButtonStates = () => (
 );
 
 storiesOf('Components|Buttons/Button/React/Visual Testing/Button', module)
-  .addParameters({component: Button})
+  .addParameters({
+    component: Button,
+    chromatic: {
+      disable: false,
+    },
+  })
   .add('States', () => <ButtonStates />);
 
 storiesOf('Components|Buttons/Button/React/Visual Testing/Dropdown', module)
-  .addParameters({component: DropdownButton})
+  .addParameters({
+    component: DropdownButton,
+    chromatic: {
+      disable: false,
+    },
+  })
   .add('States', () => <DropdownButtonStates />);
 
 storiesOf('Components|Buttons/Button/React/Visual Testing/Text', module)
-  .addParameters({component: TextButton})
+  .addParameters({
+    component: TextButton,
+    chromatic: {
+      disable: false,
+    },
+  })
   .add('States', () => <TextButtonStates />);
 
 storiesOf('Components|Buttons/Button/React/Visual Testing/Icon Button', module)
-  .addParameters({component: IconButton})
+  .addParameters({
+    component: IconButton,
+    chromatic: {
+      disable: false,
+    },
+  })
   .add('States', () => <IconButtonStates />);

--- a/modules/button/react/stories/stories_visualTesting.tsx
+++ b/modules/button/react/stories/stories_visualTesting.tsx
@@ -1,0 +1,199 @@
+/// <reference path="../../../../typings.d.ts" />
+/** @jsx jsx */
+import {jsx, CSSObject} from '@emotion/core';
+import {storiesOf} from '@storybook/react';
+import {StaticStates} from '@workday/canvas-kit-labs-react-core';
+import {ComponentStatesTable, permutateProps} from '../../../../utils/storybook';
+import {playCircleIcon} from '@workday/canvas-system-icons-web';
+import {Button, DropdownButton, TextButton} from '../index';
+
+const blueBackground: CSSObject = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  flexWrap: 'wrap',
+  backgroundColor: '#0875e1',
+  margin: '0 10px',
+  padding: '12px',
+  maxWidth: 'max-content',
+  borderRadius: '3px',
+  button: {
+    margin: '12px',
+  },
+};
+
+const ButtonStates = () => (
+  <StaticStates>
+    <ComponentStatesTable
+      rowProps={permutateProps(
+        {
+          variant: [
+            {value: Button.Variant.Primary, label: 'Primary'},
+            {value: Button.Variant.Secondary, label: 'Secondary'},
+            {value: Button.Variant.Highlight, label: 'Highlight'},
+            {value: Button.Variant.OutlinePrimary, label: 'Outline Primary'},
+            {value: Button.Variant.OutlineSecondary, label: 'Outline Secondary'},
+            {value: Button.Variant.OutlineInverse, label: 'Outline Inverse'},
+            {value: Button.Variant.Delete, label: 'Delete'},
+          ],
+          size: [
+            {value: Button.Size.Small, label: 'Small'},
+            {value: Button.Size.Medium, label: 'Medium'},
+            {value: Button.Size.Large, label: 'Large'},
+          ],
+          icon: [{value: undefined, label: ''}, {value: playCircleIcon, label: 'w/ Icon'}],
+          dataLabel: [{value: undefined, label: ''}, {value: '1:23', label: 'w/ Data Label'}],
+        },
+        props => {
+          return true;
+        }
+      )}
+      columnProps={permutateProps(
+        {
+          className: [
+            {label: 'Default', value: ''},
+            {label: 'Hover', value: 'hover'},
+            {label: 'Focus', value: 'focus'},
+            {label: 'Focus Hover', value: 'focus hover'},
+            {label: 'Active', value: 'active'},
+            {label: 'Active Hover', value: 'active hover'},
+          ],
+          disabled: [{label: '', value: false}, {label: 'Disabled', value: true}],
+        },
+        props => {
+          if (props.disabled && !['', 'hover'].includes(props.className)) {
+            return false;
+          }
+          return true;
+        }
+      )}
+    >
+      {props => {
+        const button = <Button {...props}>Test</Button>;
+        if (props.variant === Button.Variant.OutlineInverse) {
+          return <div css={blueBackground}>{button}</div>;
+        }
+        return button;
+      }}
+    </ComponentStatesTable>
+  </StaticStates>
+);
+
+const DropdownButtonStates = () => (
+  <StaticStates>
+    <ComponentStatesTable
+      rowProps={permutateProps(
+        {
+          variant: [
+            {value: DropdownButton.Variant.Primary, label: 'Primary'},
+            {value: DropdownButton.Variant.Secondary, label: 'Secondary'},
+            {value: DropdownButton.Variant.Highlight, label: 'Highlight'},
+            {value: DropdownButton.Variant.OutlinePrimary, label: 'Outline Primary'},
+            {value: DropdownButton.Variant.OutlineSecondary, label: 'Outline Secondary'},
+            {value: DropdownButton.Variant.OutlineInverse, label: 'Outline Inverse'},
+            {value: DropdownButton.Variant.Delete, label: 'Delete'},
+          ],
+          size: [
+            {value: DropdownButton.Size.Small, label: 'Small'},
+            {value: DropdownButton.Size.Medium, label: 'Medium'},
+            {value: DropdownButton.Size.Large, label: 'Large'},
+          ],
+          icon: [{value: undefined, label: ''}, {value: playCircleIcon, label: 'w/ Icon'}],
+          dataLabel: [{value: undefined, label: ''}, {value: '1:23', label: 'w/ Data Label'}],
+        },
+        props => {
+          return true;
+        }
+      )}
+      columnProps={permutateProps(
+        {
+          className: [
+            {label: 'Default', value: ''},
+            {label: 'Hover', value: 'hover'},
+            {label: 'Focus', value: 'focus'},
+            {label: 'Focus Hover', value: 'focus hover'},
+            {label: 'Active', value: 'active'},
+            {label: 'Active Hover', value: 'active hover'},
+          ],
+          disabled: [{label: '', value: false}, {label: 'Disabled', value: true}],
+        },
+        props => {
+          if (props.disabled && !['', 'hover'].includes(props.className)) {
+            return false;
+          }
+          return true;
+        }
+      )}
+    >
+      {props => <DropdownButton {...props}>Test</DropdownButton>}
+    </ComponentStatesTable>
+  </StaticStates>
+);
+
+const TextButtonStates = () => (
+  <StaticStates>
+    <ComponentStatesTable
+      rowProps={permutateProps(
+        {
+          variant: [
+            {value: TextButton.Variant.Default, label: 'Default'},
+            {value: TextButton.Variant.AllCaps, label: 'All Caps'},
+            {value: TextButton.Variant.Inverse, label: 'Inverse'},
+            {value: TextButton.Variant.InverseAllCaps, label: 'Inverse All Caps'},
+          ],
+          size: [
+            {value: TextButton.Size.Small, label: 'Small'},
+            {value: TextButton.Size.Medium, label: 'Medium'},
+            {value: TextButton.Size.Large, label: 'Large'},
+          ],
+          icon: [{value: undefined, label: ''}, {value: playCircleIcon, label: 'w/ Icon'}],
+          dataLabel: [{value: undefined, label: ''}, {value: '1:23', label: 'w/ Data Label'}],
+        },
+        props => {
+          return true;
+        }
+      )}
+      columnProps={permutateProps(
+        {
+          className: [
+            {label: 'Default', value: ''},
+            {label: 'Hover', value: 'hover'},
+            {label: 'Focus', value: 'focus'},
+            {label: 'Focus Hover', value: 'focus hover'},
+            {label: 'Active', value: 'active'},
+            {label: 'Active Hover', value: 'active hover'},
+          ],
+          disabled: [{label: '', value: false}, {label: 'Disabled', value: true}],
+        },
+        props => {
+          if (props.disabled && !['', 'hover'].includes(props.className)) {
+            return false;
+          }
+          return true;
+        }
+      )}
+    >
+      {props => {
+        const button = <TextButton {...props}>Test</TextButton>;
+        if (
+          [TextButton.Variant.Inverse, TextButton.Variant.InverseAllCaps].includes(props.variant)
+        ) {
+          return <div css={blueBackground}>{button}</div>;
+        }
+        return button;
+      }}
+    </ComponentStatesTable>
+  </StaticStates>
+);
+
+storiesOf('Components|Buttons/Button/React/Visual Testing/Button', module)
+  .addParameters({component: Button})
+  .add('States', () => <ButtonStates />);
+
+storiesOf('Components|Buttons/Button/React/Visual Testing/Dropdown', module)
+  .addParameters({component: DropdownButton})
+  .add('States', () => <DropdownButtonStates />);
+
+storiesOf('Components|Buttons/Button/React/Visual Testing/Text', module)
+  .addParameters({component: TextButton})
+  .add('States', () => <TextButtonStates />);


### PR DESCRIPTION
## Summary

In preparation for #468, we would like to have static state tables in place so that we can ensure no regressions are introduced in the upcoming button refactor. This PR adds them for `Button`, `DropdownButton`, and `TextButton`. It also moves the existing `IconButton` static states story to a common folder with the others (I thought this was clearer than having to dive into subfolders for each visual testing story - especially when we start to add multiple stories for theming).

Note: There are actually quite a few issues with some of the prop combinations. Some problems are stylistic, while others make it clear where we've exposed possible prop combinations that shouldn't be available. I would propose we leave them as is for now and try to address them in the refactor. Would love some input on this.
