### PR TITLE
ci: Travis build speed improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
 
 # cache both yarn and Cypress binary
 cache:
-  npm: false # caching node_modules is expensive and time consuming, we create longer builds with this
+  npm: true
   directories:
     - ~/.cache
 
@@ -90,6 +90,11 @@ jobs:
         on:
           branch: master
 
+before_cache:
+  - rm -rf ./node_modules/.cache/
+  - rm -rf ./node_modules/esm/node_modules/.cache/
+  - rm -rf ./node_modules/storybook-chromatic/node_modules/.cache/
+  
 env:
   global:
   - secure: 2mf5LOhqAmYsMKOoVK+4F9Yym0Y7CvrgyHZcSMsezFB/8PowxdPKDfHuwV8I5DsRQuFzv1G9xmdlrV7qWKf48bJwyFRXulAdzsElrkrXDVhW3nmzt/vpqSA/YJWqB1gsBolp1dOrC0dblNTNzCxHPHgl0y8x8A6ZpT4oUY14iVO+olg5hkD6Yx+M17+Oe1q5r7GUF5auFazZr3BeyJ5oxdIIUVeZRitJU0KxScaZmBv/pwfCKrmrfGk/GSt11WJgTA5pRG+HQZ253uy/Oxsh4JKJXCoeEp1taSnxzJpVeA9iq3Ywj+C64sAqS4NVM/wtLFxDz7RZ3w+B6MbdnAYWarYotuNWtpduiHp9rzfOhYr1DmD9uxCQ+bnt0pwfLY010wsXwnBljxTvVvUwEvMRVTgwzSDwQIbhepb3Br+KduRIZOLAa/mbk6uFQOBJrDfkcug5xZUcoNii2WMtGxdq4gRZ4mWXjiXNOKgm27zu+IRM09z9aUbRTCVsNp8TP23GnhMMdoEhxZECWwHrwT6+QrLeih9tkA7YYlPrjaA33+vajSDzNyLWBxvk7JPIwDZiaObSWOh2XD3XBSnLHN/Pt0udrWxW7Zdtumg/u2zvWRhaQCIPN8fdgYMTEYQ4a1U+hR3gKl6DhF1mgkVqo1Q98g4lY+JMaS8/HG+YCmY5HzI=

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
 # cache both yarn and Cypress binary
 cache:
   yarn: true
+  npm: false
   directories:
     - ~/.cache
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
 # cache both yarn and Cypress binary
 cache:
   yarn: true
-  npm: false
+  npm: false # caching node_modules is expensive and time consuming, we create longer builds with this
   directories:
     - ~/.cache
 
@@ -90,9 +90,6 @@ jobs:
         github_token: "$GH_STORYBOOK_TOKEN"
         on:
           branch: master
-before_cache:
-  # Removes any modules that cache inside node_modules, like the Terser plugin for Webpack
-  - rm -rf ./node_modules/.cache/
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
   - export PATH="$HOME/.yarn/bin:$PATH"
 
 install:
-  - yarn install --production=false
+  - yarn install
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
         "yarn depcheck"
         "yarn test"
       - >- # Chromatic and Cypress rely on Storybook being built, this will exit early if build-storybook fails
-        NODE_ENV=development yarn build-storybook &&
+        yarn build-storybook &&
         yarn http-server docs -p 9001 & yarn wait-on http://localhost:9001 &&
         yarn concurrently
         "yarn chromatic --quiet --exit-zero-on-changes --storybook-build-dir docs"
@@ -90,6 +90,9 @@ jobs:
         github_token: "$GH_STORYBOOK_TOKEN"
         on:
           branch: master
+before_cache:
+  # Removes any modules that cache inside node_modules, like the Terser plugin for Webpack
+  - rm -rf ./node_modules/.cache/
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ cache:
   yarn: true
   directories:
     - ~/.cache
-    - node_modules
 
 git:
   depth: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,16 +42,16 @@ jobs:
   - stage: pull_request
     script:
       - >-
-        yarn concurrently
-        "yarn lint"
-        "yarn depcheck"
-        "yarn test"
+        yarn run-p -l
+        lint
+        depcheck
+        test
       - >- # Chromatic and Cypress rely on Storybook being built, this will exit early if build-storybook fails
         yarn build-storybook &&
-        yarn http-server docs -p 9001 & yarn wait-on http://localhost:9001 &&
-        yarn concurrently
-        "yarn chromatic --quiet --exit-zero-on-changes --storybook-build-dir docs"
-        "yarn cypress run --record" &&
+        yarn http-server docs -p 9001 & npx wait-on http://localhost:9001 &&
+        yarn run-p -l
+        "chromatic --quiet --exit-zero-on-changes --storybook-build-dir docs"
+        "cypress run --record" &&
         kill $(jobs -p) || true
     env:
       # Travis doesn't support encryption on forks: https://docs.travis-ci.com/user/pull-requests#pull-requests-and-security-restrictions

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,8 @@ jobs:
         yarn build-storybook &&
         yarn http-server docs -p 9001 & npx wait-on http://localhost:9001 &&
         yarn run-p -l
-        "chromatic --quiet --exit-zero-on-changes --storybook-build-dir docs"
-        "cypress run --record" &&
+        "chromatic -- --quiet --exit-zero-on-changes --storybook-build-dir docs"
+        "cypress:run -- --record" &&
         kill $(jobs -p) || true
     env:
       # Travis doesn't support encryption on forks: https://docs.travis-ci.com/user/pull-requests#pull-requests-and-security-restrictions

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ jobs:
         yarn build-storybook &&
         yarn http-server docs -p 9001 & npx wait-on http://localhost:9001 &&
         yarn run-p -l
-        "chromatic -- --quiet --exit-zero-on-changes --storybook-build-dir docs"
+        "chromatic -- --quiet --exit-zero-on-changes --exit-once-uploaded --storybook-build-dir docs"
         "cypress:run -- --record" &&
         kill $(jobs -p) || true
     env:
@@ -73,7 +73,7 @@ jobs:
     script:
       - >- # Chromatic relies on a built Storybook, so exit early if build-storybook fails
         yarn build-storybook &&
-        yarn chromatic --quiet --auto-accept-changes --storybook-build-dir docs
+        yarn chromatic --quiet --auto-accept-changes --exit-once-uploaded --storybook-build-dir docs
       - yarn build
     env:
       - CHROMATIC_APP_CODE="dlpro96xybh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
 
 # cache both yarn and Cypress binary
 cache:
-  npm: true
+  npm: false # Caching npm makes yarn install faster but downloading and packaging up the cache makes this slower when enabled
   directories:
     - ~/.cache
 
@@ -90,11 +90,6 @@ jobs:
         on:
           branch: master
 
-before_cache:
-  - rm -rf ./node_modules/.cache/
-  - rm -rf ./node_modules/esm/node_modules/.cache/
-  - rm -rf ./node_modules/storybook-chromatic/node_modules/.cache/
-  
 env:
   global:
   - secure: 2mf5LOhqAmYsMKOoVK+4F9Yym0Y7CvrgyHZcSMsezFB/8PowxdPKDfHuwV8I5DsRQuFzv1G9xmdlrV7qWKf48bJwyFRXulAdzsElrkrXDVhW3nmzt/vpqSA/YJWqB1gsBolp1dOrC0dblNTNzCxHPHgl0y8x8A6ZpT4oUY14iVO+olg5hkD6Yx+M17+Oe1q5r7GUF5auFazZr3BeyJ5oxdIIUVeZRitJU0KxScaZmBv/pwfCKrmrfGk/GSt11WJgTA5pRG+HQZ253uy/Oxsh4JKJXCoeEp1taSnxzJpVeA9iq3Ywj+C64sAqS4NVM/wtLFxDz7RZ3w+B6MbdnAYWarYotuNWtpduiHp9rzfOhYr1DmD9uxCQ+bnt0pwfLY010wsXwnBljxTvVvUwEvMRVTgwzSDwQIbhepb3Br+KduRIZOLAa/mbk6uFQOBJrDfkcug5xZUcoNii2WMtGxdq4gRZ4mWXjiXNOKgm27zu+IRM09z9aUbRTCVsNp8TP23GnhMMdoEhxZECWwHrwT6+QrLeih9tkA7YYlPrjaA33+vajSDzNyLWBxvk7JPIwDZiaObSWOh2XD3XBSnLHN/Pt0udrWxW7Zdtumg/u2zvWRhaQCIPN8fdgYMTEYQ4a1U+hR3gKl6DhF1mgkVqo1Q98g4lY+JMaS8/HG+YCmY5HzI=

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ addons:
     packages:
     - libgconf-2-4
 
-# cache both yarn and Cypress binar
-# also cache TypeScript builds, this only rebuilds when code changes
+# cache both yarn and Cypress binary
 cache:
   yarn: true
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ addons:
 
 # cache both yarn and Cypress binary
 cache:
-  yarn: true
   npm: false # caching node_modules is expensive and time consuming, we create longer builds with this
   directories:
     - ~/.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ cache:
   yarn: true
   directories:
     - ~/.cache
+    - node_modules
 
 git:
   depth: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
         "yarn depcheck"
         "yarn test"
       - >- # Chromatic and Cypress rely on Storybook being built, this will exit early if build-storybook fails
-        yarn build-storybook &&
+        NODE_ENV=development yarn build-storybook &&
         yarn http-server docs -p 9001 & yarn wait-on http://localhost:9001 &&
         yarn concurrently
         "chromatic --quiet --exit-zero-on-changes --storybook-build-dir docs"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
     "colors": "^1.4.0",
     "commitizen": "^3.1.1",
-    "concurrently": "^5.1.0",
     "core-js": "^3.5.0",
     "css-loader": "^3.2.0",
     "css-mqpacker": "^7.0.0",
@@ -123,8 +122,7 @@
     "tslint": "^5.20.0",
     "tslint-config-prettier": "^1.14.0",
     "tslint-react": "^3.6.0",
-    "typescript": "^3.5.1",
-    "wait-on": "^4.0.1"
+    "typescript": "^3.5.1"
   },
   "scripts": {
     "start": "node --max-old-space-size=2048 node_modules/.bin/start-storybook -p 9001 -c .storybook",

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "create-module": "./utils/create-component/createComponent.js",
     "create-component": "./utils/create-component/createComponent.js",
     "precommit": "lint-staged",
+    "chromatic": "chromatic",
     "commit": "git-cz",
     "commitmsg": "commitlint --edit $HUSKY_GIT_PARAMS",
     "build-storybook": "build-storybook -c .storybook -o docs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23573,7 +23573,7 @@ webpack-virtual-modules@^0.2.0:
   dependencies:
     debug "^3.0.0"
 
-webpack@4.41.5:
+webpack@4.41.5, webpack@^4.33.0, webpack@^4.38.0:
   version "4.41.5"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.41.5.tgz#3210f1886bce5310e62bb97204d18c263341b77c"
   integrity sha512-wp0Co4vpyumnp3KlkmpM5LWuzvZYayDwM2n17EHFr4qxBBbRokC7DJawPJC7TfSFZ9HZ6GsdH40EBj4UV0nmpw==
@@ -23599,65 +23599,6 @@ webpack@4.41.5:
     schema-utils "^1.0.0"
     tapable "^1.1.3"
     terser-webpack-plugin "^1.4.3"
-    watchpack "^1.6.0"
-    webpack-sources "^1.4.1"
-
-webpack@^4.33.0:
-  version "4.34.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.34.0.tgz#a4c30129482f7b4ece4c0842002dedf2b56fab58"
-  integrity sha512-ry2IQy1wJjOefLe1uJLzn5tG/DdIKzQqNlIAd2L84kcaADqNvQDTBlo8UcCNyDaT5FiaB+16jhAkb63YeG3H8Q==
-  dependencies:
-    "@webassemblyjs/ast" "1.8.5"
-    "@webassemblyjs/helper-module-context" "1.8.5"
-    "@webassemblyjs/wasm-edit" "1.8.5"
-    "@webassemblyjs/wasm-parser" "1.8.5"
-    acorn "^6.0.5"
-    acorn-dynamic-import "^4.0.0"
-    ajv "^6.1.0"
-    ajv-keywords "^3.1.0"
-    chrome-trace-event "^1.0.0"
-    enhanced-resolve "^4.1.0"
-    eslint-scope "^4.0.0"
-    json-parse-better-errors "^1.0.2"
-    loader-runner "^2.3.0"
-    loader-utils "^1.1.0"
-    memory-fs "~0.4.1"
-    micromatch "^3.1.8"
-    mkdirp "~0.5.0"
-    neo-async "^2.5.0"
-    node-libs-browser "^2.0.0"
-    schema-utils "^1.0.0"
-    tapable "^1.1.0"
-    terser-webpack-plugin "^1.1.0"
-    watchpack "^1.5.0"
-    webpack-sources "^1.3.0"
-
-webpack@^4.38.0:
-  version "4.41.2"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.41.2.tgz#c34ec76daa3a8468c9b61a50336d8e3303dce74e"
-  integrity sha512-Zhw69edTGfbz9/8JJoyRQ/pq8FYUoY0diOXqW0T6yhgdhCv6wr0hra5DwwWexNRns2Z2+gsnrNcbe9hbGBgk/A==
-  dependencies:
-    "@webassemblyjs/ast" "1.8.5"
-    "@webassemblyjs/helper-module-context" "1.8.5"
-    "@webassemblyjs/wasm-edit" "1.8.5"
-    "@webassemblyjs/wasm-parser" "1.8.5"
-    acorn "^6.2.1"
-    ajv "^6.10.2"
-    ajv-keywords "^3.4.1"
-    chrome-trace-event "^1.0.2"
-    enhanced-resolve "^4.1.0"
-    eslint-scope "^4.0.3"
-    json-parse-better-errors "^1.0.2"
-    loader-runner "^2.4.0"
-    loader-utils "^1.2.3"
-    memory-fs "^0.4.1"
-    micromatch "^3.1.10"
-    mkdirp "^0.5.1"
-    neo-async "^2.6.1"
-    node-libs-browser "^2.2.1"
-    schema-utils "^1.0.0"
-    tapable "^1.1.3"
-    terser-webpack-plugin "^1.4.1"
     watchpack "^1.6.0"
     webpack-sources "^1.4.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2805,32 +2805,15 @@
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"
   integrity sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==
 
-"@hapi/address@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-4.0.0.tgz#36affb4509b5a6adc628bcc394450f2a7d51d111"
-  integrity sha512-GDDpkCdSUfkQCznmWUHh9dDN85BWf/V8TFKQ2JLuHdGB4Yy3YTEGBzZxoBNxfNBEvreSR/o+ZxBBSNNEVzY+lQ==
-  dependencies:
-    "@hapi/hoek" "^9.0.0"
-
 "@hapi/bourne@1.x.x":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@hapi/bourne/-/bourne-1.3.2.tgz#0a7095adea067243ce3283e1b56b8a8f453b242a"
   integrity sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==
 
-"@hapi/formula@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@hapi/formula/-/formula-2.0.0.tgz#edade0619ed58c8e4f164f233cda70211e787128"
-  integrity sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A==
-
 "@hapi/hoek@8.x.x", "@hapi/hoek@^8.3.0":
   version "8.5.1"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.5.1.tgz#fde96064ca446dec8c55a8c2f130957b070c6e06"
   integrity sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==
-
-"@hapi/hoek@^9.0.0":
-  version "9.0.3"
-  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.0.3.tgz#e49e637d5de8faa4f0d313c2590b455d7c00afd7"
-  integrity sha512-jKtjLLDiH95b002sJVc5c74PE6KKYftuyVdVmsuYId5stTaWcRFqE+5ukZI4gDUKjGn8wv2C3zPn3/nyjEI7gg==
 
 "@hapi/joi@^15.0.0":
   version "15.1.1"
@@ -2842,35 +2825,12 @@
     "@hapi/hoek" "8.x.x"
     "@hapi/topo" "3.x.x"
 
-"@hapi/joi@^17.1.0":
-  version "17.1.0"
-  resolved "https://registry.yarnpkg.com/@hapi/joi/-/joi-17.1.0.tgz#cc4000b6c928a6a39b9bef092151b6bdee10ce55"
-  integrity sha512-ob67RcPlwRWxBzLCnWvcwx5qbwf88I3ykD7gcJLWOTRfLLgosK7r6aeChz4thA3XRvuBfI0KB1tPVl2EQFlPXw==
-  dependencies:
-    "@hapi/address" "^4.0.0"
-    "@hapi/formula" "^2.0.0"
-    "@hapi/hoek" "^9.0.0"
-    "@hapi/pinpoint" "^2.0.0"
-    "@hapi/topo" "^5.0.0"
-
-"@hapi/pinpoint@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@hapi/pinpoint/-/pinpoint-2.0.0.tgz#805b40d4dbec04fc116a73089494e00f073de8df"
-  integrity sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw==
-
 "@hapi/topo@3.x.x":
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-3.1.6.tgz#68d935fa3eae7fdd5ab0d7f953f3205d8b2bfc29"
   integrity sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==
   dependencies:
     "@hapi/hoek" "^8.3.0"
-
-"@hapi/topo@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.0.0.tgz#c19af8577fa393a06e9c77b60995af959be721e7"
-  integrity sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==
-  dependencies:
-    "@hapi/hoek" "^9.0.0"
 
 "@iamstarkov/listr-update-renderer@0.4.1":
   version "0.4.1"
@@ -5792,11 +5752,6 @@ accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
     mime-types "~2.1.24"
     negotiator "0.6.2"
 
-acorn-dynamic-import@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz#482210140582a36b83c3e342e1cfebcaa9240948"
-  integrity sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==
-
 acorn-globals@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-3.1.0.tgz#fd8270f71fbb4996b004fa880ee5d46573a731bf"
@@ -5855,7 +5810,7 @@ acorn@^5.5.3:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
 
-acorn@^6.0.1, acorn@^6.0.5, acorn@^6.1.1:
+acorn@^6.0.1, acorn@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
   integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
@@ -8049,7 +8004,7 @@ chroma-js@^2.1.0:
   dependencies:
     cross-env "^6.0.3"
 
-chrome-trace-event@^1.0.0, chrome-trace-event@^1.0.2:
+chrome-trace-event@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz#234090ee97c7d4ad1a2c4beae27505deffc608a4"
   integrity sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==
@@ -8486,21 +8441,6 @@ concat-stream@^2.0.0:
     inherits "^2.0.3"
     readable-stream "^3.0.2"
     typedarray "^0.0.6"
-
-concurrently@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-5.1.0.tgz#05523986ba7aaf4b58a49ddd658fab88fa783132"
-  integrity sha512-9ViZMu3OOCID3rBgU31mjBftro2chOop0G2u1olq1OuwRBVRw/GxHTg80TVJBUTJfoswMmEUeuOg1g1yu1X2dA==
-  dependencies:
-    chalk "^2.4.2"
-    date-fns "^2.0.1"
-    lodash "^4.17.15"
-    read-pkg "^4.0.1"
-    rxjs "^6.5.2"
-    spawn-command "^0.0.2-1"
-    supports-color "^6.1.0"
-    tree-kill "^1.2.2"
-    yargs "^13.3.0"
 
 config-chain@^1.1.11:
   version "1.1.12"
@@ -9427,11 +9367,6 @@ date-fns@^1.27.2:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
-
-date-fns@^2.0.1:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.10.0.tgz#abd10604d8bafb0bcbd2ba2e9b0563b922ae4b6b"
-  integrity sha512-EhfEKevYGWhWlZbNeplfhIU/+N+x0iCIx7VzKlXma2EdQyznVlZhCptXUY+BegNpPW2kjdx15Rvq503YcXXrcA==
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -15551,7 +15486,7 @@ loader-fs-cache@^1.0.2:
     find-cache-dir "^0.1.1"
     mkdirp "0.5.1"
 
-loader-runner@^2.3.0, loader-runner@^2.4.0:
+loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
@@ -16084,7 +16019,7 @@ memoizerific@^1.11.3:
   dependencies:
     map-or-similar "^1.5.0"
 
-memory-fs@^0.4.0, memory-fs@^0.4.1, memory-fs@~0.4.1:
+memory-fs@^0.4.0, memory-fs@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
   integrity sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=
@@ -16722,7 +16657,7 @@ node-int64@^0.4.0:
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
 
-node-libs-browser@^2.0.0, node-libs-browser@^2.2.1:
+node-libs-browser@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.2.1.tgz#b64f513d18338625f90346d27b0d235e631f6425"
   integrity sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==
@@ -19822,15 +19757,6 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-read-pkg@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-4.0.1.tgz#963625378f3e1c4d48c85872b5a6ec7d5d093237"
-  integrity sha1-ljYlN48+HE1IyFhytabsfV0JMjc=
-  dependencies:
-    normalize-package-data "^2.3.2"
-    parse-json "^4.0.0"
-    pify "^3.0.0"
-
 read-pkg@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.2.0.tgz#7bf295438ca5a33e56cd30e053b34ee7250c93cc"
@@ -20737,7 +20663,7 @@ rxjs@^6.1.0, rxjs@^6.3.3, rxjs@^6.4.0:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^6.5.2, rxjs@^6.5.3, rxjs@^6.5.4:
+rxjs@^6.5.3:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.4.tgz#e0777fe0d184cec7872df147f303572d414e211c"
   integrity sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==
@@ -21430,11 +21356,6 @@ space-separated-tokens@^1.1.2:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz#85f32c3d10d9682007e917414ddc5c26d1aa6899"
   integrity sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==
-
-spawn-command@^0.0.2-1:
-  version "0.0.2-1"
-  resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2-1.tgz#62f5e9466981c1b796dc5929937e11c9c6921bd0"
-  integrity sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=
 
 spdx-correct@^3.0.0:
   version "3.1.0"
@@ -22226,37 +22147,6 @@ terser-webpack-plugin@2.3.4, terser-webpack-plugin@^2.1.2:
     terser "^4.4.3"
     webpack-sources "^1.4.3"
 
-terser-webpack-plugin@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.3.0.tgz#69aa22426299f4b5b3775cbed8cb2c5d419aa1d4"
-  integrity sha512-W2YWmxPjjkUcOWa4pBEv4OP4er1aeQJlSo2UhtCFQCuRXEHjOFscO8VyWHj9JLlA0RzQb8Y2/Ta78XZvT54uGg==
-  dependencies:
-    cacache "^11.3.2"
-    find-cache-dir "^2.0.0"
-    is-wsl "^1.1.0"
-    loader-utils "^1.2.3"
-    schema-utils "^1.0.0"
-    serialize-javascript "^1.7.0"
-    source-map "^0.6.1"
-    terser "^4.0.0"
-    webpack-sources "^1.3.0"
-    worker-farm "^1.7.0"
-
-terser-webpack-plugin@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz#61b18e40eaee5be97e771cdbb10ed1280888c2b4"
-  integrity sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==
-  dependencies:
-    cacache "^12.0.2"
-    find-cache-dir "^2.1.0"
-    is-wsl "^1.1.0"
-    schema-utils "^1.0.0"
-    serialize-javascript "^1.7.0"
-    source-map "^0.6.1"
-    terser "^4.1.2"
-    webpack-sources "^1.4.0"
-    worker-farm "^1.7.0"
-
 terser-webpack-plugin@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz#5ecaf2dbdc5fb99745fd06791f46fc9ddb1c9a7c"
@@ -22755,11 +22645,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-
-typescript-eslint@^0.0.1-alpha.0:
-  version "0.0.1-alpha.0"
-  resolved "https://registry.yarnpkg.com/typescript-eslint/-/typescript-eslint-0.0.1-alpha.0.tgz#285d68a4e96588295cd436278801bcb6a6b916c1"
-  integrity sha512-1hNKM37dAWML/2ltRXupOq2uqcdRQyDFphl+341NTPXFLLLiDhErXx8VtaSLh3xP7SyHZdcCgpt9boYYVb3fQg==
 
 typescript@^3.5.1:
   version "3.5.2"
@@ -23376,18 +23261,6 @@ wait-for-expect@^3.0.0:
   resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.1.tgz#ec204a76b0038f17711e575720aaf28505ac7185"
   integrity sha512-3Ha7lu+zshEG/CeHdcpmQsZnnZpPj/UsG3DuKO8FskjuDbkx3jE3845H+CuwZjA2YWYDfKMU2KhnCaXMLd3wVw==
 
-wait-on@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-4.0.1.tgz#c49ca18b1ea60580404feed9df76ab3af2425a56"
-  integrity sha512-x83fmTH2X0KL7vXoGt9aV5x4SMCvO8A/NbwWpaYYh4NJ16d3KSgbHwBy9dVdHj0B30cEhOFRvDob4fnpUmZxvA==
-  dependencies:
-    "@hapi/joi" "^17.1.0"
-    lodash "^4.17.15"
-    minimist "^1.2.0"
-    request "^2.88.0"
-    request-promise-native "^1.0.8"
-    rxjs "^6.5.4"
-
 walkdir@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/walkdir/-/walkdir-0.4.1.tgz#dc119f83f4421df52e3061e514228a2db20afa39"
@@ -23414,7 +23287,7 @@ warning@^4.0.1, warning@^4.0.2:
   dependencies:
     loose-envify "^1.0.0"
 
-watchpack@^1.5.0, watchpack@^1.6.0:
+watchpack@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.6.0.tgz#4bc12c2ebe8aa277a71f1d3f14d685c7b446cd00"
   integrity sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==
@@ -23550,7 +23423,7 @@ webpack-manifest-plugin@2.2.0:
     object.entries "^1.1.0"
     tapable "^1.0.0"
 
-webpack-sources@^1.1.0, webpack-sources@^1.3.0:
+webpack-sources@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.3.0.tgz#2a28dcb9f1f45fe960d8f1493252b5ee6530fa85"
   integrity sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==


### PR DESCRIPTION
Things we did to speed up Travis (hopefully for real this time):
- Exit Chromatic after upload so it doesn't hold up the build
- Remove caching for yarn and npm (node_modules). Loading and building the cache is longer than the savings incurred by having a cache.
- Deduplicate instances of Webpack in our yarn.lock
- Replace `concurrently` with `run-p` (part of `npm-run-all`, a dep we already use). Concurrently was a 40mb hit to our cache and didn't add any value from what we already have.

We went from around 20 to 25 min to 15min. Not too shabby.