### PR TITLE
chore: Refactor control wrapper to hooks for easier examples

### DIFF
--- a/utils/storybook/ControlledComponentWrapper.tsx
+++ b/utils/storybook/ControlledComponentWrapper.tsx
@@ -5,48 +5,63 @@ enum ControlledProp {
   Checked = 'checked',
 }
 
-export default class ControlledComponentWrapper extends React.Component<any, {}> {
-  static ControlledProp = ControlledProp;
-  static defaultProps = {
-    controlledProp: ControlledProp.Value,
+export const useControlledValue = <
+  T extends HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement = HTMLInputElement
+>(
+  initialValue = ''
+) => {
+  const [value, setValue] = React.useState(initialValue);
+  const onChange = (eventOrValue: React.ChangeEvent<T> | string) => {
+    setValue(typeof eventOrValue === 'object' ? eventOrValue.target.value : eventOrValue);
   };
 
-  state = {
-    value: '', // Used for string based components (e.g. text input)
-    checked: false, // Used for boolean components (e.g. checkbox)
+  return {
+    value,
+    onChange,
+  };
+};
+
+export const useControlledCheck = (initialChecked = false) => {
+  const [checked, setChecked] = React.useState(initialChecked);
+  const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setChecked(event.target.checked);
   };
 
-  onChange = (e: React.SyntheticEvent | string | number) => {
-    if (this.props.controlledProp === ControlledProp.Checked) {
-      this.setState({checked: !this.state.checked});
-    } else {
-      const value =
-        typeof e === 'object' ? (e as React.ChangeEvent<HTMLInputElement>).currentTarget.value : e;
-      this.setState({value});
-    }
-  };
+  return {checked, onChange};
+};
 
-  renderChildren = (child: React.ReactNode) => {
+export interface ControlledComponentWrapperProps extends React.Props<any> {
+  controlledProp: ControlledProp;
+}
+
+export const ControlledComponentWrapper = ({
+  children,
+  controlledProp,
+  ...props
+}: ControlledComponentWrapperProps): React.ReactElement => {
+  const valueProps = useControlledValue();
+  const checkedProps = useControlledCheck();
+
+  return (React.Children.map(children, child => {
     if (React.isValidElement<any>(child)) {
-      const {children, controlledProp, ...props} = this.props;
       const childProps = {
         ...props,
         ...child.props,
-        [controlledProp]:
-          controlledProp === ControlledProp.Checked ? this.state.checked : this.state.value,
-        onChange: this.onChange,
+        ...(controlledProp === ControlledProp.Checked ? checkedProps : valueProps),
       };
+
       return React.cloneElement(child, childProps);
     }
     return child;
-  };
+  }) as any) as React.ReactElement; // arg - cast to keep Typescript happy... Trust me Typescript, this is valid
+};
 
-  public render() {
-    return React.Children.map(this.props.children, this.renderChildren);
-  }
-}
+ControlledComponentWrapper.ControlledProp = ControlledProp;
 
-export const controlComponent = (child: React.ReactNode, controlledProp?: ControlledProp) => {
+export const controlComponent = (
+  child: React.ReactNode,
+  controlledProp: ControlledProp = ControlledProp.Value
+) => {
   return (
     <ControlledComponentWrapper controlledProp={controlledProp}>{child}</ControlledComponentWrapper>
   );

--- a/utils/storybook/ControlledComponentWrapper.tsx
+++ b/utils/storybook/ControlledComponentWrapper.tsx
@@ -31,12 +31,12 @@ export const useControlledCheck = (initialChecked = false) => {
 };
 
 export interface ControlledComponentWrapperProps extends React.Props<any> {
-  controlledProp: ControlledProp;
+  controlledProp?: ControlledProp;
 }
 
 export const ControlledComponentWrapper = ({
   children,
-  controlledProp,
+  controlledProp = ControlledProp.Value,
   ...props
 }: ControlledComponentWrapperProps): React.ReactElement => {
   const valueProps = useControlledValue();

--- a/utils/storybook/ControlledComponentWrapper.tsx
+++ b/utils/storybook/ControlledComponentWrapper.tsx
@@ -42,18 +42,22 @@ export const ControlledComponentWrapper = ({
   const valueProps = useControlledValue();
   const checkedProps = useControlledCheck();
 
-  return (React.Children.map(children, child => {
-    if (React.isValidElement<any>(child)) {
-      const childProps = {
-        ...props,
-        ...child.props,
-        ...(controlledProp === ControlledProp.Checked ? checkedProps : valueProps),
-      };
+  return (
+    <>
+      {React.Children.map(children, child => {
+        if (React.isValidElement<any>(child)) {
+          const childProps = {
+            ...props,
+            ...child.props,
+            ...(controlledProp === ControlledProp.Checked ? checkedProps : valueProps),
+          };
 
-      return React.cloneElement(child, childProps);
-    }
-    return child;
-  }) as any) as React.ReactElement; // arg - cast to keep Typescript happy... Trust me Typescript, this is valid
+          return React.cloneElement(child, childProps);
+        }
+        return child;
+      })}
+    </>
+  );
 };
 
 ControlledComponentWrapper.ControlledProp = ControlledProp;

--- a/utils/storybook/index.ts
+++ b/utils/storybook/index.ts
@@ -1,6 +1,8 @@
 export {
-  default as ControlledComponentWrapper,
+  ControlledComponentWrapper,
   controlComponent,
+  useControlledValue,
+  useControlledCheck,
 } from './ControlledComponentWrapper';
 export {customColorTheme} from './customThemes';
 export {default as CanvasProviderDecorator} from './CanvasProviderDecorator';


### PR DESCRIPTION
We have a controlled component wrapper for form inputs so that the stories update when you interact with them. But we do this in many different ways and none of them are clear when looking at the documented example.

Before:
```tsx
// example 1
export const Default = () => (
  <FormField label="Label" inputId="my-checkbox-field">
    {controlComponent(<Checkbox label="Checkbox option" disabled={true} />, ControlledWrapperComponent.ControlProp.Checked)}
  </FormField>
}

// example 2
export const Default = () => (
  <FormField label="Label" inputId="my-checkbox-field">
    <ControlledComponentWrapper controlledProp={ControlledComponentWrapper.ControlledProp.Checked}>
      <Checkbox label="Checkbox option" disabled={true} />
    </ControlledComponentWrapper>
  </FormField>
)
```

I think we did this originally because we used class components with state and it was a lot of boilerplate in the story.

I think hooks changes this. I propose we use a Hooks API to do this instead:

```tsx
// example 1 - most clear
export const Default = () => {
  const {checked, onChange} = useControlledCheck();

  return (
    <FormField label="Label" inputId="my-checkbox-field">
      <Checkbox label="Checkbox option" disabled={true} value={value} onChange={onChange} />
    </FormField>
  )
}

// example 2 - more terse
export const Default = () => {
  const checkProps = useControlledCheck();

  return (
    <FormField label="Label" inputId="my-checkbox-field">
      <Checkbox label="Checkbox option" disabled={true} {...checkProps} />
    </FormField>
  )
}
```

This change is implemented in a way that doesn't break existing code.