### PR TITLE
feat(button): Add href support

### DIFF
--- a/modules/button/react/README.md
+++ b/modules/button/react/README.md
@@ -154,6 +154,18 @@ Default: `false`
 
 ---
 
+### `as: 'a' | undefined`
+
+> The alternative container type for the button. If `as="a"` is provided, We use Emotion's special
+> `as` prop to render an `a` tag instead of a `button`.
+
+> When defined, all props available via `React.AnchorHTMLAttributes<HTMLAnchorElement>` (e.g.
+> `href`, `target`, etc.) become available.
+
+Default: `undefined`
+
+---
+
 # DeleteButton
 
 ```tsx
@@ -206,6 +218,18 @@ Default: `'medium'`
 > If true, the button will grow to its container's width.
 
 Default: `false`
+
+---
+
+### `as: 'a' | undefined`
+
+> The alternative container type for the button. If `as="a"` is provided, We use Emotion's special
+> `as` prop to render an `a` tag instead of a `button`.
+
+> When defined, all props available via `React.AnchorHTMLAttributes<HTMLAnchorElement>` (e.g.
+> `href`, `target`, etc.) become available.
+
+Default: `undefined`
 
 ---
 
@@ -284,6 +308,18 @@ Default: `false`
 
 ---
 
+### `as: 'a' | undefined`
+
+> The alternative container type for the button. If `as="a"` is provided, We use Emotion's special
+> `as` prop to render an `a` tag instead of a `button`.
+
+> When defined, all props available via `React.AnchorHTMLAttributes<HTMLAnchorElement>` (e.g.
+> `href`, `target`, etc.) become available.
+
+Default: `undefined`
+
+---
+
 # HighlightButton
 
 ```tsx
@@ -341,6 +377,18 @@ Default: `false`
 ### `icon: CanvasSystemIcon`
 
 > The icon of the button
+
+---
+
+### `as: 'a' | undefined`
+
+> The alternative container type for the button. If `as="a"` is provided, We use Emotion's special
+> `as` prop to render an `a` tag instead of a `button`.
+
+> When defined, all props available via `React.AnchorHTMLAttributes<HTMLAnchorElement>` (e.g.
+> `href`, `target`, etc.) become available.
+
+Default: `undefined`
 
 ---
 
@@ -437,6 +485,18 @@ Default: `false`
 
 ---
 
+### `as: 'a' | undefined`
+
+> The alternative container type for the button. If `as="a"` is provided, We use Emotion's special
+> `as` prop to render an `a` tag instead of a `button`.
+
+> When defined, all props available via `React.AnchorHTMLAttributes<HTMLAnchorElement>` (e.g.
+> `href`, `target`, etc.) become available.
+
+Default: `undefined`
+
+---
+
 # TextButton
 
 ```tsx
@@ -522,6 +582,18 @@ Default: `ButtonIconPosition.Left`
 ### `allCaps: boolean`
 
 > The capitialization of the text in the button.
+
+---
+
+### `as: 'a' | undefined`
+
+> The alternative container type for the button. If `as="a"` is provided, We use Emotion's special
+> `as` prop to render an `a` tag instead of a `button`.
+
+> When defined, all props available via `React.AnchorHTMLAttributes<HTMLAnchorElement>` (e.g.
+> `href`, `target`, etc.) become available.
+
+Default: `undefined`
 
 ---
 
@@ -676,6 +748,18 @@ Default: `undefined`
 ### `icon: CanvasSystemIcon`
 
 > The icon of the button. Optional because IconButton can also wrap a SystemIcon component.
+
+---
+
+### `as: 'a' | undefined`
+
+> The alternative container type for the button. If `as="a"` is provided, We use Emotion's special
+> `as` prop to render an `a` tag instead of a `button`.
+
+> When defined, all props available via `React.AnchorHTMLAttributes<HTMLAnchorElement>` (e.g.
+> `href`, `target`, etc.) become available.
+
+Default: `undefined`
 
 ---
 

--- a/modules/button/react/README.md
+++ b/modules/button/react/README.md
@@ -154,7 +154,7 @@ Default: `false`
 
 ---
 
-### `as: 'a' | undefined`
+### `as: 'a'
 
 > The alternative container type for the button. If `as="a"` is provided, We use Emotion's special
 > `as` prop to render an `a` tag instead of a `button`.
@@ -221,7 +221,7 @@ Default: `false`
 
 ---
 
-### `as: 'a' | undefined`
+### `as: 'a'
 
 > The alternative container type for the button. If `as="a"` is provided, We use Emotion's special
 > `as` prop to render an `a` tag instead of a `button`.
@@ -308,7 +308,7 @@ Default: `false`
 
 ---
 
-### `as: 'a' | undefined`
+### `as: 'a'
 
 > The alternative container type for the button. If `as="a"` is provided, We use Emotion's special
 > `as` prop to render an `a` tag instead of a `button`.
@@ -380,7 +380,7 @@ Default: `false`
 
 ---
 
-### `as: 'a' | undefined`
+### `as: 'a'
 
 > The alternative container type for the button. If `as="a"` is provided, We use Emotion's special
 > `as` prop to render an `a` tag instead of a `button`.
@@ -485,7 +485,7 @@ Default: `false`
 
 ---
 
-### `as: 'a' | undefined`
+### `as: 'a'
 
 > The alternative container type for the button. If `as="a"` is provided, We use Emotion's special
 > `as` prop to render an `a` tag instead of a `button`.
@@ -585,7 +585,7 @@ Default: `ButtonIconPosition.Left`
 
 ---
 
-### `as: 'a' | undefined`
+### `as: 'a'
 
 > The alternative container type for the button. If `as="a"` is provided, We use Emotion's special
 > `as` prop to render an `a` tag instead of a `button`.
@@ -751,7 +751,7 @@ Default: `undefined`
 
 ---
 
-### `as: 'a' | undefined`
+### `as: 'a'
 
 > The alternative container type for the button. If `as="a"` is provided, We use Emotion's special
 > `as` prop to render an `a` tag instead of a `button`.

--- a/modules/button/react/lib/Button.tsx
+++ b/modules/button/react/lib/Button.tsx
@@ -42,9 +42,13 @@ export interface ButtonProps
   icon?: CanvasSystemIcon;
 }
 
-function Button(props: ButtonProps): React.ReactElement;
-function Button(props: {as: 'a'} & AnchorButtonProps<ButtonProps>): React.ReactElement;
-function Button({
+type ButtonOverload = {
+  (props: ButtonProps): React.ReactElement;
+  (props: {as: 'a'} & AnchorButtonProps<ButtonProps>): React.ReactElement;
+  Variant: typeof ButtonVariant;
+  Size: typeof ButtonSize;
+};
+const Button: ButtonOverload = ({
   theme = useTheme(),
   variant = ButtonVariant.Secondary,
   size = 'medium',
@@ -53,20 +57,18 @@ function Button({
   icon,
   children,
   ...elemProps
-}: ButtonProps) {
-  return (
-    <ButtonContainer
-      colors={getButtonColors(variant, theme)}
-      size={size}
-      ref={buttonRef}
-      {...elemProps}
-    >
-      {icon && size !== 'small' && <ButtonLabelIcon size={size} icon={icon} />}
-      <ButtonLabel>{children}</ButtonLabel>
-      {dataLabel && size !== 'small' && <ButtonLabelData>{dataLabel}</ButtonLabelData>}
-    </ButtonContainer>
-  );
-}
+}: ButtonProps) => (
+  <ButtonContainer
+    colors={getButtonColors(variant, theme)}
+    size={size}
+    ref={buttonRef}
+    {...elemProps}
+  >
+    {icon && size !== 'small' && <ButtonLabelIcon size={size} icon={icon} />}
+    <ButtonLabel>{children}</ButtonLabel>
+    {dataLabel && size !== 'small' && <ButtonLabelData>{dataLabel}</ButtonLabelData>}
+  </ButtonContainer>
+);
 
 Button.Variant = ButtonVariant;
 Button.Size = ButtonSize;

--- a/modules/button/react/lib/Button.tsx
+++ b/modules/button/react/lib/Button.tsx
@@ -34,6 +34,7 @@ export interface ButtonProps
    * Note: not displayed at `small` size
    */
   icon?: CanvasSystemIcon;
+  href?: string;
 }
 
 const Button = ({
@@ -44,12 +45,15 @@ const Button = ({
   dataLabel,
   icon,
   children,
+  href,
   ...elemProps
 }: ButtonProps) => (
   <ButtonContainer
     colors={getButtonColors(variant, theme)}
     size={size}
     ref={buttonRef}
+    as={href ? 'a' : undefined}
+    href={href}
     {...elemProps}
   >
     {icon && size !== 'small' && <ButtonLabelIcon size={size} icon={icon} />}

--- a/modules/button/react/lib/Button.tsx
+++ b/modules/button/react/lib/Button.tsx
@@ -8,7 +8,7 @@ import {
   ButtonColors,
   DropdownButtonVariant,
   ButtonSize,
-  AnchorButtonProps,
+  ButtonOrAnchorComponent,
 } from './types';
 import {ButtonContainer, ButtonLabel, ButtonLabelData, ButtonLabelIcon} from './parts';
 
@@ -42,13 +42,7 @@ export interface ButtonProps
   icon?: CanvasSystemIcon;
 }
 
-type ButtonOverload = {
-  (props: ButtonProps): React.ReactElement;
-  (props: {as: 'a'} & AnchorButtonProps<ButtonProps>): React.ReactElement;
-  Variant: typeof ButtonVariant;
-  Size: typeof ButtonSize;
-};
-const Button: ButtonOverload = ({
+const Button: ButtonOrAnchorComponent<ButtonProps, typeof ButtonVariant> = ({
   theme = useTheme(),
   variant = ButtonVariant.Secondary,
   size = 'medium',

--- a/modules/button/react/lib/Button.tsx
+++ b/modules/button/react/lib/Button.tsx
@@ -40,6 +40,11 @@ export interface ButtonProps
    * Note: not displayed at `small` size
    */
   icon?: CanvasSystemIcon;
+  /**
+   * The alternative container type for the button. Uses Emotion's special `as` prop.
+   * Will render an `a` tag instead of a `button` when defined.
+   */
+  as?: 'a' | undefined;
 }
 
 const Button: ButtonOrAnchorComponent<ButtonProps, typeof ButtonVariant> = ({

--- a/modules/button/react/lib/Button.tsx
+++ b/modules/button/react/lib/Button.tsx
@@ -44,7 +44,7 @@ export interface ButtonProps
    * The alternative container type for the button. Uses Emotion's special `as` prop.
    * Will render an `a` tag instead of a `button` when defined.
    */
-  as?: 'a' | undefined;
+  as?: 'a';
 }
 
 const Button: ButtonOrAnchorComponent<ButtonProps, typeof ButtonVariant> = ({

--- a/modules/button/react/lib/Button.tsx
+++ b/modules/button/react/lib/Button.tsx
@@ -3,7 +3,13 @@ import {Themeable, CanvasTheme} from '@workday/canvas-kit-labs-react-core';
 import {colors} from '@workday/canvas-kit-react-core';
 import {GrowthBehavior, useTheme} from '@workday/canvas-kit-react-common';
 import {CanvasSystemIcon} from '@workday/design-assets-types';
-import {ButtonVariant, ButtonColors, DropdownButtonVariant, ButtonSize} from './types';
+import {
+  ButtonVariant,
+  ButtonColors,
+  DropdownButtonVariant,
+  ButtonSize,
+  AnchorButtonProps,
+} from './types';
 import {ButtonContainer, ButtonLabel, ButtonLabelData, ButtonLabelIcon} from './parts';
 
 export interface ButtonProps
@@ -34,10 +40,11 @@ export interface ButtonProps
    * Note: not displayed at `small` size
    */
   icon?: CanvasSystemIcon;
-  href?: string;
 }
 
-const Button = ({
+function Button(props: ButtonProps): React.ReactElement;
+function Button(props: {as: 'a'} & AnchorButtonProps<ButtonProps>): React.ReactElement;
+function Button({
   theme = useTheme(),
   variant = ButtonVariant.Secondary,
   size = 'medium',
@@ -45,22 +52,21 @@ const Button = ({
   dataLabel,
   icon,
   children,
-  href,
   ...elemProps
-}: ButtonProps) => (
-  <ButtonContainer
-    colors={getButtonColors(variant, theme)}
-    size={size}
-    ref={buttonRef}
-    as={href ? 'a' : undefined}
-    href={href}
-    {...elemProps}
-  >
-    {icon && size !== 'small' && <ButtonLabelIcon size={size} icon={icon} />}
-    <ButtonLabel>{children}</ButtonLabel>
-    {dataLabel && size !== 'small' && <ButtonLabelData>{dataLabel}</ButtonLabelData>}
-  </ButtonContainer>
-);
+}: ButtonProps) {
+  return (
+    <ButtonContainer
+      colors={getButtonColors(variant, theme)}
+      size={size}
+      ref={buttonRef}
+      {...elemProps}
+    >
+      {icon && size !== 'small' && <ButtonLabelIcon size={size} icon={icon} />}
+      <ButtonLabel>{children}</ButtonLabel>
+      {dataLabel && size !== 'small' && <ButtonLabelData>{dataLabel}</ButtonLabelData>}
+    </ButtonContainer>
+  );
+}
 
 Button.Variant = ButtonVariant;
 Button.Size = ButtonSize;

--- a/modules/button/react/lib/DeleteButton.tsx
+++ b/modules/button/react/lib/DeleteButton.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {Themeable, CanvasTheme} from '@workday/canvas-kit-labs-react-core';
-import {ButtonColors, ButtonSize} from './types';
+import {ButtonColors, ButtonSize, ButtonOrAnchorComponent} from './types';
 import {ButtonContainer, ButtonLabel} from './parts';
 import {GrowthBehavior, useTheme} from '@workday/canvas-kit-react-common';
 
@@ -38,7 +38,7 @@ const getDeleteButtonColors = (theme: CanvasTheme): ButtonColors => ({
   },
 });
 
-const DeleteButton = ({
+const DeleteButton: ButtonOrAnchorComponent<DeleteButtonProps> = ({
   theme = useTheme(),
   size = 'medium',
   buttonRef,

--- a/modules/button/react/lib/DeleteButton.tsx
+++ b/modules/button/react/lib/DeleteButton.tsx
@@ -17,6 +17,11 @@ export interface DeleteButtonProps
    * The ref to the button that the styled component renders.
    */
   buttonRef?: React.Ref<HTMLButtonElement>;
+  /**
+   * The alternative container type for the button. Uses Emotion's special `as` prop.
+   * Will render an `a` tag instead of a `button` when defined.
+   */
+  as?: 'a' | undefined;
 }
 
 const getDeleteButtonColors = (theme: CanvasTheme): ButtonColors => ({

--- a/modules/button/react/lib/DeleteButton.tsx
+++ b/modules/button/react/lib/DeleteButton.tsx
@@ -21,7 +21,7 @@ export interface DeleteButtonProps
    * The alternative container type for the button. Uses Emotion's special `as` prop.
    * Will render an `a` tag instead of a `button` when defined.
    */
-  as?: 'a' | undefined;
+  as?: 'a';
 }
 
 const getDeleteButtonColors = (theme: CanvasTheme): ButtonColors => ({

--- a/modules/button/react/lib/DropdownButton.tsx
+++ b/modules/button/react/lib/DropdownButton.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {Themeable} from '@workday/canvas-kit-labs-react-core';
 import {caretDownIcon} from '@workday/canvas-system-icons-web';
 import {GrowthBehavior, useTheme} from '@workday/canvas-kit-react-common';
-import {DropdownButtonVariant, ButtonIconPosition} from './types';
+import {DropdownButtonVariant, ButtonIconPosition, ButtonOrAnchorComponent} from './types';
 import {ButtonContainer, ButtonLabel, ButtonLabelIcon} from './parts';
 import {getButtonColors} from './Button';
 
@@ -26,7 +26,10 @@ export interface DropdownButtonProps
   buttonRef?: React.Ref<HTMLButtonElement>;
 }
 
-const DropdownButton = ({
+const DropdownButton: ButtonOrAnchorComponent<
+  DropdownButtonProps,
+  typeof DropdownButtonVariant
+> = ({
   theme = useTheme(),
   variant = DropdownButtonVariant.Secondary,
   size = 'medium',

--- a/modules/button/react/lib/DropdownButton.tsx
+++ b/modules/button/react/lib/DropdownButton.tsx
@@ -28,7 +28,7 @@ export interface DropdownButtonProps
    * The alternative container type for the button. Uses Emotion's special `as` prop.
    * Will render an `a` tag instead of a `button` when defined.
    */
-  as?: 'a' | undefined;
+  as?: 'a';
 }
 
 const DropdownButton: ButtonOrAnchorComponent<

--- a/modules/button/react/lib/DropdownButton.tsx
+++ b/modules/button/react/lib/DropdownButton.tsx
@@ -24,6 +24,11 @@ export interface DropdownButtonProps
    * The ref to the button that the styled component renders.
    */
   buttonRef?: React.Ref<HTMLButtonElement>;
+  /**
+   * The alternative container type for the button. Uses Emotion's special `as` prop.
+   * Will render an `a` tag instead of a `button` when defined.
+   */
+  as?: 'a' | undefined;
 }
 
 const DropdownButton: ButtonOrAnchorComponent<

--- a/modules/button/react/lib/HighlightButton.tsx
+++ b/modules/button/react/lib/HighlightButton.tsx
@@ -3,7 +3,7 @@ import {Themeable, CanvasTheme} from '@workday/canvas-kit-labs-react-core';
 import {colors} from '@workday/canvas-kit-react-core';
 import {GrowthBehavior, useTheme} from '@workday/canvas-kit-react-common';
 import {CanvasSystemIcon} from '@workday/design-assets-types';
-import {ButtonColors} from './types';
+import {ButtonColors, ButtonOrAnchorComponent} from './types';
 import {ButtonContainer, ButtonLabel, ButtonLabelIcon} from './parts';
 
 export interface HighlightButtonProps
@@ -58,7 +58,7 @@ const getHighlightButtonColors = (theme: CanvasTheme): ButtonColors => ({
   },
 });
 
-const HighlightButton = ({
+const HighlightButton: ButtonOrAnchorComponent<HighlightButtonProps> = ({
   theme = useTheme(),
   size = 'medium',
   buttonRef,

--- a/modules/button/react/lib/HighlightButton.tsx
+++ b/modules/button/react/lib/HighlightButton.tsx
@@ -23,6 +23,11 @@ export interface HighlightButtonProps
    * The icon of the HighlightButton.
    */
   icon?: CanvasSystemIcon;
+  /**
+   * The alternative container type for the button. Uses Emotion's special `as` prop.
+   * Will render an `a` tag instead of a `button` when defined.
+   */
+  as?: 'a' | undefined;
 }
 
 const getHighlightButtonColors = (theme: CanvasTheme): ButtonColors => ({

--- a/modules/button/react/lib/HighlightButton.tsx
+++ b/modules/button/react/lib/HighlightButton.tsx
@@ -27,7 +27,7 @@ export interface HighlightButtonProps
    * The alternative container type for the button. Uses Emotion's special `as` prop.
    * Will render an `a` tag instead of a `button` when defined.
    */
-  as?: 'a' | undefined;
+  as?: 'a';
 }
 
 const getHighlightButtonColors = (theme: CanvasTheme): ButtonColors => ({

--- a/modules/button/react/lib/IconButton.tsx
+++ b/modules/button/react/lib/IconButton.tsx
@@ -43,7 +43,7 @@ export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEl
    * The alternative container type for the button. Uses Emotion's special `as` prop.
    * Will render an `a` tag instead of a `button` when defined.
    */
-  as?: 'a' | undefined;
+  as?: 'a';
 }
 
 /**

--- a/modules/button/react/lib/IconButton.tsx
+++ b/modules/button/react/lib/IconButton.tsx
@@ -39,6 +39,11 @@ export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEl
    * The function called when the IconButton toggled state changes.
    */
   onToggleChange?: (toggled: boolean | undefined) => void;
+  /**
+   * The alternative container type for the button. Uses Emotion's special `as` prop.
+   * Will render an `a` tag instead of a `button` when defined.
+   */
+  as?: 'a' | undefined;
 }
 
 /**

--- a/modules/button/react/lib/IconButton.tsx
+++ b/modules/button/react/lib/IconButton.tsx
@@ -4,7 +4,7 @@ import {colors, spacing, borderRadius} from '@workday/canvas-kit-react-core';
 import {focusRing, useTheme} from '@workday/canvas-kit-react-common';
 import {SystemIcon} from '@workday/canvas-kit-react-icon';
 import {CanvasSystemIcon} from '@workday/design-assets-types';
-import {IconButtonVariant, ButtonColors} from './types';
+import {IconButtonVariant, ButtonColors, ButtonSize} from './types';
 import {ButtonContainer} from './parts';
 
 export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>, Themeable {
@@ -41,7 +41,24 @@ export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEl
   onToggleChange?: (toggled: boolean | undefined) => void;
 }
 
-const IconButton = ({
+/**
+ * Type for an overloaded functional component to enable button or anchor tags.
+ * Note: Cannot use `./types.tsx > ButtonOrAnchorElement` type due to `aria-label` conflict.
+ */
+type ButtonOrAnchorComponent = {
+  (props: IconButtonProps): React.ReactElement;
+  (
+    props: {as: 'a'} & Omit<
+      IconButtonProps,
+      keyof Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'aria-label'>
+    > &
+      React.AnchorHTMLAttributes<HTMLAnchorElement>
+  ): React.ReactElement;
+  Variant: typeof IconButtonVariant;
+  Size: Partial<typeof ButtonSize>;
+};
+
+const IconButton: ButtonOrAnchorComponent = ({
   theme = useTheme(),
   variant = IconButtonVariant.Circle,
   size = 'medium',

--- a/modules/button/react/lib/OutlineButton.tsx
+++ b/modules/button/react/lib/OutlineButton.tsx
@@ -3,7 +3,7 @@ import {Themeable, CanvasTheme} from '@workday/canvas-kit-labs-react-core';
 import {colors} from '@workday/canvas-kit-react-core';
 import {focusRing, GrowthBehavior, useTheme} from '@workday/canvas-kit-react-common';
 import {CanvasSystemIcon} from '@workday/design-assets-types';
-import {OutlineButtonVariant, ButtonColors, ButtonSize} from './types';
+import {OutlineButtonVariant, ButtonColors, ButtonSize, ButtonOrAnchorComponent} from './types';
 import {ButtonContainer, ButtonLabel, ButtonLabelData, ButtonLabelIcon} from './parts';
 
 export interface OutlineButtonProps
@@ -36,7 +36,7 @@ export interface OutlineButtonProps
   icon?: CanvasSystemIcon;
 }
 
-const OutlineButton = ({
+const OutlineButton: ButtonOrAnchorComponent<OutlineButtonProps, typeof OutlineButtonVariant> = ({
   theme = useTheme(),
   variant = OutlineButtonVariant.Secondary,
   size = 'medium',

--- a/modules/button/react/lib/OutlineButton.tsx
+++ b/modules/button/react/lib/OutlineButton.tsx
@@ -38,7 +38,7 @@ export interface OutlineButtonProps
    * The alternative container type for the button. Uses Emotion's special `as` prop.
    * Will render an `a` tag instead of a `button` when defined.
    */
-  as?: 'a' | undefined;
+  as?: 'a';
 }
 
 const OutlineButton: ButtonOrAnchorComponent<OutlineButtonProps, typeof OutlineButtonVariant> = ({

--- a/modules/button/react/lib/OutlineButton.tsx
+++ b/modules/button/react/lib/OutlineButton.tsx
@@ -34,6 +34,11 @@ export interface OutlineButtonProps
    * Note: not displayed at `small` size
    */
   icon?: CanvasSystemIcon;
+  /**
+   * The alternative container type for the button. Uses Emotion's special `as` prop.
+   * Will render an `a` tag instead of a `button` when defined.
+   */
+  as?: 'a' | undefined;
 }
 
 const OutlineButton: ButtonOrAnchorComponent<OutlineButtonProps, typeof OutlineButtonVariant> = ({

--- a/modules/button/react/lib/TextButton.tsx
+++ b/modules/button/react/lib/TextButton.tsx
@@ -39,6 +39,11 @@ export interface TextButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEl
    * The capitialization of the text in the button.
    */
   allCaps?: boolean;
+  /**
+   * The alternative container type for the button. Uses Emotion's special `as` prop.
+   * Will render an `a` tag instead of a `button` when defined.
+   */
+  as?: 'a' | undefined;
 }
 
 const getTextButtonColors = (variant: TextButtonVariant, theme: CanvasTheme): ButtonColors => {

--- a/modules/button/react/lib/TextButton.tsx
+++ b/modules/button/react/lib/TextButton.tsx
@@ -43,7 +43,7 @@ export interface TextButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEl
    * The alternative container type for the button. Uses Emotion's special `as` prop.
    * Will render an `a` tag instead of a `button` when defined.
    */
-  as?: 'a' | undefined;
+  as?: 'a';
 }
 
 const getTextButtonColors = (variant: TextButtonVariant, theme: CanvasTheme): ButtonColors => {

--- a/modules/button/react/lib/TextButton.tsx
+++ b/modules/button/react/lib/TextButton.tsx
@@ -3,7 +3,12 @@ import {Themeable, CanvasTheme, type} from '@workday/canvas-kit-labs-react-core'
 import {focusRing, useTheme} from '@workday/canvas-kit-react-common';
 import {colors, spacing, borderRadius} from '@workday/canvas-kit-react-core';
 import {CanvasSystemIcon} from '@workday/design-assets-types';
-import {TextButtonVariant, ButtonIconPosition, ButtonColors} from './types';
+import {
+  TextButtonVariant,
+  ButtonIconPosition,
+  ButtonColors,
+  ButtonOrAnchorComponent,
+} from './types';
 import {ButtonContainer, ButtonLabelIcon, ButtonLabel} from './parts';
 
 export interface TextButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>, Themeable {
@@ -120,7 +125,9 @@ const containerStyles = {
   },
 };
 
-const TextButton = ({
+const TextButton: ButtonOrAnchorComponent<TextButtonProps, typeof TextButtonVariant> & {
+  IconPosition: typeof ButtonIconPosition;
+} = ({
   theme = useTheme(),
   variant = TextButtonVariant.Default,
   size = 'medium',

--- a/modules/button/react/lib/deprecated_Button.tsx
+++ b/modules/button/react/lib/deprecated_Button.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import canvas, {borderRadius, type} from '@workday/canvas-kit-react-core';
 import {focusRing, mouseFocusBehavior, GrowthBehavior} from '@workday/canvas-kit-react-common';
-import {DeprecatedButtonVariant, ButtonSize} from './types';
+import {DeprecatedButtonVariant, ButtonSize, ButtonOrAnchorComponent} from './types';
 import styled from '@emotion/styled';
 
 export interface DeprecatedButtonProps
@@ -157,7 +157,10 @@ const Container = styled('button')<DeprecatedButtonProps>(
   }
 );
 
-const DeprecatedButton = ({
+const DeprecatedButton: ButtonOrAnchorComponent<
+  DeprecatedButtonProps,
+  typeof DeprecatedButtonVariant
+> = ({
   variant = DeprecatedButtonVariant.Secondary,
   size = 'large',
   buttonRef,

--- a/modules/button/react/lib/deprecated_Button.tsx
+++ b/modules/button/react/lib/deprecated_Button.tsx
@@ -25,7 +25,7 @@ export interface DeprecatedButtonProps
    * The alternative container type for the button. Uses Emotion's special `as` prop.
    * Will render an `a` tag instead of a `button` when defined.
    */
-  as?: 'a' | undefined;
+  as?: 'a';
 }
 
 const Container = styled('button')<DeprecatedButtonProps>(

--- a/modules/button/react/lib/deprecated_Button.tsx
+++ b/modules/button/react/lib/deprecated_Button.tsx
@@ -21,6 +21,11 @@ export interface DeprecatedButtonProps
    * The ref to the button that the styled component renders.
    */
   buttonRef?: React.Ref<HTMLButtonElement>;
+  /**
+   * The alternative container type for the button. Uses Emotion's special `as` prop.
+   * Will render an `a` tag instead of a `button` when defined.
+   */
+  as?: 'a' | undefined;
 }
 
 const Container = styled('button')<DeprecatedButtonProps>(

--- a/modules/button/react/lib/parts/ButtonContainer.tsx
+++ b/modules/button/react/lib/parts/ButtonContainer.tsx
@@ -12,14 +12,8 @@ import {
 import {ButtonColors} from '../types';
 import {buttonLabelDataClassName} from './ButtonLabelData';
 
-type AnchorAttributes = Omit<
-  React.AnchorHTMLAttributes<HTMLAnchorElement>,
-  keyof React.HTMLAttributes<HTMLAnchorElement> | 'type'
->;
-
 export interface ButtonContainerProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    AnchorAttributes,
     GrowthBehavior {
   colors?: ButtonColors;
   /**
@@ -41,7 +35,6 @@ export interface ButtonContainerProps
    * This avoids using the inline `style` attribute when the shape needs to be customized (e.g. for IconButton)
    */
   extraStyles?: CSSObject;
-  as?: React.ElementType | keyof JSX.IntrinsicElements;
 }
 
 function getIconColorSelectors(theme: CanvasTheme, color: string, fill?: boolean): CSSObject {

--- a/modules/button/react/lib/parts/ButtonContainer.tsx
+++ b/modules/button/react/lib/parts/ButtonContainer.tsx
@@ -12,8 +12,14 @@ import {
 import {ButtonColors} from '../types';
 import {buttonLabelDataClassName} from './ButtonLabelData';
 
+type AnchorAttributes = Omit<
+  React.AnchorHTMLAttributes<HTMLAnchorElement>,
+  keyof React.HTMLAttributes<HTMLAnchorElement> | 'type'
+>;
+
 export interface ButtonContainerProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    AnchorAttributes,
     GrowthBehavior {
   colors?: ButtonColors;
   /**
@@ -35,6 +41,7 @@ export interface ButtonContainerProps
    * This avoids using the inline `style` attribute when the shape needs to be customized (e.g. for IconButton)
    */
   extraStyles?: CSSObject;
+  as?: React.ElementType | keyof JSX.IntrinsicElements;
 }
 
 function getIconColorSelectors(theme: CanvasTheme, color: string, fill?: boolean): CSSObject {

--- a/modules/button/react/lib/types.ts
+++ b/modules/button/react/lib/types.ts
@@ -96,5 +96,17 @@ export interface ButtonColors {
 /**
  * Used to get the props of the anchor version of a button
  */
-export type AnchorButtonProps<B> = Omit<B, keyof React.ButtonHTMLAttributes<HTMLButtonElement>> &
+export type AnchorButtonProps<P> = Omit<P, keyof React.ButtonHTMLAttributes<HTMLButtonElement>> &
   React.AnchorHTMLAttributes<HTMLAnchorElement>;
+
+/**
+ * Returns an overloaded functional component that uses props P by default,
+ * but uses AnchorButtonProps<P> when `as="a"`.
+ * Note: V must be `typeof ButtonVariant` since TS cannot assign enums as a type in a generic properly
+ */
+export type ButtonOrAnchorComponent<P, V = undefined> = {
+  (props: P): React.ReactElement;
+  (props: {as: 'a'} & AnchorButtonProps<P>): React.ReactElement;
+  Variant?: V;
+  Size: Partial<typeof ButtonSize>;
+};

--- a/modules/button/react/lib/types.ts
+++ b/modules/button/react/lib/types.ts
@@ -92,3 +92,9 @@ export interface ButtonColors {
   };
   disabled: ButtonStateColors;
 }
+
+/**
+ * Used to get the props of the anchor version of a button
+ */
+export type AnchorButtonProps<B> = Omit<B, keyof React.ButtonHTMLAttributes<HTMLButtonElement>> &
+  React.AnchorHTMLAttributes<HTMLAnchorElement>;

--- a/modules/button/react/spec/Button.spec.tsx
+++ b/modules/button/react/spec/Button.spec.tsx
@@ -77,6 +77,18 @@ Object.keys(map).forEach(buttonName => {
       });
     });
 
+    describe('when rendered as an anchor', () => {
+      it('should render an anchor link', () => {
+        const {getByRole} = render(
+          <ButtonComponent as="a" href="https://workday.com" target="_blank" />
+        );
+        const link = getByRole('link');
+        expect(link).toBeDefined();
+        expect(link).toHaveAttribute('href', 'https://workday.com');
+        expect(link).toHaveAttribute('target', '_blank');
+      });
+    });
+
     describe('when clicked', () => {
       it('should call a callback function', () => {
         const {getByRole} = render(<ButtonComponent onClick={cb} />);

--- a/modules/button/react/spec/IconButton.spec.tsx
+++ b/modules/button/react/spec/IconButton.spec.tsx
@@ -58,6 +58,24 @@ describe('Icon Button', () => {
     });
   });
 
+  describe('when rendered as an anchor', () => {
+    it('should render an anchor link', () => {
+      const {getByRole} = render(
+        <IconButton
+          aria-label="Activity Stream"
+          icon={activityStreamIcon}
+          as="a"
+          href="https://workday.com"
+          target="_blank"
+        />
+      );
+      const link = getByRole('link');
+      expect(link).toBeDefined();
+      expect(link).toHaveAttribute('href', 'https://workday.com');
+      expect(link).toHaveAttribute('target', '_blank');
+    });
+  });
+
   describe('when clicked', () => {
     it('should call a callback function', () => {
       const {getByRole} = render(


### PR DESCRIPTION
Proof of concept for adding `href`/anchor support to our button components.

Some UI buttons require an href (marketing sites, download buttons, etc.). This is in support of those use cases.

Adds a special `as` prop to all button components (excluding `Hyperlink`). When `as="a"` is defined, we switch from `React.ButtonHTMLAttributes<HTMLButtonElement>` to `React.AnchorHTMLAttributes<HTMLAnchorElement>`

Closes: https://github.com/Workday/canvas-kit/issues/87