### PR TITLE
fix(select): Support aria-required

### DIFF
--- a/cypress/integration/SelectLabs.spec.ts
+++ b/cypress/integration/SelectLabs.spec.ts
@@ -707,4 +707,38 @@ describe('Select', () => {
       }
     );
   });
+
+  context(`given the "Accessibility Test" story is rendered`, () => {
+    beforeEach(() => {
+      h.stories.load('Testing|React/Labs/Select', 'Accessibility Test');
+    });
+
+    context('when the select button with aria-required set to true is clicked', () => {
+      beforeEach(() => {
+        cy.findByLabelText(/Label \(aria-required\)/).click();
+      });
+
+      context('the menu', () => {
+        it('should have an aria-required attribute set to "true"', () => {
+          cy.findByLabelText(/Label \(aria-required\)/)
+            .pipe(h.selectLabs.getMenu)
+            .should('have.attr', 'aria-required', 'true');
+        });
+      });
+    });
+
+    context('when the select button with required set to true is clicked', () => {
+      beforeEach(() => {
+        cy.findByLabelText(/Label \(required\)/).click();
+      });
+
+      context('the menu', () => {
+        it('should have an aria-required attribute set to "true"', () => {
+          cy.findByLabelText(/Label \(required\)/)
+            .pipe(h.selectLabs.getMenu)
+            .should('have.attr', 'aria-required', 'true');
+        });
+      });
+    });
+  });
 });

--- a/modules/_labs/select/react/lib/SelectBase.tsx
+++ b/modules/_labs/select/react/lib/SelectBase.tsx
@@ -60,6 +60,7 @@ export interface CoreSelectBaseProps
   extends Themeable,
     GrowthBehavior,
     Pick<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'>,
+    Pick<React.SelectHTMLAttributes<HTMLSelectElement>, 'required'>,
     Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onChange'> {
   /**
    * The type of error associated with the Select (if applicable).
@@ -379,6 +380,7 @@ export default class SelectBase extends React.Component<SelectBaseProps> {
       onMenuBlur,
       onMenuCloseOnEscape,
       options,
+      required,
       shouldMenuAnimate,
       shouldMenuAutoFlip,
       shouldMenuAutoFocus,
@@ -428,7 +430,7 @@ export default class SelectBase extends React.Component<SelectBaseProps> {
           <SelectMenu
             aria-activedescendant={options[focusedOptionIndex].id}
             aria-labelledby={ariaLabelledBy}
-            aria-required={ariaRequired}
+            aria-required={ariaRequired || required}
             buttonRef={buttonRef}
             id={this.menuId}
             error={error}

--- a/modules/_labs/select/react/lib/SelectBase.tsx
+++ b/modules/_labs/select/react/lib/SelectBase.tsx
@@ -363,6 +363,7 @@ export default class SelectBase extends React.Component<SelectBaseProps> {
   public render() {
     const {
       'aria-labelledby': ariaLabelledBy,
+      'aria-required': ariaRequired,
       buttonRef,
       disabled,
       error,
@@ -427,6 +428,7 @@ export default class SelectBase extends React.Component<SelectBaseProps> {
           <SelectMenu
             aria-activedescendant={options[focusedOptionIndex].id}
             aria-labelledby={ariaLabelledBy}
+            aria-required={ariaRequired}
             buttonRef={buttonRef}
             id={this.menuId}
             error={error}

--- a/modules/_labs/select/react/spec/Select.spec.tsx
+++ b/modules/_labs/select/react/spec/Select.spec.tsx
@@ -41,6 +41,14 @@ describe('Select', () => {
     });
   });
 
+  describe('when rendered with the required prop', () => {
+    it('should apply aria-required to its menu listbox when the menu is activated', () => {
+      const {getByRole} = render(<Select onChange={cb} options={options} required={true} />);
+      fireEvent.click(getByRole(selectButtonRole));
+      expect(getByRole(listboxRole)).toHaveAttribute('aria-required', 'true');
+    });
+  });
+
   describe('when an option with a different value than the current value of the select is clicked', () => {
     it('should call the onChange callback', () => {
       const {getAllByRole, getByRole} = render(<Select onChange={cb} options={options} />);

--- a/modules/_labs/select/react/spec/Select.spec.tsx
+++ b/modules/_labs/select/react/spec/Select.spec.tsx
@@ -6,6 +6,7 @@ describe('Select', () => {
   const cb = jest.fn();
 
   const selectButtonRole = 'button';
+  const listboxRole = 'listbox';
   const optionRole = 'option';
 
   const options = [
@@ -29,6 +30,14 @@ describe('Select', () => {
     it('should render a disabled button', () => {
       const {getByRole} = render(<Select disabled={true} onChange={cb} options={options} />);
       expect(getByRole(selectButtonRole)).toHaveProperty('disabled', true);
+    });
+  });
+
+  describe('when rendered with the aria-required prop', () => {
+    it('should apply aria-required to its menu listbox when the menu is activated', () => {
+      const {getByRole} = render(<Select onChange={cb} options={options} aria-required={true} />);
+      fireEvent.click(getByRole(selectButtonRole));
+      expect(getByRole(listboxRole)).toHaveAttribute('aria-required', 'true');
     });
   });
 

--- a/modules/_labs/select/react/stories/stories_testing.tsx
+++ b/modules/_labs/select/react/stories/stories_testing.tsx
@@ -56,6 +56,29 @@ const SelectModal = () => {
   );
 };
 
+export const AccessibilityTest = () => (
+  <div>
+    <Container>
+      <p>
+        This Select has its <strong>aria-required</strong> prop set to true. When its listbox menu
+        is opened, we expect aria-required to be set to "true" for the listbox.
+      </p>
+      <FormField label="Label (aria-required)" inputId="select-aria-required" required={true}>
+        {controlComponent(
+          <Select name="select-aria-required" options={options} aria-required={true} />
+        )}
+      </FormField>
+      <p>
+        This Select has its <strong>required</strong> prop set to true. Again, when its listbox menu
+        is opened, we expect aria-required to be set to "true" for the listbox.
+      </p>
+      <FormField label="Label (required)" inputId="select-required" required={true}>
+        {controlComponent(<Select name="select-required" options={options} required={true} />)}
+      </FormField>
+    </Container>
+  </div>
+);
+
 export const PortalTest = () => (
   <div>
     <Container>


### PR DESCRIPTION
## Summary

Fixes #781.

Previously, the Labs Select was throwing an a11y violation when assigned the `aria-required` prop (the Select is rendered using a `button` and `button` isn't allowed to have `aria-required`). This PR adds special handling which passes `aria-required` along to the Select Menu to be applied to the `listbox` in accordance with Workday Accessibility's requirements.

I've also added a corresponding Cypress and unit tests.