### PR TITLE
ci: Improve canary builds & publish behavior

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,14 +1,16 @@
 {
-  "packages": [
-    "modules/**"
-  ],
+  "packages": ["modules/**"],
   "version": "4.0.0-beta.3",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {
     "version": {
       "gitTagVersion": false,
-      "push": false
+      "push": false,
+      "forcePublish": "*"
+    },
+    "publish": {
+      "forcePublish": "*"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "rollup-plugin-node-resolve": "^5.1.0",
     "rollup-plugin-terser": "^5.0.0",
     "sass-loader": "^8.0.0",
+    "semver": "^7.3.2",
     "storybook-chromatic": "^3.5.2",
     "storybook-readme": "^5.0.8",
     "style-loader": "^1.0.0",

--- a/utils/publish-canary.js
+++ b/utils/publish-canary.js
@@ -18,7 +18,9 @@ let distTag;
 if (TRAVIS_BRANCH === 'master') {
   distTag = 'next';
 } else if (isPrerelease) {
-  distTag = 'prerelease-next';
+  // distTag = 'prerelease-next';
+  console.error('Prerelease canary builds disabled.');
+  process.exit(0);
 } else {
   console.error('No travis branch provided');
   process.exit(1);

--- a/utils/publish-canary.js
+++ b/utils/publish-canary.js
@@ -24,7 +24,15 @@ if (TRAVIS_BRANCH === 'master') {
   process.exit(1);
 }
 
-cmd('git rev-parse --short HEAD')
+cmd('git diff --name-only HEAD HEAD^')
+  .then(filesChangedInMerge => {
+    if (filesChangedInMerge.includes('CHANGELOG.md')) {
+      console.log('Last merge commit was a release. Skipping canary build.');
+      process.exit(0);
+    }
+
+    return cmd('git rev-parse --short HEAD');
+  })
   .then(sha => {
     data.sha = sha.trim();
 

--- a/utils/publish-canary.js
+++ b/utils/publish-canary.js
@@ -17,7 +17,7 @@ let preid;
 if (TRAVIS_BRANCH === 'master') {
   preid = 'next';
 } else if (TRAVIS_BRANCH.match(/^prerelease\/v\d*$/g)) {
-  preid = 'prerelease';
+  preid = 'prerelease-next';
 } else {
   console.error('No travis branch provided');
   process.exit(1);


### PR DESCRIPTION
## Summary

Addresses everything in https://github.com/Workday/canvas-kit/issues/661:

- Change prerelease canary dist tag to `prerelease-next` so it doesn't clobber `prerelease` releases
- Use previous release for canary preids instead of the sha (which can result in unpredictable resolutions). Example: `4.0.0-beta.4-next.0`
- Skip canary builds if last merge commit was a release (if `CHANGELOG.md` was changed)
- **Disable prerelease canaries for now**. The above changes will not be reflected as we've decided to disable prerelease canary builds temporarily since we've had some issues and they're not being used.
- **Change default publish behavior of Lerna to publish all modules regardless of whether they've been updated (`--force-publish="*"`)**

Closes #661 