### PR TITLE
fix: Remove SyntheticEvent type usage

### DIFF
--- a/API_PATTERN_GUIDELINES.md
+++ b/API_PATTERN_GUIDELINES.md
@@ -359,7 +359,7 @@ Use a modified pattern for function props: `The function called when <something 
 /**
   * The function called when the Checkbox state changes.
   */
-onChange?: (e: React.SyntheticEvent) => void;
+onChange?: (e: React.ChangeEvent) => void;
 ```
 
 The pattern for booleans is also different: `If true, <do something>.` For standard 2-state booleans, set `@default false` in the description. For example:

--- a/COMPONENT_STATUS.md
+++ b/COMPONENT_STATUS.md
@@ -27,16 +27,17 @@ part of Canvas.
 | [Button - Standard](modules/button)            | :white_check_mark: | :white_check_mark: |       [:blue_book:](https://design.workday.com/components/buttons/buttons)        |
 | [Button - Drop Down](modules/button)           | :white_check_mark: | :white_check_mark: |       [:blue_book:](https://design.workday.com/components/buttons/buttons)        |
 | [Button - Icon](modules/button)                | :white_check_mark: | :white_check_mark: |     [:blue_book:](https://design.workday.com/components/buttons/icon-buttons)     |
-| [Button - Text](modules/button)                | :white_check_mark: |     :clock330:     |     [:blue_book:](https://design.workday.com/components/buttons/text-buttons)     |
+| [Button - Text](modules/button)                | :white_check_mark: | :white_check_mark: |     [:blue_book:](https://design.workday.com/components/buttons/text-buttons)     |
 | [Action Bar](modules/action-bar)               | :white_check_mark: | :white_check_mark: |      [:blue_book:](https://design.workday.com/components/buttons/action-bar)      |
 | **Containers**                                 |                    |                    |                                                                                   |
 | [Card](modules/card)                           | :white_check_mark: | :white_check_mark: |       [:blue_book:](https://design.workday.com/components/containers/cards)       |
-| Tabs                                           |                    |                    |                                                                                   |
+| [Drawer](modules/_labs/drawer/react) | :microscope:  | | |
 | [Table](modules/table)                         | :white_check_mark: | :white_check_mark: |      [:blue_book:](https://design.workday.com/components/containers/tables)       |
 | **Form Elements**                              |                    |                    |                                                                                   |
 | [Form Field](modules/form-field)               | :white_check_mark: | :white_check_mark: |                                                                                   |
 | [Checkbox](modules/checkbox)                   | :white_check_mark: | :white_check_mark: |   [:blue_book:](https://design.workday.com/components/form-elements/checkboxes)   |
 | [Color Input]([modules/color-picker)           | :white_check_mark: |                    |  [:blue_book:](https://design.workday.com/components/form-elements/color-input)   |
+| [Color Picker]([modules/_labs/color-picker/react)           | :microscope: |                    |   |
 | Date Input                                     |                    |                    |                                                                                   |
 | [Drop Down Select](modules/select)             | :white_check_mark: | :white_check_mark: |                                                                                   |
 | Numeric Input                                  |                    |                    |                                                                                   |
@@ -46,15 +47,20 @@ part of Canvas.
 | [Switch](modules/switch)                       | :white_check_mark: |                    |                                                                                   |
 | Slider                                         |                    |                    |                                                                                   |
 | **Indicators**                                 |                    |                    |                                                                                   |
-| [Banners](modules/banner)                      | :white_check_mark: | :white_check_mark: |      [:blue_book:](https://design.workday.com/components/indicators/banners)      |
+| [Avatar](modules/avatar)                      | :white_check_mark: |  |    |
+| Badge           |  |                    |    |
+| [Banner](modules/banner)                      | :white_check_mark: | :white_check_mark: |      [:blue_book:](https://design.workday.com/components/indicators/banners)      |
 | [Loading Animation](modules/loading-animation) | :white_check_mark: | :white_check_mark: | [:blue_book:](https://design.workday.com/components/indicators/loading-animation) |
-| [Skeleton Loader](modules/skeleton)            | :white_check_mark: |                    |  [:blue_book:](https://design.workday.com/components/indicators/skeleton-loader)  |
+| Pill            |  |                    |    |
 | Progress Bar                                   |                    |                    |                                                                                   |
+| [Skeleton Loader](modules/skeleton)            | :white_check_mark: |                    |  [:blue_book:](https://design.workday.com/components/indicators/skeleton-loader)  |
 | [Status Indicator](modules/status-indicator)   | :white_check_mark: |                    | [:blue_book:](https://design.workday.com/components/indicators/status-indicators) |
 | **Navigation**                                 |                    |                    |                                                                                   |
 | [Header](modules/_labs/header)                 |    :microscope:    |                    |      [:blue_book:](https://design.workday.com/components/navigation/headers)      |
 | [Page Header](modules/page-header)             | :white_check_mark: | :white_check_mark: |    [:blue_book:](https://design.workday.com/components/navigation/page-header)    |
+| [Pagination](modules/_labs/pagination/react)               | :microscope:  |                    |                                                                                   |
 | [Side Panel](modules/side-panel)               | :white_check_mark: |                    |                                                                                   |
+| Tabs                                           |                    |                    |                                                                                   |
 | **Popups**                                     |                    |                    |                                                                                   |
 | [Cookie Banner](modules/cookie-banner)         | :white_check_mark: |                    |                                                                                   |
 | [Modal](modules/modal)                         | :white_check_mark: | :white_check_mark: |                                                                                   |

--- a/modules/_labs/combobox/react/lib/Combobox.tsx
+++ b/modules/_labs/combobox/react/lib/Combobox.tsx
@@ -215,7 +215,7 @@ const Combobox = ({
   }, [autocompleteItems, isFocused, value]);
 
   const handleAutocompleteClick = (
-    event: React.SyntheticEvent,
+    event: React.KeyboardEvent | React.MouseEvent,
     menuItemProps: MenuItemProps
   ): void => {
     if (menuItemProps.isDisabled) {
@@ -225,7 +225,7 @@ const Combobox = ({
     setIsFocused(false);
     setInputValue(getTextFromElement(menuItemProps.children));
     if (menuItemProps.onClick) {
-      menuItemProps.onClick(event);
+      menuItemProps.onClick(event as React.MouseEvent);
     }
   };
 

--- a/modules/_labs/combobox/react/lib/Combobox.tsx
+++ b/modules/_labs/combobox/react/lib/Combobox.tsx
@@ -41,7 +41,7 @@ export interface ComboboxProps extends GrowthBehavior, React.HTMLAttributes<HTML
   /**
    * The function called when the Combobox text input changes.
    */
-  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   /**
    * The function called when the Combobox text input focuses.
    */

--- a/modules/_labs/header/react/README.md
+++ b/modules/_labs/header/react/README.md
@@ -169,7 +169,7 @@ Default: `DubLogoTitle` (for "Dub" variants) or `WorkdayLogoTitle` (for "Full" v
 
 ---
 
-#### `onMenuClick: (React.SyntheticEvent) => void`
+#### `onMenuClick: (React.MouseEvent) => void`
 
 > A click handler for when the user clicks the mobile collapsed nav icon.
 
@@ -254,7 +254,7 @@ Default: `<DubLogoTitle />`
 
 Default: `justifyIcon` from `@workday/canvas-system-icons-web`
 
-#### `onMenuClick: (React.SyntheticEvent) => void`
+#### `onMenuClick: (React.MouseEvent) => void`
 
 > A click handler for when the user clicks the `menuToggle` element.
 

--- a/modules/_labs/header/react/lib/GlobalHeader.tsx
+++ b/modules/_labs/header/react/lib/GlobalHeader.tsx
@@ -16,7 +16,7 @@ export interface GlobalHeaderProps {
   /**
    * The function called when the responsive menu icon is clicked.
    */
-  onMenuClick?: (e: React.SyntheticEvent) => void;
+  onMenuClick?: (e: React.MouseEvent) => void;
   /**
    * If true, render the GlobalHeader in collapsed mode.
    * @default false

--- a/modules/_labs/header/react/lib/Header.tsx
+++ b/modules/_labs/header/react/lib/Header.tsx
@@ -44,7 +44,7 @@ export interface HeaderProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * The function called when the responsive menu icon is clicked.
    */
-  onMenuClick?: (e: React.SyntheticEvent) => void;
+  onMenuClick?: (e: React.MouseEvent) => void;
   /**
    * The React element to render in the left slot of the Header. This is typically a SearchBar component.
    */

--- a/modules/_labs/header/react/stories/stories.tsx
+++ b/modules/_labs/header/react/stories/stories.tsx
@@ -47,15 +47,15 @@ const backgroundStyle = {
 // Simulate a React Router link
 const Link = styled('a')<{to: string}>({});
 
-const handleMenuClickTest = (e: React.SyntheticEvent) => {
+const handleMenuClickTest = (e: React.MouseEvent) => {
   action(`Menu clicked! ${e.target}`)();
 };
 
-const handleAvatarClickTest = (e: React.SyntheticEvent) => {
+const handleAvatarClickTest = (e: React.MouseEvent) => {
   action(`Avatar clicked! ${e.target}`);
 };
 
-const handleSearchSubmitTest = (e: React.SyntheticEvent) => {
+const handleSearchSubmitTest = (e: React.MouseEvent<HTMLFormElement>) => {
   const formInputValue = (e.target as HTMLFormElement).getElementsByTagName('input')[0].value;
   action(`search submitted ${formInputValue}`)();
 };

--- a/modules/_labs/menu/react/README.md
+++ b/modules/_labs/menu/react/README.md
@@ -172,7 +172,7 @@ Default: `false`
 
 ### Optional
 
-#### `onClick: (event: React.SyntheticEvent) => void`
+#### `onClick: (event: React.MouseEvent<HTMLLIElement>) => void`
 
 > This is the primary action to take when a menu item is clicked. If the item is a child of the Menu
 > component, this callback will be decorated with the onSelect and onClose Menu callbacks. This

--- a/modules/_labs/menu/react/lib/Menu.tsx
+++ b/modules/_labs/menu/react/lib/Menu.tsx
@@ -243,14 +243,17 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
     }
   };
 
-  private handleClick = (event: React.SyntheticEvent, menuItemProps: MenuItemProps): void => {
+  private handleClick = (
+    event: React.MouseEvent | React.KeyboardEvent,
+    menuItemProps: MenuItemProps
+  ): void => {
     /* istanbul ignore next line for coverage */
     if (menuItemProps.isDisabled) {
       // You should only hit this point if you are using a custom MenuItem implementation.
       return;
     }
     if (menuItemProps.onClick) {
-      menuItemProps.onClick(event);
+      menuItemProps.onClick(event as React.MouseEvent);
     }
     if (this.props.onSelect) {
       this.props.onSelect();

--- a/modules/_labs/menu/react/lib/MenuItem.tsx
+++ b/modules/_labs/menu/react/lib/MenuItem.tsx
@@ -15,7 +15,7 @@ export interface MenuItemProps extends React.LiHTMLAttributes<HTMLLIElement> {
   /**
    * The function called when the MenuItem is clicked. If the item is a child of the Menu component, this callback will be decorated with the onSelect and onClose Menu callbacks. This callback will not fire if the item is disabled (see below).
    */
-  onClick?: (event: React.SyntheticEvent) => void;
+  onClick?: (event: React.MouseEvent) => void;
   /**
    * The unique id for the MenuItem used for ARIA attributes. If the item is a child of the `Menu` component, this property will be generated and overridden.
    */
@@ -221,7 +221,7 @@ export default class MenuItem extends React.Component<MenuItemProps> {
     );
   }
 
-  private handleClick = (event: React.SyntheticEvent): void => {
+  private handleClick = (event: React.MouseEvent): void => {
     if (this.props.isDisabled) {
       return;
     }

--- a/modules/_labs/menu/react/stories/stories.tsx
+++ b/modules/_labs/menu/react/stories/stories.tsx
@@ -127,7 +127,7 @@ class ControlledMenu extends React.Component<{}, ControlledMenuState> {
       </ClickAwayListener>
     );
   }
-  private handleClick = (event: React.SyntheticEvent<HTMLButtonElement>) => {
+  private handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     const {currentTarget} = event;
     this.setState({
       anchorEl: currentTarget,
@@ -196,7 +196,7 @@ class ContextMenu extends React.Component<{}, ControlledMenuState> {
       </ClickAwayListener>
     );
   }
-  private handleContext = (event: React.SyntheticEvent<HTMLElement>) => {
+  private handleContext = (event: React.MouseEvent<HTMLElement>) => {
     const {currentTarget} = event;
     this.setState({
       anchorEl: currentTarget,

--- a/modules/avatar/react/README.md
+++ b/modules/avatar/react/README.md
@@ -201,6 +201,6 @@ Default: `AvatarButton.Size.m`
 
 ---
 
-#### `onClick: (React.SyntheticEvent) => void`
+#### `onClick: (React.MouseEvent<HTMLButtonElement>) => void`
 
 > A `click` event handler for this component.

--- a/modules/avatar/react/stories/stories.tsx
+++ b/modules/avatar/react/stories/stories.tsx
@@ -9,7 +9,7 @@ import {withKnobs} from '@storybook/addon-knobs';
 
 const IMAGE_URL = 'https://s3-us-west-2.amazonaws.com/design-assets-internal/avatars/lmcneil.png';
 
-const handleAvatarButtonClick = (e: React.SyntheticEvent) => {
+const handleAvatarButtonClick = () => {
   console.log('AvatarButton clicked');
 };
 

--- a/modules/banner/react/README.md
+++ b/modules/banner/react/README.md
@@ -49,7 +49,7 @@ import Banner from '@workday/canvas-kit-react-banner';
 
 ### Optional
 
-#### `onClick: (e: React.SyntheticEvent) => void`
+#### `onClick: (e: React.MouseEvent<HTMLButtonElement>) => void`
 
 > Function called when the user click on the banner
 

--- a/modules/banner/react/lib/Banner.tsx
+++ b/modules/banner/react/lib/Banner.tsx
@@ -14,7 +14,7 @@ export interface BannerProps extends Themeable, React.ButtonHTMLAttributes<HTMLB
   /**
    * The function called when the Banner is clicked.
    */
-  onClick?: (e: React.SyntheticEvent) => void;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   /**
    * The label of the Banner.
    */

--- a/modules/banner/react/stories/stories.tsx
+++ b/modules/banner/react/stories/stories.tsx
@@ -7,7 +7,7 @@ import withReadme from 'storybook-readme/with-readme';
 import Banner from '../index';
 import README from '../README.md';
 
-const handleBannerClick = (e: React.SyntheticEvent) => {
+const handleBannerClick = () => {
   alert(`onClick triggered`);
 };
 

--- a/modules/checkbox/react/README.md
+++ b/modules/checkbox/react/README.md
@@ -96,7 +96,7 @@ Default: A uniquely generated id
 
 ---
 
-#### `onChange: (e: React.SyntheticEvent<HTMLInputElement>) => void`
+#### `onChange: (e: React.ChangeEvent<HTMLInputElement>) => void`
 
 > A callback that gets called everytime the checkbox state changes.
 

--- a/modules/checkbox/react/lib/Checkbox.tsx
+++ b/modules/checkbox/react/lib/Checkbox.tsx
@@ -42,10 +42,6 @@ export interface CheckboxProps extends Themeable, React.InputHTMLAttributes<HTML
    */
   label?: string;
   /**
-   * The function called when the Checkbox state changes.
-   */
-  onChange?: (e: React.SyntheticEvent) => void;
-  /**
    * The value of the Checkbox.
    */
   value?: string;

--- a/modules/checkbox/react/lib/Checkbox.tsx
+++ b/modules/checkbox/react/lib/Checkbox.tsx
@@ -42,6 +42,10 @@ export interface CheckboxProps extends Themeable, React.InputHTMLAttributes<HTML
    */
   label?: string;
   /**
+   * The function called when the Checkbox state changes.
+   */
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  /**
    * The value of the Checkbox.
    */
   value?: string;

--- a/modules/checkbox/react/lib/Checkbox.tsx
+++ b/modules/checkbox/react/lib/Checkbox.tsx
@@ -44,7 +44,7 @@ export interface CheckboxProps extends Themeable, React.InputHTMLAttributes<HTML
   /**
    * The function called when the Checkbox state changes.
    */
-  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   /**
    * The value of the Checkbox.
    */

--- a/modules/modal/css/stories.tsx
+++ b/modules/modal/css/stories.tsx
@@ -95,7 +95,7 @@ class ModalWrapper extends React.Component<{}, ModalWrapperState> {
     });
   };
 
-  private onOpenPopupClick = (e: React.SyntheticEvent<HTMLButtonElement>) => {
+  private onOpenPopupClick = () => {
     this.setState({
       open: !this.state.open,
     });

--- a/modules/popup/css/stories.tsx
+++ b/modules/popup/css/stories.tsx
@@ -93,7 +93,7 @@ class PopupWrapper extends React.Component<{}, PopupWrapperState> {
     });
   };
 
-  private onOpenPopupClick = (e: React.SyntheticEvent<HTMLButtonElement>) => {
+  private onOpenPopupClick = () => {
     this.setState({
       open: !this.state.open,
     });

--- a/modules/popup/react/stories/stories.tsx
+++ b/modules/popup/react/stories/stories.tsx
@@ -57,7 +57,7 @@ class PopupWrapper extends React.Component<{}, PopupWrapperState> {
     });
   };
 
-  private handleClick = (e: React.SyntheticEvent<HTMLButtonElement>) => {
+  private handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     const {currentTarget} = e;
     this.setState({
       anchorEl: currentTarget,

--- a/modules/radio/react/README.md
+++ b/modules/radio/react/README.md
@@ -97,7 +97,7 @@ Default: A uniquely generated id
 
 ---
 
-#### `onChange: (e: React.SyntheticEvent<HTMLInputElement>) => void`
+#### `onChange: (e: React.ChangeEvent<HTMLInputElement>) => void`
 
 > A callback that gets called everytime the radio input state changes.
 

--- a/modules/radio/react/lib/Radio.tsx
+++ b/modules/radio/react/lib/Radio.tsx
@@ -41,7 +41,7 @@ export interface RadioProps extends Themeable, React.InputHTMLAttributes<HTMLInp
   /**
    * The function called when the Radio button state changes.
    */
-  onChange?: (e: React.SyntheticEvent) => void;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   /**
    * The value of the Radio button.
    */

--- a/modules/radio/react/lib/RadioGroup.tsx
+++ b/modules/radio/react/lib/RadioGroup.tsx
@@ -94,9 +94,9 @@ export default class RadioGroup extends React.Component<RadioGroupProps> {
   };
 
   private onRadioChange = (
-    existingOnChange: (e: React.SyntheticEvent) => void | undefined,
+    existingOnChange: (e: React.ChangeEvent) => void | undefined,
     index: number,
-    event: React.MouseEvent<HTMLButtonElement>
+    event: React.ChangeEvent<HTMLInputElement>
   ): void => {
     if (existingOnChange) {
       existingOnChange(event);

--- a/modules/select/react/lib/Select.tsx
+++ b/modules/select/react/lib/Select.tsx
@@ -33,7 +33,7 @@ export interface SelectProps
   /**
    * The function called when the Select state changes.
    */
-  onChange?: React.ChangeEventHandler<HTMLSelectElement>;
+  onChange?: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   /**
    * The value of the Select.
    */

--- a/modules/switch/react/README.md
+++ b/modules/switch/react/README.md
@@ -88,7 +88,7 @@ Default: `false`
 
 ---
 
-#### `onChange: (e: React.SyntheticEvent<HTMLInputElement>) => void`
+#### `onChange: (e: React.ChangeEvent<HTMLInputElement>) => void`
 
 > A callback that gets called everytime the switch checked state changes.
 

--- a/modules/switch/react/lib/Switch.tsx
+++ b/modules/switch/react/lib/Switch.tsx
@@ -27,7 +27,7 @@ export interface SwitchProps extends Themeable, React.InputHTMLAttributes<HTMLIn
   /**
    * The function called when the Switch state changes.
    */
-  onChange?: (e: React.SyntheticEvent) => void;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   /**
    * The value of the Switch.
    */

--- a/modules/text-area/react/README.md
+++ b/modules/text-area/react/README.md
@@ -105,7 +105,7 @@ Default: `false`
 
 ---
 
-#### `onChange: React.ChangeEventHandler<HTMLTextAreaElement>`
+#### `onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void`
 
 > The callback fired when the value is changed.
 

--- a/modules/text-area/react/lib/TextArea.tsx
+++ b/modules/text-area/react/lib/TextArea.tsx
@@ -23,7 +23,7 @@ export interface TextAreaProps
   /**
    * The function called when the TextArea state changes.
    */
-  onChange?: React.ChangeEventHandler<HTMLTextAreaElement>;
+  onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   /**
    * The placeholder text of the TextArea.
    */

--- a/modules/text-input/react/README.md
+++ b/modules/text-input/react/README.md
@@ -113,7 +113,7 @@ Default: `undefined`
 
 ---
 
-#### `onChange: React.ChangeEventHandler<HTMLInputElement>`
+#### `onChange: (e: React.ChangeEvent<HTMLInputElement>) => void`
 
 > The callback fired when the value is changed.
 

--- a/utils/storybook/ControlledComponentWrapper.tsx
+++ b/utils/storybook/ControlledComponentWrapper.tsx
@@ -16,7 +16,7 @@ export default class ControlledComponentWrapper extends React.Component<any, {}>
     checked: false, // Used for boolean components (e.g. checkbox)
   };
 
-  onChange = (e: React.SyntheticEvent | string | number) => {
+  onChange = (e: React.ChangeEvent | string | number) => {
     if (this.props.controlledProp === ControlledProp.Checked) {
       this.setState({checked: !this.state.checked});
     } else {


### PR DESCRIPTION
## Summary

Closes https://github.com/Workday/canvas-kit/issues/496

Removing the override type for `onChange` in `Checkbox`, and instead getting type from `InputHTMLAttributes` (`onChange?: ChangeEventHandler<T>;`)

Would love feedback on whether this is a breaking change, and how to handle! Getting from the default type made sense here to me, but happy to discuss

## Checklist

- [x] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [x] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)
