### PR TITLE
ci: Explicit use of yarn for Chromatic cmd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ jobs:
         yarn build-storybook &&
         yarn http-server docs -p 9001 & yarn wait-on http://localhost:9001 &&
         yarn concurrently
-        "chromatic --quiet --exit-zero-on-changes --storybook-build-dir docs"
+        "yarn chromatic --quiet --exit-zero-on-changes --storybook-build-dir docs"
         "yarn cypress run --record" &&
         kill $(jobs -p) || true
     env:


### PR DESCRIPTION
Don't want to get into trouble in the future by not specifying that we're running the workspace version of Chromatic (instead of a random global one for example).

## Summary

Oops, removed `yarn` from the `chromatic` cmd in #500, this adds it back.