### PR TITLE
fix(popup-stack): Move adapter var to popup-stack global namespace

### DIFF
--- a/modules/popup-stack/lib/PopupStack.ts
+++ b/modules/popup-stack/lib/PopupStack.ts
@@ -111,6 +111,7 @@ interface Stack {
     max: number;
     getValue: typeof getValue;
   };
+  _adapter: Partial<typeof PopupStack>;
 }
 
 /**
@@ -185,9 +186,9 @@ const stack: Stack = getFromWindow('workday.__popupStack') || {
   description: 'Global popup stack from @workday/canvas-kit-popup-stack',
   items: [] as PopupStackItem[],
   zIndex: {min: 30, max: 50, getValue: getValue},
+  _adapter: {} as Partial<typeof PopupStack>,
 };
 setToWindow('workday.__popupStack', stack);
-let _adapter: Partial<typeof PopupStack> = {};
 
 export const PopupStack = {
   /**
@@ -197,8 +198,8 @@ export const PopupStack = {
    * should be added to this element.
    */
   createContainer(): HTMLElement {
-    if (_adapter.createContainer) {
-      return _adapter.createContainer();
+    if (stack._adapter.createContainer) {
+      return stack._adapter.createContainer();
     }
     const div = document.createElement('div');
     div.style.position = 'relative'; // z-index only works on _positioned_ elements
@@ -211,8 +212,8 @@ export const PopupStack = {
    * method when the event triggers.
    */
   add(item: PopupStackItem): void {
-    if (_adapter.add) {
-      _adapter.add(item);
+    if (stack._adapter.add) {
+      stack._adapter.add(item);
       return;
     }
     stack.items.push(item);
@@ -228,8 +229,8 @@ export const PopupStack = {
    * reset z-index values of the stack
    */
   remove(element: HTMLElement): void {
-    if (_adapter.remove) {
-      _adapter.remove(element);
+    if (stack._adapter.remove) {
+      stack._adapter.remove(element);
       return;
     }
     stack.items = stack.items.filter(item => item.element !== element);
@@ -244,8 +245,8 @@ export const PopupStack = {
    * reference that was passed to `add`
    */
   isTopmost(element: HTMLElement): boolean {
-    if (_adapter.isTopmost) {
-      return _adapter.isTopmost(element);
+    if (stack._adapter.isTopmost) {
+      return stack._adapter.isTopmost(element);
     }
     const last = getLast(stack.items);
 
@@ -259,8 +260,8 @@ export const PopupStack = {
    * Returns an array of elements defined by the `element` passed to `add`.
    */
   getElements(): HTMLElement[] {
-    if (_adapter.getElements) {
-      return _adapter.getElements();
+    if (stack._adapter.getElements) {
+      return stack._adapter.getElements();
     }
     return stack.items.map(i => i.element);
   },
@@ -278,8 +279,8 @@ export const PopupStack = {
    * the top of the stack.
    */
   bringToTop(element: HTMLElement): void {
-    if (_adapter.bringToTop) {
-      _adapter.bringToTop(element);
+    if (stack._adapter.bringToTop) {
+      stack._adapter.bringToTop(element);
       return;
     }
     const item = find(stack.items, i => i.element === element);
@@ -317,8 +318,8 @@ export const PopupStack = {
    * is not inside `element`).
    */
   contains(element: HTMLElement, eventTarget: HTMLElement): boolean {
-    if (_adapter.contains) {
-      return _adapter.contains(element, eventTarget);
+    if (stack._adapter.contains) {
+      return stack._adapter.contains(element, eventTarget);
     }
     const item = find(stack.items, i => i.element === element);
 
@@ -346,5 +347,5 @@ export function resetStack() {
  * @param adapter The parts of the PopupStack that we want to override
  */
 export const createAdapter = (adapter: Partial<typeof PopupStack>) => {
-  _adapter = adapter;
+  stack._adapter = adapter;
 };


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

Previously, if there were multiple imports (from different bundles) of the PopupStack, the adapter would be overwritten each time the PopupStack was imported. While the PopupStack can be overridden, the adapter should not be (otherwise, createAdapter becomes a bit useless 😅 ) 

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [x] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->

