### PR TITLE
feat: Add iconRef to Icon components

### DIFF
--- a/modules/icon/react/README.md
+++ b/modules/icon/react/README.md
@@ -83,6 +83,12 @@ Default: `false`
 
 ---
 
+#### `iconRef: React.Ref<HTMLSpanElement>`
+
+> Returns the ref to the rendered icon.
+
+---
+
 # Applet Icons
 
 ## Usage
@@ -156,6 +162,12 @@ Default: `AppletIcon.Colors.Blueberry`
 > Size of the icon in `px`.
 
 Default: `92`
+
+---
+
+#### `iconRef: React.Ref<HTMLSpanElement>`
+
+> Returns the ref to the rendered icon.
 
 ---
 
@@ -260,6 +272,12 @@ Default: `'transparent'`
 
 ---
 
+#### `iconRef: React.Ref<HTMLSpanElement>`
+
+> Returns the ref to the rendered icon.
+
+---
+
 # System Icon Circle
 
 A system icon with a colored circular background. Icon color will be determined based on contrast
@@ -305,6 +323,12 @@ Default: `colors.soap300`
 > Size of the icon.
 
 Default: `SystemIconCircleSize.l` (`40`)
+
+---
+
+#### `iconRef: React.Ref<HTMLSpanElement>`
+
+> Returns the ref to the rendered icon.
 
 ---
 
@@ -372,3 +396,9 @@ Default: `height of graphic`
 > Expand graphic to fit container. `grow` takes precedence over both `width` and `height`.
 
 Default: `false`
+
+#### `iconRef: React.Ref<HTMLSpanElement>`
+
+> Returns the ref to the rendered icon.
+
+---

--- a/modules/icon/react/lib/AccentIcon.tsx
+++ b/modules/icon/react/lib/AccentIcon.tsx
@@ -43,7 +43,7 @@ export const accentIconStyles = ({
 
 export default class AccentIcon extends React.Component<AccentIconProps> {
   render() {
-    const {transparent = false, size = 56, icon, color, ...elemProps} = this.props;
+    const {transparent = false, size = 56, icon, color, iconRef, ...elemProps} = this.props;
 
     return (
       <Icon
@@ -51,6 +51,7 @@ export default class AccentIcon extends React.Component<AccentIconProps> {
         type={CanvasIconTypes.Accent}
         styles={accentIconStyles({color, transparent})}
         size={size}
+        iconRef={iconRef}
         {...elemProps}
       />
     );

--- a/modules/icon/react/lib/AppletIcon.tsx
+++ b/modules/icon/react/lib/AppletIcon.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {colors, BrandingColor, CanvasColor} from '@workday/canvas-kit-react-core';
 import {CanvasAppletIcon, CanvasIconTypes} from '@workday/design-assets-types';
 import {CSSObject} from '@emotion/core';
-import Icon from './Icon';
+import Icon, {IconProps} from './Icon';
 
 export interface AppletIconStyles {
   /**
@@ -54,7 +54,7 @@ export const appletIconStyles = ({
   };
 };
 
-export interface AppletIconProps extends AppletIconStyles {
+export interface AppletIconProps extends AppletIconStyles, Pick<IconProps, 'iconRef'> {
   /**
    * The icon to display from `@workday/canvas-applet-icons-web`.
    */
@@ -70,7 +70,7 @@ export default class AppletIcon extends React.Component<AppletIconProps> {
   public static Colors = BrandingColor;
 
   public render() {
-    const {size = 92, icon, color, ...elemProps} = this.props;
+    const {size = 92, icon, color, iconRef, ...elemProps} = this.props;
 
     return (
       <Icon
@@ -78,6 +78,7 @@ export default class AppletIcon extends React.Component<AppletIconProps> {
         type={CanvasIconTypes.Applet}
         styles={appletIconStyles({color})}
         size={size}
+        iconRef={iconRef}
         {...elemProps}
       />
     );

--- a/modules/icon/react/lib/Graphic.tsx
+++ b/modules/icon/react/lib/Graphic.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {CanvasGraphic, CanvasIconTypes} from '@workday/design-assets-types';
 import {CSSObject} from '@emotion/core';
-import Svg from './Svg';
+import Svg, {SvgProps} from './Svg';
 
 export interface GraphicStyles {
   /**
@@ -21,7 +21,7 @@ export interface GraphicStyles {
   grow?: boolean;
 }
 
-export interface GraphicProps extends GraphicStyles {
+export interface GraphicProps extends GraphicStyles, Pick<SvgProps, 'iconRef'> {
   /**
    * The graphic to display from `@workday/canvas-graphics-web`.
    */
@@ -60,13 +60,14 @@ export const graphicStyles = ({width, height, grow}: GraphicStyles): CSSObject =
 
 export default class Graphic extends React.Component<GraphicProps> {
   render() {
-    const {grow = false, src, width, height, ...elemProps} = this.props;
+    const {grow = false, src, width, height, iconRef, ...elemProps} = this.props;
 
     return (
       <Svg
         src={src}
         styles={graphicStyles({width, height, grow})}
         type={CanvasIconTypes.Graphic}
+        iconRef={iconRef}
         {...elemProps}
       />
     );

--- a/modules/icon/react/lib/Icon.tsx
+++ b/modules/icon/react/lib/Icon.tsx
@@ -7,11 +7,12 @@ export interface IconProps extends SvgProps {
   src: CanvasIcon;
   size?: number;
   type: CanvasIconTypes.Accent | CanvasIconTypes.Applet | CanvasIconTypes.System;
+  iconRef?: React.Ref<HTMLSpanElement>;
 }
 
 export default class Icon extends React.Component<IconProps> {
   public render() {
-    const {src, size, styles, type, ...elemProps} = this.props;
+    const {src, size, styles, type, iconRef, ...elemProps} = this.props;
 
     const iconStyles: CSSObject = {...styles};
 
@@ -22,6 +23,6 @@ export default class Icon extends React.Component<IconProps> {
       };
     }
 
-    return <Svg src={src} type={type} {...elemProps} styles={iconStyles} />;
+    return <Svg src={src} type={type} {...elemProps} styles={iconStyles} iconRef={iconRef} />;
   }
 }

--- a/modules/icon/react/lib/Svg.tsx
+++ b/modules/icon/react/lib/Svg.tsx
@@ -8,11 +8,12 @@ export interface SvgProps extends React.HTMLAttributes<HTMLSpanElement> {
   src: CanvasIcon;
   styles?: CSSObject;
   type: CanvasIconTypes;
+  iconRef?: React.Ref<HTMLSpanElement>;
 }
 
 export default class Svg extends React.Component<SvgProps> {
   public render() {
-    const {src, styles, type, ...elemProps} = this.props;
+    const {src, styles, type, iconRef, ...elemProps} = this.props;
 
     // Validation for JS
     try {
@@ -37,6 +38,7 @@ export default class Svg extends React.Component<SvgProps> {
               }),
               elemProps.className
             )}
+            ref={iconRef}
           />
         )}
       </ClassNames>

--- a/modules/icon/react/lib/SystemIcon.tsx
+++ b/modules/icon/react/lib/SystemIcon.tsx
@@ -92,6 +92,7 @@ export default class SystemIcon extends React.Component<SystemIconProps> {
       color = iconColors.standard,
       colorHover = iconColors.hover,
       icon,
+      iconRef,
       accent,
       accentHover,
       fill,
@@ -112,7 +113,14 @@ export default class SystemIcon extends React.Component<SystemIconProps> {
     });
 
     return (
-      <Icon src={icon} type={CanvasIconTypes.System} size={size} styles={style} {...elemProps} />
+      <Icon
+        src={icon}
+        type={CanvasIconTypes.System}
+        size={size}
+        styles={style}
+        iconRef={iconRef}
+        {...elemProps}
+      />
     );
   }
 }

--- a/modules/icon/react/lib/SystemIconCircle.tsx
+++ b/modules/icon/react/lib/SystemIconCircle.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import styled from '@emotion/styled';
 import isPropValid from '@emotion/is-prop-valid';
 import {colors, borderRadius} from '@workday/canvas-kit-react-core';
-import SystemIcon from './SystemIcon';
+import SystemIcon, {SystemIconProps} from './SystemIcon';
 import {CanvasSystemIcon} from '@workday/design-assets-types';
 import {pickForegroundColor} from '@workday/canvas-kit-react-common';
 
@@ -15,7 +15,7 @@ export enum SystemIconCircleSize {
   xxl = 120,
 }
 
-export interface SystemIconCircleProps {
+export interface SystemIconCircleProps extends Pick<SystemIconProps, 'iconRef'> {
   /**
    * The background color of the SystemIconCircle from `@workday/canvas-colors-web`.
    * @default colors.soap300
@@ -66,6 +66,7 @@ export default class SystemIconCircle extends React.Component<SystemIconCirclePr
       background = colors.soap200,
       size = SystemIconCircleSize.l,
       icon,
+      iconRef,
       ...elemProps
     } = this.props;
 
@@ -74,7 +75,13 @@ export default class SystemIconCircle extends React.Component<SystemIconCirclePr
 
     return (
       <Container background={background} size={size} {...elemProps}>
-        <SystemIcon icon={icon} color={iconColor} colorHover={iconColor} size={iconSize} />
+        <SystemIcon
+          icon={icon}
+          color={iconColor}
+          colorHover={iconColor}
+          size={iconSize}
+          iconRef={iconRef}
+        />
       </Container>
     );
   }


### PR DESCRIPTION
## Issue

Resolves #574 

## Overview

This PR adds an `iconRef` prop to the `Icon` component, which also affects the components listed below. Documentation was also updated to reflect this change.

* AccentIcon
* AppletIcon
* Graphic
* Svg
* SystemIcon
* SystemIconCircle

## Where Should the Reviewer Start?

`modules/icon/react/lib/Icon.tsx`

## Testing Manually

Probably the best way to test this is to add an `iconRef` to an `Icon`.

```jsx
const ref = React.createRef();

return (
  <Icon iconRef={ref} {...otherIconProps} />
)
```

## New Dependencies

n/a

## Screenshots (if applicable)

n/a

## Thank You Gif

![cat in bowl](https://media.giphy.com/media/v6aOjy0Qo1fIA/giphy.gif)
