### PR TITLE
ci: Report trunk build failures to slack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,8 @@ jobs:
         yarn build-storybook --quiet &&
         yarn chromatic --quiet --auto-accept-changes --exit-once-uploaded --storybook-build-dir docs
       - yarn build
+    after_failure:
+      - node utils/report-failure.js
     env:
       - CHROMATIC_APP_CODE="dlpro96xybh"
     deploy:

--- a/utils/report-failure.js
+++ b/utils/report-failure.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+'use strict';
+
+const request = require('request');
+
+const {
+  SLACK_WEBHOOK,
+  TRAVIS_BRANCH,
+  TRAVIS_TEST_RESULT,
+  TRAVIS_BUILD_URL = 'https://travis-ci.org/Workday/canvas-kit/branches',
+} = process.env;
+
+request.post(
+  SLACK_WEBHOOK,
+  {
+    json: {
+      attachments: [
+        {
+          fallback: `${TRAVIS_BRANCH} build failure`,
+          color: 'danger',
+          title_name: `${TRAVIS_BRANCH} build failure`,
+          title_link: TRAVIS_BUILD_URL,
+          text: `\`\`\`${TRAVIS_TEST_RESULT}\`\`\`\n`,
+          ts: Date.now(),
+        },
+      ],
+    },
+  },
+  (error, response, body) => {
+    if (error) {
+      throw error;
+    }
+  }
+);


### PR DESCRIPTION
## Summary

Currently if there is a build failure after a merge we get an email if it's on master (slow) and nothing if it's another "trunk-style" branch (e.g. `prerelease/v4`). This will post a message to slack whenever the `trunk` stage in travis fails.

Closes #617 