### PR TITLE
chore: Decrease output of build-storybook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: yarn test
 
       - name: Build Storybook
-        run: yarn build-storybook
+        run: yarn build-storybook --quiet
 
       - name: Start Server
         run: yarn http-server docs -p 9001 & npx wait-on http://localhost:9001

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
   - stage: master
     script:
       - >- # Chromatic relies on a built Storybook, so exit early if build-storybook fails
-        yarn build-storybook &&
+        yarn build-storybook --quiet &&
         yarn chromatic --quiet --auto-accept-changes --exit-once-uploaded --storybook-build-dir docs
       - yarn build
     env:


### PR DESCRIPTION
The CI is a bit hard to read with verbose output. The CI cannot rewrite lines, so it dumps out thousands of progress lines. We only need to know about errors in CI.

Example output we're trying to reduce:
```
...
<s> [webpack.Progress] 69% building 4085/4110 modules 25 active /home/runner/work/canvas-kit/canvas-kit/node_modules/string.prototype.matchall/auto.js
<s> [webpack.Progress] 69% building 4085/4111 modules 26 active /home/runner/work/canvas-kit/canvas-kit/node_modules/globalthis/auto.js
<s> [webpack.Progress] 69% building 4085/4112 modules 27 active /home/runner/work/canvas-kit/canvas-kit/node_modules/promise.allsettled/auto.js
<s> [webpack.Progress] 69% building 4085/4113 modules 28 active /home/runner/work/canvas-kit/canvas-kit/node_modules/array.prototype.flat/shim.js
<s> [webpack.Progress] 69% building 4085/4114 modules 29 active /home/runner/work/canvas-kit/canvas-kit/node_modules/array.prototype.flatmap/shim.js
<s> [webpack.Progress] 69% building 4085/4115 modules 30 active /home/runner/work/canvas-kit/canvas-kit/node_modules/symbol.prototype.description/shim.js
<s> [webpack.Progress] 69% building 4085/4116 modules 31 active /home/runner/work/canvas-kit/canvas-kit/node_modules/object.fromentries/shim.js
<s> [webpack.Progress] 69% building 4085/4117 modules 32 active /home/runner/work/canvas-kit/canvas-kit/node_modules/promise.prototype.finally/requirePromise.js
<s> [webpack.Progress] 69% building 4085/4118 modules 33 active /home/runner/work/canvas-kit/canvas-kit/node_modules/promise.prototype.finally/polyfill.js
<s> [webpack.Progress] 69% building 4085/4119 modules 34 active /home/runner/work/canvas-kit/canvas-kit/node_modules/es-abstract/es7.js
<s> [webpack.Progress] 69% building 4086/4119 modules 33 active /home/runner/work/canvas-kit/canvas-kit/node_modules/es-abstract/es7.js
...
```