### PR TITLE
fix: Update click target for switch

### DIFF
--- a/modules/switch/react/lib/Switch.tsx
+++ b/modules/switch/react/lib/Switch.tsx
@@ -65,6 +65,7 @@ const SwitchInput = styled('input')<SwitchProps>(
     marginLeft: spacing.xxxs,
     borderRadius: borderRadius.circle,
     opacity: 0,
+    display: 'block',
   },
   ({disabled}) => ({
     cursor: disabled ? 'not-allowed' : 'pointer',


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Fixes: https://github.com/Workday/canvas-kit/issues/657

The click target is off when the label and and switch are stacked, making it hard to click sometimes. By adding display block, the click target is now the full width of the input.