### PR TITLE
refactor(common): Update pickForegroundColor to use fallback color logic

### DIFF
--- a/modules/_labs/select/react/lib/SelectOption.tsx
+++ b/modules/_labs/select/react/lib/SelectOption.tsx
@@ -81,7 +81,7 @@ const Option = styled('li')<SelectOptionProps>(
       const selectedStyles = {
         '&[aria-selected="true"]': {
           backgroundColor: selectedBgColor,
-          color: pickForegroundColor(selectedBgColor, colors.blackPepper300),
+          color: pickForegroundColor(selectedBgColor),
         },
       };
       // Only display interactive (hover/active) styles if the option is interactive

--- a/modules/common/react/lib/utils/colorUtils.ts
+++ b/modules/common/react/lib/utils/colorUtils.ts
@@ -9,6 +9,15 @@ export const expandHex = (hex: string) => {
   });
 };
 
+// Used to as a fallback to determine foreground color
+const colorPriority = [
+  colors.frenchVanilla100,
+  colors.blackPepper300,
+  colors.blackPepper400,
+  colors.blackPepper500,
+  colors.blackPepper600,
+];
+
 /**
  *
  * Chooses foreground color with accesible contrast against background. If contrast ratio
@@ -28,14 +37,6 @@ export const pickForegroundColor = (
     } else if (darkColor && chroma.contrast(background, darkColor) >= 4.5) {
       return darkColor;
     } else {
-      const colorPriority = [
-        colors.frenchVanilla100,
-        colors.blackPepper300,
-        colors.blackPepper400,
-        colors.blackPepper500,
-        colors.blackPepper600,
-      ];
-
       for (let i = 0; i < colorPriority.length; i++) {
         const color = colorPriority[i];
 

--- a/modules/common/react/lib/utils/colorUtils.ts
+++ b/modules/common/react/lib/utils/colorUtils.ts
@@ -12,22 +12,38 @@ export const expandHex = (hex: string) => {
 /**
  *
  * Chooses foreground color with accesible contrast against background. If contrast ratio
- * is greater than 4.5:1, chooses light color. Otherwise, chooses light or dark based on
- * which highest contrast against background.
+ * is greater than 4.5:1, chooses provided light or dark color (favoring light color). If neither
+ * have a high enough contrast ratio, picks the first color of the following that meets 4.5:1 or higher:
+ * [frenchVanilla100, blackPepper300, blackPepper400, blackPepper500, blackPepper600]
  * (https://www.w3.org/TR/WCAG20-TECHS/G18.html)
  */
 export const pickForegroundColor = (
   background: string,
-  darkColor: string = colors.blackPepper600,
-  lightColor: string = colors.frenchVanilla100
+  darkColor?: string,
+  lightColor?: string
 ) => {
   if (chroma.valid(background)) {
-    return chroma.contrast(background, lightColor) >= 4.5
-      ? lightColor
-      : chroma.contrast(background, darkColor) >= chroma.contrast(background, lightColor)
-      ? darkColor
-      : lightColor;
-  } else {
-    return;
+    if (lightColor && chroma.contrast(background, lightColor) >= 4.5) {
+      return lightColor;
+    } else if (darkColor && chroma.contrast(background, darkColor) >= 4.5) {
+      return darkColor;
+    } else {
+      const colorPriority = [
+        colors.frenchVanilla100,
+        colors.blackPepper300,
+        colors.blackPepper400,
+        colors.blackPepper500,
+        colors.blackPepper600,
+      ];
+
+      for (let i = 0; i < colorPriority.length; i++) {
+        const color = colorPriority[i];
+
+        if (chroma.contrast(background, color) >= 4.5) {
+          return color;
+        }
+      }
+    }
   }
+  return;
 };

--- a/modules/common/react/spec/colorUtils.spec.tsx
+++ b/modules/common/react/spec/colorUtils.spec.tsx
@@ -3,35 +3,30 @@ import {pickForegroundColor} from '../index';
 
 describe('Color Utils methods', () => {
   describe('pickForegroundColor', () => {
-    it('should default to black if luminicance is light', () => {
-      expect(pickForegroundColor('#ffffff')).toEqual(colors.blackPepper600);
-      expect(pickForegroundColor('#eee')).toEqual(colors.blackPepper600);
-      expect(pickForegroundColor('orange')).toEqual(colors.blackPepper600);
-    });
-    it('should default to white if luminicance is dark', () => {
-      expect(pickForegroundColor('#555')).toEqual(colors.frenchVanilla100);
-      expect(pickForegroundColor('#000000')).toEqual(colors.frenchVanilla100);
-      expect(pickForegroundColor('black')).toEqual(colors.frenchVanilla100);
-    });
     it('should use lightColor if luminicance is dark', () => {
       expect(pickForegroundColor('black', colors.blueberry600, colors.blueberry100)).toEqual(
         colors.blueberry100
       );
     });
-    it('should use darkColor if luminicance is dark', () => {
+    it('should use darkColor if luminicance is light', () => {
       expect(pickForegroundColor('white', colors.blueberry600, colors.blueberry100)).toEqual(
         colors.blueberry600
       );
+      expect(pickForegroundColor('white', colors.blueberry600)).toEqual(colors.blueberry600);
     });
     it('should always favor lightColor if above 4.5', () => {
       // #767676 has contrast of 4.54 against white and 4.62 against black
       // should favor light even though black is higher
-      expect(pickForegroundColor('#555')).toEqual(colors.frenchVanilla100);
+      expect(pickForegroundColor('#555', colors.blackPepper600, colors.frenchVanilla100)).toEqual(
+        colors.frenchVanilla100
+      );
     });
-    it('should favor higher contrast if both below 4.5', () => {
-      // both colors have low contrast. should favor the higher one
-      expect(pickForegroundColor('white', '#eee', '#ddd')).toEqual('#ddd');
-      expect(pickForegroundColor('white', '#ddd', '#eee')).toEqual('#ddd');
+    it('should default to first valid color in priority list', () => {
+      expect(pickForegroundColor('#000')).toEqual(colors.frenchVanilla100);
+      expect(pickForegroundColor('#fff')).toEqual(colors.blackPepper300);
+      expect(pickForegroundColor('#aaa')).toEqual(colors.blackPepper400);
+      expect(pickForegroundColor('#999')).toEqual(colors.blackPepper500);
+      expect(pickForegroundColor('#777')).toEqual(colors.blackPepper600);
     });
   });
 });

--- a/modules/common/react/spec/createCanvasTheme.spec.tsx
+++ b/modules/common/react/spec/createCanvasTheme.spec.tsx
@@ -48,7 +48,7 @@ describe('createCanvasTheme', () => {
       main: 'orange',
       dark: '#c67600',
       darkest: '#904a00',
-      contrast: '#000000',
+      contrast: '#494949',
     };
 
     expect(theme).toEqual(expected);
@@ -131,7 +131,7 @@ describe('createCanvasTheme', () => {
 
     const theme = createCanvasTheme(input);
 
-    expect(theme.palette.primary.contrast).toEqual('#000000');
+    expect(theme.palette.primary.contrast).toEqual('#494949');
   });
 
   test('shift color should darken canvas color to subsequent canvas color', () => {

--- a/modules/icon/react/lib/SystemIconCircle.tsx
+++ b/modules/icon/react/lib/SystemIconCircle.tsx
@@ -69,7 +69,7 @@ export default class SystemIconCircle extends React.Component<SystemIconCirclePr
       ...elemProps
     } = this.props;
 
-    const iconColor = pickForegroundColor(background, 'rgba(0,0,0,0.65)');
+    const iconColor = pickForegroundColor(background, 'rgba(0,0,0,0.65)', colors.frenchVanilla100);
     const iconSize = size * 0.625;
 
     return (


### PR DESCRIPTION
If no colors provided or neither meets contrast requirements, falls back to the first that meets
contrast requirements of frenchVanilla100, blackPepper300, blackPepper400, blackPepper500,
blackPepper600.

## Summary

Based on our conversation today, implemented the fallback logic into `pickForegroundColor`


## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md
- [x] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [x] design approved final implementation
- [x] a11y approved final implementation
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<img width="320" alt="Screen Shot 2020-06-18 at 2 33 45 PM" src="https://user-images.githubusercontent.com/6476238/85074028-ba673180-b170-11ea-89db-f83156837b80.png">
<img width="320" alt="Screen Shot 2020-06-18 at 2 34 08 PM" src="https://user-images.githubusercontent.com/6476238/85074054-c6eb8a00-b170-11ea-9a7f-416c8d0d14a8.png">

