### PR TITLE
fix(select): Replace disabled attribute on options with aria-disabled

### DIFF
--- a/cypress/integration/SelectLabs.spec.ts
+++ b/cypress/integration/SelectLabs.spec.ts
@@ -365,6 +365,14 @@ describe('Select', () => {
           .type('{downarrow}');
       });
 
+      context('the "Carrier Pigeon" option', () => {
+        it('should have an aria-disabled attribute set to "true"', () => {
+          cy.findByLabelText('Label (Disabled Options)')
+            .pipe(h.selectLabs.getOption('Carrier Pigeon'))
+            .should('have.attr', 'aria-disabled', 'true');
+        });
+      });
+
       context('when the down arrow key is pressed', () => {
         beforeEach(() => {
           cy.focused().type('{downarrow}');

--- a/modules/_labs/select/react/lib/SelectBase.tsx
+++ b/modules/_labs/select/react/lib/SelectBase.tsx
@@ -436,7 +436,7 @@ export default class SelectBase extends React.Component<SelectBaseProps> {
           <SelectMenu
             aria-activedescendant={options[focusedOptionIndex].id}
             aria-labelledby={ariaLabelledBy}
-            aria-required={ariaRequired || required}
+            aria-required={ariaRequired || required ? true : undefined}
             buttonRef={buttonRef}
             id={this.menuId}
             error={error}

--- a/modules/_labs/select/react/lib/SelectBase.tsx
+++ b/modules/_labs/select/react/lib/SelectBase.tsx
@@ -333,8 +333,8 @@ export default class SelectBase extends React.Component<SelectBaseProps> {
 
     return options.map((option, index) => {
       const optionProps = {
+        'aria-disabled': option.disabled ? true : undefined,
         'aria-selected': selectedOptionIndex === index ? true : undefined,
-        disabled: option.disabled,
         error,
         focused: focusedOptionIndex === index,
         id: option.id,

--- a/modules/_labs/select/react/lib/SelectOption.tsx
+++ b/modules/_labs/select/react/lib/SelectOption.tsx
@@ -11,11 +11,6 @@ import {colors, commonColors, type} from '@workday/canvas-kit-react-core';
 
 export interface SelectOptionProps extends Themeable, React.LiHTMLAttributes<HTMLLIElement> {
   /**
-   * If true, set the SelectOption to the disabled state.
-   * @default false
-   */
-  disabled?: boolean;
-  /**
    * The type of error associated with the SelectOption (if applicable).
    */
   error?: ErrorType;
@@ -64,7 +59,7 @@ const Option = styled('li')<SelectOptionProps>(
     minHeight: type.body.lineHeight,
     textAlign: 'left',
   },
-  ({disabled, focused, interactive, theme}) => {
+  ({'aria-disabled': disabled, focused, interactive, theme}) => {
     if (disabled) {
       // If the option is disabled, return disabled styles...
       return {

--- a/modules/_labs/select/react/stories/stories_visualTesting.tsx
+++ b/modules/_labs/select/react/stories/stories_visualTesting.tsx
@@ -130,7 +130,7 @@ export const SelectStatesOption = () => (
           {label: 'Default', props: {}},
           {label: 'Hover', props: {className: 'hover'}},
         ],
-        rowProps: [{label: 'Disabled', props: {disabled: true}}],
+        rowProps: [{label: 'Disabled', props: {'aria-disabled': true}}],
       },
       {
         label: 'Interaction States',


### PR DESCRIPTION
## Summary

Previously, the `disabled` attribute was incorrectly being applied to disabled options; options are represented as `<li>` elements, and `disabled` is not a valid attribute for an `<li>`. Workday Accessibility advised that we set `aria-disabled="true"` on the disabled option instead.

This PR also includes a small tweak that prevents `aria-required` from being unnecessarily set to `"false"` on the Select menu if `aria-required` or `required` was never passed as a prop in the first place (i.e., render `<ul role="listbox">` instead of `<ul role="listbox" aria-required="false">`).

## Checklist
- [x] a11y approved final implementation
