### PR TITLE
fix(ColorPicker): Export ColorSwatch from the ColorPicker index

### DIFF
--- a/modules/_labs/color-picker/react/lib/parts/ColorReset.tsx
+++ b/modules/_labs/color-picker/react/lib/parts/ColorReset.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import {colors, spacing, type} from '@workday/canvas-kit-react-core';
 import {focusRing, hideMouseFocus} from '@workday/canvas-kit-react-common';
 
-import {ColorSwatch} from '@workday/canvas-kit-react-color-picker/lib/parts/ColorSwatch';
+import {ColorSwatch} from '@workday/canvas-kit-react-color-picker';
 
 export interface ResetButtonProps {
   label: string;

--- a/modules/_labs/color-picker/react/lib/parts/SwatchBook.tsx
+++ b/modules/_labs/color-picker/react/lib/parts/SwatchBook.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import styled from '@emotion/styled';
 import {borderRadius, colors, spacing} from '@workday/canvas-kit-react-core';
 import {focusRing, mouseFocusBehavior} from '@workday/canvas-kit-react-common';
-import {ColorSwatch} from '@workday/canvas-kit-react-color-picker/lib/parts/ColorSwatch';
+import {ColorSwatch} from '@workday/canvas-kit-react-color-picker';
 
 export interface SwatchBookProps {
   colors: string[];

--- a/modules/color-picker/react/index.ts
+++ b/modules/color-picker/react/index.ts
@@ -4,3 +4,4 @@ import ColorPreview from './lib/ColorPreview';
 export {ColorInput, ColorPreview};
 export * from './lib/ColorInput';
 export * from './lib/ColorPreview';
+export * from './lib/parts/ColorSwatch';


### PR DESCRIPTION
## Summary
When Importing Labs:ColorPicker, we had a build error due to improper file imports
Closes https://github.com/Workday/canvas-kit/issues/575

## Checklist
- [x] `yarn test` passes

