### PR TITLE
fix(color-picker): Prevent enter key fowarding to next focus target

### DIFF
--- a/cypress/integration/ColorPicker.spec.ts
+++ b/cypress/integration/ColorPicker.spec.ts
@@ -224,4 +224,20 @@ describe('ColorPicker', () => {
       });
     });
   });
+
+  context('when the InputInteraction story is loaded', () => {
+    beforeEach(() => {
+      h.stories.load('Testing|React/Inputs/ColorPicker', 'InputInteraction');
+    });
+
+    context('when input is entered into the color input and user hits enter', () => {
+      beforeEach(() => {
+        cy.findByLabelText('Custom Hex Color').type('111{enter}');
+      });
+
+      it('should not enter a newline in the textarea', () => {
+        cy.findByLabelText('Text Area').should('have.value', '');
+      });
+    });
+  });
 });

--- a/cypress/integration/ColorPicker.spec.ts
+++ b/cypress/integration/ColorPicker.spec.ts
@@ -227,7 +227,7 @@ describe('ColorPicker', () => {
 
   context('when the InputInteraction story is loaded', () => {
     beforeEach(() => {
-      h.stories.load('Testing|React/Inputs/ColorPicker', 'InputInteraction');
+      h.stories.load('Testing|React/Labs/Color Picker', 'InputInteraction');
     });
 
     context('when input is entered into the color input and user hits enter', () => {

--- a/modules/_labs/color-picker/react/README.md
+++ b/modules/_labs/color-picker/react/README.md
@@ -146,7 +146,7 @@ Default: `Custom Hex Color`
 
 ---
 
-#### `onSubmitClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void`
+#### `onSubmitClick: (event: React.FormEvent) => void`
 
 > When this handler is provided, an action can be tied to clicking the check button provided. This
 > handler is called when the check button is selected through a keyboard event only.

--- a/modules/_labs/color-picker/react/lib/ColorPicker.tsx
+++ b/modules/_labs/color-picker/react/lib/ColorPicker.tsx
@@ -29,14 +29,19 @@ export interface ColorPickerProps extends React.HTMLAttributes<HTMLDivElement> {
    */
   showCustomHexInput?: boolean;
   /**
-   * The label text of the custom hex input. This is also used as the aria-label
+   * The label text of the custom hex input.
    * @default 'Custom Hex Color'
    */
   customHexInputLabel?: string;
   /**
+   * The label of the custom hex color submit icon button.
+   * @default 'Submit'
+   */
+  submitLabel?: string;
+  /**
    * The function called when the submit icon is clicked.
    */
-  onSubmitClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+  onSubmitClick?: (event: React.FormEvent) => void;
   /**
    * The function called when the color rest button is selected.
    * It is required to be set for the reset button to render.
@@ -83,7 +88,7 @@ const defaultColors = [
   colors.blackPepper400,
 ];
 
-const ColorInputWrapper = styled('div')({
+const ColorInputWrapper = styled('form')({
   width: '100%',
   marginTop: spacing.s,
   display: 'flex',
@@ -117,6 +122,7 @@ const isCustomColor = (colors: string[], hexCode?: string) => {
 const ColorPicker = ({
   colorSet = defaultColors,
   customHexInputLabel = 'Custom Hex Color',
+  submitLabel = 'Submit',
   onColorChange,
   onColorReset,
   onSubmitClick,
@@ -138,17 +144,12 @@ const ColorPicker = ({
 
   const onValidCustomHexChange = (validHexValue: string) => setValidHexValue(validHexValue);
 
-  const onCustomInputKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === 'Enter' && validHexValue) {
-      onColorChange(validHexValue);
-    }
-  };
-
-  const onCheckClick = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+  const onSubmit = (event: React.FormEvent) => {
     if (onSubmitClick) {
       onSubmitClick(event);
     }
     onColorChange(validHexValue);
+    event.preventDefault(); // don't submit the form - default action is to reload the page
   };
 
   return (
@@ -158,21 +159,19 @@ const ColorPicker = ({
       )}
       <SwatchBook colors={colorSet} onSelect={onColorChange} value={value} />
       {showCustomHexInput && (
-        <ColorInputWrapper>
+        <ColorInputWrapper onSubmit={onSubmit}>
           <ColorInputAndLabel label={customHexInputLabel}>
             <HexColorInput
               onChange={onCustomHexChange}
-              onKeyDown={onCustomInputKeyDown}
               onValidColorChange={onValidCustomHexChange}
               value={customHexValue}
               showCheck={value === validHexValue || value === customHexValue}
             />
           </ColorInputAndLabel>
           <CheckButton
-            aria-label={customHexInputLabel}
+            aria-label={submitLabel}
             variant={IconButton.Variant.CircleFilled}
             icon={checkIcon}
-            onClick={onCheckClick}
           />
         </ColorInputWrapper>
       )}

--- a/modules/_labs/color-picker/react/stories/stories_ColorPicker.tsx
+++ b/modules/_labs/color-picker/react/stories/stories_ColorPicker.tsx
@@ -8,7 +8,7 @@ import {colors} from '@workday/canvas-kit-react-core';
 import {Popper} from '@workday/canvas-kit-react-popup';
 import {IconButton} from '@workday/canvas-kit-react-button';
 import {bgColorIcon} from '@workday/canvas-system-icons-web';
-import {ColorPicker} from '../index';
+import {ColorPicker} from '@workday/canvas-kit-labs-react-color-picker';
 import README from '../README.md';
 
 storiesOf('Labs|Color Picker/React', module)

--- a/modules/_labs/color-picker/react/stories/stories_testing.tsx
+++ b/modules/_labs/color-picker/react/stories/stories_testing.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import {ColorPicker} from '@workday/canvas-kit-labs-react-color-picker';
+
+export default {
+  title: 'Testing|React/Inputs/ColorPicker',
+  component: ColorPicker,
+};
+
+export const InputInteraction = () => {
+  const textAreaRef = React.useRef(null);
+  const [color, setColor] = React.useState('');
+  const handleColorChange = (c: string) => {
+    setColor(c);
+    textAreaRef.current?.focus();
+  };
+  return (
+    <div className="App">
+      <ColorPicker showCustomHexInput onColorChange={handleColorChange} />
+      <label htmlFor="test">Text Area</label>
+      <textarea id="test" style={{color: color}} ref={textAreaRef} />
+    </div>
+  );
+};

--- a/modules/_labs/color-picker/react/stories/stories_testing.tsx
+++ b/modules/_labs/color-picker/react/stories/stories_testing.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {ColorPicker} from '@workday/canvas-kit-labs-react-color-picker';
 
 export default {
-  title: 'Testing|React/Inputs/ColorPicker',
+  title: 'Testing|React/Labs/Color Picker',
   component: ColorPicker,
 };
 


### PR DESCRIPTION
Fixes #760

<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

The original implementation used keydown to detect the "Enter" key and fire the `onColorChange` event. If focus is transferred during the timing of this event, the enter key will actually be forwarded to the next target. This isn't exactly what we want.

This PR moves the custom color input into a `form` element and uses the submit event to handle special functionality like the enter key. This is a more accessible option.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md

