### PR TITLE
ci: Fix ChromaticQA Baselines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Required to retrieve git history
       - uses: actions/setup-node@v1
         with:
           node-version: 10.x


### PR DESCRIPTION
We recently changed to `actions/checkout@v2` which apparently doesn't have any git history which is preventing ChromaticQA from finding proper baselines. This is causing all PRs in the prerelease branch to have no baselines and registers all stories as new.

More info: https://www.chromatic.com/docs/ci#github-actions