### PR TITLE
fix(menu): Auto scroll to selected menu item if necessary

### DIFF
--- a/cypress/integration/Menu.spec.ts
+++ b/cypress/integration/Menu.spec.ts
@@ -1,0 +1,55 @@
+import * as h from '../helpers';
+
+function getAssistiveFocus($menu: JQuery): JQuery {
+  const activeId = $menu.attr('aria-activedescendant');
+  return $menu.find(`[id="${activeId}"]`);
+}
+
+function assertOptionInView($option: JQuery) {
+  const option = $option[0];
+  const menu = option.parentElement;
+
+  const optionBox = option.getBoundingClientRect();
+  const menuBox = menu.getBoundingClientRect();
+
+  expect(optionBox)
+    .property('top')
+    .to.be.gte(menuBox.top);
+  expect(optionBox)
+    .property('bottom')
+    .to.be.lte(menuBox.bottom);
+}
+
+describe('Menu', () => {
+  before(() => {
+    h.stories.visit();
+  });
+
+  context('given "With Many Items" story is rendered', () => {
+    beforeEach(() => {
+      h.stories.load('Labs|Menu/React', 'With Many Items');
+    });
+
+    it('should not have any axe errors', () => {
+      cy.checkA11y();
+    });
+
+    context('when the menu is opened', () => {
+      beforeEach(() => {
+        cy.findByText('Open Menu').click();
+      });
+
+      context('when the up arrow is pressed', () => {
+        beforeEach(() => {
+          cy.focused().type('{uparrow}');
+        });
+
+        it('should do something', () => {
+          cy.findByRole('menu')
+            .pipe(getAssistiveFocus)
+            .should(assertOptionInView);
+        });
+      });
+    });
+  });
+});

--- a/modules/_labs/menu/react/lib/MenuItem.tsx
+++ b/modules/_labs/menu/react/lib/MenuItem.tsx
@@ -228,7 +228,6 @@ export default class MenuItem extends React.Component<MenuItemProps> {
 
   componentDidUpdate = (prevProps: MenuItemProps) => {
     if (!prevProps.isFocused && this.props.isFocused) {
-      console.log('ref', this.ref);
       if (this.ref.current) {
         scrollIntoViewIfNeeded(this.ref.current);
       }

--- a/modules/_labs/menu/react/lib/MenuItem.tsx
+++ b/modules/_labs/menu/react/lib/MenuItem.tsx
@@ -175,10 +175,64 @@ const setIconProps = (
   return props;
 };
 
+const scrollIntoViewIfNeeded = (elem: HTMLElement, centerIfNeeded = true): void => {
+  const parent: HTMLElement | null = elem.parentElement;
+
+  if (elem && parent) {
+    const parentComputedStyle = window.getComputedStyle(parent, null),
+      parentBorderTopWidth = parseInt(parentComputedStyle.getPropertyValue('border-top-width'), 10),
+      parentBorderLeftWidth = parseInt(
+        parentComputedStyle.getPropertyValue('border-left-width'),
+        10
+      ),
+      overTop = elem.offsetTop - parent.offsetTop < parent.scrollTop,
+      overBottom =
+        elem.offsetTop - parent.offsetTop + elem.clientHeight - parentBorderTopWidth >
+        parent.scrollTop + parent.clientHeight,
+      overLeft = elem.offsetLeft - parent.offsetLeft < parent.scrollLeft,
+      overRight =
+        elem.offsetLeft - parent.offsetLeft + elem.clientWidth - parentBorderLeftWidth >
+        parent.scrollLeft + parent.clientWidth,
+      alignWithTop = overTop && !overBottom;
+
+    if ((overTop || overBottom) && centerIfNeeded) {
+      parent.scrollTop =
+        elem.offsetTop -
+        parent.offsetTop -
+        parent.clientHeight / 2 -
+        parentBorderTopWidth +
+        elem.clientHeight / 2;
+    }
+
+    if ((overLeft || overRight) && centerIfNeeded) {
+      parent.scrollLeft =
+        elem.offsetLeft -
+        parent.offsetLeft -
+        parent.clientWidth / 2 -
+        parentBorderLeftWidth +
+        elem.clientWidth / 2;
+    }
+
+    if ((overTop || overBottom || overLeft || overRight) && !centerIfNeeded) {
+      elem.scrollIntoView(alignWithTop);
+    }
+  }
+};
+
 export default class MenuItem extends React.Component<MenuItemProps> {
   static defaultProps = {
     shouldClose: true,
     role: 'menuitem',
+  };
+  ref = React.createRef<HTMLLIElement>();
+
+  componentDidUpdate = (prevProps: MenuItemProps) => {
+    if (!prevProps.isFocused && this.props.isFocused) {
+      console.log('ref', this.ref);
+      if (this.ref.current) {
+        scrollIntoViewIfNeeded(this.ref.current);
+      }
+    }
   };
 
   render(): React.ReactNode {
@@ -202,6 +256,7 @@ export default class MenuItem extends React.Component<MenuItemProps> {
       <>
         {hasDivider && <Divider />}
         <Item
+          ref={this.ref}
           tabIndex={-1}
           id={id}
           role={role}

--- a/modules/_labs/menu/react/stories/stories.tsx
+++ b/modules/_labs/menu/react/stories/stories.tsx
@@ -79,7 +79,7 @@ interface ControlledMenuState {
   anchorEl: HTMLElement | null;
   selectedItemIndex: number;
 }
-class ControlledMenu extends React.Component<{}, ControlledMenuState> {
+class ControlledMenu extends React.Component<{items?: React.ReactElement[]}, ControlledMenuState> {
   private menuId: string;
   private controlButtonId: string;
   private buttonRef: React.RefObject<HTMLButtonElement>;
@@ -119,13 +119,14 @@ class ControlledMenu extends React.Component<{}, ControlledMenuState> {
           >
             <div style={{opacity: isOpen ? 1 : 0, display: isOpen ? `initial` : `none`}}>
               <Menu
+                style={{maxHeight: 400, overflowY: 'auto'}}
                 initialSelectedItem={selectedItemIndex}
                 isOpen={isOpen}
                 onClose={this.handleClose}
                 id={this.menuId}
                 labeledBy={this.controlButtonId}
               >
-                {createMenuItems().map(buildItem)}
+                {this.props.items || createMenuItems().map(buildItem)}
               </Menu>
             </div>
           </Popper>
@@ -138,7 +139,6 @@ class ControlledMenu extends React.Component<{}, ControlledMenuState> {
     this.setState({
       anchorEl: currentTarget,
       isOpen: !this.state.isOpen,
-      selectedItemIndex: 0,
     });
   };
   private handleClose = () => {
@@ -289,6 +289,18 @@ storiesOf('Labs|Menu/React', module)
             Second
           </CustomMenuItem>
         </Menu>
+      </div>
+    );
+  })
+  .add('With Many Items', () => {
+    return (
+      <div className="story">
+        <ControlledMenu
+          items={'One Two Three Four Five Six Seven Eight Nine Ten Eleven Twelve Thirteen Fourteen Fifteen Sixteen Seventeen'
+            .split(' ')
+            .map(text => ({text: `Item ${text}`}))
+            .map(buildItem)}
+        />
       </div>
     );
   });


### PR DESCRIPTION
Fixes #808 

## Summary

Add `scrollIntoViewIfNecessary` to the `MenuItem` to make sure it is focused item is visible. Uses the same algorithm as the Labs select menu

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
![menu-item-scroll](https://user-images.githubusercontent.com/338257/89088308-cc81e580-d354-11ea-99e7-dee2d3278767.gif)
