### PR TITLE
chore: Fix create-module and promote-module

### DIFF
--- a/utils/create-component/createComponent.js
+++ b/utils/create-component/createComponent.js
@@ -59,8 +59,10 @@ inquirer
     const react = targets.includes('React');
     const componentPath = path.join(cwd, unstable ? `modules/_labs/${name}` : `modules/${name}`);
 
+    console.log(name, unstable, targets, componentPath);
+
     if (!fs.existsSync(componentPath)) {
-      mkdirp(componentPath);
+      mkdirp.sync(componentPath);
     }
 
     css && createModule(componentPath, 'css', createCssModule, answers);

--- a/utils/create-component/createComponent.js
+++ b/utils/create-component/createComponent.js
@@ -59,7 +59,6 @@ inquirer
     const react = targets.includes('React');
     const componentPath = path.join(cwd, unstable ? `modules/_labs/${name}` : `modules/${name}`);
 
-    console.log(name, unstable, targets, componentPath);
 
     if (!fs.existsSync(componentPath)) {
       mkdirp.sync(componentPath);

--- a/utils/create-component/createComponent.js
+++ b/utils/create-component/createComponent.js
@@ -59,7 +59,6 @@ inquirer
     const react = targets.includes('React');
     const componentPath = path.join(cwd, unstable ? `modules/_labs/${name}` : `modules/${name}`);
 
-
     if (!fs.existsSync(componentPath)) {
       mkdirp.sync(componentPath);
     }

--- a/utils/create-component/createCssModule.js
+++ b/utils/create-component/createCssModule.js
@@ -18,7 +18,7 @@ module.exports = (modulePath, name, description, unstable) => {
 
   console.log('\nCreating '.underline + `${moduleName}\n`.blue.underline);
 
-  mkdirp(modulePath);
+  mkdirp.sync(modulePath);
 
   const titleCaseName = getTitleCaseName(name);
   const storyPath = unstable ? `Labs/CSS/${titleCaseName}` : `CSS/${titleCaseName}`;

--- a/utils/create-component/createReactModule.js
+++ b/utils/create-component/createReactModule.js
@@ -21,7 +21,7 @@ module.exports = (modulePath, name, description, unstable) => {
 
   console.log('\nCreating ' + `${moduleName}\n`.blue.underline);
 
-  mkdirp(modulePath);
+  mkdirp.sync(modulePath);
 
   const pascalCaseName = getPascalCaseName(name);
   const titleCaseName = getTitleCaseName(name);

--- a/utils/create-component/writeModuleFiles.js
+++ b/utils/create-component/writeModuleFiles.js
@@ -16,9 +16,7 @@ module.exports = (files, modulePath) => {
 
     console.log('Creating ' + `.${filePath.replace(cwd, '')}`.cyan);
 
-    mkdirp(getDirName(filePath), function(err) {
-      if (err) return cb(err);
-
+    mkdirp(getDirName(filePath)).then(() => {
       fs.writeFileSync(filePath, file.contents);
     });
   });

--- a/utils/css-build.js
+++ b/utils/css-build.js
@@ -23,7 +23,7 @@ const postcssConfig = require('../.postcssrc.js');
 const nodeModules = path.resolve(__dirname, '../node_modules');
 
 // Make the build directory if it doesn't exist
-mkdirp(outputDir);
+mkdirp.sync(outputDir);
 
 const postcssPlugins = Object.keys(postcssConfig.plugins).map(plugin => {
   const name = plugin;

--- a/utils/js-build.js
+++ b/utils/js-build.js
@@ -23,7 +23,7 @@ const outputDir = path.join(cwd, 'dist');
 const outputFile = path.join(outputDir, path.basename(sourceFile));
 
 // Make the build directory if it doesn't exist
-mkdirp(outputDir);
+mkdirp.sync(outputDir);
 
 // Standard bundle
 const inputOptions = {

--- a/utils/promote-component.js
+++ b/utils/promote-component.js
@@ -55,7 +55,7 @@ inquirer.prompt(questions).then(answers => {
   const destPath = path.join(cwd, `modules/${component}`);
 
   if (!fs.existsSync(destPath)) {
-    mkdirp(destPath);
+    mkdirp.sync(destPath);
   }
 
   if (fs.existsSync(`${destPath}/${target}`)) {


### PR DESCRIPTION
The API of mkdirp changed with version 1.0 from callbacks to promises, but we didn't update our use-cases. The change of version was in #531. I tested this with a new module