### PR TITLE
fix(switch): Fix click target for switch

### DIFF
--- a/modules/switch/react/lib/Switch.tsx
+++ b/modules/switch/react/lib/Switch.tsx
@@ -63,6 +63,7 @@ const SwitchInput = styled('input')<SwitchProps>(
     marginLeft: spacing.xxxs,
     borderRadius: borderRadius.circle,
     opacity: 0,
+    display: 'block', // make click target width of input
   },
   ({disabled}) => ({
     cursor: disabled ? 'not-allowed' : 'pointer',

--- a/modules/switch/react/lib/Switch.tsx
+++ b/modules/switch/react/lib/Switch.tsx
@@ -63,7 +63,7 @@ const SwitchInput = styled('input')<SwitchProps>(
     marginLeft: spacing.xxxs,
     borderRadius: borderRadius.circle,
     opacity: 0,
-    display: 'block', // make click target width of input
+    display: 'block', // this makes the input a block element which pins the input to the left in a (left-to-right)
   },
   ({disabled}) => ({
     cursor: disabled ? 'not-allowed' : 'pointer',

--- a/modules/switch/react/lib/Switch.tsx
+++ b/modules/switch/react/lib/Switch.tsx
@@ -63,7 +63,7 @@ const SwitchInput = styled('input')<SwitchProps>(
     marginLeft: spacing.xxxs,
     borderRadius: borderRadius.circle,
     opacity: 0,
-    display: 'block', // this makes the input a block element which pins the input to the left in a (left-to-right)
+    display: 'block',
   },
   ({disabled}) => ({
     cursor: disabled ? 'not-allowed' : 'pointer',


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Fixes: https://github.com/Workday/canvas-kit/issues/657

Make the input display block pinning the input to the left

## Before:
<img width="917" alt="Screen Shot 2020-05-21 at 2 49 15 PM" src="https://user-images.githubusercontent.com/7966550/82614830-fdd87b00-9b85-11ea-9a2c-b180c1178ded.png">

## After: 
<img width="904" alt="Screen Shot 2020-05-21 at 2 53 07 PM" src="https://user-images.githubusercontent.com/7966550/82614860-1052b480-9b86-11ea-8ebe-d274b83e89e1.png">

