### PR TITLE
fix: Fix check-lockfile call during precommit linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
         "git add"
       ],
       "yarn.lock": [
-        "node utils/check-lockfile-links.js",
+        "node utils/check-lockfile.js",
         "git add"
       ]
     }


### PR DESCRIPTION
Fixes an invalid reference to `check-lockfile-links.js` which was renamed to `check-lockfile.js` in #644.