### PR TITLE
test(radio): Fix prop table logic

### DIFF
--- a/modules/form-field/react/stories/visual-testing/stories_Radio.tsx
+++ b/modules/form-field/react/stories/visual-testing/stories_Radio.tsx
@@ -86,7 +86,7 @@ export const RadioStates = () => (
         {props => (
           <FormField
             useFieldset={true}
-            hintText={props.error ? hintText : undefined}
+            hintText={typeof props.error !== 'undefined' ? hintText : undefined}
             hintId={hintId}
             {...props}
           >


### PR DESCRIPTION
This fixes an issue where our `Radio` component's visual regression story does not display an error message for the `Error` type `FormField`.

<img width="232" alt="Screen Shot 2020-06-15 at 9 10 24 PM" src="https://user-images.githubusercontent.com/14299381/84731098-a9d67180-af4c-11ea-90f4-c4a8cf8bc44b.png">

It should say "Error: Helpful text goes here." Underneath the second `RadioGroup`