### PR TITLE
fix(common): Remove unintended whitespace around bdo tag (IE11) (#862)

### DIFF
--- a/modules/common/react/lib/CanvasProvider.tsx
+++ b/modules/common/react/lib/CanvasProvider.tsx
@@ -10,6 +10,7 @@ export interface CanvasProviderProps {
 
 const DirectionContainer = styled('bdo')<{dir: ContentDirection}>(({dir}) => ({
   direction: dir,
+  display: 'block'
 }));
 
 export class CanvasProvider extends React.Component<CanvasProviderProps> {


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

Solves issue #862 where IE11 is not adding a display property to the bdo tag.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md
- [x] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [x] design approved final implementation
- [x] a11y approved final implementation
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
