### PR TITLE
fix(color-picker): Fix accessibility announcement for color input

### DIFF
--- a/modules/color-picker/react/lib/ColorInput.tsx
+++ b/modules/color-picker/react/lib/ColorInput.tsx
@@ -133,7 +133,7 @@ export default class ColorInput extends React.Component<ColorInputProps> {
           inputRef={inputRef}
           onChange={this.handleChange}
           type="text"
-          placeholder={value ? '' : placeholder}
+          placeholder={value ? undefined : placeholder}
           value={formattedValue}
           error={error}
           spellCheck={false}

--- a/modules/color-picker/react/lib/ColorInput.tsx
+++ b/modules/color-picker/react/lib/ColorInput.tsx
@@ -133,11 +133,12 @@ export default class ColorInput extends React.Component<ColorInputProps> {
           inputRef={inputRef}
           onChange={this.handleChange}
           type="text"
-          placeholder={placeholder}
+          placeholder={value ? '' : placeholder}
           value={formattedValue}
           error={error}
           spellCheck={false}
           disabled={disabled}
+          // aria-label={!value ? 'Label edit blank hex value' : `edit hex value ${formattedValue}`}
           grow={grow}
           maxLength={7} // 7 to allow pasting with a hash
           {...elemProps}
@@ -146,7 +147,9 @@ export default class ColorInput extends React.Component<ColorInputProps> {
           showCheck={showCheck}
           color={this.isValidHex(formattedValue) ? `#${formattedValue}` : ''}
         />
-        <PoundSignPrefix disabled={disabled}>#</PoundSignPrefix>
+        <PoundSignPrefix aria-hidden={true} disabled={disabled}>
+          #
+        </PoundSignPrefix>
       </ColorInputContainer>
     );
   }

--- a/modules/color-picker/react/lib/ColorInput.tsx
+++ b/modules/color-picker/react/lib/ColorInput.tsx
@@ -138,7 +138,6 @@ export default class ColorInput extends React.Component<ColorInputProps> {
           error={error}
           spellCheck={false}
           disabled={disabled}
-          // aria-label={!value ? 'Label edit blank hex value' : `edit hex value ${formattedValue}`}
           grow={grow}
           maxLength={7} // 7 to allow pasting with a hash
           {...elemProps}


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Fixes: https://github.com/Workday/canvas-kit/issues/364

Currently, the placeholder text confuses accessibility and announces it as if it were a value. This PR eliminated that duplication and clarifies what is announces by voice over.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [ ] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
