### PR TITLE
test(color-picker): Remove data attributes

### DIFF
--- a/cypress/integration/ColorPicker.spec.ts
+++ b/cypress/integration/ColorPicker.spec.ts
@@ -1,10 +1,10 @@
 import * as h from '../helpers';
 
 const getColorInput = () => cy.get('[type="text"]');
-const getColorPickerPopup = () => cy.get('[role=dialog]');
-const getOpenButton = () => cy.get('[data-testid=open]');
+const getColorPickerPopup = () => cy.findByRole('dialog');
+const getOpenButton = () => cy.findByLabelText('Select Background Color');
 const getResetButton = () => cy.contains('button', 'Reset');
-const getSubmitButton = () => cy.get('[aria-label=Submit]');
+const getSubmitButton = () => cy.findByLabelText('Submit');
 const getSwatch = (color: string) => cy.get(`div[color="${color}"]`);
 
 const colorInputStory = 'Components|Inputs/Color Picker/Color Input/React/Top Label';

--- a/cypress/integration/ColorPicker.spec.ts
+++ b/cypress/integration/ColorPicker.spec.ts
@@ -146,7 +146,9 @@ describe('ColorPicker', () => {
         beforeEach(() => {
           cy.get(`.wdc-color-picker--color-8660d1`).click();
           cy.get('button').click();
-          cy.get('[data-testid="color-picker-reset"]').click();
+          cy.get('button')
+            .contains('Reset')
+            .click();
         });
 
         it('should set the color picker value to the reset color', () => {
@@ -215,7 +217,9 @@ describe('ColorPicker', () => {
         beforeEach(() => {
           cy.get(`.wdc-color-picker--color-8660d1`).click();
           getColorInput().click();
-          cy.get('[data-testid="color-picker-reset"]').click();
+          cy.get('button')
+            .contains('Reset')
+            .click();
         });
 
         it('should set the color picker value to the reset color', () => {

--- a/cypress/integration/ColorPicker.spec.ts
+++ b/cypress/integration/ColorPicker.spec.ts
@@ -127,27 +127,31 @@ describe('ColorPicker', () => {
       context('when a swatch is clicked', () => {
         const color = '#ff5347';
 
-        it('should have check icon', () => {
+        beforeEach(() => {
           getSwatch(color).click();
           getOpenButton().click();
+        });
+
+        it('should have check icon', () => {
           getSwatch(color)
             .find('.wd-icon')
             .should('exist');
         });
-      });
 
-      context('when color reset is clicked', () => {
-        it('should set the color picker value to the reset color', () => {
+        context('when color reset is clicked', () => {
           const color = '#ff5347';
-          let resetColor;
+          let resetColor: string | undefined;
 
-          getResetButton().then($el => {
-            resetColor = $el.find('div[color]').attr('color');
+          beforeEach(() => {
+            getResetButton()
+              .then($button => {
+                resetColor = $button.find('[color]').attr('color');
+              })
+              .click();
+            getOpenButton().click();
+          });
 
-            getSwatch(color).click();
-            getOpenButton().click();
-            getResetButton().click();
-            getOpenButton().click();
+          it('should set the color picker value to the reset color', () => {
             getSwatch(resetColor!)
               .find('.wd-icon')
               .should('exist');
@@ -155,13 +159,16 @@ describe('ColorPicker', () => {
         });
       });
 
-      context('when custom color is entered', () => {
-        it('should set the selected color to input value', () => {
-          const customColor = '#123123';
+      context('when a custom color is submitted', () => {
+        const customColor = '#123123';
 
+        beforeEach(() => {
           getColorInput().focus();
           getColorInput().type(customColor);
           getSubmitButton().click();
+        });
+
+        it('should set the selected color to input value', () => {
           getOpenButton().click();
           getSwatch(customColor)
             .find('.wd-icon')
@@ -198,27 +205,25 @@ describe('ColorPicker', () => {
         });
 
         it('should have check icon', () => {
-          getColorInput().click();
+          getColorInput().focus();
           getSwatch(color)
             .find('.wd-icon')
             .should('exist');
         });
-      });
 
-      context('when color reset is clicked', () => {
-        const color = '#ff5347';
+        context('when color reset is clicked', () => {
+          let resetColor: string | undefined;
 
-        beforeEach(() => {
-          getResetButton().click();
-        });
+          beforeEach(() => {
+            getColorInput().focus();
+            getResetButton()
+              .then($button => {
+                resetColor = $button.find('[color]').attr('color');
+              })
+              .click();
+          });
 
-        it('should set the color picker value to the reset color', () => {
-          let resetColor;
-
-          getColorInput().focus();
-          getResetButton().then($el => {
-            resetColor = $el.find('[color]').attr('color');
-            getResetButton().click();
+          it('should set the color picker value to the reset color', () => {
             getColorInput().should('have.value', resetColor!.slice(1));
           });
         });

--- a/cypress/integration/ColorPicker.spec.ts
+++ b/cypress/integration/ColorPicker.spec.ts
@@ -1,15 +1,10 @@
 import * as h from '../helpers';
 
 const getColorInput = () => cy.get('[type="text"]');
-
 const getColorPickerPopup = () => cy.get('[role=dialog]');
-
 const getOpenButton = () => cy.get('[data-testid=open]');
-
 const getResetButton = () => cy.contains('button', 'Reset');
-
 const getSubmitButton = () => cy.get('[aria-label=Submit]');
-
 const getSwatch = (color: string) => cy.get(`div[color="${color}"]`);
 
 const colorInputStory = 'Components|Inputs/Color Picker/Color Input/React/Top Label';
@@ -134,9 +129,7 @@ describe('ColorPicker', () => {
 
         it('should have check icon', () => {
           getSwatch(color).click();
-
           getOpenButton().click();
-
           getSwatch(color)
             .find('.wd-icon')
             .should('exist');
@@ -152,10 +145,8 @@ describe('ColorPicker', () => {
             resetColor = $el.find('div[color]').attr('color');
 
             getSwatch(color).click();
-
             getOpenButton().click();
             getResetButton().click();
-
             getOpenButton().click();
             getSwatch(resetColor!)
               .find('.wd-icon')
@@ -171,7 +162,6 @@ describe('ColorPicker', () => {
           getColorInput().focus();
           getColorInput().type(customColor);
           getSubmitButton().click();
-
           getOpenButton().click();
           getSwatch(customColor)
             .find('.wd-icon')

--- a/cypress/integration/ColorPicker.spec.ts
+++ b/cypress/integration/ColorPicker.spec.ts
@@ -146,8 +146,7 @@ describe('ColorPicker', () => {
         beforeEach(() => {
           cy.get(`.wdc-color-picker--color-8660d1`).click();
           cy.get('button').click();
-          cy.get('button')
-            .contains('Reset')
+          cy.contains('button', 'Reset')
             .click();
         });
 

--- a/cypress/integration/ColorPicker.spec.ts
+++ b/cypress/integration/ColorPicker.spec.ts
@@ -216,8 +216,7 @@ describe('ColorPicker', () => {
         beforeEach(() => {
           cy.get(`.wdc-color-picker--color-8660d1`).click();
           getColorInput().click();
-          cy.get('button')
-            .contains('Reset')
+          cy.contains('button', 'Reset')
             .click();
         });
 

--- a/cypress/integration/ColorPicker.spec.ts
+++ b/cypress/integration/ColorPicker.spec.ts
@@ -139,15 +139,10 @@ describe('ColorPicker', () => {
         });
 
         context('when color reset is clicked', () => {
-          const color = '#ff5347';
-          let resetColor: string | undefined;
+          const resetColor = '#0875e1';
 
           beforeEach(() => {
-            getResetButton()
-              .then($button => {
-                resetColor = $button.find('[color]').attr('color');
-              })
-              .click();
+            getResetButton().click();
             getOpenButton().click();
           });
 
@@ -212,19 +207,15 @@ describe('ColorPicker', () => {
         });
 
         context('when color reset is clicked', () => {
-          let resetColor: string | undefined;
+          const resetColorValue = '0875e1';
 
           beforeEach(() => {
             getColorInput().focus();
-            getResetButton()
-              .then($button => {
-                resetColor = $button.find('[color]').attr('color');
-              })
-              .click();
+            getResetButton().click();
           });
 
           it('should set the color picker value to the reset color', () => {
-            getColorInput().should('have.value', resetColor!.slice(1));
+            getColorInput().should('have.value', resetColorValue);
           });
         });
       });

--- a/modules/_labs/color-picker/react/lib/ColorPicker.tsx
+++ b/modules/_labs/color-picker/react/lib/ColorPicker.tsx
@@ -3,6 +3,7 @@ import {checkIcon} from '@workday/canvas-system-icons-web';
 import {ColorInput} from '@workday/canvas-kit-react-color-picker';
 import {IconButton} from '@workday/canvas-kit-react-button';
 import {Popup} from '@workday/canvas-kit-react-popup';
+import {TransformOrigin} from '@workday/canvas-kit-react-common';
 import * as React from 'react';
 import FormField from '@workday/canvas-kit-react-form-field';
 import styled from '@emotion/styled';
@@ -57,6 +58,11 @@ export interface ColorPickerProps extends React.HTMLAttributes<HTMLDivElement> {
    * @default 'Reset'
    */
   resetLabel?: string;
+  /**
+   * The origin from which the Color Picker will animate.
+   * @default {horizontal: 'center', vertical: 'top'}
+   */
+  transformOrigin?: TransformOrigin;
 }
 
 const defaultColors = [
@@ -130,6 +136,7 @@ const ColorPicker = ({
   resetColor,
   value = '',
   showCustomHexInput = false,
+  transformOrigin,
   ...elemProps
 }: ColorPickerProps) => {
   const [validHexValue, setValidHexValue] = React.useState('');
@@ -153,7 +160,13 @@ const ColorPicker = ({
   };
 
   return (
-    <Popup width={250} padding={Popup.Padding.s} data-testid="canvas-color-picker" {...elemProps}>
+    <Popup
+      width={250}
+      padding={Popup.Padding.s}
+      transformOrigin={transformOrigin}
+      data-testid="canvas-color-picker"
+      {...elemProps}
+    >
       {onColorReset && resetColor && (
         <ResetButton onClick={onColorReset} resetColor={resetColor} label={resetLabel} />
       )}

--- a/modules/_labs/color-picker/react/lib/ColorPicker.tsx
+++ b/modules/_labs/color-picker/react/lib/ColorPicker.tsx
@@ -164,7 +164,6 @@ const ColorPicker = ({
       width={250}
       padding={Popup.Padding.s}
       transformOrigin={transformOrigin}
-      data-testid="canvas-color-picker"
       {...elemProps}
     >
       {onColorReset && resetColor && (

--- a/modules/_labs/color-picker/react/lib/parts/ColorReset.tsx
+++ b/modules/_labs/color-picker/react/lib/parts/ColorReset.tsx
@@ -50,7 +50,7 @@ export const ResetButton = ({onClick, resetColor, label}: ResetButtonProps) => {
   const handleResetColor = () => onClick(resetColor);
 
   return (
-    <Container data-testid="color-picker-reset" onClick={handleResetColor}>
+    <Container onClick={handleResetColor}>
       <ColorSwatch color={resetColor} />
       <Label>{label}</Label>
     </Container>

--- a/modules/_labs/color-picker/react/lib/parts/SwatchBook.tsx
+++ b/modules/_labs/color-picker/react/lib/parts/SwatchBook.tsx
@@ -19,14 +19,12 @@ const accessibilityBorder = `${colors.frenchVanilla100} 0px 0px 0px 2px, ${color
 const SwatchContainer = styled('div')<SwatchContainerProps>(
   {
     display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    position: 'relative',
     width: 20,
     height: 20,
     cursor: 'pointer',
     borderRadius: borderRadius.s,
     transition: 'box-shadow 120ms ease',
+    margin: `0px ${spacing.xxs} ${spacing.xxs} 0px`,
 
     '&:hover': {
       boxShadow: accessibilityBorder,
@@ -55,9 +53,9 @@ const SwatchContainer = styled('div')<SwatchContainerProps>(
 );
 
 const Container = styled('div')({
-  display: 'grid',
-  gridTemplateColumns: 'repeat(8, auto)',
-  gridGap: spacing.xxs,
+  display: 'flex',
+  flexWrap: 'wrap',
+  margin: `0px -${spacing.xxs} -${spacing.xxs} 0px`,
 });
 
 export const SwatchBook = ({colors, value, onSelect}: SwatchBookProps) => (

--- a/modules/_labs/color-picker/react/lib/parts/SwatchBook.tsx
+++ b/modules/_labs/color-picker/react/lib/parts/SwatchBook.tsx
@@ -67,15 +67,9 @@ export const SwatchBook = ({colors, value, onSelect}: SwatchBookProps) => (
       const handleKeyDown = (event: React.KeyboardEvent) =>
         (event.key === 'Enter' || event.key === ' ') && onSelect(color);
 
-      const formatHex = (value: string) => {
-        return value.replace(/#/g, '').substring(0, 6);
-      };
-      const formattedColor = formatHex(color);
-
       return (
         <SwatchContainer
           key={index + '-' + color}
-          className={`wdc-color-picker--color-${formattedColor}`}
           onClick={handleClick}
           onKeyDown={handleKeyDown}
           tabIndex={0}

--- a/modules/_labs/color-picker/react/spec/ColorPicker.spec.tsx
+++ b/modules/_labs/color-picker/react/spec/ColorPicker.spec.tsx
@@ -11,7 +11,7 @@ describe('Color Picker', () => {
     it('should call onColorChange handler when clicking a color swatch', () => {
       const onColorChange = jest.fn();
       const {container} = renderColorPicker({onColorChange: onColorChange});
-      const colorSwatch = container.querySelector('.wdc-color-picker--color-333333')!;
+      const colorSwatch = container.querySelector(`[color="${colors.blackPepper400}"]`)!;
 
       fireEvent.click(colorSwatch);
       expect(onColorChange).toHaveBeenCalledWith(colors.blackPepper400);

--- a/modules/_labs/color-picker/react/stories/stories_ColorPicker.tsx
+++ b/modules/_labs/color-picker/react/stories/stories_ColorPicker.tsx
@@ -1,7 +1,6 @@
 /// <reference path="../../../../../typings.d.ts" />
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
 import withReadme from 'storybook-readme/with-readme';
 import {ColorInput} from '@workday/canvas-kit-react-color-picker';
 import {colors} from '@workday/canvas-kit-react-core';
@@ -11,10 +10,13 @@ import {bgColorIcon} from '@workday/canvas-system-icons-web';
 import {ColorPicker} from '@workday/canvas-kit-labs-react-color-picker';
 import README from '../README.md';
 
+// eslint-disable-next-line no-empty-function
+const noop = () => {};
+
 storiesOf('Labs|Color Picker/React', module)
   .addParameters({component: ColorPicker})
   .addDecorator(withReadme(README))
-  .add('Default', () => <ColorPicker onColorChange={color => action('color-change')(color)} />)
+  .add('Default', () => <ColorPicker onColorChange={noop} />)
   .add('Icon Button Popup', () => {
     const [isOpen, setOpen] = React.useState(false);
     const [color, setColor] = React.useState('');
@@ -24,7 +26,6 @@ storiesOf('Labs|Color Picker/React', module)
 
     const handleSubmit = React.useCallback(
       (submitColor: string) => {
-        action('color-change')(submitColor);
         setColor(submitColor.toUpperCase());
         setOpen(false);
       },

--- a/modules/_labs/color-picker/react/stories/stories_ColorPicker.tsx
+++ b/modules/_labs/color-picker/react/stories/stories_ColorPicker.tsx
@@ -36,6 +36,7 @@ storiesOf('Labs|Color Picker/React', module)
         <IconButton
           icon={bgColorIcon}
           aria-label="Select Background Color"
+          data-testid="open"
           buttonRef={buttonRef}
           variant={IconButton.Variant.SquareFilled}
           onClick={toggleOpen}

--- a/modules/_labs/color-picker/react/stories/stories_ColorPicker.tsx
+++ b/modules/_labs/color-picker/react/stories/stories_ColorPicker.tsx
@@ -36,7 +36,6 @@ storiesOf('Labs|Color Picker/React', module)
         <IconButton
           icon={bgColorIcon}
           aria-label="Select Background Color"
-          data-testid="open"
           buttonRef={buttonRef}
           variant={IconButton.Variant.SquareFilled}
           onClick={toggleOpen}

--- a/modules/_labs/color-picker/react/stories/stories_VisualTesting.tsx
+++ b/modules/_labs/color-picker/react/stories/stories_VisualTesting.tsx
@@ -1,0 +1,51 @@
+/// <reference path="../../../../../typings.d.ts" />
+/** @jsx jsx */
+import {jsx} from '@emotion/core';
+import {colors} from '@workday/canvas-kit-react-core';
+import {StaticStates} from '@workday/canvas-kit-labs-react-core';
+import {ComponentStatesTable, withSnapshotsEnabled} from '../../../../../utils/storybook';
+import ColorPicker from '../lib/ColorPicker';
+
+export default withSnapshotsEnabled({
+  title: 'Testing|React/Labs/Color Picker',
+  component: ColorPicker,
+  parameters: {
+    chromatic: {
+      pauseAnimationAtEnd: true,
+    },
+  },
+});
+
+// eslint-disable-next-line no-empty-function
+const noop = () => {};
+
+export const ColorPickerStates = () => (
+  <StaticStates>
+    <ComponentStatesTable
+      rowProps={[
+        {label: 'Default', props: {}},
+        {label: 'with Hex Input', props: {showCustomHexInput: true}},
+        {
+          label: 'With Reset',
+          props: {
+            resetColor: colors.blueberry400,
+            resetLabel: 'Reset',
+            onColorReset: noop,
+          },
+        },
+        {
+          label: 'With Reset and Hex Input',
+          props: {
+            showCustomHexInput: true,
+            resetColor: colors.blueberry400,
+            resetLabel: 'Reset',
+            onColorReset: noop,
+          },
+        },
+      ]}
+      columnProps={[{label: 'Default', props: {}}]}
+    >
+      {props => <ColorPicker {...props} onColorChange={noop} />}
+    </ComponentStatesTable>
+  </StaticStates>
+);


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

As a policy, we don't add `data-` attributes to our shipped codebase. If we every need them for testing, we'll use them at the `spec` level but never at a component level. This one somehow slipped through so I'm removing them here and changing our Cypress tests accordingly.

Bonus: removed `addon-actions` from the `ColorPicker` story. This is most likely going to freeze browsers like IE11.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
