### PR TITLE
fix(modal): Add exception to modal enter animation

### DIFF
--- a/modules/modal/react/lib/ModalContent.tsx
+++ b/modules/modal/react/lib/ModalContent.tsx
@@ -80,6 +80,7 @@ const Container = styled('div')({
   background: 'rgba(0,0,0,0.65)',
   animationName: `${fadeIn}`,
   animationDuration: '0.3s',
+  // Allow overriding of animation in special cases
   '.wd-no-animation &': {
     animation: 'none',
   },

--- a/modules/modal/react/lib/ModalContent.tsx
+++ b/modules/modal/react/lib/ModalContent.tsx
@@ -80,6 +80,9 @@ const Container = styled('div')({
   background: 'rgba(0,0,0,0.65)',
   animationName: `${fadeIn}`,
   animationDuration: '0.3s',
+  '.wd-no-animation &': {
+    animation: 'none',
+  },
 });
 
 // This centering container helps fix an issue with Chrome. Chrome doesn't normally do subpixel


### PR DESCRIPTION
This fixes an issue where the Popup adapter is being used. It will flash because the adapter will remove the containing element for popups and show again. The animation makes detach/attach cycle a visible flashing. This is already added to the Popup.tsx file, we just missed the Modal.
