### PR TITLE
fix(toast): Fix chromatic stories for toast

### DIFF
--- a/modules/toast/react/stories/stories_visualTesting.tsx
+++ b/modules/toast/react/stories/stories_visualTesting.tsx
@@ -38,7 +38,7 @@ storiesOf('Components|Popups/Toast/React/Visual Testing', module)
         columnProps={[{label: 'Default', props: {}}]}
       >
         {props => (
-          <Toast aria-label="Play" {...props}>
+          <Toast transformOrigin={null} aria-label="Play" {...props}>
             Your workbook was successfully processed.
           </Toast>
         )}


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This is currently blocked until master is merged into pre release v4. With the change introduced in https://github.com/Workday/canvas-kit/pull/600 , passing null to transform origin will now capture the stories for toast.