### PR TITLE
feat: Allow a module's story to self-reference the package

### DIFF
--- a/utils/check-dependencies-exist.js
+++ b/utils/check-dependencies-exist.js
@@ -99,8 +99,15 @@ depCheck(modulePath, depCheckOptions, unused => {
       return false;
     }
     if (key === 'missing') {
-      // Make sure this package name doesn't count - it would be a circular dependency on itself
-      delete unused['missing'][packageName];
+      // Self-referencing imports are only okay in stories. It allows story code more copy/paste friendly. Stories are not packaged, so no circular dependency actually exists
+      if (unused['missing'][packageName]) {
+        unused['missing'][packageName] = unused['missing'][packageName].filter(
+          file => file.indexOf('stories') === -1
+        );
+        if (unused['missing'][packageName].length === 0) {
+          delete unused['missing'][packageName];
+        }
+      }
       if (Object.keys(unused['missing']).length === 0) {
         return false;
       }

--- a/utils/check-dependencies-exist.js
+++ b/utils/check-dependencies-exist.js
@@ -91,11 +91,19 @@ function formatErrorMessage(errors) {
 }
 
 const modulePath = process.cwd();
+const packageName = require(path.join(modulePath, 'package.json')).name;
 
 depCheck(modulePath, depCheckOptions, unused => {
   const errorKeys = Object.keys(unused).filter(key => {
     if (key === 'using') {
       return false;
+    }
+    if (key === 'missing') {
+      // Make sure this package name doesn't count - it would be a circular dependency on itself
+      delete unused['missing'][packageName];
+      if (Object.keys(unused['missing']).length === 0) {
+        return false;
+      }
     }
     if (unused[key].constructor === Object) {
       return Object.keys(unused[key]).length;


### PR DESCRIPTION
In order for stories to be friendlier to copy/paste, a story should use the package name.

This change allows for a package's story to reference the package by name. The dependency check was requiring the package to define the dependency, which was illegal.