### PR TITLE
feat(combobox): Add props for complex menu items

### DIFF
--- a/modules/_labs/combobox/react/README.md
+++ b/modules/_labs/combobox/react/README.md
@@ -84,9 +84,10 @@ Default: `'Reset Search Input'`
 
 ---
 
-#### `autocompleteItems: React.ReactElement<MenuItemProps>[]`
+#### `autocompleteItems: React.ReactElement<ComboBoxMenuItemProps>[]`
 
-> An array of MenuItems to show under the input.
+> An array of MenuItems to show under the input. This includes a short text field not found in other
+> menu item props used for more complex autocomplete menus.
 
 ---
 

--- a/modules/_labs/combobox/react/lib/Combobox.tsx
+++ b/modules/_labs/combobox/react/lib/Combobox.tsx
@@ -10,6 +10,10 @@ import {xSmallIcon} from '@workday/canvas-system-icons-web';
 import {TextInputProps} from '@workday/canvas-kit-react-text-input';
 import uuid from 'uuid/v4';
 
+export interface ComboBoxMenuItemProps extends MenuItemProps {
+  shortText?: string;
+}
+
 export interface ComboboxProps extends GrowthBehavior, React.HTMLAttributes<HTMLElement> {
   /**
    * The TextInput child of the Combobox.
@@ -37,7 +41,7 @@ export interface ComboboxProps extends GrowthBehavior, React.HTMLAttributes<HTML
   /**
    * The autocomplete items of the Combobox. This array of menu items is shown under the text input.
    */
-  autocompleteItems?: React.ReactElement<MenuItemProps>[];
+  autocompleteItems?: React.ReactElement<ComboBoxMenuItemProps>[];
   /**
    * The function called when the Combobox text input changes.
    */
@@ -207,12 +211,15 @@ export default class Combobox extends React.Component<ComboboxProps, ComboboxSta
     }.`;
   };
 
-  handleAutocompleteClick = (event: React.SyntheticEvent, menuItemProps: MenuItemProps): void => {
+  handleAutocompleteClick = (
+    event: React.SyntheticEvent,
+    menuItemProps: ComboBoxMenuItemProps
+  ): void => {
     if (menuItemProps.isDisabled) {
       return;
     }
     this.setState({showingAutocomplete: false, isFocused: false});
-    this.setInputValue(this.getTextFromElement(menuItemProps.children));
+    this.setInputValue(menuItemProps.shortText || this.getTextFromElement(menuItemProps.children));
     if (menuItemProps.onClick) {
       menuItemProps.onClick(event);
     }

--- a/modules/_labs/combobox/react/spec/Combobox.spec.tsx
+++ b/modules/_labs/combobox/react/spec/Combobox.spec.tsx
@@ -91,6 +91,29 @@ describe('Combobox', () => {
     expect(input.getAttribute('aria-activedescendant')).toEqual('');
   });
 
+  test('Clicking on item with shortText should set short value', async () => {
+    const placeholderText = 'placeholder';
+    const menuText = 'menuText';
+    const longText = 'longMenuText';
+    const autocompleteItems = [
+      <MenuItem onClick={cb} shortText={menuText}>
+        <span>{longText}</span>
+      </MenuItem>,
+    ];
+    const {findByPlaceholderText, findByText} = render(
+      <Combobox autocompleteItems={autocompleteItems}>
+        <TextInput placeholder={placeholderText} />
+      </Combobox>
+    );
+
+    const input = await findByPlaceholderText(placeholderText);
+
+    fireEvent.focus(input);
+    fireEvent.click(await findByText(longText));
+
+    expect(input).toHaveValue(menuText);
+  });
+
   test('Escape key should clear value', async () => {
     const placeholderText = 'placeholder';
     const newText = 'new text';

--- a/modules/_labs/combobox/react/stories/stories.tsx
+++ b/modules/_labs/combobox/react/stories/stories.tsx
@@ -96,7 +96,7 @@ storiesOf('Labs|Combobox/React', module)
     </FormField>
   ))
   .add('Complex Menu Items', () => (
-    <FormField id="autocomplete-123" label="No clear button">
+    <FormField id="autocomplete-123" label="Complex Menu Items">
       <Autocomplete showClearButton={false} useComplexMenu={true} />
     </FormField>
   ));

--- a/modules/_labs/combobox/react/stories/stories.tsx
+++ b/modules/_labs/combobox/react/stories/stories.tsx
@@ -6,13 +6,45 @@ import {action} from '@storybook/addon-actions';
 import {withKnobs} from '@storybook/addon-knobs';
 
 import Combobox, {ComboboxProps} from '../index';
+import {typeColors} from '../../../../core/react';
 import FormField from '../../../../form-field/react';
 import {MenuItem} from '../../../menu/react';
 import {TextInput} from '../../../../text-input/react';
+import {Avatar} from '../../../../avatar/react';
 import README from '../README.md';
 
+const autocompleteResult = (textModifier: string) => (
+  <MenuItem onClick={action(`Clicked Result ${textModifier}`)}>
+    Result{' '}
+    <span>
+      num<span>ber</span>
+    </span>{' '}
+    {textModifier}
+  </MenuItem>
+);
+
+const complexAutocompleteResult = (textModifier: string) => {
+  const shortText = `Heading ${textModifier}`;
+  return (
+    <MenuItem
+      style={{height: '70px'}}
+      onClick={action(`Clicked Result ${textModifier}`)}
+      shortText={shortText}
+    >
+      <Avatar style={{float: 'left', marginRight: '20px'}} size={Avatar.Size.m} />
+      <div>
+        <div>{shortText}</div>
+        <div style={{color: typeColors.hint}}>Some extra Info</div>
+      </div>
+    </MenuItem>
+  );
+};
+
 class Autocomplete extends React.Component<
-  Omit<ComboboxProps, 'children' | 'clearButtonType' | 'clearButtonLabel' | 'clearButtonVariant'>,
+  Omit<
+    ComboboxProps,
+    'children' | 'clearButtonType' | 'clearButtonLabel' | 'clearButtonVariant'
+  > & {useComplexMenu?: boolean},
   {currentText: string}
 > {
   state = {
@@ -24,20 +56,12 @@ class Autocomplete extends React.Component<
   };
 
   render() {
-    const autocompleteResult = (textModifier: string) => (
-      <MenuItem onClick={action(`Clicked Result ${textModifier}`)}>
-        Result{' '}
-        <span>
-          num<span>ber</span>
-        </span>{' '}
-        {textModifier}
-      </MenuItem>
-    );
+    const Results = this.props.useComplexMenu ? complexAutocompleteResult : autocompleteResult;
     return (
       <Combobox
         {...this.props}
         autocompleteItems={Array.apply(null, Array(this.state.currentText.length))
-          .map((x: any, i: string) => autocompleteResult(i))
+          .map((x: any, i: string) => Results(i))
           .splice(0, 5)}
         onChange={this.autocompleteCallback}
         showClearButton={this.props.showClearButton == null ? true : this.props.showClearButton}
@@ -69,5 +93,10 @@ storiesOf('Labs|Combobox/React', module)
   .add('No clear button', () => (
     <FormField id="autocomplete-123" label="No clear button">
       <Autocomplete showClearButton={false} />
+    </FormField>
+  ))
+  .add('Complex Menu Items', () => (
+    <FormField id="autocomplete-123" label="No clear button">
+      <Autocomplete showClearButton={false} useComplexMenu={true} />
     </FormField>
   ));

--- a/modules/_labs/header/react/stories/stories.tsx
+++ b/modules/_labs/header/react/stories/stories.tsx
@@ -110,7 +110,7 @@ class SearchWithAutoComplete extends React.Component<
       <SearchBar
         {...this.props}
         autocompleteItems={Array.apply(null, Array(this.state.currentText.length))
-          .map((x: any, i: string) => autocompleteResult(i))
+          .map((_: any, index: number) => autocompleteResult(`${index}`))
           .splice(0, 5)}
         isCollapsed={boolean('isCollapsed', false)}
         onInputChange={this.autocompleteCallback}


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Some complex comboboxes used in search boxes need menu items with help text that should not be added to the input on click. This adds that option

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md
- [x] design approved final implementation
- [x] a11y approved final implementation
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
Design:
<img width="334" alt="Screen Shot 2020-03-21 at 8 31 53 AM" src="https://user-images.githubusercontent.com/1562615/77230014-77d09180-6b4e-11ea-8708-f279799f353c.png">
