### PR TITLE
Bump focus-trap-js to 1.1.0 and add cypress test

### DIFF
--- a/cypress/integration/Modal.spec.ts
+++ b/cypress/integration/Modal.spec.ts
@@ -162,6 +162,34 @@ describe('Modal', () => {
     });
   });
 
+  context(`given the 'With Radio buttons' story is rendered`, () => {
+    beforeEach(() => {
+      h.stories.load('Components|Popups/Modal/React', 'With Radio buttons');
+    });
+
+    it('should not have any axe errors', () => {
+      cy.checkA11y();
+    });
+
+    context('test trap focus', () => {
+      beforeEach(() => {
+        cy.contains('With Radio Buttons').focus();
+        cy.contains('With Radio Buttons').click();
+      });
+
+      it('should trap focus inside the modal element', () => {
+        cy.findByLabelText('Select Item').should('be.visible');
+
+        cy.focused()
+          .tab()
+          .should('have.attr', 'value', 'email')
+          .tab()
+          .should('have.attr', 'data-close', 'close')
+          .tab();
+      });
+    });
+  });
+
   context(`given the 'Without close icon' story is rendered`, () => {
     beforeEach(() => {
       h.stories.load('Components|Popups/Modal/React', 'Without close icon');

--- a/modules/modal/react/package.json
+++ b/modules/modal/react/package.json
@@ -51,7 +51,8 @@
     "@emotion/core": "^10.0.28",
     "@emotion/styled": "^10.0.27",
     "@workday/canvas-kit-popup-stack": "^4.1.2",
-    "@workday/canvas-kit-react-popup": "^4.1.2"
+    "@workday/canvas-kit-react-popup": "^4.1.2",
+    "@workday/canvas-kit-react-radio": "^4.1.2"
   },
   "devDependencies": {
     "@workday/canvas-kit-react-button": "^4.1.2",

--- a/modules/modal/react/stories/stories.tsx
+++ b/modules/modal/react/stories/stories.tsx
@@ -7,6 +7,7 @@ import {Button, DeleteButton} from '@workday/canvas-kit-react-button';
 import {FormField} from '@workday/canvas-kit-react-form-field';
 import {TextInput} from '@workday/canvas-kit-react-text-input';
 import {Modal, useModal} from '@workday/canvas-kit-react-modal';
+import {Radio, RadioGroup} from '@workday/canvas-kit-react-radio';
 
 import README from '../README.md';
 import {controlComponent} from '../../../../utils/storybook';
@@ -63,6 +64,23 @@ export const WithoutHook = () => {
         <Button onClick={closeModal} variant={Button.Variant.Secondary}>
           Cancel
         </Button>
+      </Modal>
+    </>
+  );
+};
+
+export const WithRadioButtons = () => {
+  const {targetProps, modalProps} = useModal();
+  const [value, setValue] = React.useState('');
+
+  return (
+    <>
+      <Button {...targetProps}>With Radio Buttons</Button>
+      <Modal data-testid="TestModal" heading="Select Item" {...modalProps}>
+        <RadioGroup name="contact" data-testid="radiogroup" value={value} onChange={setValue}>
+          <Radio id="1" value="email" label="E-mail" />
+          <Radio id="2" value="phone" label="Phone" />
+        </RadioGroup>
       </Modal>
     </>
   );

--- a/modules/popup/react/package.json
+++ b/modules/popup/react/package.json
@@ -55,7 +55,7 @@
     "@workday/canvas-kit-react-common": "^4.1.2",
     "@workday/canvas-kit-react-core": "^4.1.2",
     "@workday/canvas-system-icons-web": "^1.0.20",
-    "focus-trap-js": "1.0.8",
+    "focus-trap-js": "1.1.0",
     "uuid": "^3.3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary
focus-trap-js had a bug when handling radio-buttons.

<img width="453" alt="Screen Shot 2020-09-15 at 10 36 39 AM" src="https://user-images.githubusercontent.com/10633451/93193967-6fdd5d00-f73f-11ea-8c71-660e6c267380.png">

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md
- [x] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
