### PR TITLE
[WIP] feat(popup): Add previousFocusRef to useCloseOnEscape hook

### DIFF
--- a/modules/popup/react/README.md
+++ b/modules/popup/react/README.md
@@ -377,7 +377,7 @@ This should be used on stacked UI elements that are meant to persist, like Windo
 ## useCloseOnEscape
 
 ```ts
-useCloseOnEscape(stackRef: React.RefObject<HTMLElement>, onClose: () => void): void
+useCloseOnEscape(stackRef: React.RefObject<HTMLElement>, onClose: () => void, returnFocusRef?: React.RefObject<HTMLElement>): void
 ```
 
 Registers global detection of the Escape key. It will only call the `onClose` callback if the
@@ -387,6 +387,9 @@ internally.
 
 This should be used stacked UI elements that are dismissible like Tooltips, Modals, non-modal
 dialogs, dropdown menus, etc.
+
+`returnFocusRef` is an optional prop that returns focus to a specific element on escape. This is
+useful for instances such as returning focus to a dropdown button when closing a menu.
 
 ## useCloseOnOutsideClick
 

--- a/modules/popup/react/lib/useCloseOnEscape.ts
+++ b/modules/popup/react/lib/useCloseOnEscape.ts
@@ -6,12 +6,20 @@ import {PopupStack} from '@workday/canvas-kit-popup-stack';
  * Registers global detection of the Escape key. It will only call the `onClose` callback if the
  * provided `stackRef` element is the topmost in the stack. The `stackRef` should be the same as the one passed
  * to `usePopupStack` or the `Popper` component since `Popper` uses `usePopupStack` internally.
+ * If provided, the `previousFocusRef` allows you to return focus to an element before `onClose` is called
  * @param stackRef
  * @param onClose
+ * @param previousFocusRef
  */
+
+const focusPreviousElement = (previousFocusRef?: React.RefObject<HTMLElement>) => {
+  previousFocusRef?.current?.focus();
+};
+
 export const useCloseOnEscape = <E extends HTMLElement>(
   stackRef: React.RefObject<E>,
-  onClose: () => void
+  onClose: () => void,
+  previousFocusRef?: React.RefObject<HTMLElement>
 ) => {
   const onKeyDown = React.useCallback(
     (event: KeyboardEvent) => {
@@ -19,10 +27,12 @@ export const useCloseOnEscape = <E extends HTMLElement>(
         (event.key === 'Esc' || event.key === 'Escape') &&
         PopupStack.isTopmost(stackRef.current!)
       ) {
+        // return focus to previously focused element, if provided
+        focusPreviousElement(previousFocusRef);
         onClose();
       }
     },
-    [onClose, stackRef]
+    [onClose, previousFocusRef, stackRef]
   );
 
   // `useLayoutEffect` for automation

--- a/modules/popup/react/lib/useCloseOnEscape.ts
+++ b/modules/popup/react/lib/useCloseOnEscape.ts
@@ -6,20 +6,20 @@ import {PopupStack} from '@workday/canvas-kit-popup-stack';
  * Registers global detection of the Escape key. It will only call the `onClose` callback if the
  * provided `stackRef` element is the topmost in the stack. The `stackRef` should be the same as the one passed
  * to `usePopupStack` or the `Popper` component since `Popper` uses `usePopupStack` internally.
- * If provided, the `previousFocusRef` allows you to return focus to an element before `onClose` is called
+ * If provided, the `returnFocusRef` allows you to return focus to an element before `onClose` is called
  * @param stackRef
  * @param onClose
- * @param previousFocusRef
+ * @param returnFocusRef
  */
 
-const focusPreviousElement = (previousFocusRef?: React.RefObject<HTMLElement>) => {
-  previousFocusRef?.current?.focus();
+const focusElement = (returnFocusRef?: React.RefObject<HTMLElement>) => {
+  returnFocusRef?.current?.focus();
 };
 
 export const useCloseOnEscape = <E extends HTMLElement>(
   stackRef: React.RefObject<E>,
   onClose: () => void,
-  previousFocusRef?: React.RefObject<HTMLElement>
+  returnFocusRef?: React.RefObject<HTMLElement>
 ) => {
   const onKeyDown = React.useCallback(
     (event: KeyboardEvent) => {
@@ -27,12 +27,12 @@ export const useCloseOnEscape = <E extends HTMLElement>(
         (event.key === 'Esc' || event.key === 'Escape') &&
         PopupStack.isTopmost(stackRef.current!)
       ) {
-        // return focus to previously focused element, if provided
-        focusPreviousElement(previousFocusRef);
+        // return focus to another element, if provided
+        focusElement(returnFocusRef);
         onClose();
       }
     },
-    [onClose, previousFocusRef, stackRef]
+    [onClose, returnFocusRef, stackRef]
   );
 
   // `useLayoutEffect` for automation


### PR DESCRIPTION
## Issue

Fixes #877

## Overview

This PR adds an optional parameter, `previousFocusRef`, to the `useCloseOnEscape` hook. If provided, this allows the focus to return the specified element before calling `onClose`.

## Where Should the Reviewer Start?

`modules/popup/react/lib/useCloseOnEscape.ts`

## New Dependencies

n/a

## Screenshots (if applicable)

n/a

## Thank You Gif
_Share a fun [gif](https://giphy.com) to say thanks to your reviewer:_

![](https://media.giphy.com/media/26FPqut4lzK3AECEo/giphy-downsized.gif)

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [ ] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
