### PR TITLE
chore: Fix version issue in beta build

### DIFF
--- a/modules/toast/react/package.json
+++ b/modules/toast/react/package.json
@@ -48,7 +48,7 @@
     "react": ">= 16.8 < 17"
   },
   "devDependencies": {
-    "@workday/canvas-kit-labs-react-core": "^3.6.0"
+    "@workday/canvas-kit-labs-react-core": "^4.0.0-beta.2"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "commit": "git-cz",
     "commitmsg": "commitlint --edit $HUSKY_GIT_PARAMS",
     "build-storybook": "build-storybook -c .storybook -o docs",
-    "lint": "node utils/check-lockfile-links.js && node utils/check-mismatched-dependencies.js && eslint -c ./.eslintrc.js --ext=jsx,ts,tsx .",
+    "lint": "node utils/check-lockfile.js && node utils/check-mismatched-dependencies.js && eslint -c ./.eslintrc.js --ext=jsx,ts,tsx .",
     "typecheck": "yarn typecheck:src && yarn typecheck:cypress",
     "typecheck:src": "tsc -p . --noEmit --incremental false",
     "typecheck:cypress": "tsc -p cypress --noEmit",

--- a/utils/check-lockfile.js
+++ b/utils/check-lockfile.js
@@ -12,3 +12,10 @@ if (/resolved\s".*(artifactory).*\n/.test(contents)) {
   );
   process.exit(1);
 }
+
+if (/@workday\/canvas-kit/.test(contents)) {
+  console.error(
+    `This 'yarn.lock' file contains references to Canvas Kit. If the monorepo versions are set correctly, this should never happen. Find the version listed in yarn.lock within the repo and adjust this dependency to the correct version.`
+  );
+  process.exit(1);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4131,32 +4131,6 @@
   resolved "https://registry.yarnpkg.com/@workday/canvas-depth-web/-/canvas-depth-web-0.16.4.tgz#3714a1a955055386a2b70cc05852162b1e056bf2"
   integrity sha512-l4LpCUk2G1FVRfo0Z+MkCWa9bzNIfWdUqGtdXaFSBySYgYvLhG6vNNuTK1VXls8jQdFCUROhKRWcy3Ht1n7NDg==
 
-"@workday/canvas-kit-labs-react-core@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@workday/canvas-kit-labs-react-core/-/canvas-kit-labs-react-core-3.6.0.tgz#0dab22e05e09145574c1e2db8dccbcdfc74ee404"
-  integrity sha512-Xv/7clq1Y8X8qwnxkkJzloYG8V+aK5N3DqQ2zKgQhKGYgAMaAkdVwYryCbT4eHkL+FgFTnNb4H7HOPxhEraFkw==
-  dependencies:
-    "@emotion/core" "^10.0.28"
-    "@emotion/styled" "^10.0.27"
-    "@workday/canvas-colors-web" "^0.17.13"
-    "@workday/canvas-kit-react-core" "^3.6.0"
-    chroma-js "^2.1.0"
-    emotion-theming "^10.0.10"
-    lodash "^4.17.14"
-    rtl-css-js "^1.13.1"
-
-"@workday/canvas-kit-react-core@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@workday/canvas-kit-react-core/-/canvas-kit-react-core-3.6.0.tgz#a55ab7afc150ea3cb534b82493703ce92fd80b64"
-  integrity sha512-4coFDWgKxfcFGBnGIdNBzm/8hMfnE8f574SB7DEoEqE+fe7rpQGOd6r7gTsQPT8KdgkvhaNZaV5P7YRChy5zuw==
-  dependencies:
-    "@emotion/core" "^10.0.28"
-    "@emotion/styled" "^10.0.27"
-    "@workday/canvas-colors-web" "^0.17.13"
-    "@workday/canvas-depth-web" "^0.16.4"
-    "@workday/canvas-space-web" "^0.15.5"
-    element-closest "^3.0.2"
-
 "@workday/canvas-space-web@^0.15.5":
   version "0.15.6"
   resolved "https://registry.yarnpkg.com/@workday/canvas-space-web/-/canvas-space-web-0.15.6.tgz#8a7ddca7734507860360d6e67abdf519c9c7a4f1"


### PR DESCRIPTION
## Summary

Our latest beta build (`4.0.0-beta.2`) was broken due to an incorrect merge which caused `@workday/canvas-kit-react-toast` to have a dev dependency on `@workday/canvas-kit-labs-react-core@3.6.0`. This meant some of our components were pulling an old version of CK, which caused issues due to incompatibility between v4 and 3.6.0. 

This PR updates the old dev dep, removes the CK references from our yarn.lock file, and updates our check-lockfile script to look for CK dependencies (which should not be there).

In the future, we plan to remove these devDeps all together to avoid this entirely (since they're not required in a yarn workspace) (see #645)