### PR TITLE
refactor(form-field): Update error message color

### DIFF
--- a/modules/form-field/react/lib/Hint.tsx
+++ b/modules/form-field/react/lib/Hint.tsx
@@ -22,7 +22,7 @@ export interface HintProps extends Themeable, React.HTMLAttributes<HTMLParagraph
 const Label = styled('span')<Pick<HintProps, 'error'>>(
   type.body2,
   type.variant.label,
-  ({error}) => error === ErrorType.Error && {color: statusColors.error}
+  ({error, theme}) => error === ErrorType.Error && {color: theme.canvas.palette.error.main}
 );
 
 const Message = styled('p')<Pick<HintProps, 'error'>>(
@@ -31,7 +31,7 @@ const Message = styled('p')<Pick<HintProps, 'error'>>(
     margin: `${spacing.xxs} 0 0`,
     width: '100%',
   },
-  ({error}) => error === ErrorType.Error && {color: statusColors.error}
+  ({error, theme}) => error === ErrorType.Error && {color: theme.canvas.palette.error.main}
 );
 
 export default class Hint extends React.Component<HintProps> {

--- a/modules/form-field/react/lib/Hint.tsx
+++ b/modules/form-field/react/lib/Hint.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {ErrorType, styled, Themeable} from '@workday/canvas-kit-react-common';
-import {spacing, statusColors, type} from '@workday/canvas-kit-react-core';
+import {spacing, type} from '@workday/canvas-kit-react-core';
 
 export interface HintProps extends Themeable, React.HTMLAttributes<HTMLParagraphElement> {
   /**

--- a/modules/form-field/react/lib/Hint.tsx
+++ b/modules/form-field/react/lib/Hint.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {ErrorType, styled, Themeable} from '@workday/canvas-kit-react-common';
-import {spacing, type} from '@workday/canvas-kit-react-core';
+import {spacing, statusColors, type} from '@workday/canvas-kit-react-core';
 
 export interface HintProps extends Themeable, React.HTMLAttributes<HTMLParagraphElement> {
   /**
@@ -19,9 +19,20 @@ export interface HintProps extends Themeable, React.HTMLAttributes<HTMLParagraph
   alertLabel?: string;
 }
 
-const Label = styled('span')(type.body2, type.variant.label);
+const Label = styled('span')<Pick<HintProps, 'error'>>(
+  type.body2,
+  type.variant.label,
+  ({error}) => error === ErrorType.Error && {color: statusColors.error}
+);
 
-const Message = styled('p')(type.body2, {width: '100%', margin: `${spacing.xxs} 0 0`});
+const Message = styled('p')<Pick<HintProps, 'error'>>(
+  type.body2,
+  {
+    margin: `${spacing.xxs} 0 0`,
+    width: '100%',
+  },
+  ({error}) => error === ErrorType.Error && {color: statusColors.error}
+);
 
 export default class Hint extends React.Component<HintProps> {
   static ErrorType = ErrorType;
@@ -42,7 +53,7 @@ export default class Hint extends React.Component<HintProps> {
 
     return (
       <Message {...this.props}>
-        {typeof error !== 'undefined' && hintLabel && <Label>{hintLabel}: </Label>}
+        {typeof error !== 'undefined' && hintLabel && <Label error={error}>{hintLabel}: </Label>}
         {children}
       </Message>
     );

--- a/modules/form-field/react/stories/visual-testing/theming/stories_FormField.tsx
+++ b/modules/form-field/react/stories/visual-testing/theming/stories_FormField.tsx
@@ -1,0 +1,15 @@
+/// <reference path="../../../../../../typings.d.ts" />
+import {customColorTheme, withSnapshotsEnabled} from '../../../../../../utils/storybook';
+import FormField from '../../../lib/FormField';
+import {FormFieldStates} from '../stories_FormField';
+
+export default withSnapshotsEnabled({
+  title: 'Testing|React/Inputs/Form Field',
+  component: FormField,
+  parameters: {
+    canvasProviderDecorator: {
+      theme: customColorTheme,
+    },
+  },
+});
+export const FormFieldThemedStates = FormFieldStates;


### PR DESCRIPTION
## Summary

Closes #768.

Updates the text color of form field error messages to pull from the `error.main` theme color (`cinnamon500` in the default Canvas theme).

Also adds a `Form Field Themed States` visual testing story.
