### PR TITLE
ci: Remove new line in lerna publish canary script

### DIFF
--- a/utils/publish-canary.js
+++ b/utils/publish-canary.js
@@ -27,13 +27,13 @@ const regex = new RegExp('@workday\\/[a-z-]*@(\\d*.\\d*.\\d*-' + preid + '.\\d*\
 
 cmd('git rev-parse --short HEAD')
   .then(sha => {
-    data.sha = sha;
+    data.sha = sha.trim();
 
     const lernaFlags = [
       `--yes`,
       `--force-publish="*"`,
       `--canary`,
-      `--preid ${preid}.${sha}`,
+      `--preid ${preid}.${data.sha}`,
       `--dist-tag ${preid}`,
       preid === 'prerelease' ? 'major' : '',
     ];


### PR DESCRIPTION
In #616 we updated our prerelease canary versions to include the sha. Unfortunately `git rev-parse --short HEAD` returns with a trailing new line, which means the full command wasn't executed (ignoring the `--dist-tag prerelease` param). 

The last canary build based on the merge of #616 used the default preid `canary`, which will unfortunately need to be removed for all modules.

This PR trims the sha before using it so we don't insert a new line into the lerna publish command before running it.