### PR TITLE
feat(popup-stack): Add adapter API to integrate with other popup systems

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -19,3 +19,30 @@
     padding-bottom: 16px;
   }
 </style>
+<!-- preload fonts for Chromatic -->
+<link
+  rel="preload"
+  href="https://design.workdaycdn.com/beta/assets/fonts@1.0.0/roboto/ttf/Roboto-Light.ttf"
+  as="font"
+  type="font/ttf"
+/><link
+  rel="preload"
+  href="https://design.workdaycdn.com/beta/assets/fonts@1.0.0/roboto/ttf/Roboto-Regular.ttf"
+  as="font"
+  type="font/ttf"
+/><link
+  rel="preload"
+  href="https://design.workdaycdn.com/beta/assets/fonts@1.0.0/roboto/ttf/Roboto-Medium.ttf"
+  as="font"
+  type="font/ttf"
+/><link
+  rel="preload"
+  href="https://design.workdaycdn.com/beta/assets/fonts@1.0.0/roboto/ttf/Roboto-Bold.ttf"
+  as="font"
+  type="font/ttf"
+/><link
+  rel="preload"
+  href="https://design.workdaycdn.com/beta/assets/fonts@1.0.0/roboto/ttf/RobotoMono-Regular.ttf"
+  as="font"
+  type="font/ttf"
+/>

--- a/cypress/helpers/modal.ts
+++ b/cypress/helpers/modal.ts
@@ -28,5 +28,16 @@ export function getCloseButton($modal: JQuery): JQuery {
  * @param $modal Modal element with [role=dialog]
  */
 export function getOverlay($modal: JQuery): JQuery {
-  return $modal.parent().parent();
+  const bodyEl = Cypress.$('body')[0];
+  return getElement($modal, $el => $el.parent()[0] === bodyEl);
+}
+
+function getElement(element: JQuery, predicate: (element: JQuery) => boolean): JQuery {
+  if (predicate(element)) {
+    return element;
+  } else if (element.parent().length) {
+    return getElement(element.parent(), predicate);
+  } else {
+    return Cypress.$();
+  }
 }

--- a/cypress/integration/Modal.spec.ts
+++ b/cypress/integration/Modal.spec.ts
@@ -110,6 +110,17 @@ describe('Modal', () => {
           });
         });
 
+        context('when clicking inside the modal', () => {
+          beforeEach(() => {
+            // click somewhere on the modal where there shouldn't be a close target
+            cy.findByLabelText('Delete Item').click('top');
+          });
+
+          it('should not close the modal', () => {
+            cy.findByLabelText('Delete Item').should('be.visible');
+          });
+        });
+
         context('when the close button is clicked', () => {
           beforeEach(() => {
             cy.findByLabelText('Delete Item')
@@ -141,7 +152,7 @@ describe('Modal', () => {
         context('when the overlay is clicked', () => {
           beforeEach(() => {
             cy.findByLabelText('Delete Item')
-              .pipe(h.modal.getOverlay)
+              .parent()
               .click('top');
           });
 
@@ -281,7 +292,7 @@ describe('Modal', () => {
       context('when the overlay is clicked', () => {
         beforeEach(() => {
           cy.findByLabelText('Delete Item')
-            .pipe(h.modal.getOverlay)
+            .parent()
             .click('top');
         });
 
@@ -374,7 +385,7 @@ describe('Modal', () => {
       context('when the overlay is clicked', () => {
         beforeEach(() => {
           cy.findByLabelText('Delete Item')
-            .pipe(h.modal.getOverlay)
+            .parent()
             .click('top');
         });
 
@@ -419,7 +430,7 @@ describe('Modal', () => {
       context('when the overlay is clicked', () => {
         beforeEach(() => {
           cy.findByLabelText('Really Delete Item')
-            .pipe(h.modal.getOverlay)
+            .parent()
             .click('top');
         });
 
@@ -452,7 +463,7 @@ describe('Modal', () => {
       context('when the modal overlay is clicked', () => {
         beforeEach(() => {
           cy.findByLabelText('Delete Item')
-            .pipe(h.modal.getOverlay)
+            .parent()
             .click('top');
         });
 

--- a/cypress/integration/Modal.spec.ts
+++ b/cypress/integration/Modal.spec.ts
@@ -149,7 +149,7 @@ describe('Modal', () => {
           });
         });
 
-        context('when the overlay is clicked', () => {
+        context('when clicking outside the modal', () => {
           beforeEach(() => {
             cy.get('body').click('top');
           });
@@ -287,7 +287,7 @@ describe('Modal', () => {
         });
       });
 
-      context('when the overlay is clicked', () => {
+      context('when clicking outside the modal', () => {
         beforeEach(() => {
           cy.get('body').click('top');
         });
@@ -378,7 +378,7 @@ describe('Modal', () => {
         });
       });
 
-      context('when the overlay is clicked', () => {
+      context('when clicking outside the modal', () => {
         beforeEach(() => {
           cy.get('body').click('top');
         });
@@ -421,7 +421,7 @@ describe('Modal', () => {
         });
       });
 
-      context('when the overlay is clicked', () => {
+      context('when clicking outside the modal', () => {
         beforeEach(() => {
           cy.get('body').click('top');
         });

--- a/cypress/integration/Modal.spec.ts
+++ b/cypress/integration/Modal.spec.ts
@@ -151,9 +151,7 @@ describe('Modal', () => {
 
         context('when the overlay is clicked', () => {
           beforeEach(() => {
-            cy.findByLabelText('Delete Item')
-              .parent()
-              .click('top');
+            cy.get('body').click('top');
           });
 
           it('should close the modal', () => {
@@ -291,9 +289,7 @@ describe('Modal', () => {
 
       context('when the overlay is clicked', () => {
         beforeEach(() => {
-          cy.findByLabelText('Delete Item')
-            .parent()
-            .click('top');
+          cy.get('body').click('top');
         });
 
         it('should not close the modal', () => {
@@ -384,9 +380,7 @@ describe('Modal', () => {
 
       context('when the overlay is clicked', () => {
         beforeEach(() => {
-          cy.findByLabelText('Delete Item')
-            .parent()
-            .click('top');
+          cy.get('body').click('top');
         });
 
         it('should not close the modal', () => {
@@ -429,9 +423,7 @@ describe('Modal', () => {
 
       context('when the overlay is clicked', () => {
         beforeEach(() => {
-          cy.findByLabelText('Really Delete Item')
-            .parent()
-            .click('top');
+          cy.get('body').click('top');
         });
 
         it('should close the second modal', () => {
@@ -462,9 +454,7 @@ describe('Modal', () => {
 
       context('when the modal overlay is clicked', () => {
         beforeEach(() => {
-          cy.findByLabelText('Delete Item')
-            .parent()
-            .click('top');
+          cy.get('body').click('top');
         });
 
         it('should close the popup', () => {

--- a/cypress/integration/Modal.spec.ts
+++ b/cypress/integration/Modal.spec.ts
@@ -452,7 +452,7 @@ describe('Modal', () => {
         cy.findByLabelText('Really Delete Item').should('exist');
       });
 
-      context('when the modal overlay is clicked', () => {
+      context('when clicking outside the modal', () => {
         beforeEach(() => {
           cy.get('body').click('top');
         });

--- a/cypress/integration/PopupStack.spec.ts
+++ b/cypress/integration/PopupStack.spec.ts
@@ -1,14 +1,25 @@
 import * as h from '../helpers';
 import {queries} from '@testing-library/dom';
 
+const getStackedParent = (element: HTMLElement): HTMLElement | null => {
+  if (element.style.zIndex !== '') {
+    return element;
+  } else {
+    if (element.parentElement) {
+      return getStackedParent(element.parentElement);
+    } else {
+      return null;
+    }
+  }
+};
+
 const beOnTopOfLabelledByText = (labelText: string) => ($el: JQuery) => {
   const comparingElement = queries.getByLabelText(Cypress.$('body')[0], labelText);
 
-  const comparingElementZIndex =
-    parseFloat(comparingElement.style.zIndex) ||
-    parseFloat(comparingElement.parentElement?.style.zIndex || '');
-  const actualElementZIndex =
-    parseFloat($el.css('zIndex')) || parseFloat($el.parent().css('zIndex'));
+  const comparingElementZIndex = parseFloat(
+    getStackedParent(comparingElement)?.style?.zIndex || ''
+  );
+  const actualElementZIndex = parseFloat(getStackedParent($el[0])?.style?.zIndex || '');
   expect(actualElementZIndex).to.be.greaterThan(comparingElementZIndex);
 };
 

--- a/modules/modal/react/lib/Modal.tsx
+++ b/modules/modal/react/lib/Modal.tsx
@@ -27,12 +27,7 @@ const Modal = ({
 }: ModalProps): JSX.Element | null =>
   // Only render if on the client and `open` is `true`
   open && typeof window !== 'undefined' ? (
-    <ModalContent
-      container={container || document.body}
-      padding={padding}
-      width={width}
-      {...modalContentProps}
-    />
+    <ModalContent container={container} padding={padding} width={width} {...modalContentProps} />
   ) : null;
 
 Modal.Padding = PopupPadding;

--- a/modules/modal/react/lib/ModalContent.tsx
+++ b/modules/modal/react/lib/ModalContent.tsx
@@ -235,7 +235,6 @@ const ModalContent = ({
 
   // only render something on the client
   if (typeof window !== 'undefined') {
-    console.log(container, modalRef.current);
     return ReactDOM.createPortal(content, container || modalRef.current!);
   } else {
     return null;

--- a/modules/modal/react/lib/ModalContent.tsx
+++ b/modules/modal/react/lib/ModalContent.tsx
@@ -10,7 +10,6 @@ import Popup, {
   useFocusTrap,
 } from '@workday/canvas-kit-react-popup';
 import {PopupStack} from '@workday/canvas-kit-popup-stack';
-import {mergeCallback} from '@workday/canvas-kit-react-common';
 
 import {ModalWidth} from './Modal';
 
@@ -60,7 +59,7 @@ export interface ModalContentProps extends React.HTMLAttributes<HTMLDivElement> 
    * This should be a sibling or higher than the header and navigation elements of the application.
    * @default document.body
    */
-  container: HTMLElement;
+  container?: HTMLElement;
 }
 
 const fadeIn = keyframes`
@@ -193,13 +192,14 @@ const ModalContent = ({
   ...elemProps
 }: ModalContentProps) => {
   const modalRef = React.useRef<HTMLDivElement>(null);
+  const centeringRef = React.useRef<HTMLDivElement>(null);
 
   const onClose = () => handleClose?.();
 
   // special handling for clicking on the overlay
   const onOverlayClick = (event: React.MouseEvent<HTMLElement>) => {
     // Detect clicks only on the centering wrapper element
-    if (event.target === modalRef.current?.children[0] && PopupStack.isTopmost(modalRef.current)) {
+    if (event.target === centeringRef.current && PopupStack.isTopmost(modalRef.current!)) {
       onClose();
     }
   };
@@ -212,10 +212,11 @@ const ModalContent = ({
   useAssistiveHideSiblings(modalRef);
 
   const content = (
-    <Container {...elemProps} ref={modalRef}>
+    <Container {...elemProps}>
       <CenteringContainer
+        ref={centeringRef}
         style={{width: windowSize.width % 2 === 1 ? 'calc(100vw - 1px)' : '100vw'}}
-        onClick={mergeCallback(onOverlayClick, elemProps.onClick)}
+        onMouseDown={onOverlayClick}
       >
         <Popup
           width={width}
@@ -234,7 +235,8 @@ const ModalContent = ({
 
   // only render something on the client
   if (typeof window !== 'undefined') {
-    return ReactDOM.createPortal(content, container || document.body);
+    console.log(container, modalRef.current);
+    return ReactDOM.createPortal(content, container || modalRef.current!);
   } else {
     return null;
   }

--- a/modules/modal/react/lib/ModalContent.tsx
+++ b/modules/modal/react/lib/ModalContent.tsx
@@ -191,10 +191,14 @@ const ModalContent = ({
   heading,
   ...elemProps
 }: ModalContentProps) => {
-  const modalRef = React.useRef<HTMLDivElement>(null);
   const centeringRef = React.useRef<HTMLDivElement>(null);
-
   const onClose = () => handleClose?.();
+
+  const modalRef = usePopupStack();
+  useCloseOnEscape(modalRef, onClose);
+  useFocusTrap(modalRef);
+  useInitialFocus(modalRef, firstFocusRef);
+  useAssistiveHideSiblings(modalRef);
 
   // special handling for clicking on the overlay
   const onOverlayClick = (event: React.MouseEvent<HTMLElement>) => {
@@ -204,12 +208,6 @@ const ModalContent = ({
     }
   };
   const windowSize = useWindowSize();
-
-  usePopupStack(modalRef);
-  useCloseOnEscape(modalRef, onClose);
-  useFocusTrap(modalRef);
-  useInitialFocus(modalRef, firstFocusRef);
-  useAssistiveHideSiblings(modalRef);
 
   const content = (
     <Container {...elemProps}>

--- a/modules/modal/react/lib/ModalContent.tsx
+++ b/modules/modal/react/lib/ModalContent.tsx
@@ -194,16 +194,16 @@ const ModalContent = ({
   const centeringRef = React.useRef<HTMLDivElement>(null);
   const onClose = () => handleClose?.();
 
-  const modalRef = usePopupStack();
-  useCloseOnEscape(modalRef, onClose);
-  useFocusTrap(modalRef);
-  useInitialFocus(modalRef, firstFocusRef);
-  useAssistiveHideSiblings(modalRef);
+  const stackRef = usePopupStack();
+  useCloseOnEscape(stackRef, onClose);
+  useFocusTrap(stackRef);
+  useInitialFocus(stackRef, firstFocusRef);
+  useAssistiveHideSiblings(stackRef);
 
   // special handling for clicking on the overlay
   const onOverlayClick = (event: React.MouseEvent<HTMLElement>) => {
     // Detect clicks only on the centering wrapper element
-    if (event.target === centeringRef.current && PopupStack.isTopmost(modalRef.current!)) {
+    if (event.target === centeringRef.current && PopupStack.isTopmost(stackRef.current!)) {
       onClose();
     }
   };
@@ -233,7 +233,7 @@ const ModalContent = ({
 
   // only render something on the client
   if (typeof window !== 'undefined') {
-    return ReactDOM.createPortal(content, container || modalRef.current!);
+    return ReactDOM.createPortal(content, container || stackRef.current!);
   } else {
     return null;
   }

--- a/modules/modal/react/package.json
+++ b/modules/modal/react/package.json
@@ -51,7 +51,6 @@
     "@emotion/core": "^10.0.28",
     "@emotion/styled": "^10.0.27",
     "@workday/canvas-kit-popup-stack": "^4.0.0",
-    "@workday/canvas-kit-react-common": "^4.0.0",
     "@workday/canvas-kit-react-popup": "^4.0.0"
   },
   "devDependencies": {

--- a/modules/modal/react/stories/stories_VisualTesting.tsx
+++ b/modules/modal/react/stories/stories_VisualTesting.tsx
@@ -1,5 +1,6 @@
 /// <reference path="../../../../typings.d.ts" />
-import * as React from 'react';
+import React from 'react';
+import ReactDOM from 'react-dom';
 import {Button, DeleteButton} from '../../../button/react';
 import {withSnapshotsEnabled} from '../../../../utils/storybook';
 
@@ -17,12 +18,33 @@ export default withSnapshotsEnabled({
 
 const noop = () => {}; // eslint-disable-line no-empty-function
 
+const TestContent = () => {
+  const content = (
+    <div
+      style={{
+        color: 'white',
+        zIndex: 1,
+        position: 'relative',
+      }}
+    >
+      This should be invisible if the Modal is rendering correctly, because the Modal should use the
+      PopupStack which will set a zIndex and place the modal and its overlay _on top_ of the this
+      text. If the text renders on top of the overlay, the text will show up
+    </div>
+  );
+
+  return ReactDOM.createPortal(content, document.body);
+};
+
 const TestModal = ({width}: {width: ModalWidth}) => (
-  <Modal heading="Delete Item" open={true} handleClose={noop} width={width}>
-    <p>Are you sure you'd like to delete the item titled 'My Item'?</p>
-    <DeleteButton style={{marginRight: '16px'}}>Delete</DeleteButton>
-    <Button variant={Button.Variant.Secondary}>Cancel</Button>
-  </Modal>
+  <>
+    <TestContent />
+    <Modal heading="Delete Item" open={true} handleClose={noop} width={width}>
+      <p>Are you sure you'd like to delete the item titled 'My Item'?</p>
+      <DeleteButton style={{marginRight: '16px'}}>Delete</DeleteButton>
+      <Button variant={Button.Variant.Secondary}>Cancel</Button>
+    </Modal>
+  </>
 );
 
 export const ModalSmallWidth = () => <TestModal width={Modal.Width.s} />;

--- a/modules/modal/react/stories/stories_VisualTesting.tsx
+++ b/modules/modal/react/stories/stories_VisualTesting.tsx
@@ -27,9 +27,9 @@ const TestContent = () => {
         position: 'relative',
       }}
     >
-      This should be invisible if the Modal is rendering correctly, because the Modal should use the
-      PopupStack which will set a zIndex and place the modal and its overlay _on top_ of the this
-      text. If the text renders on top of the overlay, the text will show up
+      This text should be invisible if the Modal is rendering correctly. It is white text on a white
+      background. The Popup Stack should set up the zIndex of the Modal's overlay. If rendered
+      incorrectly, the text will be visible on top of the overlay.
     </div>
   );
 

--- a/modules/popup-stack/README.md
+++ b/modules/popup-stack/README.md
@@ -119,8 +119,9 @@ export interface PopupStackItem {
 ### createContainer
 
 Create a HTMLElement as the container for the popup stack item. The returned element reference will
-be the reference to be passed to all other methods. This method allows for the integration into
-other popup systems
+be the reference to be passed to all other methods. The Popup Stack will control when this element
+is added and removed from the DOM as well as the `z-index` style property. Your content should be
+added to this element.
 
 ### add
 

--- a/modules/popup-stack/README.md
+++ b/modules/popup-stack/README.md
@@ -120,8 +120,12 @@ export interface PopupStackItem {
 
 Create a HTMLElement as the container for the popup stack item. The returned element reference will
 be the reference to be passed to all other methods. The Popup Stack will control when this element
-is added and removed from the DOM as well as the `z-index` style property. Your content should be
-added to this element.
+is added and removed from the DOM as well as the `z-index` style property. Your stack UI content
+should be added to this element.
+
+```tsx
+PopupStack.createContainer(): HTMLElement
+```
 
 ### add
 
@@ -190,4 +194,14 @@ considered to be "contained" by an element under the following conditions:
 
 ```tsx
 PopupStack.contains(element: HTMLElement, eventTarget: HTMLElement): boolean
+```
+
+### createAdapter
+
+Create an adapter for the PopupStack. Any method provided will override the default method of
+`PopupStack`. This is useful if you already have a popup stack and need Canvas Kit to properly
+interact with it.
+
+```tsx
+createAdapter({}: Partial<typeof PopupStack>): void
 ```

--- a/modules/popup-stack/README.md
+++ b/modules/popup-stack/README.md
@@ -63,7 +63,8 @@ yarn add @workday/canvas-kit-popup-stack
 ```tsx
 import PopupStack from '@workday/canvas-kit-popup-stack';
 
-const div = document.createElement('div');
+// Create a container to portal popup content into
+const div = PopupStack.createContainer();
 
 // Add to the stack. This will force-set z-index on the element for proper rendering
 PopupStack.add({element: div});
@@ -114,6 +115,12 @@ export interface PopupStackItem {
   owner?: HTMLElement;
 }
 ```
+
+### createContainer
+
+Create a HTMLElement as the container for the popup stack item. The returned element reference will
+be the reference to be passed to all other methods. This method allows for the integration into
+other popup systems
 
 ### add
 

--- a/modules/popup-stack/lib/PopupStack.ts
+++ b/modules/popup-stack/lib/PopupStack.ts
@@ -187,8 +187,20 @@ const stack: Stack = getFromWindow('workday.__popupStack') || {
   zIndex: {min: 30, max: 50, getValue: getValue},
 };
 setToWindow('workday.__popupStack', stack);
+let _adapter: Partial<typeof PopupStack> = {};
 
 export const PopupStack = {
+  /**
+   *
+   */
+  createContainer(): HTMLElement {
+    if (_adapter.createContainer) {
+      return _adapter.createContainer();
+    }
+    const div = document.createElement('div');
+    div.style.position = 'relative'; // z-index only works on _positioned_ elements
+    return div;
+  },
   /**
    * Adds a PopupStackItem to the stack. This should only be called when the item is rendered to the
    * page. Z-indexes are set when the item is added to the stack. If your application requires
@@ -196,7 +208,12 @@ export const PopupStack = {
    * method when the event triggers.
    */
   add(item: PopupStackItem): void {
+    if (_adapter.add) {
+      _adapter.add(item);
+      return;
+    }
     stack.items.push(item);
+    document.body.appendChild(item.element);
 
     setZIndexOfElements(PopupStack.getElements());
   },
@@ -208,7 +225,12 @@ export const PopupStack = {
    * reset z-index values of the stack
    */
   remove(element: HTMLElement): void {
+    if (_adapter.remove) {
+      _adapter.remove(element);
+      return;
+    }
     stack.items = stack.items.filter(item => item.element !== element);
+    document.body.removeChild(element);
 
     setZIndexOfElements(PopupStack.getElements());
   },
@@ -219,6 +241,9 @@ export const PopupStack = {
    * reference that was passed to `add`
    */
   isTopmost(element: HTMLElement): boolean {
+    if (_adapter.isTopmost) {
+      return _adapter.isTopmost(element);
+    }
     const last = getLast(stack.items);
 
     if (last) {
@@ -231,6 +256,9 @@ export const PopupStack = {
    * Returns an array of elements defined by the `element` passed to `add`.
    */
   getElements(): HTMLElement[] {
+    if (_adapter.getElements) {
+      return _adapter.getElements();
+    }
     return stack.items.map(i => i.element);
   },
 
@@ -247,6 +275,10 @@ export const PopupStack = {
    * the top of the stack.
    */
   bringToTop(element: HTMLElement): void {
+    if (_adapter.bringToTop) {
+      _adapter.bringToTop(element);
+      return;
+    }
     const item = find(stack.items, i => i.element === element);
 
     if (item) {
@@ -282,6 +314,9 @@ export const PopupStack = {
    * is not inside `element`).
    */
   contains(element: HTMLElement, eventTarget: HTMLElement): boolean {
+    if (_adapter.contains) {
+      return _adapter.contains(element, eventTarget);
+    }
     const item = find(stack.items, i => i.element === element);
 
     if (item) {
@@ -302,3 +337,11 @@ export const PopupStack = {
 export function resetStack() {
   stack.items = [];
 }
+
+/**
+ *
+ * @param adapter The parts of the PopupStack that we want to override
+ */
+export const createAdapter = (adapter: Partial<typeof PopupStack>) => {
+  _adapter = adapter;
+};

--- a/modules/popup-stack/lib/PopupStack.ts
+++ b/modules/popup-stack/lib/PopupStack.ts
@@ -191,7 +191,10 @@ let _adapter: Partial<typeof PopupStack> = {};
 
 export const PopupStack = {
   /**
-   *
+   * Create a HTMLElement as the container for the popup stack item. The returned element reference
+   * will be the reference to be passed to all other methods. The Popup Stack will control when this
+   * element is added and removed from the DOM as well as the `z-index` style property. Your content
+   * should be added to this element.
    */
   createContainer(): HTMLElement {
     if (_adapter.createContainer) {

--- a/modules/popup-stack/stories/stories_testing.tsx
+++ b/modules/popup-stack/stories/stories_testing.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {css, jsx} from '@emotion/core';
+import {css, jsx, CSSObject} from '@emotion/core';
 
 import {Tooltip} from '@workday/canvas-kit-react-tooltip';
 
@@ -27,7 +27,6 @@ interface WindowProps {
   heading: string;
   children: React.ReactNode;
 }
-
 const styles = css({
   position: 'absolute',
   width: 500,
@@ -40,10 +39,10 @@ const Window = ({children, heading, top, left}: WindowProps) => {
   useBringToTopOnClick(ref);
 
   return ReactDOM.createPortal(
-    <Popup popupRef={ref} css={styles} heading={heading} style={{top, left}}>
+    <Popup css={styles} heading={heading} style={{top, left}}>
       {children}
     </Popup>,
-    document.body
+    ref.current
   );
 };
 

--- a/modules/popup-stack/stories/stories_testing.tsx
+++ b/modules/popup-stack/stories/stories_testing.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {css, jsx, CSSObject} from '@emotion/core';
+import {css, jsx} from '@emotion/core';
 
 import {Tooltip} from '@workday/canvas-kit-react-tooltip';
 

--- a/modules/popup/react/README.md
+++ b/modules/popup/react/README.md
@@ -330,7 +330,7 @@ const MyDeleteButton = ({onConfirm}) => {
 
   return (
     <>
-      <DeleteButton {...targetPropsa}>Delete Item</DeleteButton>
+      <DeleteButton {...targetProps}>Delete Item</DeleteButton>
       <Popper placement="bottom" {...popperProps}>
         <Popup heading="Delete Item" handleClose={closePopup}>
           <p>Are you sure you'd like to delete?</p>
@@ -342,8 +342,6 @@ const MyDeleteButton = ({onConfirm}) => {
   );
 };
 ```
-
-> targetProps: Apply to your
 
 ## useAssistiveHideSiblings
 

--- a/modules/popup/react/README.md
+++ b/modules/popup/react/README.md
@@ -166,11 +166,11 @@ import {Button} from '@workday/canvas-kit-react-button';
 import {Popup, Popper, usePopup, use} from '@workday/canvas-kit-react-popup';
 
 const MyPopup = () => {
-  const { targetProps, closePopup, popperProps } = usePopup()
+  const { targetProps, closePopup, popperProps, stackRef } = usePopup()
 
   // Add some behaviors
-  useCloseOnOutsideClick(popperProps.ref, closePopup);
-  useCloseOnEscape(popperProps.ref, closePopup);
+  useCloseOnOutsideClick(stackRef, closePopup);
+  useCloseOnEscape(stackRef, closePopup);
 
   return (
     <Button {...targetProps}>Toggle Popup</Button>
@@ -273,16 +273,77 @@ Default:
 ### usePopupStack
 
 ```ts
-usePopupStack(ref: React.RefObject<HTMLElement>): void
+const stackRef = usePopupStack(forwardRef?: React.RefObject<HTMLElement>): React.RefObject<HTMLDivElement>
 ```
 
-This hook will add a `ref` element to the Popup stack on mount and remove on unmount. If you use
-`Popper`, the popper `ref` is automatically added/removed from the Popup stack. The Popup stack is
-required for proper z-index values to ensure Popups are rendered correct. It is also required for
-global listeners like click outside or escape key closing a popup. Without the Popup stack, all
-popups will close rather than only the topmost one.
+This hook should not be used directly. Use the `Popper` component instead. There is also a
+convenience [usePopup](#usePopup)
 
-This should be used by all stacked UIs unless using the `Popper` component.
+This hook will add the `stackRef` element to the Popup stack on mount and remove on unmount. If you
+use `Popper`, the popper `stackRef` is automatically added/removed from the Popup stack. The Popup
+stack is required for proper z-index values to ensure Popups are rendered correct. It is also
+required for global listeners like click outside or escape key closing a popup. Without the Popup
+stack, all popups will close rather than only the topmost one.
+
+If `forwardRef` is provided, it will be the same as `stackRef`. If `forwardRef` is not provided`,
+this hook will create one and return it.
+
+This hook should be used by all stacked UIs unless using the `Popper` component.
+
+Example:
+
+```tsx
+const [open, setOpen] = React.useState(false);
+const stackRef = usePopupStack();
+
+const closePopup = () => {
+  setOpen(false);
+};
+
+// add some popup functionality
+useCloseOnOutsideClick(stackRef, closePopup);
+useCloseOnEscape(stackRef, closePopup);
+```
+
+### usePopup
+
+Convenience hook for common Popups used as non-modal dialogs. It provides props to mix into
+composite parts of the Popup pattern.
+
+```tsx
+import {
+  Button,
+  DeleteButton,
+  Popper,
+  Popup,
+  usePopup,
+  useCloseOnOutsideClick,
+  useCloseOnEscape,
+} from '@workday/canvas-kit-react';
+
+const MyDeleteButton = ({onConfirm}) => {
+  const {targetProps, closePopup, popperProps, stackRef} = usePopup();
+
+  // popup traits
+  useCloseOnOutsideClick(stackRef);
+  useCloseOnEscape(stackRef);
+
+  return (
+    <>
+      <DeleteButton {...targetPropsa}>Delete Item</DeleteButton>
+      <Popper placement="bottom" {...popperProps}>
+        <Popup heading="Delete Item" handleClose={closePopup}>
+          <p>Are you sure you'd like to delete?</p>
+          <DeleteButton onClick={onConfirm}>Yes</DeleteButton>
+          <Button onClick={closePopup}>No</Button>
+        </Popup>
+      </Popper>
+    </>
+  );
+};
+```
+
+> targetProps: Apply to your
 
 ## useAssistiveHideSiblings
 
@@ -291,39 +352,40 @@ useAssistiveHideSiblings(ref: React.RefObject<HTMLElement>): void
 ```
 
 This hook will hide all sibling elements from assistive technology. Very useful for modal dialogs.
-This will set `aria-hidden` for sibling elements of the provided `ref` element and restore the
+This will set `aria-hidden` for sibling elements of the provided `stackRef` element and restore the
 previous `aria-hidden` to each component when the component is unmounted. For example, if added to a
 Modal component, all children of `document.body` will have an `aria-hidden=true` applied _except_
-for the provided `ref` element (the Modal). This will effectively hide all content outside the Modal
-from assistive technology including Web Rotor for VoiceOver for example.
+for the provided `stackRef` element (the Modal). This will effectively hide all content outside the
+Modal from assistive technology including Web Rotor for VoiceOver for example.
 
-**Note**: The provided `ref` element should be root element of your component so that other elements
-_outside_ your component will be hidden rather than elements _inside_ your component.
+**Note**: The provided `stackRef` element should be root element of your component so that other
+elements _outside_ your component will be hidden rather than elements _inside_ your component.
 
 This should be used on stacked UI elements that need to hide content. Like Modals.
 
 ## useBringToTopOnClick
 
 ```ts
-useBringToTopOnClick(ref: React.RefObject<HTMLElement>): void
+useBringToTopOnClick(stackRef: React.RefObject<HTMLElement>): void
 ```
 
-This hook will bring an element to the top of the stack when any element inside the provided `ref`
-element is clicked. If `Popper` was used or `PopupStack.add` provided an `owner`, all "child" popups
-will also be brought to the top. A "child" popup is a Popup that was opened from another Popup.
-Usually this is a Tooltip or Select component inside something like a Modal.
+This hook will bring an element to the top of the stack when any element inside the provided
+`stackRef` element is clicked. If `Popper` was used or `PopupStack.add` provided an `owner`, all
+"child" popups will also be brought to the top. A "child" popup is a Popup that was opened from
+another Popup. Usually this is a Tooltip or Select component inside something like a Modal.
 
 This should be used on stacked UI elements that are meant to persist, like Windows.
 
 ## useCloseOnEscape
 
 ```ts
-useCloseOnEscape(ref: React.RefObject<HTMLElement>, onClose: () => void): void
+useCloseOnEscape(stackRef: React.RefObject<HTMLElement>, onClose: () => void): void
 ```
 
 Registers global detection of the Escape key. It will only call the `onClose` callback if the
-provided `ref` element is the topmost in the stack. The `ref` should be the same as the one passed
-to `usePopupStack` or the `Popper` component since `Popper` uses `usePopupStack` internally.
+provided `stackRef` element is the topmost in the stack. The `stackRef` should be the same as the
+one passed to `usePopupStack` or the `Popper` component since `Popper` uses `usePopupStack`
+internally.
 
 This should be used stacked UI elements that are dismissible like Tooltips, Modals, non-modal
 dialogs, dropdown menus, etc.
@@ -331,13 +393,13 @@ dialogs, dropdown menus, etc.
 ## useCloseOnOutsideClick
 
 ```ts
-useCloseOnOutsideClick(ref: React.RefObject<HTMLElement>, onClose: () => void): void
+useCloseOnOutsideClick(stackRef: React.RefObject<HTMLElement>, onClose: () => void): void
 ```
 
 Registers global listener for all clicks. It will only call the `onClose` callback if the click
-happened outside the `ref` element and its children _and_ the provided `ref` element is the topmost
-in the stack. The `ref` should be the same as the one passed to `usePopupStack` or the `Popper`
-component since `Popper` uses `usePopupStack` internally.
+happened outside the `stackRef` element and its children _and_ the provided `stackRef` element is
+the topmost in the stack. The `stackRef` should be the same as the one passed to `usePopupStack` or
+the `Popper` component since `Popper` uses `usePopupStack` internally.
 
 This should be used stacked UI elements that are dismissible like Tooltips, Modals, non-modal
 dialogs, dropdown menus, etc.
@@ -345,10 +407,10 @@ dialogs, dropdown menus, etc.
 ## useFocusTrap
 
 ```ts
-useFocusTrap(ref: React.RefObject<HTMLElement>): void
+useFocusTrap(stackRef: React.RefObject<HTMLElement>): void
 ```
 
-"Trap" or "loop" focus within a provided `ref` element. This is required for accessibility on
+"Trap" or "loop" focus within a provided `stackRef` element. This is required for accessibility on
 modals. If a keyboard users hits the Tab or Shift + Tab, this will force "looping" of focus. It
 effectively "hides" outside content from keyboard users. Use an overlay to hide content from mouse
 users and `useAssistiveHideSiblings` to hide content from assistive technology users.

--- a/modules/popup/react/lib/Popper.tsx
+++ b/modules/popup/react/lib/Popper.tsx
@@ -121,7 +121,6 @@ const OpenPopper = React.forwardRef<HTMLDivElement, PopperProps>(
     },
     forwardRef: React.RefObject<HTMLDivElement>
   ) => {
-    // const ref = React.useRef<HTMLDivElement>(null);
     const firstRender = React.useRef(true);
     const popperInstance = React.useRef<PopperJS.Instance>();
     const [placement, setPlacement] = React.useState(popperPlacement);

--- a/modules/popup/react/lib/Popper.tsx
+++ b/modules/popup/react/lib/Popper.tsx
@@ -121,15 +121,11 @@ const OpenPopper = React.forwardRef<HTMLDivElement, PopperProps>(
     },
     forwardRef: React.RefObject<HTMLDivElement>
   ) => {
-    const localRef = React.useRef<HTMLDivElement>(null);
-    const ref = (forwardRef || localRef) as React.RefObject<HTMLDivElement>;
+    // const ref = React.useRef<HTMLDivElement>(null);
     const firstRender = React.useRef(true);
     const popperInstance = React.useRef<PopperJS.Instance>();
     const [placement, setPlacement] = React.useState(popperPlacement);
-    usePopupStack(
-      ref,
-      getElementFromRefOrElement(anchorElement ?? null) as HTMLElement | undefined
-    );
+    const stackRef = usePopupStack(forwardRef, anchorElement as HTMLElement);
 
     // useLayoutEffect prevents flashing of the popup before position is determined
     React.useLayoutEffect(() => {
@@ -143,8 +139,8 @@ const OpenPopper = React.forwardRef<HTMLDivElement, PopperProps>(
         return undefined;
       }
 
-      if (ref.current) {
-        popperInstance.current = PopperJS.createPopper(anchorEl, ref.current, {
+      if (stackRef.current) {
+        popperInstance.current = PopperJS.createPopper(anchorEl, stackRef.current, {
           placement: popperPlacement,
           ...popperOptions,
           modifiers: [...(popperOptions.modifiers || []), createSetPlacementModifier(setPlacement)],
@@ -160,7 +156,7 @@ const OpenPopper = React.forwardRef<HTMLDivElement, PopperProps>(
       // prop dependencies. We do _not_ want to destroy the Popper instance if options or placement
       // change, only if anchor or target refs change
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [anchorElement, getAnchorClientRect, ref]);
+    }, [anchorElement, getAnchorClientRect, stackRef]);
 
     React.useLayoutEffect(() => {
       // Only update options if this is _not_ the first render
@@ -182,7 +178,7 @@ const OpenPopper = React.forwardRef<HTMLDivElement, PopperProps>(
       return contents;
     }
 
-    return ReactDOM.createPortal(contents, containerElement || ref.current!);
+    return ReactDOM.createPortal(contents, containerElement || stackRef.current!);
   }
 );
 

--- a/modules/popup/react/lib/Popper.tsx
+++ b/modules/popup/react/lib/Popper.tsx
@@ -65,32 +65,15 @@ export interface PopperProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 export const Popper = React.forwardRef<HTMLDivElement, PopperProps>(
-  (
-    {
-      placement,
-      popperOptions,
-      portal = true,
-      open = true,
-      anchorElement,
-      children,
-      containerElement,
-      ...elemProps
-    }: PopperProps,
-    ref
-  ) => {
+  ({portal = true, open = true, ...elemProps}: PopperProps, forwardRef) => {
+    const localRef = React.useRef<HTMLDivElement>(null);
+    const ref = (forwardRef || localRef) as React.RefObject<HTMLDivElement>;
+
     if (!open) {
       return null;
     }
 
-    const contents = (
-      <OpenPopper {...{ref, anchorElement, popperOptions, placement, children, ...elemProps}} />
-    );
-
-    if (!portal) {
-      return contents;
-    }
-
-    return ReactDOM.createPortal(contents, containerElement || document.body);
+    return <OpenPopper ref={ref} portal={portal} {...elemProps} />;
   }
 );
 
@@ -132,6 +115,8 @@ const OpenPopper = React.forwardRef<HTMLDivElement, PopperProps>(
       popperOptions = defaultPopperOptions,
       placement: popperPlacement = 'bottom',
       children,
+      portal,
+      containerElement,
       ...elemProps
     },
     forwardRef: React.RefObject<HTMLDivElement>
@@ -189,11 +174,15 @@ const OpenPopper = React.forwardRef<HTMLDivElement, PopperProps>(
       firstRender.current = false;
     }, [popperOptions, popperPlacement]);
 
-    return (
-      <div {...elemProps} ref={ref}>
-        {isRenderProp(children) ? children({placement}) : children}
-      </div>
+    const contents = (
+      <div {...elemProps}>{isRenderProp(children) ? children({placement}) : children}</div>
     );
+
+    if (!portal) {
+      return contents;
+    }
+
+    return ReactDOM.createPortal(contents, containerElement || ref.current!);
   }
 );
 

--- a/modules/popup/react/lib/Popup.tsx
+++ b/modules/popup/react/lib/Popup.tsx
@@ -104,7 +104,7 @@ const Container = styled('div', {
       animationTimingFunction: 'ease-out',
       transformOrigin: `${transformOrigin.vertical} ${transformOrigin.horizontal}`,
       // Allow overriding of animation in special cases
-      '.no-animation &': {
+      '.wd-no-animation &': {
         animation: 'none',
       },
     };

--- a/modules/popup/react/lib/Popup.tsx
+++ b/modules/popup/react/lib/Popup.tsx
@@ -198,7 +198,7 @@ export default class Popup extends React.Component<PopupProps> {
 export const usePopup = <T extends HTMLElement = HTMLElement>() => {
   const [open, setOpen] = React.useState(false);
   const [anchorElement, setAnchorElement] = React.useState<T | null>(null);
-  const ref = React.useRef<HTMLDivElement>(null);
+  const stackRef = React.useRef<HTMLDivElement>(null);
 
   const togglePopup = (event: React.MouseEvent<T>) => {
     setAnchorElement(event.currentTarget as T);
@@ -215,7 +215,8 @@ export const usePopup = <T extends HTMLElement = HTMLElement>() => {
     popperProps: {
       open,
       anchorElement,
-      ref,
+      ref: stackRef,
     },
+    stackRef,
   };
 };

--- a/modules/popup/react/lib/Popup.tsx
+++ b/modules/popup/react/lib/Popup.tsx
@@ -103,6 +103,10 @@ const Container = styled('div', {
       animationDuration: '150ms',
       animationTimingFunction: 'ease-out',
       transformOrigin: `${transformOrigin.vertical} ${transformOrigin.horizontal}`,
+      // Allow overriding of animation in special cases
+      '.no-animation &': {
+        animation: 'none',
+      },
     };
   }
 );

--- a/modules/popup/react/lib/useAssistiveHideSiblings.ts
+++ b/modules/popup/react/lib/useAssistiveHideSiblings.ts
@@ -1,23 +1,24 @@
 import React from 'react';
 
 /**
- * This hook will hide all sibling elements from assistive technology. Very useful for modal dialogs.
- * This will set `aria-hidden` for sibling elements of the provided `ref` element and restore the
- * previous `aria-hidden` to each component when the component is unmounted. For example, if added to a
- * Modal component, all children of `document.body` will have an `aria-hidden=true` applied _except_
- * for the provided `ref` element (the Modal). This will effectively hide all content outside the Modal
- * from assistive technology including Web Rotor for VoiceOver for example.
+ * This hook will hide all sibling elements from assistive technology. Very useful for modal
+ * dialogs. This will set `aria-hidden` for sibling elements of the provided `stackRef` element and
+ * restore the previous `aria-hidden` to each component when the component is unmounted. For
+ * example, if added to a Modal component, all children of `document.body` will have an
+ * `aria-hidden=true` applied _except_ for the provided `stackRef` element (the Modal). This will
+ * effectively hide all content outside the Modal from assistive technology including Web Rotor for
+ * VoiceOver for example.
  *
- * **Note**: The provided `ref` element should be root element of your component so that other elements
- * _outside_ your component will be hidden rather than elements _inside_ your component
+ * **Note**: The provided `stackRef` element should be root element of your component so that other
+ * elements _outside_ your component will be hidden rather than elements _inside_ your component
  *
- * @param ref The ref element where siblings will be hidden.
+ * @param stackRef The ref element where siblings will be hidden.
  */
-export const useAssistiveHideSiblings = <E extends HTMLElement>(ref: React.RefObject<E>) => {
+export const useAssistiveHideSiblings = <E extends HTMLElement>(stackRef: React.RefObject<E>) => {
   React.useEffect(() => {
-    const siblings = [...((ref.current?.parentElement?.children as any) as HTMLElement[])].filter(
-      el => el !== ref.current
-    );
+    const siblings = [
+      ...((stackRef.current?.parentElement?.children as any) as HTMLElement[]),
+    ].filter(el => el !== stackRef.current);
     const prevAriaHidden = siblings.map(el => el.getAttribute('aria-hidden'));
     siblings.forEach(el => {
       el.setAttribute('aria-hidden', 'true');
@@ -33,5 +34,5 @@ export const useAssistiveHideSiblings = <E extends HTMLElement>(ref: React.RefOb
         }
       });
     };
-  }, [ref]);
+  }, [stackRef]);
 };

--- a/modules/popup/react/lib/useBringToTopOnClick.ts
+++ b/modules/popup/react/lib/useBringToTopOnClick.ts
@@ -3,18 +3,18 @@ import {PopupStack} from '@workday/canvas-kit-popup-stack';
 
 /**
  * This hook will bring an element to the top of the stack when any element inside the provided
- * `ref` element is clicked. If `Popper` was used or `PopupStack.add` provided an `owner`, all
+ * `stackRef` element is clicked. If `Popper` was used or `PopupStack.add` provided an `owner`, all
  * "child" popups will also be brought to the top. A "child" popup is a Popup that was opened from
  * another Popup. Usually this is a Tooltip or Select component inside something like a Modal.
  */
-export const useBringToTopOnClick = <E extends HTMLElement>(ref: React.RefObject<E>) => {
+export const useBringToTopOnClick = <E extends HTMLElement>(stackRef: React.RefObject<E>) => {
   let timer: number;
   const onClick = (event: MouseEvent) => {
     // requestAnimationFrame is used to control timing of when `bringToTop` is called.
     // https://github.com/Workday/canvas-kit/pull/670#discussion_r436158184
     timer = requestAnimationFrame(() => {
-      if (ref.current?.contains(event.target as Node)) {
-        PopupStack.bringToTop(ref.current!);
+      if (stackRef.current?.contains(event.target as Node)) {
+        PopupStack.bringToTop(stackRef.current!);
       }
     });
   };

--- a/modules/popup/react/lib/useCloseOnEscape.ts
+++ b/modules/popup/react/lib/useCloseOnEscape.ts
@@ -4,22 +4,25 @@ import {PopupStack} from '@workday/canvas-kit-popup-stack';
 
 /**
  * Registers global detection of the Escape key. It will only call the `onClose` callback if the
- * provided `ref` element is the topmost in the stack. The `ref` should be the same as the one passed
+ * provided `stackRef` element is the topmost in the stack. The `stackRef` should be the same as the one passed
  * to `usePopupStack` or the `Popper` component since `Popper` uses `usePopupStack` internally.
- * @param ref
+ * @param stackRef
  * @param onClose
  */
 export const useCloseOnEscape = <E extends HTMLElement>(
-  ref: React.RefObject<E>,
+  stackRef: React.RefObject<E>,
   onClose: () => void
 ) => {
   const onKeyDown = React.useCallback(
     (event: KeyboardEvent) => {
-      if ((event.key === 'Esc' || event.key === 'Escape') && PopupStack.isTopmost(ref.current!)) {
+      if (
+        (event.key === 'Esc' || event.key === 'Escape') &&
+        PopupStack.isTopmost(stackRef.current!)
+      ) {
         onClose();
       }
     },
-    [onClose, ref]
+    [onClose, stackRef]
   );
 
   // `useLayoutEffect` for automation

--- a/modules/popup/react/lib/useCloseOnOutsideClick.ts
+++ b/modules/popup/react/lib/useCloseOnOutsideClick.ts
@@ -25,11 +25,12 @@ export const useCloseOnOutsideClick = <E extends HTMLElement>(
       onClose();
     }
   };
+
   React.useLayoutEffect(() => {
-    document.addEventListener('click', onClick);
+    document.addEventListener('mousedown', onClick);
 
     return () => {
-      document.removeEventListener('click', onClick);
+      document.removeEventListener('mousedown', onClick);
     };
   });
 };

--- a/modules/popup/react/lib/useCloseOnOutsideClick.ts
+++ b/modules/popup/react/lib/useCloseOnOutsideClick.ts
@@ -4,23 +4,23 @@ import {PopupStack} from '@workday/canvas-kit-popup-stack';
 
 /**
  * Registers global listener for all clicks. It will only call the `onClose` callback if the click
- * happened outside the `ref` element and its children _and_ the provided `ref` element is the
- * topmost in the stack. The `ref` should be the same as the one passed to `usePopupStack` or the
- * `Popper` component since `Popper` uses `usePopupStack` internally.
- * @param ref
+ * happened outside the `stackRef` element and its children _and_ the provided `stackRef` element is
+ * the topmost in the stack. The `stackRef` should be the same as the one passed to `usePopupStack`
+ * or the `Popper` component since `Popper` uses `usePopupStack` internally.
+ * @param stackRef
  * @param onClose
  */
 export const useCloseOnOutsideClick = <E extends HTMLElement>(
-  ref: React.RefObject<E>,
+  stackRef: React.RefObject<E>,
   onClose: () => void
 ) => {
   const onClick = (event: MouseEvent) => {
     if (
-      PopupStack.isTopmost(ref.current!) &&
+      PopupStack.isTopmost(stackRef.current!) &&
       // Use `PopupStack.contains` instead of `ref.current.contains` so that the application can
       // decide if clicking the target should toggle the popup rather than it toggling implicitly
       // because the target is outside `ref.current`
-      !PopupStack.contains(ref.current!, event.target as HTMLElement)
+      !PopupStack.contains(stackRef.current!, event.target as HTMLElement)
     ) {
       onClose();
     }

--- a/modules/popup/react/lib/useFocusTrap.ts
+++ b/modules/popup/react/lib/useFocusTrap.ts
@@ -12,16 +12,16 @@ const useKeyDownListener = (onKeyDown: EventListenerOrEventListenerObject) => {
 };
 
 /**
- * "Trap" or "loop" focus within a provided `ref` element. This is required for accessibility on
+ * "Trap" or "loop" focus within a provided `stackRef` element. This is required for accessibility on
  * modals. If a keyboard users hits the Tab or Shift + Tab, this will force "looping" of focus. It
  * effectively "hides" outside content from keyboard users. Use an overlay to hide content from mouse
  * users and `useAssistiveHideSiblings` to hide content from assistive technology users.
- * @param ref The element ref you wish to trap focus into
+ * @param stackRef The element ref you wish to trap focus into
  */
-export const useFocusTrap = <E extends HTMLElement>(ref: React.RefObject<E>) => {
+export const useFocusTrap = <E extends HTMLElement>(stackRef: React.RefObject<E>) => {
   const handleKeydown = (event: KeyboardEvent) => {
-    if (ref.current) {
-      tabTrappingKey(event, ref.current);
+    if (stackRef.current) {
+      tabTrappingKey(event, stackRef.current);
     }
   };
 

--- a/modules/popup/react/lib/usePopupStack.ts
+++ b/modules/popup/react/lib/usePopupStack.ts
@@ -4,27 +4,42 @@ import {PopupStack} from '@workday/canvas-kit-popup-stack';
 
 /**
  * This hook will add a `ref` element to the Popup stack on mount and remove on unmount. If you use
- * `Popper`, the popper `ref` is automatically added/removed from the Popup stack. The Popup stack is
- * required for proper z-index values to ensure Popups are rendered correct. It is also required for
- * global listeners like click outside or escape key closing a popup. Without the Popup stack, all
- * popups will close rather than only the topmost one.
- * @param ref Ref of the element that is considered the container for a Popup. Usually the `Popup` component
- * @param target Usually the trigger of a popup. This will fix `bringToTop` and should be provided by all
- * ephemeral-type popups (like Tooltips, Select menus, etc). It will also add in clickOutside detection
+ * `Popper`, the popper `ref` is automatically added/removed from the Popup stack. The Popup stack
+ * is required for proper z-index values to ensure Popups are rendered correct. It is also required
+ * for global listeners like click outside or escape key closing a popup. Without the Popup stack,
+ * all popups will close rather than only the topmost one.
+ * @param ref This ref will be managed by the PopupStack and should not be managed by React. Do not
+ * apply this ref to a React element. Doing so will result in an error. Instead, use this `ref`
+ * directly with `ReactDOM.createPortal(<YourComponent>, ref.current!)`. This is definitely strange
+ * for React code, but is necessary for the PopupStack to remain framework agnostic and flexible to
+ * integrate with existing popup stack systems
+ * @param target Usually the trigger of a popup. This will fix `bringToTop` and should be provided
+ * by all ephemeral-type popups (like Tooltips, Select menus, etc). It will also add in clickOutside
+ * detection
  */
 export const usePopupStack = <E extends HTMLElement>(
   ref: React.RefObject<E>,
   target?: HTMLElement
 ): void => {
-  // We useLayoutEffect to ensure proper timing of registration
-  // of the element to the popup stack. Without this, the timing is unpredictable
-  // when mixed with other frameworks. Other frameworks should also register as soon
-  // as the element is available
+  // useState function input ensures we only create a container once.
+  const [popupRef] = React.useState(() => {
+    const container = PopupStack.createContainer();
+    (ref as any).current = container;
+    return container;
+  });
+  // We useLayoutEffect to ensure proper timing of registration of the element to the popup stack.
+  // Without this, the timing is unpredictable when mixed with other frameworks. Other frameworks
+  // should also register as soon as the element is available
   React.useLayoutEffect(() => {
+    if (popupRef !== ref.current) {
+      throw Error(
+        `The 'ref' passed to usePopupStack should not be applied to a React element. This will cause a runtime error where the PopupStack and React compete for the element. Instead use ReactDOM.createPortal(<YourComponent />, ref.current)`
+      );
+    }
     PopupStack.add({element: ref.current!, owner: target});
     const element = ref.current!;
     return () => {
       PopupStack.remove(element);
     };
-  }, [ref, target]);
+  }, [ref, target, popupRef]);
 };

--- a/modules/popup/react/lib/usePopupStack.ts
+++ b/modules/popup/react/lib/usePopupStack.ts
@@ -3,24 +3,49 @@ import React from 'react';
 import {PopupStack} from '@workday/canvas-kit-popup-stack';
 
 /**
- * This hook will add a `ref` element to the Popup stack on mount and remove on unmount. If you use
- * `Popper`, the popper `ref` is automatically added/removed from the Popup stack. The Popup stack
- * is required for proper z-index values to ensure Popups are rendered correct. It is also required
- * for global listeners like click outside or escape key closing a popup. Without the Popup stack,
- * all popups will close rather than only the topmost one.
- * @param ref This ref will be managed by the PopupStack and should not be managed by React. Do not
- * apply this ref to a React element. Doing so will result in an error. Instead, use this `ref`
- * directly with `ReactDOM.createPortal(<YourComponent>, ref.current!)`. This is definitely strange
- * for React code, but is necessary for the PopupStack to remain framework agnostic and flexible to
- * integrate with existing popup stack systems
+ * This hook should not be used directly. Use the `Popper` component instead.
+ *
+ * This hook will add the `stackRef` element to the Popup stack on mount and remove on unmount. If
+ * you use `Popper`, the popper `stackRef` is automatically added/removed from the Popup stack. The
+ * Popup stack is required for proper z-index values to ensure Popups are rendered correct. It is
+ * also required for global listeners like click outside or escape key closing a popup. Without the
+ * Popup stack, all popups will close rather than only the topmost one.
+ *
+ * If `forwardRef` is provided, it will be the same as `stackRef`. If `forwardRef` is not provided`,
+ * this hook will create one and return it.
+ *
+ * This hook should be used by all stacked UIs unless using the `Popper` component.
+ *
+ * @param forwardRef This ref will be managed by the PopupStack and should not be managed by React. Do
+ * not apply this stackRef to a React element. Doing so will result in an error. Instead, use this
+ * `stackRef` directly with `ReactDOM.createPortal(<YourComponent>, stackRef.current!)`. This is
+ * definitely strange for React code, but is necessary for the PopupStack to remain framework
+ * agnostic and flexible to integrate with existing popup stack systems. If not provided, this hook
+ * will create one and return that `stackRef` instead.
+ *
  * @param target Usually the trigger of a popup. This will fix `bringToTop` and should be provided
  * by all ephemeral-type popups (like Tooltips, Select menus, etc). It will also add in clickOutside
- * detection
+ * detection.
+ *
+ * @example
+ * const [open, setOpen] = React.useState(false)
+ * const stackRef = usePopupStack()
+ *
+ * const closePopup = () => {
+ *   setOpen(false)
+ * }
+ *
+ * // add some popup functionality
+ * useCloseOnOutsideClick(stackRef, closePopup)
+ * useCloseOnEscape(stackRef, closePopup)
  */
 export const usePopupStack = <E extends HTMLElement>(
-  ref: React.RefObject<E>,
-  target?: HTMLElement
-): void => {
+  forwardRef?: React.RefObject<E>,
+  target?: HTMLElement | React.RefObject<HTMLElement>
+): React.RefObject<HTMLDivElement> => {
+  const internalRef = React.useRef<HTMLDivElement>(null);
+  const ref = (forwardRef || internalRef) as React.RefObject<HTMLDivElement>;
+
   // useState function input ensures we only create a container once.
   const [popupRef] = React.useState(() => {
     const container = PopupStack.createContainer();
@@ -36,10 +61,17 @@ export const usePopupStack = <E extends HTMLElement>(
         `The 'ref' passed to usePopupStack should not be applied to a React element. This will cause a runtime error where the PopupStack and React compete for the element. Instead use ReactDOM.createPortal(<YourComponent />, ref.current)`
       );
     }
-    PopupStack.add({element: ref.current!, owner: target});
+    const targetEl = target
+      ? 'current' in target
+        ? target.current || undefined
+        : target
+      : undefined;
+    PopupStack.add({element: ref.current!, owner: targetEl});
     const element = ref.current!;
     return () => {
       PopupStack.remove(element);
     };
   }, [ref, target, popupRef]);
+
+  return ref;
 };

--- a/modules/popup/react/stories/stories.tsx
+++ b/modules/popup/react/stories/stories.tsx
@@ -20,10 +20,10 @@ export default {
 };
 
 export const Default = () => {
-  const {targetProps, closePopup, popperProps} = usePopup();
+  const {targetProps, closePopup, popperProps, stackRef} = usePopup();
 
-  useCloseOnOutsideClick(popperProps.ref, closePopup);
-  useCloseOnEscape(popperProps.ref, closePopup);
+  useCloseOnOutsideClick(stackRef, closePopup);
+  useCloseOnEscape(stackRef, closePopup);
 
   return (
     <div style={{display: 'flex', justifyContent: 'center'}}>

--- a/modules/popup/react/stories/stories_testing.tsx
+++ b/modules/popup/react/stories/stories_testing.tsx
@@ -13,8 +13,8 @@ export const MultiplePopups = () => {
   const popup1 = usePopup();
   const popup2 = usePopup();
 
-  useCloseOnOutsideClick(popup1.popperProps.ref, popup1.closePopup);
-  useCloseOnOutsideClick(popup2.popperProps.ref, popup2.closePopup);
+  useCloseOnOutsideClick(popup1.stackRef, popup1.closePopup);
+  useCloseOnOutsideClick(popup2.stackRef, popup2.closePopup);
 
   return (
     <>

--- a/modules/tooltip/react/lib/useTooltip.tsx
+++ b/modules/tooltip/react/lib/useTooltip.tsx
@@ -76,7 +76,7 @@ export function useTooltip<T extends HTMLElement = HTMLElement>({
       'aria-label': type === 'label' ? titleText : undefined,
       onMouseEnter: onOpenFromTarget,
       onMouseLeave: intentTimer.start,
-      onClick: closeTooltip,
+      onMouseDown: closeTooltip,
       onFocus: onOpenFromTarget,
       onBlur: intentTimer.start,
     },

--- a/modules/tooltip/react/stories/visual.tsx
+++ b/modules/tooltip/react/stories/visual.tsx
@@ -59,7 +59,6 @@ export const Placements = () => {
         !open ? null : (
           <Popper
             key={placement}
-            containerElement={containerElement}
             placement={placement}
             popperOptions={{
               modifiers: [


### PR DESCRIPTION
Fixes #750

<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md
- [x] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->

## Commit message
feat(popup-stack): Add adapter API to integrate with other popup systems (#782)

### BREAKING CHANGE
This is a potentially breaking  change if you use `usePopupStack` and `ReactDOM.createPortal(contents, document.body)`:
We added `createContainer` to `PopupStack`. React no longer controls the element that is given to the the `PopupStack`. The `PopupStack` will now create a containing element that your content should render into. If you recognize this pattern, you'll need to render into `stackRef.current` instead of `document.body`.

Before:
```tsx
const ref = React.createRef<HTMLDivElement>(null);

usePopupStack(ref)

React.createPortal(contents, document.body)
```

Now
```tsx
const stackRef = usePopupStack()

React.createPortal(contents, stackRef.current)
```