### PR TITLE
fix: Fix incorrect dep listing

### DIFF
--- a/modules/_canvas-kit-css/package.json
+++ b/modules/_canvas-kit-css/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@workday/canvas-kit-css-action-bar": "^3.7.0",
-    "@workday/canvas-kit-react-badge": "^0.0.0",
+    "@workday/canvas-kit-css-badge": "^0.0.0",
     "@workday/canvas-kit-css-banner": "^3.7.0",
     "@workday/canvas-kit-css-button": "^3.7.0",
     "@workday/canvas-kit-css-card": "^3.7.0",


### PR DESCRIPTION
This hasn't been cut to an official release yet but technically >=3.7.1-next.0 may be broken. Not sure when this change went in.

Changing the package listing for badge to be the correct one in CSS.

Not sure how we can catch this one via testing. Another dep-check rule?