### PR TITLE
fix(button): Fix Component Selector Issue

### DIFF
--- a/modules/button/react/lib/IconButton.tsx
+++ b/modules/button/react/lib/IconButton.tsx
@@ -8,7 +8,7 @@ import {colors} from '@workday/canvas-kit-react-core';
 import {SystemIcon} from '@workday/canvas-kit-react-icon';
 import {focusRing, mouseFocusBehavior} from '@workday/canvas-kit-react-common';
 import {CanvasSystemIcon} from '@workday/design-assets-types';
-import {CSSObject} from '@emotion/core';
+import {ClassNames, CSSObject} from '@emotion/core';
 
 export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /**
@@ -67,6 +67,8 @@ function getAccentSelector(fillColor: string): CSSObject {
     },
   };
 }
+
+export const iconButtonIdentifier = 'wdc-ckr-icon-button';
 
 export const IconButtonCon = styled('button', {
   shouldForwardProp: prop => isPropValid(prop) && prop !== 'size',
@@ -243,20 +245,26 @@ export default class IconButton extends React.Component<IconButtonProps> {
       icon,
       toggled,
       children,
+      className,
       ...elemProps
     } = this.props;
 
     return (
-      <IconButtonCon
-        toggled={toggled}
-        ref={buttonRef}
-        variant={variant}
-        size={size}
-        aria-pressed={toggled}
-        {...elemProps}
-      >
-        {icon ? <SystemIcon icon={icon} /> : children}
-      </IconButtonCon>
+      <ClassNames>
+        {({cx}) => (
+          <IconButtonCon
+            toggled={toggled}
+            ref={buttonRef}
+            variant={variant}
+            size={size}
+            aria-pressed={toggled}
+            className={cx(iconButtonIdentifier, className)}
+            {...elemProps}
+          >
+            {icon ? <SystemIcon icon={icon} /> : children}
+          </IconButtonCon>
+        )}
+      </ClassNames>
     );
   }
 }

--- a/modules/button/react/lib/IconButtonToggleGroup.tsx
+++ b/modules/button/react/lib/IconButtonToggleGroup.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styled from '@emotion/styled';
 import {spacing, borderRadius} from '@workday/canvas-kit-react-core';
-import IconButton, {IconButtonCon, IconButtonProps} from './IconButton';
+import IconButton, {IconButtonProps, iconButtonIdentifier} from './IconButton';
 
 export interface IconButtonToggleGroupProps {
   /**
@@ -28,7 +28,7 @@ export interface IconButtonToggleGroupProps {
 }
 
 const Container = styled('div')({
-  [IconButtonCon as any]: {
+  [`.${iconButtonIdentifier}`]: {
     borderRadius: borderRadius.zero,
     borderWidth: '1px',
     marginLeft: '-1px',

--- a/modules/button/react/spec/IconButton.spec.tsx
+++ b/modules/button/react/spec/IconButton.spec.tsx
@@ -24,17 +24,17 @@ describe('Icon Button', () => {
   });
 
   it('should have an identifier class', () => {
-    const {getByTestId} = render(
-      <IconButton data-testid={iconButtonIdentifier} aria-label="Activity Stream">
+    const {getByRole} = render(
+      <IconButton aria-label="Activity Stream">
         <SystemIcon icon={activityStreamIcon} />
       </IconButton>
     );
 
-    expect(getByTestId(iconButtonIdentifier).className).toContain(iconButtonIdentifier);
+    expect(getByRole('button').className).toContain(iconButtonIdentifier);
   });
   it('should compose custom classNames with the identifier class', () => {
     const testClassName = 'test classname';
-    const {getByTestId} = render(
+    const {getByRole} = render(
       <IconButton
         data-testid={iconButtonIdentifier}
         className={testClassName}
@@ -44,9 +44,7 @@ describe('Icon Button', () => {
       </IconButton>
     );
 
-    expect(getByTestId(iconButtonIdentifier).className).toContain(
-      `${iconButtonIdentifier} ${testClassName}`
-    );
+    expect(getByRole('button').className).toContain(`${iconButtonIdentifier} ${testClassName}`);
   });
 
   test('should call a callback function', () => {

--- a/modules/button/react/spec/IconButton.spec.tsx
+++ b/modules/button/react/spec/IconButton.spec.tsx
@@ -36,7 +36,6 @@ describe('Icon Button', () => {
     const testClassName = 'test classname';
     const {getByRole} = render(
       <IconButton
-        data-testid={iconButtonIdentifier}
         className={testClassName}
         aria-label="Activity Stream"
       >

--- a/modules/button/react/spec/IconButton.spec.tsx
+++ b/modules/button/react/spec/IconButton.spec.tsx
@@ -35,10 +35,7 @@ describe('Icon Button', () => {
   it('should compose custom classNames with the identifier class', () => {
     const testClassName = 'test classname';
     const {getByRole} = render(
-      <IconButton
-        className={testClassName}
-        aria-label="Activity Stream"
-      >
+      <IconButton className={testClassName} aria-label="Activity Stream">
         <SystemIcon icon={activityStreamIcon} />
       </IconButton>
     );

--- a/modules/button/react/spec/IconButton.spec.tsx
+++ b/modules/button/react/spec/IconButton.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {mount} from 'enzyme';
-import IconButton from '../lib/IconButton';
+import {render} from '@testing-library/react';
+import IconButton, {iconButtonIdentifier} from '../lib/IconButton';
 import {SystemIcon} from '@workday/canvas-kit-react-icon';
 import {activityStreamIcon} from '@workday/canvas-system-icons-web';
 import ReactDOMServer from 'react-dom/server';
@@ -20,6 +21,32 @@ describe('Icon Button', () => {
     );
     expect(component.find('button').props().id).toBe('myBtn');
     component.unmount();
+  });
+
+  it('should have an identifier class', () => {
+    const {getByTestId} = render(
+      <IconButton data-testid={iconButtonIdentifier} aria-label="Activity Stream">
+        <SystemIcon icon={activityStreamIcon} />
+      </IconButton>
+    );
+
+    expect(getByTestId(iconButtonIdentifier).className).toContain(iconButtonIdentifier);
+  });
+  it('should compose custom classNames with the identifier class', () => {
+    const testClassName = 'test classname';
+    const {getByTestId} = render(
+      <IconButton
+        data-testid={iconButtonIdentifier}
+        className={testClassName}
+        aria-label="Activity Stream"
+      >
+        <SystemIcon icon={activityStreamIcon} />
+      </IconButton>
+    );
+
+    expect(getByTestId(iconButtonIdentifier).className).toContain(
+      `${iconButtonIdentifier} ${testClassName}`
+    );
   });
 
   test('should call a callback function', () => {


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Due to some changes in the way we use `@emotion/styled`, we are no longer able use [component selectors](https://emotion.sh/docs/styled#targeting-another-emotion-component) in Emotion via Babel. This is because `styled` functions using Emotion's `CreateStyled`, like our own [Canvas styled component](https://github.com/Workday/canvas-kit/blob/ed41a76be50068cb1ae15b666d9305a6a97c4b72/modules/_labs/core/react/lib/theming/styled.ts#L52), does not work with the babel plugin for emotion.

This is a known issue and will be fixed in Emotion 11 by https://github.com/emotion-js/emotion/pull/1220 via a mapping configuration so the plugin knows about custom styled functions.

For now the fix is to just remove the usage of component selectors. This PR addresses that by using an identifier class name (similar to how Emotion identifies component selectors) in `IconButton` and then styling that class name in `IconButtonToggleGroup`.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [ ] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
