### PR TITLE
test(avatar): Fix visual regression threshold

### DIFF
--- a/modules/avatar/react/stories/stories_visualTesting.tsx
+++ b/modules/avatar/react/stories/stories_visualTesting.tsx
@@ -19,6 +19,7 @@ export default withSnapshotsEnabled({
   component: Avatar,
   parameters: {
     chromatic: {
+      threshold: 0.3, // Chrome downsizes images non-deterministically. From testing, 0.28 is the minimum.
       delay: 300, // Ensure we capture the image after loading and transition
     },
   },


### PR DESCRIPTION
Fixes the Avatar visual test from showing as constant regressions in Chromatic