### PR TITLE
chore: Add public config to create-component script

### DIFF
--- a/utils/create-component/createComponent.js
+++ b/utils/create-component/createComponent.js
@@ -6,6 +6,7 @@ const path = require('path');
 const mkdirp = require('mkdirp');
 const inquirer = require('inquirer');
 const cmd = require('node-cmd');
+const colors = require('colors');
 
 const createReactModule = require('./createReactModule');
 const createCssModule = require('./createCssModule');

--- a/utils/create-component/createComponent.js
+++ b/utils/create-component/createComponent.js
@@ -46,7 +46,7 @@ const questions = [
   {
     type: 'confirm',
     name: 'publicModule',
-    message: 'Should this module be public?:',
+    message: 'Make access public when publishing?:',
     default: true,
   },
   /**

--- a/utils/create-component/createComponent.js
+++ b/utils/create-component/createComponent.js
@@ -6,7 +6,6 @@ const path = require('path');
 const mkdirp = require('mkdirp');
 const inquirer = require('inquirer');
 const cmd = require('node-cmd');
-const colors = require('colors');
 
 const createReactModule = require('./createReactModule');
 const createCssModule = require('./createCssModule');
@@ -44,6 +43,12 @@ const questions = [
     message: 'Is this an unstable component (i.e. should it go in Canvas Kit Labs)?:',
     default: false,
   },
+  {
+    type: 'confirm',
+    name: 'publicModule',
+    message: 'Should this module be public?:',
+    default: true,
+  },
   /**
    * Add question to add deps
    * React: CK core, emotion
@@ -74,7 +79,7 @@ inquirer
   });
 
 const createModule = (componentPath, target, moduleGenerator, answers) => {
-  const {name, description, unstable} = answers;
+  const {name, description, unstable, publicModule} = answers;
 
   const modulePath = path.join(componentPath, target);
 
@@ -82,7 +87,7 @@ const createModule = (componentPath, target, moduleGenerator, answers) => {
     const moduleName = `Module @workday/canvas-kit-${unstable ? 'labs-' : ''}${target}-${name}`;
     console.log(`\nModule ${moduleName} already exists. Skipping.`.yellow);
   } else {
-    moduleGenerator(modulePath, name, description, unstable);
+    moduleGenerator(modulePath, name, description, unstable, publicModule);
 
     console.log('\nBootstrapping dependencies.');
     cmd.run('yarn');

--- a/utils/create-component/createCssModule.js
+++ b/utils/create-component/createCssModule.js
@@ -13,7 +13,7 @@ const readme = require('./templates/css/readme');
 
 const cwd = process.cwd();
 
-module.exports = (modulePath, name, description, unstable) => {
+module.exports = (modulePath, name, description, unstable, public) => {
   const moduleName = `@workday/canvas-kit-${unstable ? 'labs-' : ''}css-${name}`;
 
   console.log('\nCreating '.underline + `${moduleName}\n`.blue.underline);
@@ -26,7 +26,7 @@ module.exports = (modulePath, name, description, unstable) => {
   const files = {
     package: {
       path: 'package.json',
-      contents: packageJson(name, moduleName, description, unstable),
+      contents: packageJson(name, moduleName, description, unstable, public),
     },
     component: {
       path: `lib/${name}.scss`,

--- a/utils/create-component/createReactModule.js
+++ b/utils/create-component/createReactModule.js
@@ -16,7 +16,7 @@ const tsconfig = require('./templates/react/tsconfig');
 
 const cwd = process.cwd();
 
-module.exports = (modulePath, name, description, unstable) => {
+module.exports = (modulePath, name, description, unstable, public) => {
   const moduleName = `@workday/canvas-kit-${unstable ? 'labs-' : ''}react-${name}`;
 
   console.log('\nCreating ' + `${moduleName}\n`.blue.underline);
@@ -31,7 +31,7 @@ module.exports = (modulePath, name, description, unstable) => {
   const files = {
     package: {
       path: 'package.json',
-      contents: packageJson(name, moduleName, description, unstable),
+      contents: packageJson(name, moduleName, description, unstable, public),
     },
     component: {
       path: `lib/${pascalCaseName}.tsx`,

--- a/utils/create-component/templates/css/packageJson.js
+++ b/utils/create-component/templates/css/packageJson.js
@@ -1,4 +1,4 @@
-module.exports = (name, moduleName, description, unstable) => `
+module.exports = (name, moduleName, description, unstable, public) => `
 {
   "name": "${moduleName}",
   "version": "0.0.0",
@@ -21,7 +21,14 @@ module.exports = (name, moduleName, description, unstable) => `
   "scripts": {
     "test": "echo \\"Error: no test specified\\" && exit 1",
     "build": "node ../../../${unstable ? '../' : ''}utils/css-build.js index.scss"
-  },
+  }, ${
+    public
+      ? `
+  "publishConfig": {
+    "access": "public"
+  },`
+      : ``
+  }
   "keywords": [
     "canvas",
     "canvas-kit",

--- a/utils/create-component/templates/react/packageJson.js
+++ b/utils/create-component/templates/react/packageJson.js
@@ -1,4 +1,4 @@
-module.exports = (name, moduleName, description, unstable) => `
+module.exports = (name, moduleName, description, unstable, public) => `
 {
   "name": "${moduleName}",
   "version": "0.0.0",
@@ -28,7 +28,14 @@ module.exports = (name, moduleName, description, unstable) => `
     "build:rebuild": "npm-run-all clean build",
     "build": "npm-run-all --parallel build:cjs build:es6",
     "depcheck": "node ../../../${unstable ? '../' : ''}utils/check-dependencies-exist.js"
-  },
+  }, ${
+    public
+      ? `
+  "publishConfig": {
+    "access": "public"
+  },`
+      : ``
+  }
   "keywords": [
     "canvas",
     "canvas-kit",


### PR DESCRIPTION
## Summary

Resolves #643

Adds a step in the create-component cli to add a public config to new modules

## Where Should the Reviewer Start?

`utils/create-component/createComponent.js`

## Testing Manually

Run the script!

```sh
yarn create-component
```

If the module should be public (the default), this config will be added to the package.json

```json
  "publishConfig": {
    "access": "public"
  },
```

Otherwise, it will be omitted, and the module will be private when published.

## New Dependencies

n/a

## Thank You Gif
_Share a fun [gif](https://giphy.com) to say thanks to your reviewer:_

![](https://media.giphy.com/media/BHJUXL0QCuyBi/giphy.gif)

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [ ] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
