### PR TITLE
feat(core): Add window configuration option to inherit font family

### DIFF
--- a/modules/_labs/core/react/lib/theming/useTheme.ts
+++ b/modules/_labs/core/react/lib/theming/useTheme.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import get from 'lodash/get';
 import {ThemeContext} from '@emotion/core';
 import {CanvasTheme} from './types';
 import {defaultCanvasTheme} from './theme';
@@ -30,10 +31,9 @@ export function useTheme(theme?: Object): CanvasTheme {
     // Context not supported or invalid (probably called from within a class component)
   }
 
-  // @ts-ignore
-  if (window.workday && window.workday.canvas && window.workday.canvas.theme) {
-    // @ts-ignore
-    return window.workday.canvas.theme;
+  const windowTheme = get(window, 'window.workday.canvas.theme');
+  if (windowTheme) {
+    return windowTheme;
   }
 
   return defaultCanvasTheme;

--- a/modules/_labs/core/react/lib/type.ts
+++ b/modules/_labs/core/react/lib/type.ts
@@ -80,7 +80,10 @@ const hierarchy: CanvasTypeHierarchy = {
 
 // Add fontFamily to each level of hierarchy
 Object.keys(hierarchy).forEach(key => {
-  hierarchy[key] = {...hierarchy[key], fontFamily};
+  hierarchy[key] = {
+    ...hierarchy[key],
+    fontFamily,
+  };
 });
 
 const updatedVariants: Pick<CanvasTypeVariant, 'button' | 'caps'> = {

--- a/modules/core/react/lib/type.ts
+++ b/modules/core/react/lib/type.ts
@@ -1,7 +1,11 @@
+import get from 'lodash/get';
 import canvasColors, {typeColors, statusColors} from '@workday/canvas-colors-web';
 import {CSSProperties} from './types';
 
-export const fontFamily = '"Roboto", "Helvetica Neue", "Helvetica", Arial, sans-serif';
+const inheritFont = get(window, 'window.workday.canvas.inheritFontFamily');
+export const fontFamily = inheritFont
+  ? 'inherit'
+  : '"Roboto", "Helvetica Neue", "Helvetica", Arial, sans-serif';
 export const monoFontFamily = '"Roboto Mono", "Courier New", Courier, monospace';
 
 export interface CanvasTypeHierarchy {
@@ -100,7 +104,10 @@ const hierarchy: CanvasTypeHierarchy = {
 
 // Add fontFamily to each level of hierarchy
 Object.keys(hierarchy).forEach(key => {
-  hierarchy[key] = {...hierarchy[key], fontFamily};
+  hierarchy[key] = {
+    ...hierarchy[key],
+    fontFamily,
+  };
 });
 
 const variants: CanvasTypeVariant = {

--- a/modules/core/react/package.json
+++ b/modules/core/react/package.json
@@ -44,6 +44,7 @@
     "@workday/canvas-colors-web": "^0.17.13",
     "@workday/canvas-depth-web": "^0.16.4",
     "@workday/canvas-space-web": "^0.15.5",
-    "element-closest": "^3.0.2"
+    "element-closest": "^3.0.2",
+    "lodash": "^4.17.14"
   }
 }


### PR DESCRIPTION
Backport https://github.com/Workday/canvas-kit/pull/553 into v3 

closes #689 