### PR TITLE
feat(drawer): Make the close icon in DrawerHeader optional

### DIFF
--- a/modules/_labs/drawer/react/lib/DrawerHeader.tsx
+++ b/modules/_labs/drawer/react/lib/DrawerHeader.tsx
@@ -73,7 +73,7 @@ const CloseButton = styled(IconButton)({
 
 export default class DrawerHeader extends React.Component<DrawerHeaderProps, {}> {
   static defaultProps = {
-    iconLabel: 'Close',
+    closeIconLabel: 'Close',
     headerColor: colors.soap100,
     borderColor: colors.soap500,
     showInverseButton: false,
@@ -97,14 +97,14 @@ export default class DrawerHeader extends React.Component<DrawerHeaderProps, {}>
         <HeaderTitle id={id} inverse={inverse} title={title}>
           {title}
         </HeaderTitle>
-        {onClose && closeIconLabel ? (
+        {onClose && closeIconLabel && (
           <CloseButton
             variant={inverse ? IconButtonVariant.Inverse : IconButtonVariant.Plain}
             onClick={onClose}
             aria-label={closeIconLabel}
             icon={xIcon}
           />
-        ) : null}
+        )}
       </HeaderContainer>
     );
   }

--- a/modules/_labs/drawer/react/lib/DrawerHeader.tsx
+++ b/modules/_labs/drawer/react/lib/DrawerHeader.tsx
@@ -12,12 +12,12 @@ export interface DrawerHeaderProps extends React.HTMLAttributes<HTMLDivElement> 
   /**
    * The function called when the DrawerHeader close button is clicked.
    */
-  onClose: IconButtonProps['onClick'];
+  onClose?: IconButtonProps['onClick'];
   /**
    * The `aria-label` for the DrawHeader close button. Useful for i18n.
    * @default Close
    */
-  closeIconLabel: string;
+  closeIconLabel?: string;
   /**
    * The background color of the DrawerHeader.
    */
@@ -97,12 +97,14 @@ export default class DrawerHeader extends React.Component<DrawerHeaderProps, {}>
         <HeaderTitle id={id} inverse={inverse} title={title}>
           {title}
         </HeaderTitle>
-        <CloseButton
-          variant={inverse ? IconButtonVariant.Inverse : IconButtonVariant.Plain}
-          onClick={onClose}
-          aria-label={closeIconLabel}
-          icon={xIcon}
-        ></CloseButton>
+        {onClose && closeIconLabel ? (
+          <CloseButton
+            variant={inverse ? IconButtonVariant.Inverse : IconButtonVariant.Plain}
+            onClick={onClose}
+            aria-label={closeIconLabel}
+            icon={xIcon}
+          />
+        ) : null}
       </HeaderContainer>
     );
   }

--- a/modules/_labs/drawer/react/spec/Drawer.spec.tsx
+++ b/modules/_labs/drawer/react/spec/Drawer.spec.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {render, fireEvent} from '@testing-library/react';
+// import {toBeInTheDocument} from '@testing-library/jest-dom/matchers';
 
 import {Drawer, DrawerHeader, DrawerDirection} from '../index';
 
@@ -15,13 +16,12 @@ describe('Drawer', () => {
     );
 
     fireEvent.click(await findByLabelText('Close'));
-
     expect(cb).toHaveBeenCalledTimes(1);
   });
 
   test('should not render a close icon button', async () => {
     const {container} = render(<DrawerHeader headerText={'Header Title'} />);
-    expect(container.firstChild.childNodes.length).toEqual(1);
+    expect(container.querySelector('svg')).not.toBeInTheDocument();
   });
 
   test('Drawer should spread extra props', async () => {

--- a/modules/_labs/drawer/react/spec/Drawer.spec.tsx
+++ b/modules/_labs/drawer/react/spec/Drawer.spec.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {render, fireEvent} from '@testing-library/react';
-// import {toBeInTheDocument} from '@testing-library/jest-dom/matchers';
 
 import {Drawer, DrawerHeader, DrawerDirection} from '../index';
 
@@ -16,11 +15,13 @@ describe('Drawer', () => {
     );
 
     fireEvent.click(await findByLabelText('Close'));
+
     expect(cb).toHaveBeenCalledTimes(1);
   });
 
   test('should not render a close icon button', async () => {
     const {container} = render(<DrawerHeader headerText={'Header Title'} />);
+
     expect(container.querySelector('svg')).not.toBeInTheDocument();
   });
 

--- a/modules/_labs/drawer/react/spec/Drawer.spec.tsx
+++ b/modules/_labs/drawer/react/spec/Drawer.spec.tsx
@@ -19,6 +19,11 @@ describe('Drawer', () => {
     expect(cb).toHaveBeenCalledTimes(1);
   });
 
+  test('should not render a close icon button', async () => {
+    const {container} = render(<DrawerHeader headerText={'Header Title'} />);
+    expect(container.firstChild.childNodes.length).toEqual(1);
+  });
+
   test('Drawer should spread extra props', async () => {
     const {container} = render(<Drawer data-id={'1234'} openDirection={DrawerDirection.Right} />);
 

--- a/modules/_labs/drawer/react/stories/stories.tsx
+++ b/modules/_labs/drawer/react/stories/stories.tsx
@@ -76,6 +76,18 @@ storiesOf('Labs|Drawer/React', module)
       </div>
     </div>
   ))
+  .add('With Header, No Close Icon', () => (
+    <div className="story">
+      <div style={{height: '80vh', position: 'relative'}}>
+        <Drawer
+          header={<DrawerHeader title={'Drawer Header'} />}
+          openDirection={DrawerDirection.Left}
+          padding={spacing.s}
+          showDropShadow={true}
+        />
+      </div>
+    </div>
+  ))
   .add('Configurable', () => (
     <div className="story">
       <div style={{height: '80vh', position: 'relative'}}>


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

We want to be able to use the side panel with the header. However we are going to keep it open and therefore we do not want to render a close button. 

<img width="281" alt="Screen Shot 2020-03-10 at 2 14 46 PM" src="https://user-images.githubusercontent.com/17392486/76355238-878fe080-62d9-11ea-9c8f-1ea71f0999ea.png">

Closes #506 

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] branch has been rebased on the latest master commit
- [ x] tests are changed or added
- [ x] `yarn test` passes
- [ x] all (dev)dependencies that the module needs is added to its `package.json`
- [ x] code has been documented and, if applicable, usage described in README.md
- [ x] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ x] design approved final implementation
- [ ] a11y approved final implementation
- [ x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
