### PR TITLE
ci: Fix prerelease canary builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ stages:
   if: type = pull_request
 
 - name: trunk
-  if: branch = master OR branch =~ /^prerelease\// AND type != pull_request
+  if: (branch = master OR branch =~ /^prerelease\//) AND type != pull_request
 
 - name: tag
   if: branch =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND tag IS present

--- a/utils/publish-canary.js
+++ b/utils/publish-canary.js
@@ -11,7 +11,6 @@ const {
   TRAVIS_BUILD_URL = 'https://travis-ci.org/Workday/canvas-kit/branches',
 } = process.env;
 
-const regex = /@workday\/[a-z-]*@(\d*.\d*.\d*-next.\d*\+\w*)/gm;
 const data = {};
 let preid;
 
@@ -23,6 +22,8 @@ if (TRAVIS_BRANCH === 'master') {
   console.error('No travis branch provided');
   process.exit(1);
 }
+
+const regex = new RegExp('@workday\\/[a-z-]*@(\\d*.\\d*.\\d*-' + preid + '.\\d*\\+\\w*)', 'g');
 
 cmd(`yarn lerna publish --yes --force-publish="*" --canary --preid ${preid} --dist-tag ${preid}`)
   .then(output => {

--- a/utils/publish-canary.js
+++ b/utils/publish-canary.js
@@ -24,8 +24,16 @@ if (TRAVIS_BRANCH === 'master') {
 }
 
 const regex = new RegExp('@workday\\/[a-z-]*@(\\d*.\\d*.\\d*-' + preid + '.\\d*\\+\\w*)', 'g');
+const lernaFlags = [
+  `--yes`,
+  `--force-publish="*"`,
+  `--canary`,
+  `--preid ${preid}`,
+  `--dist-tag ${preid}`,
+  preid === 'prerelease' ? 'major' : '',
+];
 
-cmd(`yarn lerna publish --yes --force-publish="*" --canary --preid ${preid} --dist-tag ${preid}`)
+cmd(`yarn lerna publish ${lernaFlags.join(' ')}`)
   .then(output => {
     console.log(output);
 
@@ -41,8 +49,8 @@ cmd(`yarn lerna publish --yes --force-publish="*" --canary --preid ${preid} --di
         json: {
           attachments: [
             {
-              fallback: 'Plain-text summary of the attachment.',
-              color: '#2eb886',
+              fallback: `New canary build published (v${data.version})`,
+              color: 'good',
               author_name: `New canary build published (v${data.version})`,
               author_link: TRAVIS_BUILD_URL,
               title: `Merge commit ${sha}`,


### PR DESCRIPTION
#481 forgot to account for the variable preid (`next` vs. `prerelease` in the regex for searching the Lerna output). This resolves that error [seen here](https://travis-ci.org/Workday/canvas-kit/builds/658924582).

Also, we want to push these prelease canary builds under a major release (e.g. `v4.0.0-prerelease.3+SHA`). This also tells Lerna to use a major bump for prerelease branches.