### PR TITLE
fix(button): Misc. styling fixes and update to focusRing API

### DIFF
--- a/4.0-MIGRATION-GUIDE.md
+++ b/4.0-MIGRATION-GUIDE.md
@@ -99,7 +99,8 @@ PRs:
   (https://github.com/Workday/canvas-kit/pull/551). These changes are broken down by component
   below.
 - Our `focusRing` utility has been updated with a new API to support theming and improve legibility.
-  (https://github.com/Workday/canvas-kit/pull/558). Example:
+  (https://github.com/Workday/canvas-kit/pull/558 & https://github.com/Workday/canvas-kit/pull/726).
+  Example:
   ```tsx
   focusRing(2, 2, true, false, buttonColors.focusRingInner, buttonColors.focusRingOuter);
   ```

--- a/modules/button/react/lib/TextButton.tsx
+++ b/modules/button/react/lib/TextButton.tsx
@@ -109,6 +109,7 @@ const getTextButtonColors = (
           focusRing: focusRing(
             {
               separation: 2,
+              inset: 'inner',
               innerColor: 'currentColor',
               outerColor: colors.frenchVanilla100,
             },

--- a/modules/button/react/lib/ToolbarDropdownButton.tsx
+++ b/modules/button/react/lib/ToolbarDropdownButton.tsx
@@ -66,15 +66,14 @@ const getToolbarDropdownButtonColors = (theme: EmotionCanvasTheme): ButtonColors
   return {
     default: {
       icon: colors.licorice200,
-      background: 'transparent',
     },
     hover: {
       icon: colors.licorice500,
-      background: colors.soap400,
+      background: colors.soap300,
     },
     active: {
       icon: colors.licorice500,
-      background: colors.soap400,
+      background: colors.soap500,
     },
     focus: {
       icon: colors.licorice200,

--- a/modules/button/react/lib/ToolbarIconButton.tsx
+++ b/modules/button/react/lib/ToolbarIconButton.tsx
@@ -78,11 +78,11 @@ const getToolbarIconButtonColors = (theme: EmotionCanvasTheme, toggled?: boolean
     },
     hover: {
       icon: toggled ? themePrimary.dark : colors.licorice500,
-      background: toggled ? colors.soap400 : colors.soap400,
+      background: colors.soap300,
     },
     active: {
       icon: toggled ? themePrimary.dark : colors.licorice500,
-      background: colors.soap400,
+      background: colors.soap500,
     },
     focus: {
       icon: toggled ? themePrimary.main : colors.licorice200,

--- a/modules/common/react/spec/focusRing.spec.ts
+++ b/modules/common/react/spec/focusRing.spec.ts
@@ -6,10 +6,10 @@ describe('memoizedFocusRing', () => {
       ringWidth: 3,
       separationWidth: 1,
       animate: true,
-      inset: 'outer' as const,
+      inset: 'outer',
       innerShadowColor: '#333333',
       outerShadowColor: '#666666',
-    };
+    } as const;
     const received0 = memoizedFocusRing(args);
     const received1 = memoizedFocusRing(args);
     (memoizedFocusRing.cache as Map<

--- a/modules/common/react/spec/focusRing.spec.ts
+++ b/modules/common/react/spec/focusRing.spec.ts
@@ -6,7 +6,7 @@ describe('memoizedFocusRing', () => {
       ringWidth: 3,
       separationWidth: 1,
       animate: true,
-      inset: true,
+      inset: 'outer' as const,
       innerShadowColor: '#333333',
       outerShadowColor: '#666666',
     };


### PR DESCRIPTION
## Summary

- Updates background colors of `ToolbarIconButton` and `ToolbarDropdownButton` to use the same backgrounds as icon buttons per the spec.
- Updates `focusRing` API to add more control over how the shadows are inset
- Shifts inverse `TextButton` variant focus outline 2px inwards (using new `focusRing` API) per the spec

### Breaking Changes
- `focusRing`'s `inset` option has changed slightly. It used to be a boolean type. Now it is typed as `undefined | 'inner' | 'outer'`. This allows consumers to specify whether both shadows are on the outside (`undefined`), just the inner shadow is inset (`'inner'`), or both shadows are inset (`'outer'`). This was option was unused throughout most of our codebase so it shouldn't have much impact.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [ ] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)
