### PR TITLE
feat(button): Add theming support to buttons

### DIFF
--- a/modules/_labs/core/react/lib/theming/theme.ts
+++ b/modules/_labs/core/react/lib/theming/theme.ts
@@ -22,7 +22,7 @@ export const defaultCanvasTheme: CanvasTheme = {
     },
     error: {
       lightest: colors.cinnamon100,
-      light: colors.cinnamon300,
+      light: colors.cinnamon200,
       main: colors.cinnamon500,
       dark: colors.cinnamon600,
       darkest: '#80160E',

--- a/modules/_labs/core/react/lib/theming/types.ts
+++ b/modules/_labs/core/react/lib/theming/types.ts
@@ -50,7 +50,7 @@ export interface CanvasTheme {
  * Indicates a component is themeable with a CanvasTheme
  */
 export interface Themeable {
-  theme: CanvasTheme;
+  theme?: CanvasTheme;
 }
 
 /**

--- a/modules/_labs/core/react/lib/theming/types.ts
+++ b/modules/_labs/core/react/lib/theming/types.ts
@@ -50,7 +50,7 @@ export interface CanvasTheme {
  * Indicates a component is themeable with a CanvasTheme
  */
 export interface Themeable {
-  theme?: CanvasTheme;
+  theme: CanvasTheme;
 }
 
 /**

--- a/modules/button/react/lib/Button.tsx
+++ b/modules/button/react/lib/Button.tsx
@@ -37,13 +37,13 @@ export interface ButtonProps
 }
 
 const Button = ({
+  theme = useTheme(),
   variant = ButtonVariant.Secondary,
   size = 'medium',
   buttonRef,
   dataLabel,
   icon,
   children,
-  theme = useTheme(),
   ...elemProps
 }: ButtonProps) => (
   <ButtonContainer

--- a/modules/button/react/lib/Button.tsx
+++ b/modules/button/react/lib/Button.tsx
@@ -1,11 +1,15 @@
 import * as React from 'react';
+import {Themeable, CanvasTheme, useTheme} from '@workday/canvas-kit-labs-react-core';
 import {colors} from '@workday/canvas-kit-react-core';
 import {GrowthBehavior} from '@workday/canvas-kit-react-common';
 import {CanvasSystemIcon} from '@workday/design-assets-types';
 import {ButtonVariant, ButtonColors, DropdownButtonVariant, ButtonSize} from './types';
 import {ButtonContainer, ButtonLabel, ButtonLabelData, ButtonLabelIcon} from './parts';
 
-export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>, GrowthBehavior {
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    Themeable,
+    GrowthBehavior {
   /**
    * The variant of the Button.
    * @default ButtonVariant.Secondary
@@ -39,9 +43,15 @@ const Button = ({
   dataLabel,
   icon,
   children,
+  theme = useTheme(),
   ...elemProps
 }: ButtonProps) => (
-  <ButtonContainer colors={getButtonColors(variant)} size={size} ref={buttonRef} {...elemProps}>
+  <ButtonContainer
+    colors={getButtonColors(variant, theme)}
+    size={size}
+    ref={buttonRef}
+    {...elemProps}
+  >
     {icon && size !== 'small' && <ButtonLabelIcon size={size} icon={icon} />}
     <ButtonLabel>{children}</ButtonLabel>
     {dataLabel && size !== 'small' && <ButtonLabelData>{dataLabel}</ButtonLabelData>}
@@ -53,27 +63,30 @@ Button.Size = ButtonSize;
 
 export default Button;
 
-export const getButtonColors = (variant: ButtonVariant | DropdownButtonVariant): ButtonColors => {
+export const getButtonColors = (
+  variant: ButtonVariant | DropdownButtonVariant,
+  theme: CanvasTheme
+): ButtonColors => {
   switch (variant) {
     case ButtonVariant.Primary:
     case DropdownButtonVariant.Primary:
       return {
         default: {
-          background: colors.blueberry400,
-          icon: colors.frenchVanilla100,
-          label: colors.frenchVanilla100,
+          background: theme.palette.primary.main,
+          icon: theme.palette.primary.contrast,
+          label: theme.palette.primary.contrast,
         },
         hover: {
-          background: colors.blueberry500,
+          background: theme.palette.primary.dark,
         },
         active: {
-          background: colors.blueberry600,
+          background: theme.palette.primary.darkest,
         },
         focus: {
-          background: colors.blueberry400,
+          background: theme.palette.primary.main,
         },
         disabled: {
-          background: colors.blueberry200,
+          background: theme.palette.primary.light,
         },
       };
     case ButtonVariant.Secondary:

--- a/modules/button/react/lib/DeleteButton.tsx
+++ b/modules/button/react/lib/DeleteButton.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import {colors} from '@workday/canvas-kit-react-core';
+import {Themeable, CanvasTheme, useTheme} from '@workday/canvas-kit-labs-react-core';
 import {ButtonColors, ButtonSize} from './types';
 import {ButtonContainer, ButtonLabel} from './parts';
 import {GrowthBehavior} from '@workday/canvas-kit-react-common';
 
 export interface DeleteButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    Themeable,
     GrowthBehavior {
   /**
    * The size of the Button.
@@ -18,27 +19,33 @@ export interface DeleteButtonProps
   buttonRef?: React.Ref<HTMLButtonElement>;
 }
 
-const getDeleteButtonColors = (): ButtonColors => ({
+const getDeleteButtonColors = (theme: CanvasTheme): ButtonColors => ({
   default: {
-    background: colors.cinnamon500,
-    label: colors.frenchVanilla100,
+    background: theme.palette.error.main,
+    label: theme.palette.error.contrast,
   },
   hover: {
-    background: colors.cinnamon600,
+    background: theme.palette.error.dark,
   },
   active: {
-    background: '#80160E',
+    background: theme.palette.error.darkest,
   },
   focus: {
-    background: colors.cinnamon500,
+    background: theme.palette.error.main,
   },
   disabled: {
-    background: colors.cinnamon200,
+    background: theme.palette.error.light,
   },
 });
 
-const DeleteButton = ({size = 'medium', buttonRef, children, ...elemProps}: DeleteButtonProps) => (
-  <ButtonContainer colors={getDeleteButtonColors()} size={size} ref={buttonRef} {...elemProps}>
+const DeleteButton = ({
+  theme = useTheme(),
+  size = 'medium',
+  buttonRef,
+  children,
+  ...elemProps
+}: DeleteButtonProps) => (
+  <ButtonContainer colors={getDeleteButtonColors(theme)} size={size} ref={buttonRef} {...elemProps}>
     <ButtonLabel>{children}</ButtonLabel>
   </ButtonContainer>
 );

--- a/modules/button/react/lib/DropdownButton.tsx
+++ b/modules/button/react/lib/DropdownButton.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {Themeable, useTheme} from '@workday/canvas-kit-labs-react-core';
 import {caretDownIcon} from '@workday/canvas-system-icons-web';
 import {GrowthBehavior} from '@workday/canvas-kit-react-common';
 import {DropdownButtonVariant, ButtonIconPosition} from './types';
@@ -7,6 +8,7 @@ import {getButtonColors} from './Button';
 
 export interface DropdownButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    Themeable,
     GrowthBehavior {
   /**
    * The variant of the Button.
@@ -25,13 +27,19 @@ export interface DropdownButtonProps
 }
 
 const DropdownButton = ({
+  theme = useTheme(),
   variant = DropdownButtonVariant.Secondary,
   size = 'medium',
   buttonRef,
   children,
   ...elemProps
 }: DropdownButtonProps) => (
-  <ButtonContainer colors={getButtonColors(variant)} size={size} ref={buttonRef} {...elemProps}>
+  <ButtonContainer
+    colors={getButtonColors(variant, theme)}
+    size={size}
+    ref={buttonRef}
+    {...elemProps}
+  >
     <ButtonLabel>{children}</ButtonLabel>
     <ButtonLabelIcon
       size={size}

--- a/modules/button/react/lib/HighlightButton.tsx
+++ b/modules/button/react/lib/HighlightButton.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {Themeable, CanvasTheme, useTheme} from '@workday/canvas-kit-labs-react-core';
 import {colors} from '@workday/canvas-kit-react-core';
 import {GrowthBehavior} from '@workday/canvas-kit-react-common';
 import {CanvasSystemIcon} from '@workday/design-assets-types';
@@ -7,6 +8,7 @@ import {ButtonContainer, ButtonLabel, ButtonLabelIcon} from './parts';
 
 export interface HighlightButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    Themeable,
     GrowthBehavior {
   /**
    * The size of the HighlightButton.
@@ -23,30 +25,30 @@ export interface HighlightButtonProps
   icon?: CanvasSystemIcon;
 }
 
-const getHighlightButtonColors = (): ButtonColors => ({
+const getHighlightButtonColors = (theme: CanvasTheme): ButtonColors => ({
   default: {
     background: colors.soap200,
     border: colors.soap200,
-    icon: colors.blueberry500,
-    label: colors.blueberry500,
+    icon: theme.palette.primary.dark,
+    label: theme.palette.primary.dark,
   },
   hover: {
     background: colors.soap400,
     border: 'transparent',
-    icon: colors.blueberry500,
-    label: colors.blueberry500,
+    icon: theme.palette.primary.dark,
+    label: theme.palette.primary.dark,
   },
   active: {
     background: colors.soap500,
     border: 'transparent',
-    icon: colors.blueberry500,
-    label: colors.blueberry500,
+    icon: theme.palette.primary.dark,
+    label: theme.palette.primary.dark,
   },
   focus: {
     background: colors.soap200,
     border: 'transparent',
-    icon: colors.blueberry500,
-    label: colors.blueberry500,
+    icon: theme.palette.primary.dark,
+    label: theme.palette.primary.dark,
   },
   disabled: {
     background: colors.soap100,
@@ -57,13 +59,19 @@ const getHighlightButtonColors = (): ButtonColors => ({
 });
 
 const HighlightButton = ({
+  theme = useTheme(),
   size = 'medium',
   buttonRef,
   icon,
   children,
   ...elemProps
 }: HighlightButtonProps) => (
-  <ButtonContainer colors={getHighlightButtonColors()} size={size} ref={buttonRef} {...elemProps}>
+  <ButtonContainer
+    colors={getHighlightButtonColors(theme)}
+    size={size}
+    ref={buttonRef}
+    {...elemProps}
+  >
     {icon && <ButtonLabelIcon size={size} icon={icon} />}
     <ButtonLabel>{children}</ButtonLabel>
   </ButtonContainer>

--- a/modules/button/react/lib/IconButton.tsx
+++ b/modules/button/react/lib/IconButton.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
+import {Themeable, CanvasTheme, useTheme} from '@workday/canvas-kit-labs-react-core';
 import {colors, spacing, borderRadius} from '@workday/canvas-kit-react-core';
-import {focusRing} from '@workday/canvas-kit-react-common';
+import {themedFocusRing} from '@workday/canvas-kit-react-common';
 import {SystemIcon} from '@workday/canvas-kit-react-icon';
 import {CanvasSystemIcon} from '@workday/design-assets-types';
 import {IconButtonVariant, ButtonColors} from './types';
 import {ButtonContainer} from './parts';
 
-export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>, Themeable {
   /**
    * The accessibility label to indicate the action triggered by clicking the IconButton.
    */
@@ -41,6 +42,7 @@ export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEl
 }
 
 const IconButton = ({
+  theme = useTheme(),
   variant = IconButtonVariant.Circle,
   size = 'medium',
   buttonRef,
@@ -83,7 +85,7 @@ const IconButton = ({
 
   return (
     <ButtonContainer
-      colors={getIconButtonColors(variant, toggled)}
+      colors={getIconButtonColors(variant, theme, toggled)}
       size={size}
       ref={buttonRef}
       fillIcon={toggled}
@@ -104,122 +106,134 @@ IconButton.Size = {
 
 export default IconButton;
 
-const getIconButtonColors = (variant: IconButtonVariant, toggled?: boolean): ButtonColors => {
+const getIconButtonColors = (
+  variant: IconButtonVariant,
+  theme: CanvasTheme,
+  toggled?: boolean
+): ButtonColors => {
   switch (variant) {
     case IconButton.Variant.Square:
     case IconButtonVariant.Circle:
     default:
       return {
         default: {
-          background: toggled ? colors.blueberry400 : undefined,
-          icon: toggled ? colors.frenchVanilla100 : colors.licorice200,
+          background: toggled ? theme.palette.primary.main : undefined,
+          icon: toggled ? theme.palette.primary.contrast : colors.licorice200,
         },
         hover: {
-          background: toggled ? colors.blueberry500 : colors.soap300,
-          icon: toggled ? colors.frenchVanilla100 : colors.licorice500,
+          background: toggled ? theme.palette.primary.dark : colors.soap300,
+          icon: toggled ? theme.palette.primary.contrast : colors.licorice500,
         },
         active: {
-          background: toggled ? colors.blueberry500 : colors.soap500,
-          icon: toggled ? colors.frenchVanilla100 : colors.licorice500,
+          background: toggled ? theme.palette.primary.dark : colors.soap500,
+          icon: toggled ? theme.palette.primary.contrast : colors.licorice500,
         },
         focus: {
-          background: toggled ? colors.blueberry500 : colors.soap300,
-          icon: toggled ? colors.frenchVanilla100 : colors.licorice500,
+          background: toggled ? theme.palette.primary.dark : colors.soap300,
+          icon: toggled ? theme.palette.primary.contrast : colors.licorice500,
         },
         disabled: {
-          background: toggled ? colors.blueberry100 : 'transparent',
-          icon: toggled ? colors.blueberry300 : colors.soap600,
+          background: toggled ? theme.palette.primary.lightest : 'transparent',
+          icon: toggled ? theme.palette.primary.light : colors.soap600,
         },
       };
     case IconButtonVariant.SquareFilled:
     case IconButtonVariant.CircleFilled:
       return {
         default: {
-          background: toggled ? colors.blueberry400 : colors.soap200,
-          icon: toggled ? colors.frenchVanilla100 : colors.licorice200,
+          background: toggled ? theme.palette.primary.main : colors.soap200,
+          icon: toggled ? theme.palette.primary.contrast : colors.licorice200,
         },
         hover: {
-          background: toggled ? colors.blueberry500 : colors.soap400,
-          icon: toggled ? colors.frenchVanilla100 : colors.licorice500,
+          background: toggled ? theme.palette.primary.dark : colors.soap400,
+          icon: toggled ? theme.palette.primary.contrast : colors.licorice500,
         },
         active: {
-          background: toggled ? colors.blueberry500 : colors.soap500,
-          icon: toggled ? colors.frenchVanilla100 : colors.licorice500,
+          background: toggled ? theme.palette.primary.dark : colors.soap500,
+          icon: toggled ? theme.palette.primary.contrast : colors.licorice500,
         },
         focus: {
-          background: toggled ? colors.blueberry500 : colors.soap400,
-          icon: toggled ? colors.frenchVanilla100 : colors.licorice500,
+          background: toggled ? theme.palette.primary.dark : colors.soap400,
+          icon: toggled ? theme.palette.primary.contrast : colors.licorice500,
         },
         disabled: {
-          background: toggled ? colors.blueberry100 : colors.soap100,
-          icon: toggled ? colors.blueberry300 : colors.soap600,
+          background: toggled ? theme.palette.primary.lightest : colors.soap100,
+          icon: toggled ? theme.palette.primary.light : colors.soap600,
         },
       };
     case IconButtonVariant.Plain:
       return {
         default: {
-          icon: toggled ? colors.blueberry400 : colors.licorice200,
+          icon: toggled ? theme.palette.primary.main : colors.licorice200,
         },
         hover: {
-          icon: toggled ? colors.blueberry400 : colors.licorice500,
+          icon: toggled ? theme.palette.primary.main : colors.licorice500,
         },
         active: {
-          icon: toggled ? colors.blueberry400 : colors.licorice500,
+          icon: toggled ? theme.palette.primary.main : colors.licorice500,
         },
         focus: {
-          icon: toggled ? colors.blueberry400 : colors.licorice500,
-          focusRing: focusRing(2, 0),
+          icon: toggled ? theme.palette.primary.main : colors.licorice500,
+          focusRing: themedFocusRing(theme),
         },
         disabled: {
-          icon: toggled ? colors.blueberry200 : colors.soap600,
+          icon: toggled ? theme.palette.primary.light : colors.soap600,
         },
       };
     case IconButtonVariant.Inverse:
       return {
         default: {
-          background: toggled ? colors.frenchVanilla100 : undefined,
-          icon: toggled ? colors.blueberry400 : colors.frenchVanilla100,
+          background: toggled ? theme.palette.primary.contrast : undefined,
+          icon: toggled ? theme.palette.primary.main : theme.palette.primary.contrast,
         },
         hover: {
-          background: toggled ? colors.frenchVanilla100 : 'rgba(0, 0, 0, 0.2)',
-          icon: toggled ? colors.blueberry400 : colors.frenchVanilla100,
+          background: toggled ? theme.palette.primary.contrast : 'rgba(0, 0, 0, 0.2)',
+          icon: toggled ? theme.palette.primary.main : theme.palette.primary.contrast,
         },
         active: {
-          background: toggled ? colors.frenchVanilla100 : 'rgba(0, 0, 0, 0.3)',
-          icon: toggled ? colors.blueberry400 : colors.frenchVanilla100,
+          background: toggled ? theme.palette.primary.contrast : 'rgba(0, 0, 0, 0.3)',
+          icon: toggled ? theme.palette.primary.main : theme.palette.primary.contrast,
         },
         focus: {
-          background: toggled ? colors.frenchVanilla100 : 'rgba(0, 0, 0, 0.2)',
-          icon: toggled ? colors.blueberry400 : colors.frenchVanilla100,
-          focusRing: focusRing(2, 2, true, false, 'currentColor', colors.frenchVanilla100),
+          background: toggled ? theme.palette.primary.contrast : 'rgba(0, 0, 0, 0.2)',
+          icon: toggled ? theme.palette.primary.main : theme.palette.primary.contrast,
+          focusRing: themedFocusRing(theme, {
+            separation: 2,
+            innerColor: 'currentColor',
+            outerColor: theme.palette.primary.contrast,
+          }),
         },
         disabled: {
           background: toggled ? 'rgba(255,255,255,0.75)' : 'transparent',
-          icon: toggled ? colors.blueberry400 : 'rgba(255, 255, 255, 0.75)',
+          icon: toggled ? theme.palette.primary.main : 'rgba(255, 255, 255, 0.75)',
         },
       };
     case IconButtonVariant.InverseFilled:
       return {
         default: {
-          background: toggled ? colors.frenchVanilla100 : 'rgba(0, 0, 0, 0.2)',
-          icon: toggled ? colors.blueberry400 : colors.frenchVanilla100,
+          background: toggled ? theme.palette.primary.contrast : 'rgba(0, 0, 0, 0.2)',
+          icon: toggled ? theme.palette.primary.main : theme.palette.primary.contrast,
         },
         hover: {
-          background: toggled ? colors.frenchVanilla100 : 'rgba(0, 0, 0, 0.3)',
-          icon: toggled ? colors.blueberry400 : colors.frenchVanilla100,
+          background: toggled ? theme.palette.primary.contrast : 'rgba(0, 0, 0, 0.3)',
+          icon: toggled ? theme.palette.primary.main : theme.palette.primary.contrast,
         },
         active: {
-          background: toggled ? colors.frenchVanilla100 : 'rgba(0, 0, 0, 0.4)',
-          icon: toggled ? colors.blueberry400 : colors.frenchVanilla100,
+          background: toggled ? theme.palette.primary.contrast : 'rgba(0, 0, 0, 0.4)',
+          icon: toggled ? theme.palette.primary.main : theme.palette.primary.contrast,
         },
         focus: {
-          background: toggled ? colors.frenchVanilla100 : 'rgba(0, 0, 0, 0.2)',
-          icon: toggled ? colors.blueberry400 : colors.frenchVanilla100,
-          focusRing: focusRing(2, 2, true, false, 'currentColor', colors.frenchVanilla100),
+          background: toggled ? theme.palette.primary.contrast : 'rgba(0, 0, 0, 0.2)',
+          icon: toggled ? theme.palette.primary.main : theme.palette.primary.contrast,
+          focusRing: themedFocusRing(theme, {
+            separation: 2,
+            innerColor: 'currentColor',
+            outerColor: theme.palette.primary.contrast,
+          }),
         },
         disabled: {
           background: toggled ? 'rgba(255,255,255,0.75)' : 'rgba(0, 0, 0, 0.2)',
-          icon: toggled ? colors.blueberry400 : 'rgba(255, 255, 255, 0.75)',
+          icon: toggled ? theme.palette.primary.main : 'rgba(255, 255, 255, 0.75)',
         },
       };
   }

--- a/modules/button/react/lib/OutlineButton.tsx
+++ b/modules/button/react/lib/OutlineButton.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
+import {Themeable, CanvasTheme, useTheme} from '@workday/canvas-kit-labs-react-core';
 import {colors} from '@workday/canvas-kit-react-core';
-import {focusRing, GrowthBehavior} from '@workday/canvas-kit-react-common';
+import {themedFocusRing, GrowthBehavior} from '@workday/canvas-kit-react-common';
 import {CanvasSystemIcon} from '@workday/design-assets-types';
 import {OutlineButtonVariant, ButtonColors, ButtonSize} from './types';
 import {ButtonContainer, ButtonLabel, ButtonLabelData, ButtonLabelIcon} from './parts';
 
 export interface OutlineButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    Themeable,
     GrowthBehavior {
   /**
    * The variant of the Button.
@@ -35,6 +37,7 @@ export interface OutlineButtonProps
 }
 
 const OutlineButton = ({
+  theme = useTheme(),
   variant = OutlineButtonVariant.Secondary,
   size = 'medium',
   buttonRef,
@@ -44,7 +47,7 @@ const OutlineButton = ({
   ...elemProps
 }: OutlineButtonProps) => (
   <ButtonContainer
-    colors={getOutlineButtonColors(variant)}
+    colors={getOutlineButtonColors(variant, theme)}
     size={size}
     ref={buttonRef}
     {...elemProps}
@@ -60,33 +63,36 @@ OutlineButton.Size = ButtonSize;
 
 export default OutlineButton;
 
-export const getOutlineButtonColors = (variant: OutlineButtonVariant): ButtonColors => {
+export const getOutlineButtonColors = (
+  variant: OutlineButtonVariant,
+  theme: CanvasTheme
+): ButtonColors => {
   switch (variant) {
     case OutlineButtonVariant.Primary:
       return {
         default: {
-          border: colors.blueberry400,
-          icon: colors.blueberry400,
-          label: colors.blueberry400,
+          border: theme.palette.primary.main,
+          icon: theme.palette.primary.main,
+          label: theme.palette.primary.main,
         },
         hover: {
-          background: colors.blueberry400,
-          icon: colors.frenchVanilla100,
-          label: colors.frenchVanilla100,
+          background: theme.palette.primary.main,
+          icon: theme.palette.primary.contrast,
+          label: theme.palette.primary.contrast,
         },
         active: {
-          background: colors.blueberry500,
-          border: colors.blueberry500,
-          icon: colors.frenchVanilla100,
-          label: colors.frenchVanilla100,
+          background: theme.palette.primary.dark,
+          border: theme.palette.primary.dark,
+          icon: theme.palette.primary.contrast,
+          label: theme.palette.primary.contrast,
         },
         focus: {
-          background: colors.blueberry400,
-          icon: colors.frenchVanilla100,
-          label: colors.frenchVanilla100,
+          background: theme.palette.primary.main,
+          icon: theme.palette.primary.contrast,
+          label: theme.palette.primary.contrast,
         },
         disabled: {
-          background: colors.frenchVanilla100,
+          background: theme.palette.primary.contrast,
           border: colors.soap500,
           icon: colors.soap600,
           label: colors.licorice100,
@@ -103,23 +109,23 @@ export const getOutlineButtonColors = (variant: OutlineButtonVariant): ButtonCol
         hover: {
           background: colors.licorice500,
           border: colors.licorice500,
-          icon: colors.frenchVanilla100,
-          label: colors.frenchVanilla100,
+          icon: theme.palette.primary.contrast,
+          label: theme.palette.primary.contrast,
         },
         active: {
           background: colors.licorice600,
           border: colors.licorice600,
-          icon: colors.frenchVanilla100,
-          label: colors.frenchVanilla100,
+          icon: theme.palette.primary.contrast,
+          label: theme.palette.primary.contrast,
         },
         focus: {
           background: colors.licorice500,
           border: colors.licorice500,
-          icon: colors.frenchVanilla100,
-          label: colors.frenchVanilla100,
+          icon: theme.palette.primary.contrast,
+          label: theme.palette.primary.contrast,
         },
         disabled: {
-          background: colors.frenchVanilla100,
+          background: theme.palette.primary.contrast,
           border: colors.soap500,
           icon: colors.soap600,
           label: colors.licorice100,
@@ -128,12 +134,12 @@ export const getOutlineButtonColors = (variant: OutlineButtonVariant): ButtonCol
     case OutlineButtonVariant.Inverse:
       return {
         default: {
-          border: colors.frenchVanilla100,
-          icon: colors.frenchVanilla100,
-          label: colors.frenchVanilla100,
+          border: theme.palette.primary.contrast,
+          icon: theme.palette.primary.contrast,
+          label: theme.palette.primary.contrast,
         },
         hover: {
-          background: colors.frenchVanilla100,
+          background: theme.palette.primary.contrast,
           icon: colors.licorice500,
           label: colors.blackPepper400,
           labelData: colors.licorice300,
@@ -146,11 +152,15 @@ export const getOutlineButtonColors = (variant: OutlineButtonVariant): ButtonCol
           labelData: colors.licorice300,
         },
         focus: {
-          background: colors.frenchVanilla100,
+          background: theme.palette.primary.contrast,
           icon: colors.licorice500,
           label: colors.blackPepper400,
           labelData: colors.licorice300,
-          focusRing: focusRing(2, 2, true, false, 'currentColor', colors.frenchVanilla100),
+          focusRing: themedFocusRing(theme, {
+            separation: 2,
+            innerColor: 'currentColor',
+            outerColor: theme.palette.primary.contrast,
+          }),
         },
         disabled: {
           background: 'transparent',

--- a/modules/button/react/lib/TextButton.tsx
+++ b/modules/button/react/lib/TextButton.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import {type} from '@workday/canvas-kit-labs-react-core';
-import {focusRing} from '@workday/canvas-kit-react-common';
+import {Themeable, CanvasTheme, useTheme, type} from '@workday/canvas-kit-labs-react-core';
+import {themedFocusRing} from '@workday/canvas-kit-react-common';
 import {colors, spacing, borderRadius} from '@workday/canvas-kit-react-core';
 import {CanvasSystemIcon} from '@workday/design-assets-types';
 import {TextButtonVariant, ButtonIconPosition, ButtonColors} from './types';
 import {ButtonContainer, ButtonLabelIcon, ButtonLabel} from './parts';
 
-export interface TextButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface TextButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>, Themeable {
   /**
    * The variant of the TextButton.
    * @default TextButtonVariant.Default
@@ -36,31 +36,31 @@ export interface TextButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEl
   allCaps?: boolean;
 }
 
-const getTextButtonColors = (variant: TextButtonVariant): ButtonColors => {
+const getTextButtonColors = (variant: TextButtonVariant, theme: CanvasTheme): ButtonColors => {
   switch (variant) {
     case TextButtonVariant.Default:
     default:
       return {
         default: {
-          icon: colors.blueberry400,
-          label: colors.blueberry400,
+          icon: theme.palette.primary.main,
+          label: theme.palette.primary.main,
         },
         hover: {
-          icon: colors.blueberry500,
-          label: colors.blueberry500,
+          icon: theme.palette.primary.dark,
+          label: theme.palette.primary.dark,
         },
         active: {
-          icon: colors.blueberry500,
-          label: colors.blueberry500,
+          icon: theme.palette.primary.dark,
+          label: theme.palette.primary.dark,
         },
         focus: {
-          icon: colors.blueberry500,
-          label: colors.blueberry500,
-          focusRing: focusRing(2, 0),
+          icon: theme.palette.primary.dark,
+          label: theme.palette.primary.dark,
+          focusRing: themedFocusRing(theme),
         },
         disabled: {
-          icon: 'rgba(8, 117, 225, 0.5)',
-          label: 'rgba(8, 117, 225, 0.5)',
+          icon: theme.palette.primary.lightest,
+          label: theme.palette.primary.lightest,
         },
       };
     case TextButtonVariant.Inverse:
@@ -72,7 +72,7 @@ const getTextButtonColors = (variant: TextButtonVariant): ButtonColors => {
         hover: {},
         active: {},
         focus: {
-          focusRing: focusRing(2, 0, true, false, undefined, 'currentColor'),
+          focusRing: themedFocusRing(theme, {outerColor: 'currentColor'}),
         },
         disabled: {
           icon: 'rgba(255, 255, 255, 0.5)',
@@ -91,6 +91,7 @@ const containerStyles = {
 };
 
 const TextButton = ({
+  theme = useTheme(),
   variant = TextButtonVariant.Default,
   size = 'medium',
   iconPosition = ButtonIconPosition.Left,
@@ -116,7 +117,7 @@ const TextButton = ({
 
   return (
     <ButtonContainer
-      colors={getTextButtonColors(variant)}
+      colors={getTextButtonColors(variant, theme)}
       ref={buttonRef}
       size={size}
       extraStyles={allContainerStyles}

--- a/modules/button/react/lib/TextButton.tsx
+++ b/modules/button/react/lib/TextButton.tsx
@@ -59,8 +59,8 @@ const getTextButtonColors = (variant: TextButtonVariant, theme: CanvasTheme): Bu
           focusRing: themedFocusRing(theme),
         },
         disabled: {
-          icon: theme.palette.primary.lightest,
-          label: theme.palette.primary.lightest,
+          icon: theme.palette.primary.light,
+          label: theme.palette.primary.light,
         },
       };
     case TextButtonVariant.Inverse:

--- a/modules/button/react/lib/parts/ButtonContainer.tsx
+++ b/modules/button/react/lib/parts/ButtonContainer.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import isPropValid from '@emotion/is-prop-valid';
 import {CSSObject} from '@emotion/core';
-import {styled, type} from '@workday/canvas-kit-labs-react-core';
-import canvas, {borderRadius, spacing, spacingNumbers} from '@workday/canvas-kit-react-core';
+import {styled, type, CanvasTheme} from '@workday/canvas-kit-labs-react-core';
+import {borderRadius, spacing, spacingNumbers} from '@workday/canvas-kit-react-core';
 import {
   GrowthBehavior,
   mouseFocusBehavior,
@@ -36,7 +36,7 @@ export interface ButtonContainerProps
   extraStyles?: CSSObject;
 }
 
-function getIconColorSelectors(color: string, fill?: boolean): CSSObject {
+function getIconColorSelectors(theme: CanvasTheme, color: string, fill?: boolean): CSSObject {
   return {
     '&:focus span, &:hover span, & span': {
       '.wd-icon-fill': {
@@ -47,9 +47,9 @@ function getIconColorSelectors(color: string, fill?: boolean): CSSObject {
       },
       '.wd-icon-accent, .wd-icon-accent2': {
         fill: fill
-          ? color === canvas.colors.frenchVanilla100
-            ? canvas.colors.blueberry400
-            : canvas.colors.frenchVanilla100
+          ? color === theme.palette.primary.contrast
+            ? theme.palette.primary.main
+            : theme.palette.primary.contrast
           : color,
       },
     },
@@ -136,7 +136,7 @@ export const ButtonContainer = styled('button', {
         '.wd-icon-fill, .wd-icon-accent, .wd-icon-accent2, .wd-icon-background': {
           transition: 'fill 120ms ease-in',
         },
-        ...getIconColorSelectors(colors.default.icon, fillIcon),
+        ...getIconColorSelectors(theme, colors.default.icon, fillIcon),
       }),
       ...(colors.default.labelData && {
         ['.' + buttonLabelDataClassName]: {
@@ -156,7 +156,7 @@ export const ButtonContainer = styled('button', {
             color: colors.hover.labelData,
           },
         }),
-        ...(colors.hover.icon && getIconColorSelectors(colors.hover.icon, fillIcon)),
+        ...(colors.hover.icon && getIconColorSelectors(theme, colors.hover.icon, fillIcon)),
       },
     };
 
@@ -170,7 +170,7 @@ export const ButtonContainer = styled('button', {
             color: colors.active.labelData,
           },
         }),
-        ...(colors.active.icon && getIconColorSelectors(colors.active.icon, fillIcon)),
+        ...(colors.active.icon && getIconColorSelectors(theme, colors.active.icon, fillIcon)),
       },
     };
 
@@ -186,7 +186,7 @@ export const ButtonContainer = styled('button', {
             color: colors.focus.labelData,
           },
         }),
-        ...(colors.focus.icon && getIconColorSelectors(colors.focus.icon, fillIcon)),
+        ...(colors.focus.icon && getIconColorSelectors(theme, colors.focus.icon, fillIcon)),
       },
 
       ...activeStyles,
@@ -195,7 +195,7 @@ export const ButtonContainer = styled('button', {
         backgroundColor: colors.disabled.background,
         borderColor: colors.disabled.border,
         color: colors.disabled.label,
-        ...(colors.disabled.icon && getIconColorSelectors(colors.disabled.icon, fillIcon)),
+        ...(colors.disabled.icon && getIconColorSelectors(theme, colors.disabled.icon, fillIcon)),
         ...(colors.disabled.labelData && {
           ['.' + buttonLabelDataClassName]: {
             color: colors.disabled.labelData,

--- a/modules/button/react/lib/parts/ButtonContainer.tsx
+++ b/modules/button/react/lib/parts/ButtonContainer.tsx
@@ -3,7 +3,11 @@ import isPropValid from '@emotion/is-prop-valid';
 import {CSSObject} from '@emotion/core';
 import {styled, type} from '@workday/canvas-kit-labs-react-core';
 import canvas, {borderRadius, spacing, spacingNumbers} from '@workday/canvas-kit-react-core';
-import {GrowthBehavior, focusRing, mouseFocusBehavior} from '@workday/canvas-kit-react-common';
+import {
+  GrowthBehavior,
+  mouseFocusBehavior,
+  themedFocusRing,
+} from '@workday/canvas-kit-react-common';
 import {ButtonColors} from '../types';
 import {buttonLabelDataClassName} from './ButtonLabelData';
 
@@ -120,7 +124,7 @@ export const ButtonContainer = styled('button', {
     }
   },
   ({grow}) => grow && {width: '100%', maxWidth: '100%'},
-  ({colors, fillIcon}) => {
+  ({colors, fillIcon, theme}) => {
     if (!colors) {
       return;
     }
@@ -176,7 +180,7 @@ export const ButtonContainer = styled('button', {
         backgroundColor: colors.focus.background,
         borderColor: colors.focus.border,
         color: colors.focus.label,
-        ...(colors.focus.focusRing || focusRing(2, 2)),
+        ...(colors.focus.focusRing || themedFocusRing(theme, {separation: 2})),
         ...(colors.focus.labelData && {
           ['.' + buttonLabelDataClassName]: {
             color: colors.focus.labelData,

--- a/modules/button/react/stories/stories_visualTesting.tsx
+++ b/modules/button/react/stories/stories_visualTesting.tsx
@@ -63,52 +63,35 @@ const getButtonStates = (rowProps: any, renderFn: (props: any) => React.ReactNod
   </StaticStates>
 );
 
-const ButtonStates = () =>
-  getButtonStates(
-    {
-      variant: [
-        {value: Button.Variant.Primary, label: 'Primary'},
-        {value: Button.Variant.Secondary, label: 'Secondary'},
-      ],
-      size: [
-        {value: Button.Size.Small, label: 'Small'},
-        {value: Button.Size.Medium, label: 'Medium'},
-        {value: Button.Size.Large, label: 'Large'},
-      ],
-      icon: [{value: undefined, label: ''}, {value: playCircleIcon, label: 'w/ Icon'}],
-      dataLabel: [{value: undefined, label: ''}, {value: '1:23', label: 'w/ Data Label'}],
-    },
-    (props: any) => (
-      <Container>
-        <Button {...props}>Test</Button>
-      </Container>
-    )
-  );
-
-storiesOf('Components|Buttons/Button/React/Visual Testing/Button', module)
-  .addParameters({
+const buttonStories = [
+  {
+    name: 'Button',
     component: Button,
-    chromatic: {
-      disable: false,
-    },
-  })
-  .add('States', () => <ButtonStates />)
-  .addParameters({
-    canvasProviderDecorator: {
-      theme: customColorTheme,
-    },
-  })
-  .add('Theming', () => <ButtonStates />);
-
-storiesOf('Components|Buttons/Button/React/Visual Testing/Delete Button', module)
-  .addParameters({
+    states: getButtonStates(
+      {
+        variant: [
+          {value: Button.Variant.Primary, label: 'Primary'},
+          {value: Button.Variant.Secondary, label: 'Secondary'},
+        ],
+        size: [
+          {value: Button.Size.Small, label: 'Small'},
+          {value: Button.Size.Medium, label: 'Medium'},
+          {value: Button.Size.Large, label: 'Large'},
+        ],
+        icon: [{value: undefined, label: ''}, {value: playCircleIcon, label: 'w/ Icon'}],
+        dataLabel: [{value: undefined, label: ''}, {value: '1:23', label: 'w/ Data Label'}],
+      },
+      (props: any) => (
+        <Container>
+          <Button {...props}>Test</Button>
+        </Container>
+      )
+    ),
+  },
+  {
+    name: 'Delete Button',
     component: DeleteButton,
-    chromatic: {
-      disable: false,
-    },
-  })
-  .add('States', () =>
-    getButtonStates(
+    states: getButtonStates(
       {
         size: [
           {value: DeleteButton.Size.Small, label: 'Small'},
@@ -121,18 +104,12 @@ storiesOf('Components|Buttons/Button/React/Visual Testing/Delete Button', module
           <DeleteButton {...props}>Test</DeleteButton>
         </Container>
       )
-    )
-  );
-
-storiesOf('Components|Buttons/Button/React/Visual Testing/Deprecated Button', module)
-  .addParameters({
+    ),
+  },
+  {
+    name: 'Deprecated Button',
     component: DeprecatedButton,
-    chromatic: {
-      disable: false,
-    },
-  })
-  .add('States', () =>
-    getButtonStates(
+    states: getButtonStates(
       {
         variant: [
           {value: DeprecatedButton.Variant.Primary, label: 'Primary'},
@@ -150,18 +127,12 @@ storiesOf('Components|Buttons/Button/React/Visual Testing/Deprecated Button', mo
           <DeprecatedButton {...props}>Test</DeprecatedButton>
         </Container>
       )
-    )
-  );
-
-storiesOf('Components|Buttons/Button/React/Visual Testing/Dropdown Button', module)
-  .addParameters({
+    ),
+  },
+  {
+    name: 'Dropdown Button',
     component: DropdownButton,
-    chromatic: {
-      disable: false,
-    },
-  })
-  .add('States', () =>
-    getButtonStates(
+    states: getButtonStates(
       {
         variant: [
           {value: DropdownButton.Variant.Primary, label: 'Primary'},
@@ -179,18 +150,12 @@ storiesOf('Components|Buttons/Button/React/Visual Testing/Dropdown Button', modu
           <DropdownButton {...props}>Test</DropdownButton>
         </Container>
       )
-    )
-  );
-
-storiesOf('Components|Buttons/Button/React/Visual Testing/Highlight Button', module)
-  .addParameters({
+    ),
+  },
+  {
+    name: 'Highlight Button',
     component: HighlightButton,
-    chromatic: {
-      disable: false,
-    },
-  })
-  .add('States', () =>
-    getButtonStates(
+    states: getButtonStates(
       {
         size: [
           {value: Button.Size.Small, label: 'Small'},
@@ -204,18 +169,12 @@ storiesOf('Components|Buttons/Button/React/Visual Testing/Highlight Button', mod
           <HighlightButton {...props}>Test</HighlightButton>
         </Container>
       )
-    )
-  );
-
-storiesOf('Components|Buttons/Button/React/Visual Testing/Outline Button', module)
-  .addParameters({
-    component: Button,
-    chromatic: {
-      disable: false,
-    },
-  })
-  .add('States', () =>
-    getButtonStates(
+    ),
+  },
+  {
+    name: 'Outline Button',
+    component: OutlineButton,
+    states: getButtonStates(
       {
         variant: [
           {value: OutlineButton.Variant.Primary, label: 'Outline Primary'},
@@ -235,18 +194,12 @@ storiesOf('Components|Buttons/Button/React/Visual Testing/Outline Button', modul
           <OutlineButton {...props}>Test</OutlineButton>
         </Container>
       )
-    )
-  );
-
-storiesOf('Components|Buttons/Button/React/Visual Testing/Text Button', module)
-  .addParameters({
+    ),
+  },
+  {
+    name: 'Text Button',
     component: TextButton,
-    chromatic: {
-      disable: false,
-    },
-  })
-  .add('States', () =>
-    getButtonStates(
+    states: getButtonStates(
       {
         variant: [
           {value: TextButton.Variant.Default, label: 'Default'},
@@ -264,54 +217,68 @@ storiesOf('Components|Buttons/Button/React/Visual Testing/Text Button', module)
           <TextButton {...props}>Test</TextButton>
         </Container>
       )
-    )
-  );
-
-storiesOf('Components|Buttons/Button/React/Visual Testing/Icon Button', module)
-  .addParameters({
+    ),
+  },
+  {
+    name: 'Icon Button',
     component: IconButton,
-    chromatic: {
-      disable: false,
-    },
-  })
-  .add('States', () => (
-    <React.Fragment>
-      {[false, true].map(toggled => (
-        <div key={`toggled-${toggled}`}>
-          <h3>Toggled {toggled ? 'On' : 'Off'}</h3>
-          {getButtonStates(
-            {
-              variant: [
-                {value: IconButton.Variant.Inverse, label: 'Inverse'},
-                {value: IconButton.Variant.InverseFilled, label: 'Inverse Filled'},
-                {value: IconButton.Variant.Plain, label: 'Plain'},
-                {value: IconButton.Variant.Circle, label: 'Circle'},
-                {value: IconButton.Variant.CircleFilled, label: 'Circle Filled'},
-                {value: IconButton.Variant.Square, label: 'Square'},
-                {value: IconButton.Variant.SquareFilled, label: 'Square Filled'},
-              ],
-              size: [
-                {value: IconButton.Size.Small, label: 'Small'},
-                {value: IconButton.Size.Medium, label: 'Medium'},
-              ],
-            },
-            (props: any) => (
-              <Container
-                blue={[IconButton.Variant.Inverse, IconButton.Variant.InverseFilled].includes(
-                  props.variant
-                )}
-              >
-                <IconButton
-                  toggled={toggled}
-                  icon={activityStreamIcon}
-                  aria-label="Play"
-                  {...props}
-                  onChange={() => {}} // eslint-disable-line no-empty-function
-                />
-              </Container>
-            )
-          )}
-        </div>
-      ))}
-    </React.Fragment>
-  ));
+    states: (
+      <React.Fragment>
+        {[false, true].map(toggled => (
+          <div key={`toggled-${toggled}`}>
+            <h3>Toggled {toggled ? 'On' : 'Off'}</h3>
+            {getButtonStates(
+              {
+                variant: [
+                  {value: IconButton.Variant.Inverse, label: 'Inverse'},
+                  {value: IconButton.Variant.InverseFilled, label: 'Inverse Filled'},
+                  {value: IconButton.Variant.Plain, label: 'Plain'},
+                  {value: IconButton.Variant.Circle, label: 'Circle'},
+                  {value: IconButton.Variant.CircleFilled, label: 'Circle Filled'},
+                  {value: IconButton.Variant.Square, label: 'Square'},
+                  {value: IconButton.Variant.SquareFilled, label: 'Square Filled'},
+                ],
+                size: [
+                  {value: IconButton.Size.Small, label: 'Small'},
+                  {value: IconButton.Size.Medium, label: 'Medium'},
+                ],
+              },
+              (props: any) => (
+                <Container
+                  blue={[IconButton.Variant.Inverse, IconButton.Variant.InverseFilled].includes(
+                    props.variant
+                  )}
+                >
+                  <IconButton
+                    toggled={toggled}
+                    icon={activityStreamIcon}
+                    aria-label="Play"
+                    {...props}
+                    onChange={() => {}} // eslint-disable-line no-empty-function
+                  />
+                </Container>
+              )
+            )}
+          </div>
+        ))}
+      </React.Fragment>
+    ),
+  },
+];
+
+buttonStories.forEach(({name, component, states}) => {
+  storiesOf(`Components|Buttons/Button/React/Visual Testing/${name}`, module)
+    .addParameters({
+      component: component,
+      chromatic: {
+        disable: false,
+      },
+    })
+    .add('States', () => states as React.ReactElement)
+    .addParameters({
+      canvasProviderDecorator: {
+        theme: customColorTheme,
+      },
+    })
+    .add('Theming', () => states as React.ReactElement);
+});

--- a/modules/button/react/stories/stories_visualTesting.tsx
+++ b/modules/button/react/stories/stories_visualTesting.tsx
@@ -4,7 +4,7 @@ import {jsx, CSSObject} from '@emotion/core';
 import * as React from 'react';
 import {storiesOf} from '@storybook/react';
 import {StaticStates} from '@workday/canvas-kit-labs-react-core';
-import {ComponentStatesTable, permutateProps} from '../../../../utils/storybook';
+import {ComponentStatesTable, permutateProps, customColorTheme} from '../../../../utils/storybook';
 import {playCircleIcon, activityStreamIcon} from '@workday/canvas-system-icons-web';
 import {
   Button,
@@ -63,6 +63,28 @@ const getButtonStates = (rowProps: any, renderFn: (props: any) => React.ReactNod
   </StaticStates>
 );
 
+const ButtonStates = () =>
+  getButtonStates(
+    {
+      variant: [
+        {value: Button.Variant.Primary, label: 'Primary'},
+        {value: Button.Variant.Secondary, label: 'Secondary'},
+      ],
+      size: [
+        {value: Button.Size.Small, label: 'Small'},
+        {value: Button.Size.Medium, label: 'Medium'},
+        {value: Button.Size.Large, label: 'Large'},
+      ],
+      icon: [{value: undefined, label: ''}, {value: playCircleIcon, label: 'w/ Icon'}],
+      dataLabel: [{value: undefined, label: ''}, {value: '1:23', label: 'w/ Data Label'}],
+    },
+    (props: any) => (
+      <Container>
+        <Button {...props}>Test</Button>
+      </Container>
+    )
+  );
+
 storiesOf('Components|Buttons/Button/React/Visual Testing/Button', module)
   .addParameters({
     component: Button,
@@ -70,28 +92,13 @@ storiesOf('Components|Buttons/Button/React/Visual Testing/Button', module)
       disable: false,
     },
   })
-  .add('States', () =>
-    getButtonStates(
-      {
-        variant: [
-          {value: Button.Variant.Primary, label: 'Primary'},
-          {value: Button.Variant.Secondary, label: 'Secondary'},
-        ],
-        size: [
-          {value: Button.Size.Small, label: 'Small'},
-          {value: Button.Size.Medium, label: 'Medium'},
-          {value: Button.Size.Large, label: 'Large'},
-        ],
-        icon: [{value: undefined, label: ''}, {value: playCircleIcon, label: 'w/ Icon'}],
-        dataLabel: [{value: undefined, label: ''}, {value: '1:23', label: 'w/ Data Label'}],
-      },
-      (props: any) => (
-        <Container>
-          <Button {...props}>Test</Button>
-        </Container>
-      )
-    )
-  );
+  .add('States', () => <ButtonStates />)
+  .addParameters({
+    canvasProviderDecorator: {
+      theme: customColorTheme,
+    },
+  })
+  .add('Theming', () => <ButtonStates />);
 
 storiesOf('Components|Buttons/Button/React/Visual Testing/Delete Button', module)
   .addParameters({

--- a/modules/button/react/stories/stories_visualTesting.tsx
+++ b/modules/button/react/stories/stories_visualTesting.tsx
@@ -274,11 +274,19 @@ buttonStories.forEach(({name, component, states}) => {
         disable: false,
       },
     })
-    .add('States', () => states as React.ReactElement)
-    .addParameters({
-      canvasProviderDecorator: {
-        theme: customColorTheme,
-      },
-    })
-    .add('Theming', () => states as React.ReactElement);
+    .add('States', () => states as React.ReactElement);
+
+  if (component !== DeprecatedButton) {
+    storiesOf(`Components|Buttons/Button/React/Visual Testing/${name}`, module)
+      .addParameters({
+        component: component,
+        chromatic: {
+          disable: false,
+        },
+        canvasProviderDecorator: {
+          theme: customColorTheme,
+        },
+      })
+      .add('Theming', () => states as React.ReactElement);
+  }
 });


### PR DESCRIPTION
## Summary

Does what it says! Excludes `deprecated_Button`

Closes #518 

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md
- [x] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [x] design approved final implementation
- [x] a11y approved final implementation
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)
