### PR TITLE
feat(core): Add window configuration option to inherit font family

### DIFF
--- a/modules/_labs/core/react/lib/type.ts
+++ b/modules/_labs/core/react/lib/type.ts
@@ -78,9 +78,15 @@ const hierarchy: CanvasTypeHierarchy = {
   },
 };
 
-// Add fontFamily to each level of hierarchy
+// Add fontFamily to each level of hierarchy unless it's been explicitly disabled at a higher level
+const inheritFont =
+  // @ts-ignore
+  window.workday && window.workday.canvas && window.workday.canvas.inheritFontFamily;
 Object.keys(hierarchy).forEach(key => {
-  hierarchy[key] = {...hierarchy[key], fontFamily};
+  hierarchy[key] = {
+    ...hierarchy[key],
+    fontFamily: inheritFont ? 'inherit' : fontFamily,
+  };
 });
 
 const updatedVariants: Pick<CanvasTypeVariant, 'button' | 'caps'> = {

--- a/modules/_labs/core/react/lib/type.ts
+++ b/modules/_labs/core/react/lib/type.ts
@@ -78,14 +78,11 @@ const hierarchy: CanvasTypeHierarchy = {
   },
 };
 
-// Add fontFamily to each level of hierarchy unless it's been explicitly disabled at a higher level
-const inheritFont =
-  // @ts-ignore
-  window.workday && window.workday.canvas && window.workday.canvas.inheritFontFamily;
+// Add fontFamily to each level of hierarchy
 Object.keys(hierarchy).forEach(key => {
   hierarchy[key] = {
     ...hierarchy[key],
-    fontFamily: inheritFont ? 'inherit' : fontFamily,
+    fontFamily: fontFamily,
   };
 });
 

--- a/modules/common/react/lib/theming/useTheme.ts
+++ b/modules/common/react/lib/theming/useTheme.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import get from 'lodash/get';
 import {ThemeContext} from '@emotion/core';
 import {CanvasTheme, defaultCanvasTheme} from '@workday/canvas-kit-labs-react-core';
 
@@ -29,10 +30,9 @@ export default function useTheme(theme?: Object): CanvasTheme {
     // Context not supported or invalid (probably called from within a class component)
   }
 
-  // @ts-ignore
-  if (window.workday && window.workday.canvas && window.workday.canvas.theme) {
-    // @ts-ignore
-    return window.workday.canvas.theme;
+  const windowTheme = get(window, 'window.workday.canvas.theme');
+  if (windowTheme) {
+    return windowTheme;
   }
 
   return defaultCanvasTheme;

--- a/modules/core/react/lib/type.ts
+++ b/modules/core/react/lib/type.ts
@@ -1,10 +1,9 @@
+import get from 'lodash/get';
 import {default as colors, typeColors, statusColors} from '@workday/canvas-colors-web';
 import {borderRadius} from './radius';
 import {CSSProperties} from './types';
 
-const inheritFont =
-  // @ts-ignore
-  window.workday && window.workday.canvas && window.workday.canvas.inheritFontFamily;
+const inheritFont = get(window, 'window.workday.canvas.inheritFontFamily');
 export const fontFamily = inheritFont
   ? 'inherit'
   : '"Roboto", "Helvetica Neue", "Helvetica", Arial, sans-serif';

--- a/modules/core/react/lib/type.ts
+++ b/modules/core/react/lib/type.ts
@@ -2,7 +2,12 @@ import {default as colors, typeColors, statusColors} from '@workday/canvas-color
 import {borderRadius} from './radius';
 import {CSSProperties} from './types';
 
-export const fontFamily = '"Roboto", "Helvetica Neue", "Helvetica", Arial, sans-serif';
+const inheritFont =
+  // @ts-ignore
+  window.workday && window.workday.canvas && window.workday.canvas.inheritFontFamily;
+export const fontFamily = inheritFont
+  ? 'inherit'
+  : '"Roboto", "Helvetica Neue", "Helvetica", Arial, sans-serif';
 export const monoFontFamily = '"Roboto Mono", "Courier New", Courier, monospace';
 
 export interface CanvasTypeHierarchy {
@@ -99,14 +104,11 @@ const hierarchy: CanvasTypeHierarchy = {
   },
 };
 
-// Add fontFamily to each level of hierarchy unless it's been explicitly disabled at a higher level
-const inheritFont =
-  // @ts-ignore
-  window.workday && window.workday.canvas && window.workday.canvas.inheritFontFamily;
+// Add fontFamily to each level of hierarchy
 Object.keys(hierarchy).forEach(key => {
   hierarchy[key] = {
     ...hierarchy[key],
-    fontFamily: inheritFont ? 'inherit' : fontFamily,
+    fontFamily: fontFamily,
   };
 });
 

--- a/modules/core/react/lib/type.ts
+++ b/modules/core/react/lib/type.ts
@@ -99,9 +99,15 @@ const hierarchy: CanvasTypeHierarchy = {
   },
 };
 
-// Add fontFamily to each level of hierarchy
+// Add fontFamily to each level of hierarchy unless it's been explicitly disabled at a higher level
+const inheritFont =
+  // @ts-ignore
+  window.workday && window.workday.canvas && window.workday.canvas.inheritFontFamily;
 Object.keys(hierarchy).forEach(key => {
-  hierarchy[key] = {...hierarchy[key], fontFamily};
+  hierarchy[key] = {
+    ...hierarchy[key],
+    fontFamily: inheritFont ? 'inherit' : fontFamily,
+  };
 });
 
 const variants: CanvasTypeVariant = {

--- a/modules/core/react/package.json
+++ b/modules/core/react/package.json
@@ -53,6 +53,7 @@
     "@workday/canvas-colors-web": "^0.17.13",
     "@workday/canvas-depth-web": "^0.16.4",
     "@workday/canvas-space-web": "^0.15.5",
-    "element-closest": "^3.0.2"
+    "element-closest": "^3.0.2",
+    "lodash": "^4.17.14"
   }
 }


### PR DESCRIPTION
## Summary

Under certain location circumstances, our product needs to load extra fonts for the best experience (e.g. using Noto for CJK character support). We don't want to always load these fonts as they can take a while to load and are often unnecessary. To remedy this, we need to enable consumers to opt out of our font stack at page load so they can rely on a font stack they've specified at a higher level.

Since this only needs to happen at page load, this PR simply updates our type hierarchy to look for a window variable set before adding the `fontFamily` property to our various levels. This method is more performant, simpler and provides less room for error than what was explored in #552. It also avoids all bespoke teams within the Workday application from having to manage the font stack themselves (since this window variable can be set at the highest level of the app and not the nearest `CanvasProvider`)

Note: we are not currently worried about mono fonts because mono text is not getting any special treatment like this in the app at the moment.

### Usage Example

Consumers simply need to set the following variable before `@workday/canvas-kit-react-core/lib/index.js` is loaded`:
```tsx
window.workday.canvas.inheritFontFamily = true;
```
Note: You may need to add this definition to your window object if using Typescript.