### PR TITLE
fix(menu): Delay focus to prevent scrolling

### DIFF
--- a/modules/_labs/menu/react/lib/Menu.tsx
+++ b/modules/_labs/menu/react/lib/Menu.tsx
@@ -62,6 +62,7 @@ const List = styled('ul')({
 
 export default class Menu extends React.Component<MenuProps, MenuState> {
   private id = uuid();
+  private animateId: number;
 
   private menuRef: React.RefObject<HTMLUListElement>;
   private firstCharacters: string[];
@@ -89,14 +90,20 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
     if (this.props.isOpen && !prevProps.isOpen) {
       this.setInitialSelectedItem();
     }
-    if (this.props.isOpen && this.menuRef.current) {
-      this.menuRef.current.focus();
-    }
+    this.animateId = requestAnimationFrame(() => {
+      if (this.props.isOpen && this.menuRef.current) {
+        this.menuRef.current.focus();
+      }
+    });
   }
 
   componentDidMount() {
     this.setFirstCharacters();
     this.setInitialSelectedItem();
+  }
+
+  componentWillUnmount() {
+    cancelAnimationFrame(this.animateId);
   }
 
   public render() {


### PR DESCRIPTION
Fixes #632

## Summary

Prevent scrolling the page. The Menu calls `focus` on the `ul` on mount, but this is before PopperJS positions the menu. This causes the browser to scroll to the top of the page (default position of the Popper until positioning). This change delays the `focus` call until after the Popper is positioned.

We'll have a more robust focus utility function later. VoiceOver on iOS has issues with setting focus on newly created DOM too early. See #694

## Additional References

![menu-not-scrolling-on-open](https://user-images.githubusercontent.com/338257/88415735-38d07800-cd9c-11ea-9f24-87dc770c1685.gif)

