### PR TITLE
WIP feat(breadcrumbs): Add Breadcrumbs component to Canvas Labs

### DIFF
--- a/modules/_labs/breadcrumbs/react/LICENSE
+++ b/modules/_labs/breadcrumbs/react/LICENSE
@@ -1,0 +1,52 @@
+Apache License, Version 2.0 Apache License Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License.
+Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+You must give any other recipients of the Work or Derivative Works a copy of this License; and You must cause any modified files to carry prominent notices stating that You changed the files; and You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions.
+Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks.
+This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability.
+In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+©2020. Workday, Inc. All rights reserved. Workday and the Workday logo are registered trademarks of Workday, Inc. All other brand and product names are trademarks or registered trademarks of their respective holders.
+
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/modules/_labs/breadcrumbs/react/README.md
+++ b/modules/_labs/breadcrumbs/react/README.md
@@ -1,0 +1,48 @@
+# Canvas Kit React Breadcrumbs
+
+<a href="https://github.com/Workday/canvas-kit/tree/master/modules/_labs/README.md">
+  <img src="https://img.shields.io/badge/LABS-alpha-orange" alt="LABS: Alpha" />
+</a>  This component is work in progress and currently in pre-release.
+
+Breadcrumbs component for navigation through different levels of some structure. Adjustable to container width.
+
+## Installation
+
+```sh
+yarn add @workday/canvas-kit-labs-react-breadcrumbs
+```
+
+## Usage
+
+```tsx
+import * as React from 'react';
+import Breadcrumbs from '@workday/canvas-kit-labs-react-breadcrumbs';
+
+<Breadcrumbs />;
+```
+
+## Static Properties
+
+> None
+
+## Component Props
+
+### Required
+
+#### `breadcrumbs: Breadcrumb[]`
+
+> This is an array of objects that contain a `name` and an `onAction` function for
+that respective name. They will be listed from index 0 - n as breadcrumbs, starting
+at root and ending at the current location.
+
+#### `containerWidth: number`
+
+> This is a number that represents the maximum width you want the breadcrumbs to
+take up. If there are too many breadcrumbs passed in for this width, the component
+will hide exactly enough breadcrumbs under the expander until the component's total width is less than this prop.
+
+### Optional
+
+#### `variation: BreadcrumbVariation`
+
+> Possible options are `medium` and `large` and change the styling of the breadcrumbs as such.

--- a/modules/_labs/breadcrumbs/react/index.ts
+++ b/modules/_labs/breadcrumbs/react/index.ts
@@ -1,0 +1,5 @@
+import Breadcrumbs from './lib/Breadcrumbs';
+
+export default Breadcrumbs;
+export {Breadcrumbs};
+export * from './lib/Breadcrumbs';

--- a/modules/_labs/breadcrumbs/react/lib/Breadcrumbs.tsx
+++ b/modules/_labs/breadcrumbs/react/lib/Breadcrumbs.tsx
@@ -1,0 +1,255 @@
+import * as React from 'react';
+import styled from '@emotion/styled';
+import {colors, type} from '@workday/canvas-kit-react-core';
+import {chevronRightSmallIcon, relatedActionsIcon} from '@workday/canvas-system-icons-web';
+import {DropdownPopover, dummyOption, OptionProps} from './DropdownPopover';
+import {SystemIcon} from '@workday/canvas-kit-react-icon';
+import {IconButton} from '@workday/canvas-kit-react-button';
+
+export type BreadcrumbVariation = `large` | `medium`;
+
+export type Breadcrumb = {
+  /**
+   * The text displayed for the Breadcrumb.
+   */
+  name: string;
+  /**
+   * The function called when the Breadcrumb is interacted with.
+   */
+  onAction: () => void;
+};
+
+export interface BreadcrumbsProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * A list of all the Breadcrumbs in order from root to current location.
+   */
+  breadcrumbs: Breadcrumb[];
+  /**
+   * The width of the breadcrumbs container, used to determine which breadcrumbs to hide.
+   */
+  containerWidth: number;
+  /**
+   * The size variation of the breadcrumbs.
+   */
+  variation?: BreadcrumbVariation;
+}
+
+type CrumbProps = {
+  variation: BreadcrumbVariation;
+};
+
+const LinkedCrumb = styled.span((props: CrumbProps) => ({
+  ...type.body,
+  ...type.variant.link,
+  fontSize: props.variation === `large` ? `16px` : `14px`,
+}));
+
+const CurrentCrumb = styled.span((props: CrumbProps) => ({
+  ...type.body,
+  ...type.variant.label,
+  fontSize: props.variation === `large` ? `16px` : `14px`,
+}));
+
+const BreadcrumbsContainer = styled.div({
+  display: `flex`,
+  alignItems: `center`,
+});
+
+const breadcrumbOptionEquality = (breadcrumb: Breadcrumb, option: OptionProps) => {
+  return breadcrumb.name === option.text;
+};
+
+export const Breadcrumbs = (props: BreadcrumbsProps) => {
+  const [expanderOpen, setExpanderOpen] = React.useState<boolean>(false);
+  const [breadcrumbsHidden, setBreadcrumbsHidden] = React.useState<number[]>([]);
+  const [activeOption, setActiveOption] = React.useState(dummyOption);
+  const expanderRef: React.RefObject<HTMLButtonElement> = React.useRef(null);
+  const activeOptionEl: React.RefObject<HTMLDivElement> = React.useRef(null);
+  const dividerWidth = 42;
+  const breadcrumbsWidths: number[] = [];
+  let context: CanvasRenderingContext2D | null | undefined;
+
+  React.useLayoutEffect(() => {
+    if (activeOptionEl.current) {
+      activeOptionEl.current.focus();
+    }
+  });
+
+  React.useLayoutEffect(() => {
+    if (context) {
+      context.font.fontsize(props.variation === `large` ? 16 : 14);
+    }
+
+    // Store widths of each breadcrumb and calculate total breadcrumb width
+    let widthOfBreadcrumbNames = 0;
+    props.breadcrumbs.forEach(breadcrumb => {
+      const width = context ? context.measureText(breadcrumb.name).width : 0;
+      breadcrumbsWidths.push(width ? width : 0);
+      if (width) {
+        widthOfBreadcrumbNames += width;
+      }
+    });
+
+    // If too wide for container, hide breadcrumbs starting after root
+    let totalWidth = widthOfBreadcrumbNames + dividerWidth * (props.breadcrumbs.length - 1);
+    if (totalWidth > props.containerWidth) {
+      const newHidden = [...breadcrumbsHidden];
+      for (let i = 1; i < props.breadcrumbs.length; i++) {
+        if (breadcrumbsHidden.indexOf(i) === -1) {
+          newHidden.push(i);
+        }
+        totalWidth = totalWidth - breadcrumbsWidths[i] - dividerWidth;
+        if (totalWidth <= props.containerWidth) {
+          break;
+        }
+      }
+      setBreadcrumbsHidden(newHidden);
+    } else {
+      // The container width is large enough to show all breadcrumbs
+      setBreadcrumbsHidden([]);
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.breadcrumbs, props.containerWidth]);
+
+  let expanderRendered = false;
+
+  const getHiddenDropdownOptions = () => {
+    const hiddenSorted = breadcrumbsHidden.sort();
+    return [
+      hiddenSorted.map(crumb => {
+        return {text: props.breadcrumbs[crumb].name};
+      }),
+    ];
+  };
+
+  const dropdownOptions = getHiddenDropdownOptions();
+
+  const getExpanderDropdown = () => {
+    return (
+      <DropdownPopover
+        isOpen={expanderOpen}
+        buttonRef={expanderRef}
+        options={dropdownOptions}
+        activeOption={activeOption}
+        activeOptionEl={activeOptionEl}
+        setOpenState={setExpanderOpen}
+        setActiveOption={setActiveOption}
+        onOptionChange={option => {
+          const crumb = props.breadcrumbs.find(breadcrumb =>
+            breadcrumbOptionEquality(breadcrumb, option)
+          );
+          if (crumb) {
+            crumb.onAction();
+          }
+        }}
+        portalElement={document.body}
+      />
+    );
+  };
+
+  const handleExpanderKeyPress = (
+    e: React.KeyboardEvent<HTMLSpanElement>,
+    setOpenState: React.Dispatch<React.SetStateAction<boolean>>,
+    setActiveOption: React.Dispatch<React.SetStateAction<OptionProps>>,
+    firstOption: OptionProps
+  ) => {
+    if (e.key === 'Enter') {
+      setOpenState(true);
+      setActiveOption(firstOption);
+    }
+  };
+
+  const onLinkedCrumbKeyPress = (
+    e: React.KeyboardEvent<HTMLSpanElement>,
+    onOptionChange: () => void
+  ) => {
+    if (e.key === 'Enter') {
+      onOptionChange();
+    }
+  };
+
+  return (
+    <BreadcrumbsContainer role={`navigation`}>
+      <canvas
+        ref={c => {
+          if (c) {
+            context = c.getContext(`2d`);
+          }
+        }}
+        width={0}
+        height={0}
+      />
+      {props.breadcrumbs.map((breadcrumb, index) => {
+        if (breadcrumbsHidden.indexOf(index) === -1) {
+          if (index < props.breadcrumbs.length - 1) {
+            return (
+              <BreadcrumbsContainer key={index}>
+                <LinkedCrumb
+                  title="Breadcrumb"
+                  variation={props.variation || `medium`}
+                  onClick={breadcrumb.onAction}
+                  tabIndex={0}
+                  onKeyDown={e => onLinkedCrumbKeyPress(e, breadcrumb.onAction)}
+                >
+                  {breadcrumb.name}
+                </LinkedCrumb>
+                <SystemIcon
+                  icon={chevronRightSmallIcon}
+                  color={colors.licorice200}
+                  colorHover={colors.licorice200}
+                  aria-hidden={true}
+                />
+              </BreadcrumbsContainer>
+            );
+          } else {
+            return (
+              <CurrentCrumb key={index} variation={props.variation || `medium`} title="Breadcrumb">
+                {breadcrumb.name}
+              </CurrentCrumb>
+            );
+          }
+        } else if (!expanderRendered && breadcrumbsHidden.length > 0) {
+          expanderRendered = true;
+          return (
+            <BreadcrumbsContainer key={index}>
+              <IconButton
+                icon={relatedActionsIcon}
+                color={colors.licorice200}
+                buttonRef={expanderRef}
+                toggled={expanderOpen}
+                onClick={() => {
+                  if (activeOption !== dropdownOptions[0][0]) {
+                    setExpanderOpen(!expanderOpen);
+                  }
+                }}
+                onKeyUp={e => {
+                  handleExpanderKeyPress(
+                    e,
+                    setExpanderOpen,
+                    setActiveOption,
+                    dropdownOptions[0][0]
+                  );
+                }}
+                data-testid={`more-breadcrumbs`}
+                aria-label={`more-breadcrumbs`}
+              />
+              {breadcrumbsHidden.indexOf(props.breadcrumbs.length - 1) === -1 && (
+                <SystemIcon
+                  icon={chevronRightSmallIcon}
+                  color={colors.licorice200}
+                  colorHover={colors.licorice200}
+                  aria-hidden={true}
+                />
+              )}
+            </BreadcrumbsContainer>
+          );
+        }
+        return <div key={index}></div>;
+      })}
+      {expanderOpen && getExpanderDropdown()}
+    </BreadcrumbsContainer>
+  );
+};
+
+export default Breadcrumbs;

--- a/modules/_labs/breadcrumbs/react/lib/DropdownPopover.tsx
+++ b/modules/_labs/breadcrumbs/react/lib/DropdownPopover.tsx
@@ -1,0 +1,257 @@
+import * as React from 'react';
+import styled from '@emotion/styled';
+import {colors, spacing, depth, type} from '@workday/canvas-kit-react-core';
+import {SystemIcon} from '@workday/canvas-kit-react-icon';
+import {CanvasSystemIcon} from '@workday/design-assets-types';
+import {plusIcon} from '@workday/canvas-system-icons-web';
+import {createPortal} from 'react-dom';
+
+type DropdownPopoverProps = {
+  /**
+   * The button element from which the dropdown is appearing.
+   */
+  buttonElement?: HTMLElement;
+  /**
+   * The next focusable element on the page after the dropdown options.
+   */
+  nextFocusableElement?: HTMLElement;
+  /**
+   * The currently active option.
+   */
+  activeOption: OptionProps;
+  /**
+   * A ref to the currently active option.
+   */
+  activeOptionEl: React.RefObject<HTMLDivElement>;
+  /**
+   * A ref tot he button element from which the dropdown is appearing.
+   */
+  buttonRef: React.RefObject<HTMLElement>;
+  /**
+   * Whether or not the dropdown is open.
+   */
+  isOpen: boolean;
+  /**
+   * The function to call when the option is changed.
+   */
+  onOptionChange: (option: OptionProps) => void;
+  /**
+   * Each option in the dropdown.
+   */
+  options: OptionProps[][];
+  /**
+   * The element on which to portal the dropdown.
+   */
+  portalElement: HTMLElement;
+  /**
+   * A function to set the currently active option.
+   */
+  setActiveOption: React.Dispatch<React.SetStateAction<OptionProps>>;
+  /**
+   * A function to set the current open state.
+   */
+  setOpenState: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+const dropDownPadding = 5;
+
+export type OptionProps = {
+  icon?: CanvasSystemIcon;
+  text: string;
+  color?: string;
+  createType?: string;
+};
+
+export const dummyOption = {
+  text: `unfocusable`,
+  color: `null`,
+  icon: plusIcon,
+  createType: `Workday.Folder`,
+} as OptionProps;
+
+type FocusProps = {
+  isFocused: boolean;
+};
+
+export const Option = styled.div<FocusProps>(props => ({
+  ...type.body,
+  alignItems: `center`,
+  cursor: `pointer`,
+  display: `flex`,
+  padding: `7px 14px`,
+  backgroundColor: props.isFocused ? colors.blueberry400 : colors.frenchVanilla100,
+  color: props.isFocused ? colors.frenchVanilla100 : colors.blackPepper300,
+  outline: `none`,
+  '&:hover': {
+    backgroundColor: props.isFocused ? colors.blueberry400 : colors.soap300,
+  },
+}));
+
+const BackDrop = styled.div({
+  left: 0,
+  top: 0,
+  position: `fixed`,
+  width: `100%`,
+  height: `100%`,
+  zIndex: 10000,
+});
+
+type OptionGroupWrapperProps = {
+  isLast: boolean;
+};
+
+const OptionGroupWrapper = styled.div<OptionGroupWrapperProps>(props => ({
+  borderBottom: props.isLast
+    ? `1px solid ${colors.frenchVanilla100}`
+    : `1px solid ${colors.soap400}`,
+}));
+
+const OptionText = styled.div({
+  paddingLeft: `10px`,
+});
+
+type OptionsProps = {
+  buttonRef: React.RefObject<HTMLElement>;
+};
+
+const Options = styled.div<OptionsProps>(props => ({
+  borderRadius: `3px`,
+  border: `1px solid ${colors.soap400}`,
+  ...depth[1],
+  left: props.buttonRef.current ? props.buttonRef.current.getBoundingClientRect().left : 0,
+  minWidth: `132px`,
+  padding: `${spacing.xxxs} ${spacing.zero}`,
+  position: `absolute`,
+  top: props.buttonRef.current
+    ? props.buttonRef.current.getBoundingClientRect().bottom
+      ? props.buttonRef.current.getBoundingClientRect().bottom + dropDownPadding
+      : 0
+    : 0,
+  zIndex: 10001,
+}));
+
+export const DropdownPopover = (props: DropdownPopoverProps) => {
+  const optionList = Array.prototype.concat.apply([], props.options);
+
+  const handleUpdateActiveOption = (optionIndex: number, moveUp: boolean) => {
+    const modifier = moveUp ? -1 : 1;
+    // adding the length of the list and modulus by the length in order to wrap from top to bottom or bottom to top
+    const index = (optionIndex + modifier + optionList.length) % optionList.length;
+    props.setActiveOption(optionList[index]);
+  };
+
+  const handleOptionKeyUp = (
+    e: React.KeyboardEvent<HTMLSpanElement>,
+    option: OptionProps,
+    onOptionChange: (option: OptionProps) => void
+  ) => {
+    e.stopPropagation(); // use to keep event from bubbling up to the drag and drop key handler
+    switch (e.key) {
+      case `Enter`:
+        props.setOpenState(false);
+        props.setActiveOption(dummyOption);
+        onOptionChange(option);
+        break;
+
+      case `ArrowUp`:
+      case `ArrowLeft`:
+      case `Up`:
+        handleUpdateActiveOption(optionList.indexOf(option), true);
+        break;
+
+      case `ArrowDown`:
+      case `Down`:
+      case `ArrowRight`:
+        handleUpdateActiveOption(optionList.indexOf(option), false);
+        break;
+
+      case `Escape`:
+      case `Esc`:
+        props.setOpenState(false);
+        props.setActiveOption(dummyOption);
+        break;
+
+      case `Tab`:
+        props.setOpenState(false);
+        props.setActiveOption(dummyOption);
+        e.preventDefault();
+        if (props.nextFocusableElement) {
+          props.nextFocusableElement.focus();
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
+  const getDropdownOptions = () => {
+    return (
+      <Options buttonRef={props.buttonRef} data-testid={`dropdown-menu`}>
+        {props.options.map(function(group: OptionProps[], index: number) {
+          return (
+            <OptionGroupWrapper key={index} isLast={index === props.options.length - 1}>
+              {group.map(option => {
+                const isFocused = props.activeOption.text === option.text;
+                return (
+                  <Option
+                    key={option.text}
+                    onKeyUp={e => {
+                      handleOptionKeyUp(e, option, props.onOptionChange);
+                    }}
+                    onKeyDown={e => {
+                      if (e.key === `Tab` && e.shiftKey) {
+                        props.setOpenState(false);
+                        props.setActiveOption(dummyOption);
+                        e.preventDefault();
+                        if (props.buttonElement) {
+                          props.buttonElement.focus();
+                        }
+                      }
+                    }}
+                    onClick={() => {
+                      props.setOpenState(false);
+                      props.onOptionChange(option);
+                    }}
+                    ref={isFocused ? props.activeOptionEl : null}
+                    tabIndex={0}
+                    isFocused={isFocused}
+                    data-testid={`dropdown-option-${option.text}`}
+                  >
+                    {option.icon && option.color && (
+                      <SystemIcon
+                        icon={option.icon}
+                        color={isFocused ? colors.soap100 : option.color}
+                        colorHover={isFocused ? colors.soap100 : option.color}
+                      />
+                    )}
+                    <OptionText>{option.text}</OptionText>
+                  </Option>
+                );
+              })}
+            </OptionGroupWrapper>
+          );
+        })}
+      </Options>
+    );
+  };
+
+  return (
+    <>
+      <div>{props.isOpen && createPortal(getDropdownOptions(), props.portalElement)}</div>
+      {props.isOpen && (
+        <BackDrop
+          data-testid={`backdrop`}
+          onMouseDown={() => {
+            props.setActiveOption(dummyOption);
+            props.setOpenState(false);
+          }}
+          onScroll={e => {
+            e.preventDefault();
+          }}
+        />
+      )}
+    </>
+  );
+};
+
+export default DropdownPopover;

--- a/modules/_labs/breadcrumbs/react/package.json
+++ b/modules/_labs/breadcrumbs/react/package.json
@@ -1,0 +1,41 @@
+
+{
+  "name": "@workday/canvas-kit-labs-react-breadcrumbs",
+  "version": "0.0.0",
+  "description": "Breadcrumbs component for navigation through different levels of some structure. Adjustable to container width.",
+  "author": "Workday, Inc. (https://www.workday.com)",
+  "license": "Apache-2.0",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/es6/index.js",
+  "sideEffects": false,
+  "types": "dist/es6/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Workday/canvas-kit/tree/master/modules/_labs/breadcrumbs/react"
+  },
+  "files": [
+    "dist/",
+    "lib/",
+    "index.ts"
+  ],
+  "scripts": {
+    "watch": "yarn build:es6 -w",
+    "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:es6": "tsc -p tsconfig.es6.json",
+    "build:rebuild": "npm-run-all clean build",
+    "build": "npm-run-all --parallel build:cjs build:es6",
+    "depcheck": "node ../../../../utils/check-dependencies-exist.js"
+  },
+  "keywords": [
+    "canvas",
+    "canvas-kit",
+    "react",
+    "components",
+    "workday",
+    "breadcrumbs"
+  ],
+  "peerDependencies": {
+    "react": ">= 16.8 < 17"
+  }
+}

--- a/modules/_labs/breadcrumbs/react/spec/Breadcrumbs.spec.tsx
+++ b/modules/_labs/breadcrumbs/react/spec/Breadcrumbs.spec.tsx
@@ -1,0 +1,184 @@
+import * as React from 'react';
+import {render, waitForElement, act, fireEvent, createEvent} from '@testing-library/react';
+import Breadcrumbs from '../lib/Breadcrumbs';
+
+export const enterEvent = {
+  key: `Enter`,
+  code: `Enter`,
+  keyCode: 13,
+};
+
+export const downEvent = {
+  key: `ArrowDown`,
+  code: `ArrowDown`,
+  keyCode: 40,
+};
+
+export const tabEvent = {
+  key: `Tab`,
+  code: `Tab`,
+  keyCode: 9,
+};
+
+const exampleBreadcrumbs = [
+  {
+    name: 'Root',
+    onAction: () => {
+      window.alert(`Root`);
+    },
+  },
+  {
+    name: 'Folder1',
+    onAction: () => {
+      window.alert(`Folder1`);
+    },
+  },
+  {
+    name: 'Folder2',
+    onAction: () => {
+      window.alert(`Folder2`);
+    },
+  },
+  {
+    name: 'Folder3',
+    onAction: () => {
+      window.alert(`Folder3`);
+    },
+  },
+  {
+    name: 'Folder4',
+    onAction: () => {
+      window.alert(`Folder4`);
+    },
+  },
+  {
+    name: 'Folder5',
+    onAction: () => {
+      window.alert(`Folder5`);
+    },
+  },
+];
+
+describe(`<Breadcrumbs />`, () => {
+  beforeEach(() => {
+    jest
+      .spyOn(window.HTMLCanvasElement.prototype, `getContext`)
+      .mockImplementation((contextId: string, options?: any): any => {
+        return {
+          measureText: () => {
+            return {width: 50};
+          },
+          font: ``,
+        };
+      });
+  });
+  test(`properly renders text in breadcrumbs with no truncation`, async () => {
+    // Arrange:
+    const {findByText, queryByTestId} = render(
+      <Breadcrumbs breadcrumbs={exampleBreadcrumbs} containerWidth={600} />
+    );
+
+    // Act:
+    const root = await findByText(`Root`);
+    const first = await findByText(`Folder1`);
+    const second = await findByText(`Folder2`);
+    const third = await findByText(`Folder3`);
+    const fourth = await findByText(`Folder4`);
+    const fifth = await findByText(`Folder5`);
+
+    const ellipsis = queryByTestId(`more-breadcrumbs`);
+    expect(ellipsis).toBe(null);
+  });
+
+  test(`properly renders truncation icon if container is too small`, async () => {
+    // Arrange:
+    const {findByTestId} = render(
+      <Breadcrumbs breadcrumbs={exampleBreadcrumbs} containerWidth={300} />
+    );
+
+    // Act:
+    const ellipsis = await waitForElement(() => findByTestId(`more-breadcrumbs`));
+
+    // Assert:
+    expect(ellipsis).toBeDefined();
+  });
+
+  test(`dropdown calls action when clicked`, async () => {
+    // Arrange:
+    const alert = jest.spyOn(window, `alert`).mockImplementation(() => {}); // eslint-disable-line no-empty-function
+    const {findByTestId, findByText} = render(
+      <Breadcrumbs breadcrumbs={exampleBreadcrumbs} containerWidth={300} />
+    );
+
+    // Act:
+    const ellipsis = await waitForElement(() => findByTestId(`more-breadcrumbs`));
+    act(() => {
+      fireEvent.click(ellipsis);
+    });
+
+    const secondOption = await findByText(`Folder2`);
+    act(() => {
+      fireEvent.click(secondOption);
+    });
+
+    // Assert:
+    expect(alert).toHaveBeenCalledTimes(1);
+  });
+
+  test(`dropdown calls action on enter press and is navigable through arrow keys`, async () => {
+    // Arrange:
+    const alert = jest.spyOn(window, `alert`).mockImplementation(() => {}); // eslint-disable-line no-empty-function
+    const {findByTestId, findByText} = render(
+      <Breadcrumbs breadcrumbs={exampleBreadcrumbs} containerWidth={300} />
+    );
+
+    // Act:
+    const ellipsis = await waitForElement(() => findByTestId(`more-breadcrumbs`));
+    act(() => {
+      const event = createEvent.keyUp(ellipsis, enterEvent);
+      fireEvent(ellipsis, event);
+    });
+
+    const firstOption = await findByText(`Folder1`);
+    const secondOption = await findByText(`Folder2`);
+
+    act(() => {
+      const event = createEvent.keyUp(firstOption, downEvent);
+      fireEvent(firstOption, event);
+    });
+
+    act(() => {
+      const event = createEvent.keyUp(secondOption, enterEvent);
+      fireEvent(secondOption, event);
+    });
+
+    // Assert:
+    expect(alert).toHaveBeenCalledTimes(1);
+  });
+
+  test(`crumb calls action on enter press and is navigable through tab`, async () => {
+    // Arrange:
+    const alert = jest.spyOn(window, `alert`).mockImplementation(() => {}); // eslint-disable-line no-empty-function
+    const {findByText} = render(
+      <Breadcrumbs breadcrumbs={exampleBreadcrumbs} containerWidth={600} />
+    );
+
+    // Act:
+    const firstOption = await findByText(`Folder1`);
+    const secondOption = await findByText(`Folder2`);
+    firstOption.focus();
+
+    act(() => {
+      const event = createEvent.keyDown(firstOption, tabEvent);
+      fireEvent(firstOption, event);
+    });
+
+    act(() => {
+      const event = createEvent.keyDown(secondOption, enterEvent);
+      fireEvent(secondOption, event);
+    });
+
+    // Assert:
+    expect(alert).toHaveBeenCalledTimes(1);
+  });
+});

--- a/modules/_labs/breadcrumbs/react/stories/stories_Breadcrumbs.tsx
+++ b/modules/_labs/breadcrumbs/react/stories/stories_Breadcrumbs.tsx
@@ -1,0 +1,64 @@
+/// <reference path="../../../../../typings.d.ts" />
+import * as React from 'react';
+import {storiesOf} from '@storybook/react';
+import withReadme from 'storybook-readme/with-readme';
+import Breadcrumbs from '../index';
+import README from '../README.md';
+
+const exampleBreadcrumbs = [
+  {
+    name: 'Root',
+    onAction: () => {
+      window.alert(`Root`);
+    },
+  },
+  {
+    name: 'Folder1',
+    onAction: () => {
+      window.alert(`Folder1`);
+    },
+  },
+  {
+    name: 'Folder2',
+    onAction: () => {
+      window.alert(`Folder2`);
+    },
+  },
+  {
+    name: 'Folder3',
+    onAction: () => {
+      window.alert(`Folder3`);
+    },
+  },
+  {
+    name: 'Folder4',
+    onAction: () => {
+      window.alert(`Folder4`);
+    },
+  },
+  {
+    name: 'Folder5',
+    onAction: () => {
+      window.alert(`Folder5`);
+    },
+  },
+];
+
+storiesOf('Labs/Breadcrumbs', module)
+  .addParameters({component: Breadcrumbs})
+  .addDecorator(withReadme(README))
+  .add('Default', () => (
+    <div className="story">
+      <Breadcrumbs breadcrumbs={exampleBreadcrumbs} containerWidth={600} />
+    </div>
+  ))
+  .add('Truncated', () => (
+    <div className="story">
+      <Breadcrumbs breadcrumbs={exampleBreadcrumbs} containerWidth={300} />
+    </div>
+  ))
+  .add('Extra Truncated', () => (
+    <div className="story">
+      <Breadcrumbs breadcrumbs={exampleBreadcrumbs} containerWidth={80} />
+    </div>
+  ));

--- a/modules/_labs/breadcrumbs/react/tsconfig.cjs.json
+++ b/modules/_labs/breadcrumbs/react/tsconfig.cjs.json
@@ -1,0 +1,11 @@
+
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "module": "commonjs",
+    "outDir": "dist/commonjs",
+    "skipLibCheck": true,
+    "tsBuildInfoFile": "./.build-info/tsconfig.cjs.tsbuildinfo"
+  }
+}

--- a/modules/_labs/breadcrumbs/react/tsconfig.es6.json
+++ b/modules/_labs/breadcrumbs/react/tsconfig.es6.json
@@ -1,0 +1,9 @@
+
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "dist/es6",
+    "tsBuildInfoFile": "./.build-info/tsconfig.es6.tsbuildinfo"
+  }
+}

--- a/modules/_labs/breadcrumbs/react/tsconfig.json
+++ b/modules/_labs/breadcrumbs/react/tsconfig.json
@@ -1,0 +1,5 @@
+
+{
+  "extends": "../../../../tsconfig.json",
+  "exclude": ["node_modules", "ts-tmp", "dist", "spec", "stories"]
+}


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

This PR introduces a Breadcrumb component in Labs for use navigating item structures. It uses a Canvas element to size the list of breadcrumbs based on the container's width, and dynamically hides any that do not fit appropriately under an expander.

This PR is currently a WIP and will continue to be iterated upon.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References
<img width="382" alt="Screen Shot 2020-05-14 at 5 59 15 PM" src="https://user-images.githubusercontent.com/65367387/81997353-b6de0900-960c-11ea-8653-f23f2401a9b5.png">

