### PR TITLE
ci: Add new issues into Backlog project

### DIFF
--- a/blank.yml
+++ b/blank.yml
@@ -1,0 +1,15 @@
+name: Add new issues into Backlog project
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  automate-project-columns:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.2.4
+        with:
+          project: Backlog
+          column: Open
+          repo-token: ${{ secrets.GH_RW_TOKEN }}


### PR DESCRIPTION
This workflow file will run when an issue is first opened, adding it to the `Backlog` project and the `Open` column. It uses the `GH_RW_TOKEN` secret which is currently one of my personal tokens. We can update this secret at any time to any account we want.

I was unable to get the `GITHUB_TOKEN` to work as expected: https://github.com/NicholasBoll/test-github-actions/actions/runs/198099260. If we can get the `GITHUB_TOKEN` to work in the future, we should use that so the account shows up as the github_actions account instead of mine. For now, I'm just magically triaging every new issue! Yay me!