### PR TITLE
Fix: Add missing accessibility aria-modal=true to the Modal and aria-label

### DIFF
--- a/cypress/integration/Modal.spec.ts
+++ b/cypress/integration/Modal.spec.ts
@@ -75,6 +75,10 @@ describe('Modal', () => {
             h.modal.get().should('have.attr', 'aria-labelledby');
           });
 
+          it('should have an aria-modal=true', () => {
+            h.modal.get().should('have.attr', 'aria-modal', 'true');
+          });
+
           it('should contain the title', () => {
             h.modal
               .get()
@@ -235,6 +239,10 @@ describe('Modal', () => {
           h.modal.get().should('have.attr', 'aria-labelledby');
         });
 
+        it('should have an aria-modal=true', () => {
+          h.modal.get().should('have.attr', 'aria-modal', 'true');
+        });
+
         it('should contain the title', () => {
           h.modal
             .get()
@@ -330,6 +338,10 @@ describe('Modal', () => {
 
         it('should have an aria-labelledby attribute', () => {
           h.modal.get().should('have.attr', 'aria-labelledby');
+        });
+
+        it('should have an aria-modal=true', () => {
+          h.modal.get().should('have.attr', 'aria-modal', 'true');
         });
 
         it('should contain the title', () => {

--- a/modules/modal/react/lib/ModalContent.tsx
+++ b/modules/modal/react/lib/ModalContent.tsx
@@ -9,6 +9,10 @@ import {ModalWidth} from './Modal';
 
 export interface ModalContentProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
+   * Aria label will override aria-labelledby, it is used if there is no heading or we need custom label for popup
+   */
+  ariaLabel?: string;
+  /**
    * The padding of the Modal. Accepts `zero`, `s`, or `l`.
    * @default PopupPadding.l
    */
@@ -152,6 +156,7 @@ const useInitialFocus = (
 };
 
 const ModalContent = ({
+  ariaLabel,
   closeOnEscape = true,
   width = ModalWidth.s,
   padding = PopupPadding.l,
@@ -216,6 +221,7 @@ const ModalContent = ({
         padding={padding}
         transformOrigin={transformOrigin}
         aria-modal={true}
+        ariaLabel={ariaLabel}
       >
         {children}
       </Popup>

--- a/modules/modal/react/lib/ModalContent.tsx
+++ b/modules/modal/react/lib/ModalContent.tsx
@@ -215,6 +215,7 @@ const ModalContent = ({
         handleClose={handleClose}
         padding={padding}
         transformOrigin={transformOrigin}
+        aria-modal={true}
       >
         {children}
       </Popup>

--- a/modules/modal/react/spec/Modal.spec.tsx
+++ b/modules/modal/react/spec/Modal.spec.tsx
@@ -3,26 +3,28 @@ import {render, fireEvent} from '@testing-library/react';
 
 import Modal from '../lib/Modal';
 
+const renderModal = (props?: any) =>
+  render(
+    <Modal open={true} handleClose={jest.fn()} heading="Test" {...props}>
+      Hello World
+    </Modal>
+  );
+
 describe('Modal', () => {
   test('should call a callback function', async () => {
-    const cb = jest.fn();
-    const {findByLabelText} = render(
-      <Modal open={true} handleClose={cb} heading="Test">
-        Hello World
-      </Modal>
-    );
-
+    const handleClose = jest.fn();
+    const {findByLabelText} = renderModal({handleClose});
     fireEvent.click(await findByLabelText('Close'));
-
-    expect(cb).toHaveBeenCalledTimes(1);
+    expect(handleClose).toHaveBeenCalledTimes(1);
   });
 
-  test('Modal should spread extra props', async () => {
-    const cb = jest.fn();
-    const {getByRole} = render(
-      <Modal handleClose={cb} heading="Test" open={true} data-propspread="test" />
-    );
-
+  test('Modal should spread extra props', () => {
+    const {getByRole} = renderModal({['data-propspread']: 'test'});
     expect(getByRole('dialog').parentElement).toHaveAttribute('data-propspread', 'test');
+  });
+  test('Modal should replace aria-labeldBy with custom aria-label', () => {
+    const customAriaLabel = 'custom aria label';
+    const {getByRole} = renderModal({ariaLabel: customAriaLabel});
+    expect(getByRole('dialog')).toHaveAttribute('aria-label', customAriaLabel);
   });
 });

--- a/modules/modal/react/spec/Modal.spec.tsx
+++ b/modules/modal/react/spec/Modal.spec.tsx
@@ -22,6 +22,7 @@ describe('Modal', () => {
     const {getByRole} = renderModal({['data-propspread']: 'test'});
     expect(getByRole('dialog').parentElement).toHaveAttribute('data-propspread', 'test');
   });
+
   test('Modal should replace aria-labeldBy with custom aria-label', () => {
     const customAriaLabel = 'custom aria label';
     const {getByRole} = renderModal({ariaLabel: customAriaLabel});

--- a/modules/popup/react/lib/Popup.tsx
+++ b/modules/popup/react/lib/Popup.tsx
@@ -22,6 +22,10 @@ export enum PopupPadding {
 
 export interface PopupProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
+   * Aria label will override aria-labelledby, it is used if there is no heading or we need custom label for popup
+   */
+  ariaLabel?: string;
+  /**
    * The padding of the Popup. Accepts `zero`, `s`, or `l`.
    * @default PopupPadding.l
    */
@@ -98,6 +102,21 @@ const Container = styled('div', {
   })
 );
 
+const getHeadingId = (heading: React.ReactNode, id: string) => (heading ? id : undefined);
+
+const getAriaLabel = (
+  ariaLabel: string | undefined,
+  headingId: string | undefined
+): object | undefined => {
+  if (ariaLabel) {
+    return {['aria-label']: ariaLabel};
+  }
+  if (headingId) {
+    return {['aria-labelledby']: headingId};
+  }
+  return undefined;
+};
+
 const CloseIconContainer = styled('div')<Pick<PopupProps, 'closeIconSize'>>(
   {
     position: 'absolute',
@@ -128,16 +147,17 @@ export default class Popup extends React.Component<PopupProps> {
       width,
       heading,
       popupRef,
+      ariaLabel,
       ...elemProps
     } = this.props;
-
+    const headingId = getHeadingId(heading, this.id);
     return (
       <Container
         transformOrigin={transformOrigin}
         width={width}
         role="dialog"
-        aria-labelledby={heading ? this.id : undefined}
         ref={popupRef}
+        {...getAriaLabel(ariaLabel, headingId)}
         {...elemProps}
       >
         {handleClose && (
@@ -154,13 +174,7 @@ export default class Popup extends React.Component<PopupProps> {
             />
           </CloseIconContainer>
         )}
-        <Card
-          depth={depth}
-          heading={heading}
-          headingId={heading ? this.id : undefined}
-          width="100%"
-          padding={padding}
-        >
+        <Card depth={depth} heading={heading} headingId={headingId} width="100%" padding={padding}>
           {this.props.children}
         </Card>
       </Container>


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

Fixes: https://github.com/Workday/canvas-kit/issues/587

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md
- [x] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [x] design approved final implementation
- [x] a11y approved final implementation
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
