### PR TITLE
fix(select): Fix a11y issues

### DIFF
--- a/cypress/helpers/selectLabs.ts
+++ b/cypress/helpers/selectLabs.ts
@@ -6,7 +6,7 @@
  *   .should('be.visible')
  */
 export function getMenu($select: JQuery): JQuery {
-  const id = $select.attr('aria-owns');
+  const id = $select.attr('aria-controls');
   return Cypress.$(`#${id}[role=listbox]`);
 }
 

--- a/modules/_labs/select/react/lib/SelectBase.tsx
+++ b/modules/_labs/select/react/lib/SelectBase.tsx
@@ -391,7 +391,7 @@ export default class SelectBase extends React.Component<SelectBaseProps> {
         <SelectButton
           aria-expanded={!isMenuHidden ? 'true' : undefined}
           aria-haspopup="listbox"
-          aria-owns={!isMenuHidden ? this.id : undefined}
+          aria-controls={!isMenuHidden ? this.id : undefined}
           disabled={disabled}
           error={error}
           grow={grow}

--- a/modules/_labs/select/react/lib/SelectBase.tsx
+++ b/modules/_labs/select/react/lib/SelectBase.tsx
@@ -391,7 +391,7 @@ export default class SelectBase extends React.Component<SelectBaseProps> {
         <SelectButton
           aria-expanded={!isMenuHidden ? 'true' : undefined}
           aria-haspopup="listbox"
-          aria-owns={this.id}
+          aria-owns={!isMenuHidden ? this.id : undefined}
           disabled={disabled}
           error={error}
           grow={grow}

--- a/modules/_labs/select/react/lib/SelectBase.tsx
+++ b/modules/_labs/select/react/lib/SelectBase.tsx
@@ -279,8 +279,9 @@ export default class SelectBase extends React.Component<SelectBaseProps> {
   };
 
   private focusedOptionRef = React.createRef<HTMLLIElement>();
+
   private menuRef = React.createRef<HTMLUListElement>();
-  private id = `a${uuid()}`; // make sure it is a valid [IDREF](https://www.w3.org/TR/xmlschema11-2/#IDREF)
+  private menuId = `a${uuid()}`; // make sure it is a valid [IDREF](https://www.w3.org/TR/xmlschema11-2/#IDREF)
 
   private scrollFocusedOptionIntoView = (center: boolean) => {
     const focusedOption = this.focusedOptionRef.current;
@@ -391,7 +392,7 @@ export default class SelectBase extends React.Component<SelectBaseProps> {
         <SelectButton
           aria-expanded={!isMenuHidden ? 'true' : undefined}
           aria-haspopup="listbox"
-          aria-controls={!isMenuHidden ? this.id : undefined}
+          aria-controls={!isMenuHidden ? this.menuId : undefined}
           disabled={disabled}
           error={error}
           grow={grow}
@@ -417,7 +418,7 @@ export default class SelectBase extends React.Component<SelectBaseProps> {
             aria-activedescendant={options[focusedOptionIndex].id}
             aria-labelledby={ariaLabelledBy}
             buttonRef={buttonRef}
-            id={this.id}
+            id={this.menuId}
             error={error}
             isFlipped={isMenuFlipped}
             isHidden={isMenuHidden}


### PR DESCRIPTION
## Summary

Fixes #761.

In addition to fixing the a11y violation reported in #761, this PR replaces the `aria-owns` attribute assigned to the Select button with the more appropriate `aria-controls`.

Previously, we had been linking the Select button with its corresponding menu using `aria-owns`. `aria-owns` expresses a parent/child relationship between DOM elements, which doesn't reflect the relationship between the Select button and its corresponding menu ([source](https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-owns), [source](https://github.com/w3c/html-aria/issues/124#issuecomment-451726237)).

`aria-controls` more accurately describes the relationship between the button and its menu ([source](https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-controls)).

## Checklist

- [x] Discussed with a11y (William)

