### PR TITLE
fix: Align hover ripple for checkbox and radio components in IE11

### DIFF
--- a/modules/checkbox/react/lib/Checkbox.tsx
+++ b/modules/checkbox/react/lib/Checkbox.tsx
@@ -87,6 +87,18 @@ const CheckboxInputWrapper = styled('div')<Pick<CheckboxProps, 'disabled'>>({
   alignSelf: 'flex-start',
 });
 
+const CheckboxRipple = styled('span')<Pick<CheckboxProps, 'disabled'>>({
+  borderRadius: borderRadius.circle,
+  boxShadow: `0 0 0 0 ${colors.soap200}`,
+  content: '""',
+  height: checkboxHeight,
+  transition: 'box-shadow 150ms ease-out',
+  width: checkboxWidth,
+  position: 'absolute',
+  pointerEvents: 'none',
+  zIndex: -1,
+});
+
 /**
  * Note: `~ div:first-of-type` refers to `CheckboxBackground`
  * and was easier to use than a component selector in this case.
@@ -157,25 +169,8 @@ const CheckboxInput = styled('input')<CheckboxProps>(
       },
     }),
   }),
-
-  // Ripple
-  {
-    '& ~ div:first-of-type::after': {
-      borderRadius: borderRadius.circle,
-      boxShadow: `0 0 0 0 ${colors.soap200}`,
-      content: '""',
-      display: 'inline-block',
-      height: checkboxHeight,
-      transition: 'box-shadow 150ms ease-out',
-      width: checkboxWidth,
-      position: 'absolute',
-      top: -1,
-      left: -1,
-      zIndex: -1,
-    },
-  },
   ({disabled}) => ({
-    '&:hover ~ div:first-of-type::after': {
+    '&:hover ~ span:first-of-type': {
       boxShadow: disabled ? undefined : `0 0 0 ${rippleRadius}px ${colors.soap200}`,
     },
   }),
@@ -311,6 +306,7 @@ export default class Checkbox extends React.Component<CheckboxProps> {
             error={error}
             {...elemProps}
           />
+          <CheckboxRipple />
           <CheckboxBackground checked={checked} disabled={disabled}>
             <CheckboxCheck checked={checked}>
               {indeterminate ? (

--- a/modules/checkbox/react/lib/Checkbox.tsx
+++ b/modules/checkbox/react/lib/Checkbox.tsx
@@ -94,7 +94,7 @@ const CheckboxRipple = styled('span')<Pick<CheckboxProps, 'disabled'>>({
   transition: 'box-shadow 150ms ease-out',
   width: checkboxWidth,
   position: 'absolute',
-  pointerEvents: 'none',
+  pointerEvents: 'none', // This is a decorative element we don't want it to block clicks to input
   zIndex: -1,
 });
 

--- a/modules/checkbox/react/lib/Checkbox.tsx
+++ b/modules/checkbox/react/lib/Checkbox.tsx
@@ -169,6 +169,8 @@ const CheckboxInput = styled('input')<CheckboxProps>(
       transition: 'box-shadow 150ms ease-out',
       width: checkboxWidth,
       position: 'absolute',
+      top: -1,
+      left: -1,
       zIndex: -1,
     },
   },

--- a/modules/checkbox/react/lib/Checkbox.tsx
+++ b/modules/checkbox/react/lib/Checkbox.tsx
@@ -90,7 +90,6 @@ const CheckboxInputWrapper = styled('div')<Pick<CheckboxProps, 'disabled'>>({
 const CheckboxRipple = styled('span')<Pick<CheckboxProps, 'disabled'>>({
   borderRadius: borderRadius.circle,
   boxShadow: `0 0 0 0 ${colors.soap200}`,
-  content: '""',
   height: checkboxHeight,
   transition: 'box-shadow 150ms ease-out',
   width: checkboxWidth,

--- a/modules/radio/react/lib/Radio.tsx
+++ b/modules/radio/react/lib/Radio.tsx
@@ -84,7 +84,7 @@ const RadioRipple = styled('span')<Pick<RadioProps, 'disabled'>>({
   width: radioWidth,
   position: 'absolute',
   pointerEvents: 'none',
-  zIndex: 1,
+  zIndex: -1,
 });
 
 const RadioInput = styled('input')<RadioProps>(

--- a/modules/radio/react/lib/Radio.tsx
+++ b/modules/radio/react/lib/Radio.tsx
@@ -105,6 +105,8 @@ const RadioInput = styled('input')<RadioProps>(
       transition: 'box-shadow 150ms ease-out',
       width: radioWidth,
       position: 'absolute',
+      top: -1,
+      left: -1,
       zIndex: -1,
     },
   },

--- a/modules/radio/react/lib/Radio.tsx
+++ b/modules/radio/react/lib/Radio.tsx
@@ -82,7 +82,7 @@ const RadioRipple = styled('span')<Pick<RadioProps, 'disabled'>>({
   transition: 'box-shadow 150ms ease-out',
   width: radioWidth,
   position: 'absolute',
-  pointerEvents: 'none',
+  pointerEvents: 'none', // This is a decorative element we don't want it to block clicks to input
   zIndex: -1,
 });
 

--- a/modules/radio/react/lib/Radio.tsx
+++ b/modules/radio/react/lib/Radio.tsx
@@ -78,7 +78,6 @@ const RadioInputWrapper = styled('div')<Pick<RadioProps, 'disabled'>>({
 const RadioRipple = styled('span')<Pick<RadioProps, 'disabled'>>({
   borderRadius: borderRadius.circle,
   boxShadow: `0 0 0 0 ${colors.soap200}`,
-  content: '""',
   height: radioHeight,
   transition: 'box-shadow 150ms ease-out',
   width: radioWidth,

--- a/modules/radio/react/lib/Radio.tsx
+++ b/modules/radio/react/lib/Radio.tsx
@@ -75,10 +75,18 @@ const RadioInputWrapper = styled('div')<Pick<RadioProps, 'disabled'>>({
   width: radioWidth,
 });
 
-/**
- * Note: `~ div:first-of-type` refers to `RadioBackground`
- * and was easier to use than a component selector in this case.
- */
+const RadioRipple = styled('span')<Pick<RadioProps, 'disabled'>>({
+  borderRadius: borderRadius.circle,
+  boxShadow: `0 0 0 0 ${colors.soap200}`,
+  content: '""',
+  height: radioHeight,
+  transition: 'box-shadow 150ms ease-out',
+  width: radioWidth,
+  position: 'absolute',
+  pointerEvents: 'none',
+  zIndex: 1,
+});
+
 const RadioInput = styled('input')<RadioProps>(
   {
     borderRadius: radioBorderRadius,
@@ -93,28 +101,25 @@ const RadioInput = styled('input')<RadioProps>(
       outline: 'none',
     },
   },
-
-  // Ripple
-  {
-    '& ~ div:first-of-type::after': {
-      borderRadius: borderRadius.circle,
-      boxShadow: `0 0 0 0 ${colors.soap200}`,
-      content: '""',
-      display: 'inline-block',
-      height: radioHeight,
-      transition: 'box-shadow 150ms ease-out',
-      width: radioWidth,
-      position: 'absolute',
-      top: -1,
-      left: -1,
-      zIndex: -1,
-    },
-  },
   ({checked, disabled, theme}) => ({
     cursor: disabled ? undefined : 'pointer',
-    '&:hover ~ div:first-of-type::after': {
+    /**
+     * These selectors are targetting various sibling elements (~) here because
+     * their styles need to be connected to changes around the input's state
+     * (e.g. hover, focus, etc.).
+     *
+     * We are choosing not to use component selectors from Emotion in this case.
+     * The Babel transforms have been problematic in the past.
+     */
+
+    // `span:first-of-type` refers to `RadioRipple`, the light grey
+    // element that animates around the component on hover
+    '&:hover ~ span:first-of-type': {
       boxShadow: disabled ? undefined : `0 0 0 ${rippleRadius}px ${colors.soap200}`,
     },
+
+    // `div:first-of-type` refers to the `RadioBackground`, the visual facade of the
+    // input (which is visually hidden)
     '&:hover ~ div:first-of-type': {
       backgroundColor: checked
         ? theme.palette.primary.main
@@ -132,7 +137,6 @@ const RadioInput = styled('input')<RadioProps>(
       '& ~ div:first-of-type': {
         borderColor: checked ? theme.palette.primary.main : theme.palette.common.focusOutline,
         borderWidth: '2px',
-        zIndex: 2,
       },
     },
     '&:checked:focus ~ div:first-of-type': {
@@ -244,6 +248,7 @@ export default class Radio extends React.Component<RadioProps> {
             aria-checked={checked}
             {...elemProps}
           />
+          <RadioRipple />
           <RadioBackground checked={checked} disabled={disabled}>
             <RadioCheck checked={checked} />
           </RadioBackground>


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes #650 

## Explanation
I'll do my best to explain how this fix came to be for both `Radio` and `Checkbox` because they are implemented similarly.

### Align browsers by explicit positioning (i.e. change top: auto to top: 0px)
The first thing was to fix ripple positioning in IE11. This means that we have to make sure that the ripple is placed intentionally by setting `top: 0px` instead of the default `top:auto` which is browser controlled.

### Unfortunately, that introduces offset errors due to border-width changes
Hang on, not that simple though. The width of the border for the parent element (`RadioBackground`, `CheckboxBackground`) will render with offset errors on all browsers when this happens.

Why? This is because absolutely positioned element coordinates are based on the parent's content not the content + border width (border-box doesn't help this). So to align correctly you have to account for the border's width, i.e. `top: -1px`. If the border changes to `2px` (which it does), this becomes problematic since you also have to adjust the ripple's positioning. They're tightly coupled.

I tried, and as I adjusted for the changing `border-width` the visual state tables would look correct, I got offset errors while transitioning between states with different border sizes! This is not good and really hard to reason about and impossible to catch with our tests today.

Offset errors look something like this:

<img width="188" alt="Screen Shot 2020-05-20 at 7 23 16 AM" src="https://user-images.githubusercontent.com/14299381/82457862-d2ad3900-9a6a-11ea-9683-4e27811b0565.png">

### Solution: Move it so it wouldn't be influenced by changes in parent's border-width
The solution was to move the ripple to a place where it wouldn't be influenced by changes in `border-width` from the background components. Moving it to be a sibling of the background component makes positioning a bit easier to reason about since changes in one doesn't affect the other.

### Still needs to be connected to the input though
But one requirement is that the ripple animates via the `input` element's state changes (hover, active, disabled, etc.) so instead of a keeping it as a pseudo element (originally `::after`), it was changed to a concrete element (`span`) so it could be targeted in a CSS sibling selector (`~ span:first-of-type`).

### An alternative solution
An alternative was to transition everything to `box-shadow`s because that doesn't influence positioning. You can't change individual components of it like you can a border (`border-color`, `border-width`, etc.) so that change worked but was also more code and nasty-looking ternaries when we wanted to have new `box-shadow`s based on props.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] `yarn test` passes (No tests were added because this regression already exists as a baseline 😓 )
- [x] Fix for `Radio`
- [x] Fix for `Checkbox`
- [ ] Inconsistencies with the Figma spec (could be a different issue/PR)