### PR TITLE
fix(color-picker): Fix IE rendering for color picker swatchbook

### DIFF
--- a/modules/_labs/color-picker/react/lib/ColorPicker.tsx
+++ b/modules/_labs/color-picker/react/lib/ColorPicker.tsx
@@ -3,6 +3,7 @@ import {checkIcon} from '@workday/canvas-system-icons-web';
 import {ColorInput} from '@workday/canvas-kit-react-color-picker';
 import {IconButton} from '@workday/canvas-kit-react-button';
 import {Popup} from '@workday/canvas-kit-react-popup';
+import {TransformOrigin} from '@workday/canvas-kit-react-common';
 import * as React from 'react';
 import FormField from '@workday/canvas-kit-react-form-field';
 import styled from '@emotion/styled';
@@ -57,6 +58,11 @@ export interface ColorPickerProps extends React.HTMLAttributes<HTMLDivElement> {
    * @default 'Reset'
    */
   resetLabel?: string;
+  /**
+   * The origin from which the Toast will animate.
+   * @default {horizontal: 'center', vertical: 'top'}
+   */
+  transformOrigin?: TransformOrigin;
 }
 
 const defaultColors = [

--- a/modules/_labs/color-picker/react/lib/ColorPicker.tsx
+++ b/modules/_labs/color-picker/react/lib/ColorPicker.tsx
@@ -136,6 +136,7 @@ const ColorPicker = ({
   resetColor,
   value = '',
   showCustomHexInput = false,
+  transformOrigin,
   ...elemProps
 }: ColorPickerProps) => {
   const [validHexValue, setValidHexValue] = React.useState('');
@@ -159,7 +160,13 @@ const ColorPicker = ({
   };
 
   return (
-    <Popup width={250} padding={Popup.Padding.s} data-testid="canvas-color-picker" {...elemProps}>
+    <Popup
+      width={250}
+      padding={Popup.Padding.s}
+      transformOrigin={transformOrigin}
+      data-testid="canvas-color-picker"
+      {...elemProps}
+    >
       {onColorReset && resetColor && (
         <ResetButton onClick={onColorReset} resetColor={resetColor} label={resetLabel} />
       )}

--- a/modules/_labs/color-picker/react/lib/ColorPicker.tsx
+++ b/modules/_labs/color-picker/react/lib/ColorPicker.tsx
@@ -59,7 +59,7 @@ export interface ColorPickerProps extends React.HTMLAttributes<HTMLDivElement> {
    */
   resetLabel?: string;
   /**
-   * The origin from which the Toast will animate.
+   * The origin from which the Color Picker will animate.
    * @default {horizontal: 'center', vertical: 'top'}
    */
   transformOrigin?: TransformOrigin;

--- a/modules/_labs/color-picker/react/lib/parts/SwatchBook.tsx
+++ b/modules/_labs/color-picker/react/lib/parts/SwatchBook.tsx
@@ -4,8 +4,6 @@ import {borderRadius, colors, spacing} from '@workday/canvas-kit-react-core';
 import {focusRing, mouseFocusBehavior} from '@workday/canvas-kit-react-common';
 import {ColorSwatch} from '@workday/canvas-kit-react-color-picker';
 
-const numberOfSwatchColumns = 8;
-
 export interface SwatchBookProps {
   colors: string[];
   value?: string;
@@ -14,7 +12,6 @@ export interface SwatchBookProps {
 
 interface SwatchContainerProps {
   isSelected: boolean;
-  index: number;
 }
 
 const accessibilityBorder = `${colors.frenchVanilla100} 0px 0px 0px 2px, ${colors.licorice200} 0px 0px 0px 3px`;
@@ -22,9 +19,6 @@ const accessibilityBorder = `${colors.frenchVanilla100} 0px 0px 0px 2px, ${color
 const SwatchContainer = styled('div')<SwatchContainerProps>(
   {
     display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    position: 'relative',
     width: 20,
     height: 20,
     cursor: 'pointer',
@@ -41,10 +35,6 @@ const SwatchContainer = styled('div')<SwatchContainerProps>(
       ...focusRing({separation: 2}),
     },
   },
-  ({index}) => ({
-    '-ms-grid-column': (index % numberOfSwatchColumns) + 1 + '',
-    '-ms-grid-row': Math.ceil((index + 1) / numberOfSwatchColumns) + '',
-  }),
   ({isSelected}) => ({
     boxShadow: isSelected ? accessibilityBorder : undefined,
     ...mouseFocusBehavior({
@@ -63,8 +53,8 @@ const SwatchContainer = styled('div')<SwatchContainerProps>(
 );
 
 const Container = styled('div')({
-  display: ['-ms-grid', 'grid'],
-  gridTemplateColumns: `repeat(${numberOfSwatchColumns}, auto)`,
+  display: 'flex',
+  flexWrap: 'wrap',
   margin: `0px -${spacing.xxs} -${spacing.xxs} 0px`,
 });
 
@@ -90,7 +80,6 @@ export const SwatchBook = ({colors, value, onSelect}: SwatchBookProps) => (
           onKeyDown={handleKeyDown}
           tabIndex={0}
           isSelected={isSelected}
-          index={index}
         >
           <ColorSwatch color={color} showCheck={isSelected} />
         </SwatchContainer>

--- a/modules/_labs/color-picker/react/lib/parts/SwatchBook.tsx
+++ b/modules/_labs/color-picker/react/lib/parts/SwatchBook.tsx
@@ -4,7 +4,7 @@ import {borderRadius, colors, spacing} from '@workday/canvas-kit-react-core';
 import {focusRing, mouseFocusBehavior} from '@workday/canvas-kit-react-common';
 import {ColorSwatch} from '@workday/canvas-kit-react-color-picker';
 
-const numberOfSwatchColumns: number = 8;
+const numberOfSwatchColumns = 8;
 
 export interface SwatchBookProps {
   colors: string[];

--- a/modules/_labs/color-picker/react/lib/parts/SwatchBook.tsx
+++ b/modules/_labs/color-picker/react/lib/parts/SwatchBook.tsx
@@ -63,7 +63,7 @@ const SwatchContainer = styled('div')<SwatchContainerProps>(
 );
 
 const Container = styled('div')({
-  display: ['grid', '-ms-grid'],
+  display: ['-ms-grid', 'grid'],
   gridTemplateColumns: `repeat(${numberOfSwatchColumns}, auto)`,
   margin: `0px -${spacing.xxs} -${spacing.xxs} 0px`,
 });

--- a/modules/_labs/color-picker/react/lib/parts/SwatchBook.tsx
+++ b/modules/_labs/color-picker/react/lib/parts/SwatchBook.tsx
@@ -4,6 +4,8 @@ import {borderRadius, colors, spacing} from '@workday/canvas-kit-react-core';
 import {focusRing, mouseFocusBehavior} from '@workday/canvas-kit-react-common';
 import {ColorSwatch} from '@workday/canvas-kit-react-color-picker';
 
+const numberOfSwatchColumns: number = 8;
+
 export interface SwatchBookProps {
   colors: string[];
   value?: string;
@@ -12,6 +14,7 @@ export interface SwatchBookProps {
 
 interface SwatchContainerProps {
   isSelected: boolean;
+  index: number;
 }
 
 const accessibilityBorder = `${colors.frenchVanilla100} 0px 0px 0px 2px, ${colors.licorice200} 0px 0px 0px 3px`;
@@ -27,6 +30,7 @@ const SwatchContainer = styled('div')<SwatchContainerProps>(
     cursor: 'pointer',
     borderRadius: borderRadius.s,
     transition: 'box-shadow 120ms ease',
+    margin: `0px ${spacing.xxs} ${spacing.xxs} 0px`,
 
     '&:hover': {
       boxShadow: accessibilityBorder,
@@ -37,6 +41,10 @@ const SwatchContainer = styled('div')<SwatchContainerProps>(
       ...focusRing({separation: 2}),
     },
   },
+  ({index}) => ({
+    '-ms-grid-column': (index % numberOfSwatchColumns) + 1 + '',
+    '-ms-grid-row': Math.ceil((index + 1) / numberOfSwatchColumns) + '',
+  }),
   ({isSelected}) => ({
     boxShadow: isSelected ? accessibilityBorder : undefined,
     ...mouseFocusBehavior({
@@ -55,9 +63,9 @@ const SwatchContainer = styled('div')<SwatchContainerProps>(
 );
 
 const Container = styled('div')({
-  display: 'grid',
-  gridTemplateColumns: 'repeat(8, auto)',
-  gridGap: spacing.xxs,
+  display: ['grid', '-ms-grid'],
+  gridTemplateColumns: `repeat(${numberOfSwatchColumns}, auto)`,
+  margin: `0px -${spacing.xxs} -${spacing.xxs} 0px`,
 });
 
 export const SwatchBook = ({colors, value, onSelect}: SwatchBookProps) => (
@@ -82,6 +90,7 @@ export const SwatchBook = ({colors, value, onSelect}: SwatchBookProps) => (
           onKeyDown={handleKeyDown}
           tabIndex={0}
           isSelected={isSelected}
+          index={index}
         >
           <ColorSwatch color={color} showCheck={isSelected} />
         </SwatchContainer>

--- a/modules/_labs/color-picker/react/stories/stories_VisualTesting.tsx
+++ b/modules/_labs/color-picker/react/stories/stories_VisualTesting.tsx
@@ -1,0 +1,44 @@
+/// <reference path="../../../../../typings.d.ts" />
+/** @jsx jsx */
+import {jsx} from '@emotion/core';
+import {colors} from '@workday/canvas-kit-react-core';
+import {StaticStates} from '@workday/canvas-kit-labs-react-core';
+import {action} from '@storybook/addon-actions';
+import {ComponentStatesTable, withSnapshotsEnabled} from '../../../../../utils/storybook';
+import ColorPicker from '../lib/ColorPicker';
+
+export default withSnapshotsEnabled({
+  title: 'Testing|React/Labs/Color Picker',
+  component: ColorPicker,
+});
+
+export const ColorPickerStates = () => (
+  <StaticStates>
+    <ComponentStatesTable
+      rowProps={[
+        {label: 'Default', props: {}},
+        {label: 'with Hex Input', props: {showCustomHexInput: true}},
+        {
+          label: 'With Reset',
+          props: {
+            resetColor: colors.blueberry400,
+            resetLabel: 'Reset',
+            onColorReset: action('Reset Clicked'),
+          },
+        },
+        {
+          label: 'With Reset and Hex Input',
+          props: {
+            showCustomHexInput: true,
+            resetColor: colors.blueberry400,
+            resetLabel: 'Reset',
+            onColorReset: action('Reset Clicked'),
+          },
+        },
+      ]}
+      columnProps={[{label: 'Default', props: {}}]}
+    >
+      {props => <ColorPicker {...props} onColorChange={action('Color Changed')} />}
+    </ComponentStatesTable>
+  </StaticStates>
+);

--- a/modules/_labs/color-picker/react/stories/stories_VisualTesting.tsx
+++ b/modules/_labs/color-picker/react/stories/stories_VisualTesting.tsx
@@ -38,7 +38,9 @@ export const ColorPickerStates = () => (
       ]}
       columnProps={[{label: 'Default', props: {}}]}
     >
-      {props => <ColorPicker {...props} onColorChange={action('Color Changed')} />}
+      {props => (
+        <ColorPicker {...props} transformOrigin={null} onColorChange={action('Color Changed')} />
+      )}
     </ComponentStatesTable>
   </StaticStates>
 );

--- a/modules/_labs/color-picker/react/stories/stories_VisualTesting.tsx
+++ b/modules/_labs/color-picker/react/stories/stories_VisualTesting.tsx
@@ -3,7 +3,6 @@
 import {jsx} from '@emotion/core';
 import {colors} from '@workday/canvas-kit-react-core';
 import {StaticStates} from '@workday/canvas-kit-labs-react-core';
-import {action} from '@storybook/addon-actions';
 import {ComponentStatesTable, withSnapshotsEnabled} from '../../../../../utils/storybook';
 import ColorPicker from '../lib/ColorPicker';
 
@@ -11,6 +10,9 @@ export default withSnapshotsEnabled({
   title: 'Testing|React/Labs/Color Picker',
   component: ColorPicker,
 });
+
+// eslint-disable-next-line no-empty-function
+const noop = () => {};
 
 export const ColorPickerStates = () => (
   <StaticStates>
@@ -23,7 +25,7 @@ export const ColorPickerStates = () => (
           props: {
             resetColor: colors.blueberry400,
             resetLabel: 'Reset',
-            onColorReset: action('Reset Clicked'),
+            onColorReset: noop,
           },
         },
         {
@@ -32,15 +34,13 @@ export const ColorPickerStates = () => (
             showCustomHexInput: true,
             resetColor: colors.blueberry400,
             resetLabel: 'Reset',
-            onColorReset: action('Reset Clicked'),
+            onColorReset: noop,
           },
         },
       ]}
       columnProps={[{label: 'Default', props: {}}]}
     >
-      {props => (
-        <ColorPicker {...props} transformOrigin={null} onColorChange={action('Color Changed')} />
-      )}
+      {props => <ColorPicker {...props} onColorChange={noop} />}
     </ComponentStatesTable>
   </StaticStates>
 );

--- a/modules/_labs/color-picker/react/stories/stories_VisualTesting.tsx
+++ b/modules/_labs/color-picker/react/stories/stories_VisualTesting.tsx
@@ -9,6 +9,11 @@ import ColorPicker from '../lib/ColorPicker';
 export default withSnapshotsEnabled({
   title: 'Testing|React/Labs/Color Picker',
   component: ColorPicker,
+  parameters: {
+    chromatic: {
+      pauseAnimationAtEnd: true,
+    },
+  },
 });
 
 // eslint-disable-next-line no-empty-function


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary
Fixes issue: https://github.com/Workday/canvas-kit/issues/770

In order to support grid layout in IE11, -ms-grid-row and -ms-grid-column need to be explicitly set. In addition IE doesn't support gridGap, so adjusted to use margin spacing. Lastly, I abstracted out some variables regarding the number of swatches within a row to possibly help support further future development.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] `yarn test` passes

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
<img width="578" alt="Screen Shot 2020-08-17 at 9 11 44 PM" src="https://user-images.githubusercontent.com/1635644/90466315-b901a900-e0ce-11ea-8f62-286d1a9a93eb.png">
