### PR TITLE
fix(form-field): Fix legend overflow bug (IE11)

### DIFF
--- a/modules/form-field/react/lib/Label.tsx
+++ b/modules/form-field/react/lib/Label.tsx
@@ -72,8 +72,12 @@ const RequiredAstrisk = styled('abbr')({
   textDecoration: 'unset',
 });
 
-// Used inside the fieldset component instead of a label for accessible radio groups
-const LegendComponent = styled('legend')<LabelProps>(...labelStyles);
+// Used inside the fieldset component instead of a label for accessible radio groups.
+// Extra `width: 100%` style is to help IE11 wrap text properly in a top-positioned
+// FormField's legend element.
+const LegendComponent = styled('legend')<LabelProps>(...labelStyles, ({labelPosition}) => ({
+  width: labelPosition === Label.Position.Top ? '100%' : undefined,
+}));
 const LabelComponent = styled('label')<LabelProps>(...labelStyles);
 
 export default class Label extends React.Component<LabelProps> {

--- a/modules/form-field/react/stories/visual-testing/stories_Radio.tsx
+++ b/modules/form-field/react/stories/visual-testing/stories_Radio.tsx
@@ -18,6 +18,19 @@ export default withSnapshotsEnabled({
   component: FormField,
 });
 
+const testGroup = (
+  <RadioGroup name="contact" value={'email'}>
+    <Radio id="1" value="email" label="E-mail" />
+    <Radio id="2" value="phone" label="Phone" />
+    <Radio id="3" value="fax" label="Fax (disabled)" disabled={true} />
+    <Radio
+      id="4"
+      value="mail"
+      label="Mail (US Postal Service aka USPS), a longer than normal label"
+    />
+  </RadioGroup>
+);
+
 export const RadioStates = () => (
   <div>
     <h3>Radio</h3>
@@ -90,13 +103,56 @@ export const RadioStates = () => (
             hintId={hintId}
             {...props}
           >
-            <RadioGroup name="contact" value={'email'}>
-              <Radio id="1" value="email" label="E-mail" />
-              <Radio id="2" value="fax" label="Fax (disabled)" disabled={true} />
-            </RadioGroup>
+            {testGroup}
           </FormField>
         )}
       </ComponentStatesTable>
     </StaticStates>
+    <h3>Radio Group (grow)</h3>
+    <StaticStates>
+      <ComponentStatesTable
+        rowProps={permutateProps({
+          error: [
+            {value: undefined, label: 'No Error'},
+            {value: FormField.ErrorType.Alert, label: 'Alert'},
+            {value: FormField.ErrorType.Error, label: 'Error'},
+          ],
+        })}
+        columnProps={[
+          {
+            label: 'Grow',
+            props: {label: 'Contact', grow: true},
+          },
+        ]}
+      >
+        {props => (
+          <FormField
+            useFieldset={true}
+            hintText={typeof props.error !== 'undefined' ? hintText : undefined}
+            hintId={hintId}
+            {...props}
+          >
+            {testGroup}
+          </FormField>
+        )}
+      </ComponentStatesTable>
+    </StaticStates>
+
+    <h3>RadioGroup (wrapping)</h3>
+    <div style={{maxWidth: 480}}>
+      <FormField
+        label="Really long label. Really long label. Really long label. Really long label. Really long label. Really long label."
+        labelPosition={FormField.LabelPosition.Left}
+        useFieldset={true}
+      >
+        {testGroup}
+      </FormField>
+      <FormField
+        label="Really long label. Really long label. Really long label. Really long label. Really long label. Really long label. Really long label. Really long label. Really long label. Really long label. Really long label. Really long label. Really long label. Really long label. Really long label. Really long label. Really long label. Really long label. Really long label. Really long label. Really long label. Really long label. Really long label. Really long label. Really long label. Really long label."
+        useFieldset={true}
+      >
+        {testGroup}
+      </FormField>
+    </div>
   </div>
 );


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This fixes #852 . When a `FormField` renders a `legend` as its label (i.e. when the `useFieldset` prop is true) and long-form text overflows the parent container's width. This doesn't happen in Chrome or FF.

Adding `width: 100%` on the `legend` element fixes this bug but can only be applied to top-labeled `FormField`s. If it's applied to the side-labeled fields then it will interfere with the `min-width` property for that label position.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->

Does this on IE11:
![image](https://user-images.githubusercontent.com/14299381/92945566-4d2f0980-f40a-11ea-8a15-30a8af1046f9.png)

Should do this on all browsers:
![image](https://user-images.githubusercontent.com/14299381/92945664-7059b900-f40a-11ea-846a-d27ab3e55703.png)

