### PR TITLE
fix(select): Fix undesired scrolling when activating menu

### DIFF
--- a/cypress/integration/SelectLabs.spec.ts
+++ b/cypress/integration/SelectLabs.spec.ts
@@ -680,4 +680,31 @@ describe('Select', () => {
       }
     );
   });
+
+  context(`given the "Portal Test" story is rendered`, () => {
+    beforeEach(() => {
+      h.stories.load('Testing|React/Labs/Select', 'Portal Test');
+    });
+
+    context(
+      'when the page is scrolled to the bottom and the bottommost select button is clicked',
+      () => {
+        beforeEach(() => {
+          cy.scrollTo('bottom');
+          cy.window()
+            .its('scrollY')
+            .as('originalWindowScrollY');
+          cy.findByLabelText('Label (Bottom)').click();
+        });
+
+        context('the page', () => {
+          it('should not scroll', () => {
+            cy.window().then($window => {
+              cy.get('@originalWindowScrollY').should('equal', $window.scrollY);
+            });
+          });
+        });
+      }
+    );
+  });
 });

--- a/modules/_labs/select/react/lib/SelectMenu.tsx
+++ b/modules/_labs/select/react/lib/SelectMenu.tsx
@@ -188,8 +188,10 @@ const MenuList = styled('ul')<Pick<SelectProps, 'error' | 'theme'>>(
   })
 );
 
-const generatePopperOptions = (props: Pick<SelectMenuProps, 'isFlipped' | 'shouldAutoFlip'>) => {
-  const {isFlipped, shouldAutoFlip} = props;
+const generatePopperOptions = (
+  props: Pick<SelectMenuProps, 'isFlipped' | 'menuRef' | 'shouldAutoFlip' | 'shouldAutoFocus'>
+) => {
+  const {isFlipped, menuRef, shouldAutoFlip, shouldAutoFocus} = props;
 
   let fallbackPlacements: Placement[] = [];
   if (shouldAutoFlip) {
@@ -230,6 +232,14 @@ const generatePopperOptions = (props: Pick<SelectMenuProps, 'isFlipped' | 'shoul
 
   return {
     modifiers,
+    // TODO: Consider using a more general-purpose focus function here rather
+    // than relying on Popper's onFirstUpdate for better control over how
+    // focus is managed
+    onFirstUpdate: () => {
+      if (shouldAutoFocus && menuRef && menuRef.current) {
+        menuRef.current.focus();
+      }
+    },
   };
 };
 
@@ -259,14 +269,6 @@ const SelectMenu = (props: SelectMenuProps) => {
       setWidth(newMenuWidth);
     }
   }, [buttonRef, isHidden]);
-
-  useLayoutEffect(() => {
-    if (shouldAutoFocus) {
-      menuRef?.current?.focus();
-    }
-    // Only focus on mount, so omit dependencies
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   useLayoutEffect(() => {
     handleWidthChange();
@@ -311,7 +313,9 @@ const SelectMenu = (props: SelectMenuProps) => {
       anchorElement={buttonRef}
       popperOptions={generatePopperOptions({
         isFlipped,
+        menuRef,
         shouldAutoFlip,
+        shouldAutoFocus,
       })}
       ref={popupRef}
     >

--- a/modules/_labs/select/react/stories/stories_testing.tsx
+++ b/modules/_labs/select/react/stories/stories_testing.tsx
@@ -117,7 +117,7 @@ export const PortalTest = () => (
     </Container>
     <Container>
       <p>This Select is forced to display its menu upwards since it's at the bottom the page.</p>
-      <FormField label="Label" inputId="select-last" error={FormField.ErrorType.Error}>
+      <FormField label="Label (Bottom)" inputId="select-bottom" error={FormField.ErrorType.Error}>
         {controlComponent(<Select name="contact" options={options} />)}
       </FormField>
     </Container>


### PR DESCRIPTION
## Summary

Fixes an issue where activating the Labs Select menu caused the browser to scroll to the top of the page.

In #535, we modified Select to focus the menu inside of a `useLayoutEffect` call with an empty dependency array (previously, focus was being applied to the menu using Popper's `onFirstUpdate`). This had the unintended consequence of causing the browser to scroll to the top of the page whenever a Select menu was activated -- we suspect focus was being applied after the menu had been rendered but _before_ it had been positioned by Popper, thus causing the browser to scroll to the top of the page where the menu is originally positioned prior to being moved by Popper.

As an immediate fix, I've reverted to the previous method of focusing the menu using `onFirstUpdate`. The long-term solution to this issue (and other similar timing issues) may involve creating a programmatic focus function to handle these issues in a more centralized fashion.

I've also added a Cypress test to protect against this regression in the future.