### PR TITLE
ci: Use secrets and pull_request_target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: pull_request
+on: pull_request_target
 
 jobs:
   verify:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,8 @@ jobs:
 
       - uses: chromaui/action@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          appCode: dlpro96xybh
+          token: ${{ secrets.GH_RW_TOKEN }}
+          projectToken: ${{ secrets.CHROMATIC_APP_CODE }}
           storybookBuildDir: docs
           exitOnceUploaded: true
           exitZeroOnChanges: true
@@ -73,8 +73,5 @@ jobs:
       - name: Integration tests
         run: yarn cypress run --record
         env:
-          # Github Actions doesn't support encryption on forks
-          # If these keys become compromised, we will rotate and disable these features
-          # on forked PRs until a suitable workaround is found
-          CYPRESS_RECORD_KEY: 3a9347b6-36ab-4a36-823d-709f4078b148
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_KEY }}
           CYPRESS_CACHE_FOLDER: .cache/cypress

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
 
       - uses: chromaui/action@v1
         with:
-          token: ${{ secrets.GH_RW_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: ${{ secrets.CHROMATIC_APP_CODE }}
           storybookBuildDir: docs
           exitOnceUploaded: true


### PR DESCRIPTION
Update to use `pull_request_target` so we aren't exposing our service keys anymore.

First run will be to make sure everything works, but I'm still using the `pull_request` event instead of `pull_request_target`. Once that passes, I'll change it to use `pull_request_target`. The reason is I cannot test `pull_request_target` in a pull request because that event will use the base branch instead of the changes in the pull request...

Then we won't even know 100% for sure until merge this PR and then open another PR to make sure the CI passes there...
