### PR TITLE
fix(skeleton): Remove aria-live and add loading text content

### DIFF
--- a/modules/skeleton/react/lib/skeleton.tsx
+++ b/modules/skeleton/react/lib/skeleton.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import styled from '@emotion/styled';
 import {keyframes} from '@emotion/core';
 import canvas from '@workday/canvas-kit-react-core';
+import {accessibleHide} from '@workday/canvas-kit-react-common';
 
 export interface SkeletonProps {
   /**
@@ -14,6 +15,8 @@ export interface SkeletonProps {
 const TRANSPARENCY_POSITION = 45;
 const WHITE_SHEEN_WIDTH = 10;
 const DURATION = 5;
+
+const AccessibleHide = styled('div')(accessibleHide);
 
 const SkeletonAnimator = styled('div')<{diagonal: number; topPosition: number; width: number}>(
   ({diagonal, topPosition, width}) => {
@@ -72,13 +75,8 @@ export default class Skeleton extends React.Component<SkeletonProps, SkeletonSta
     const {loadingLabel} = this.props;
 
     return (
-      <SkeletonContainer
-        aria-label={loadingLabel}
-        aria-live={'polite'}
-        role={'status'}
-        ref={this.ref}
-        {...elemProps}
-      >
+      <SkeletonContainer ref={this.ref} {...elemProps}>
+        <AccessibleHide>{loadingLabel}</AccessibleHide>
         <SkeletonAnimator diagonal={diagonal} topPosition={topPosition} width={width} />
         <div aria-hidden={true}>{children}</div>
       </SkeletonContainer>

--- a/modules/skeleton/react/package.json
+++ b/modules/skeleton/react/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@emotion/core": "^10.0.28",
     "@emotion/styled": "^10.0.27",
-    "@workday/canvas-kit-react-core": "^3.9.1"
+    "@workday/canvas-kit-react-core": "^3.9.1",
+    "@workday/canvas-kit-react-common": "^3.9.1"
   }
 }

--- a/modules/skeleton/react/spec/skeleton.spec.tsx
+++ b/modules/skeleton/react/spec/skeleton.spec.tsx
@@ -1,87 +1,52 @@
 import * as React from 'react';
-import {mount} from 'enzyme';
+import {render} from '@testing-library/react';
 import Skeleton from '../lib/skeleton';
 
 describe('Skeleton', () => {
   it('should render', () => {
-    const subject = mount(
+    const screen = render(
       <Skeleton>
-        <span> Hello </span>
+        <span>Hello</span>
       </Skeleton>
     );
 
-    expect(subject).toHaveLength(1);
-    subject.unmount();
+    expect(screen.container).toHaveTextContent('Hello');
   });
 
-  test('Skeleton should spread extra props', () => {
-    const component = mount(<Skeleton data-propspread="test" />);
-    const container = component.at(0).getDOMNode();
-    expect(container.getAttribute('data-propspread')).toBe('test');
-    component.unmount();
+  it('Skeleton should spread extra props', () => {
+    const screen = render(<Skeleton data-propspread="test" />);
+    expect(screen.container.firstChild).toHaveAttribute('data-propspread', 'test');
   });
 
   describe('Accessibility', () => {
     it('should add aria-hidden to all of the children', () => {
-      const subject = mount(
+      const screen = render(
         <Skeleton>
-          <span> Hello </span>
+          <span data-testid="span">Hello</span>
         </Skeleton>
       );
 
-      expect(
-        subject
-          .find('div')
-          .at(2)
-          .getDOMNode()
-          .getAttribute('aria-hidden')
-      ).toEqual('true');
-      subject.unmount();
+      expect(screen.getByTestId('span').parentElement).toHaveAttribute('aria-hidden', 'true');
     });
-    it('should have role status', () => {
-      const subject = mount(
+
+    it('should have a text element with the loading label', () => {
+      const screen = render(
         <Skeleton>
-          <span> Hello </span>
+          <span data-testid="span">Hello</span>
         </Skeleton>
       );
 
-      expect(
-        subject
-          .first()
-          .getDOMNode()
-          .getAttribute('role')
-      ).toEqual('status');
-      subject.unmount();
+      expect(screen.container).toHaveTextContent('Loading');
     });
-    it('should have aria-live polite', () => {
-      const subject = mount(
-        <Skeleton>
-          <span> Hello </span>
+
+    it('should have a text element with a custom loading label', () => {
+      const screen = render(
+        <Skeleton loadingLabel="Loading items">
+          <span data-testid="span">Hello</span>
         </Skeleton>
       );
 
-      expect(
-        subject
-          .first()
-          .getDOMNode()
-          .getAttribute('aria-live')
-      ).toEqual('polite');
-      subject.unmount();
-    });
-    it('should have aria-label loading', () => {
-      const subject = mount(
-        <Skeleton>
-          <span> Hello </span>
-        </Skeleton>
-      );
-
-      expect(
-        subject
-          .first()
-          .getDOMNode()
-          .getAttribute('aria-label')
-      ).toEqual('Loading');
-      subject.unmount();
+      expect(screen.container).toHaveTextContent('Loading items');
     });
   });
 });


### PR DESCRIPTION
Fixes #792

Removes aria-live from Skeleton loaders and replaces with visually-hidden text content for a better and more consistent screen reader experience.
