### PR TITLE
ci: Fix version regex for canary publish

### DIFF
--- a/utils/publish-canary.js
+++ b/utils/publish-canary.js
@@ -75,5 +75,31 @@ cmd('git rev-parse --short HEAD')
   })
   .catch(err => {
     console.error(err);
+
+    request.post(
+      SLACK_WEBHOOK,
+      {
+        json: {
+          attachments: [
+            {
+              fallback: `Canary publish failed (v${data.version})`,
+              color: 'danger',
+              author_name: `Canary publish failed (v${data.version})`,
+              author_link: TRAVIS_BUILD_URL,
+              title: `Merge commit ${data.sha}`,
+              title_link: `https://github.com/Workday/canvas-kit/commit/${data.sha}`,
+              text: `\`\`\`${err}\`\`\`\n`,
+              ts: Date.now(),
+            },
+          ],
+        },
+      },
+      (error, response, body) => {
+        if (error) {
+          throw error;
+        }
+      }
+    );
+
     process.exit(1);
   });

--- a/utils/publish-canary.js
+++ b/utils/publish-canary.js
@@ -23,8 +23,6 @@ if (TRAVIS_BRANCH === 'master') {
   process.exit(1);
 }
 
-const regex = new RegExp('@workday\\/[a-z-]*@(\\d*.\\d*.\\d*-' + preid + '.\\d*\\+\\w*)', 'g');
-
 cmd('git rev-parse --short HEAD')
   .then(sha => {
     data.sha = sha.trim();
@@ -43,6 +41,10 @@ cmd('git rev-parse --short HEAD')
   .then(output => {
     console.log(output);
 
+    const regex = new RegExp(
+      `@workday\\/[a-z-]*@(\\d*.\\d*.\\d*-${preid}.${data.sha}.\\d*\\+\\w*)`,
+      'g'
+    );
     data.packages = output.match(regex);
     data.version = regex.exec(data.packages[0])[1];
 


### PR DESCRIPTION
One more! #616 added a sha to canary release versions, but I forgot to update the regex used to pull the version for the slack update.

Also, I added an extra slack announcement for failed canary publishes.