### PR TITLE
fix(select): Prevent disabled options from being keyboard-focused

### DIFF
--- a/cypress/integration/SelectLabs.spec.ts
+++ b/cypress/integration/SelectLabs.spec.ts
@@ -353,6 +353,110 @@ describe('Select', () => {
     });
   });
 
+  context('given the "Disabled Options Test" story is rendered', () => {
+    beforeEach(() => {
+      h.stories.load('Testing|React/Labs/Select', 'Disabled Options Test');
+    });
+
+    context('when the menu is opened', () => {
+      beforeEach(() => {
+        cy.findByLabelText('Label (Disabled Options)')
+          .focus()
+          .type('{downarrow}');
+      });
+
+      context('when the down arrow key is pressed', () => {
+        beforeEach(() => {
+          cy.focused().type('{downarrow}');
+        });
+
+        context('the menu', () => {
+          it('should set assistive focus to first enabled option ("E-mail")', () => {
+            cy.findByLabelText('Label (Disabled Options)')
+              .pipe(h.selectLabs.getMenu)
+              .pipe(getAssistiveFocus)
+              .should('have.text', 'E-mail');
+          });
+        });
+
+        context('when the up arrow key is pressed', () => {
+          beforeEach(() => {
+            cy.focused().type('{uparrow}');
+          });
+
+          context('the menu', () => {
+            it('should retain assistive focus on the "E-mail" option since the previous option ("Carrier Pigeon", which also happens to be the first option) is disabled', () => {
+              cy.findByLabelText('Label (Disabled Options)')
+                .pipe(h.selectLabs.getMenu)
+                .pipe(getAssistiveFocus)
+                .should('have.text', 'E-mail');
+            });
+          });
+        });
+
+        context('when the down arrow key is pressed 2 more times', () => {
+          beforeEach(() => {
+            cy.focused().type('{downarrow}{downarrow}');
+          });
+
+          context('the menu', () => {
+            it('should set assistive focus to the third option down ("Mail") since focus will have skipped one disabled option ("Fax")', () => {
+              cy.findByLabelText('Label (Disabled Options)')
+                .pipe(h.selectLabs.getMenu)
+                .pipe(getAssistiveFocus)
+                .should('have.text', 'Mail');
+            });
+          });
+
+          context('when the down arrow key is pressed 2 more times', () => {
+            beforeEach(() => {
+              cy.focused().type('{downarrow}{downarrow}');
+            });
+
+            context('the menu', () => {
+              it('should set assistive focus to the first option down ("Mobile Phone") since the second option down ("Telegram", which also happens to be the last option) is disabled', () => {
+                cy.findByLabelText('Label (Disabled Options)')
+                  .pipe(h.selectLabs.getMenu)
+                  .pipe(getAssistiveFocus)
+                  .should('have.text', 'Mobile Phone');
+              });
+            });
+          });
+        });
+      });
+
+      context('when the Home key is pressed', () => {
+        beforeEach(() => {
+          cy.focused().type('{home}');
+        });
+
+        context('the menu', () => {
+          it('should set assistive focus to the first enabled option ("E-mail")', () => {
+            cy.findByLabelText('Label (Disabled Options)')
+              .pipe(h.selectLabs.getMenu)
+              .pipe(getAssistiveFocus)
+              .should('have.text', 'E-mail');
+          });
+        });
+      });
+
+      context('when the End key is pressed', () => {
+        beforeEach(() => {
+          cy.focused().type('{end}');
+        });
+
+        context('the menu', () => {
+          it('should set assistive focus to the last enabled option ("Mobile Phone")', () => {
+            cy.findByLabelText('Label (Disabled Options)')
+              .pipe(h.selectLabs.getMenu)
+              .pipe(getAssistiveFocus)
+              .should('have.text', 'Mobile Phone');
+          });
+        });
+      });
+    });
+  });
+
   context(`given the "Scrollable" story is rendered`, () => {
     beforeEach(() => {
       h.stories.load('Labs|Select/React/Top Label', 'Scrollable');

--- a/modules/_labs/select/react/lib/Select.tsx
+++ b/modules/_labs/select/react/lib/Select.tsx
@@ -118,6 +118,25 @@ export default class Select extends React.Component<SelectProps, SelectState> {
     return -1;
   };
 
+  // Helper adds safeguards to prevent us from applying focus in invalid ways
+  // when navigating the menu using the keyboard
+  private updateFocusedOptionIndex = (index: number) => {
+    const numOptions = this.normalizedOptions.length;
+
+    // Ensure we're not focusing an index out of bounds. If index < 0,
+    // focus the first option; if index exceeds the length of the options
+    // array, focus the last option.
+    const focusedIndex = index < 0 ? 0 : index >= numOptions ? numOptions - 1 : index;
+
+    // As a final check, only update the focused index if it refers to an
+    // enabled option. This prevents us from applying focus to the first or
+    // last options (after accounting for out of bounds indices above) if
+    // either is disabled.
+    if (!this.normalizedOptions[focusedIndex].disabled) {
+      this.setState({focusedOptionIndex: focusedIndex});
+    }
+  };
+
   private updateStateFromValue = () => {
     this.setState({
       focusedOptionIndex: getCorrectedIndexByValue(this.normalizedOptions, this.props.value),
@@ -354,14 +373,7 @@ export default class Select extends React.Component<SelectProps, SelectState> {
             ) {
               nextIndex += direction;
             }
-            // Ensure we're not out of bounds
-            nextIndex = nextIndex < 0 ? 0 : nextIndex >= numOptions ? numOptions - 1 : nextIndex;
-            // Update the focused index only if it refers to an enabled
-            // option (it's possible for us to still end up at a disabled
-            // option if that option is at the beginning or end of the array)
-            if (!this.normalizedOptions[nextIndex].disabled) {
-              this.setState({focusedOptionIndex: nextIndex});
-            }
+            this.updateFocusedOptionIndex(nextIndex);
           }
           break;
 
@@ -379,14 +391,7 @@ export default class Select extends React.Component<SelectProps, SelectState> {
               nextIndex--;
             }
           }
-          // Ensure we're not out of bounds
-          nextIndex = nextIndex < 0 ? 0 : nextIndex >= numOptions ? numOptions - 1 : nextIndex;
-          // Update the focused index only if it refers to an enabled
-          // option (it's possible for us to still end up at a disabled
-          // option if every option in the array is disabled)
-          if (!this.normalizedOptions[nextIndex].disabled) {
-            this.setState({focusedOptionIndex: nextIndex});
-          }
+          this.updateFocusedOptionIndex(nextIndex);
           break;
 
         case 'Tab':

--- a/modules/_labs/select/react/stories/stories_testing.tsx
+++ b/modules/_labs/select/react/stories/stories_testing.tsx
@@ -92,7 +92,7 @@ export const AccessibilityTest = () => (
 export const DisabledOptionsTest = () => (
   <div>
     <Container>
-      <p>Disabled options may not be assistively (keyboard) focused.</p>
+      <p>Disabled options may not be assistively focused using the keyboard.</p>
       <FormField label="Label (Disabled Options)" inputId="select-disabled-options">
         {controlComponent(<Select name="select-disabled-options" options={disabledOptions} />)}
       </FormField>

--- a/modules/_labs/select/react/stories/stories_testing.tsx
+++ b/modules/_labs/select/react/stories/stories_testing.tsx
@@ -15,6 +15,16 @@ export default {
   component: Select,
 };
 
+const disabledOptions = [
+  {label: 'Carrier Pigeon', value: 'pigeon', disabled: true},
+  {label: 'E-mail', value: 'email'},
+  {label: 'Phone', value: 'phone'},
+  {label: 'Fax', value: 'fax', disabled: true},
+  {label: 'Mail', value: 'mail'},
+  {label: 'Mobile Phone', value: 'mobile_phone'},
+  {label: 'Telegram', value: 'telegram', disabled: true},
+];
+
 const Container = ({children, style = {}, ...elemProps}) => {
   return (
     <div
@@ -74,6 +84,17 @@ export const AccessibilityTest = () => (
       </p>
       <FormField label="Label (required)" inputId="select-required" required={true}>
         {controlComponent(<Select name="select-required" options={options} required={true} />)}
+      </FormField>
+    </Container>
+  </div>
+);
+
+export const DisabledOptionsTest = () => (
+  <div>
+    <Container>
+      <p>Disabled options may not be assistively (keyboard) focused.</p>
+      <FormField label="Label (Disabled Options)" inputId="select-disabled-options">
+        {controlComponent(<Select name="select-disabled-options" options={disabledOptions} />)}
       </FormField>
     </Container>
   </div>


### PR DESCRIPTION
## Summary

We manage assistive focus on the Select component using [aria-activedescendant](https://www.w3.org/TR/wai-aria-practices-1.1/#kbd_focus_activedescendant); when the keyboard is used to navigate the menu, `aria-activedescendant` is updated to refer to the ID of the currently focused option.

Prior to this fix, assistive focus could be applied to a disabled option using the keyboard (Up/Down/Home/End keys) if that disabled option happened to be the first or last option in the menu. The disabled option was correctly styled without focus styles and it was unselectable, but `aria-activedescendant` was still being set to refer to the disabled option's ID. The Select's internal component state also incorrectly set focus to the disabled option. This meant the user could navigate to a disabled option using the keyboard as long as it was the first or last option (although it wouldn't appear to be focused visually, and they wouldn't be able to select it).

This PR addresses this edge case and prevents all options from receiving assistive focus using the keyboard, even if they're the first or last option in the menu.

I've added Cypress tests to protect against this behavior in the future.