### PR TITLE
feat: Add support for Secondary Outline Button AB test

### DIFF
--- a/modules/button/react/lib/OutlineButton.tsx
+++ b/modules/button/react/lib/OutlineButton.tsx
@@ -124,25 +124,25 @@ export const getOutlineButtonColors = (
       return {
         default: {
           background: 'transparent',
-          border: ABTestColors.main || colors.soap500,
+          border: ABTestColors?.main || colors.soap500,
           icon: colors.licorice200,
           label: colors.blackPepper400,
         },
         hover: {
-          background: ABTestColors.dark || colors.licorice500,
-          border: ABTestColors.dark || colors.licorice500,
+          background: ABTestColors?.dark || colors.licorice500,
+          border: ABTestColors?.dark || colors.licorice500,
           icon: themePrimary.contrast,
           label: themePrimary.contrast,
         },
         active: {
-          background: ABTestColors.darkest || colors.licorice600,
-          border: ABTestColors.darkest || colors.licorice600,
+          background: ABTestColors?.darkest || colors.licorice600,
+          border: ABTestColors?.darkest || colors.licorice600,
           icon: themePrimary.contrast,
           label: themePrimary.contrast,
         },
         focus: {
-          background: ABTestColors.dark || colors.licorice500,
-          border: ABTestColors.dark || colors.licorice500,
+          background: ABTestColors?.dark || colors.licorice500,
+          border: ABTestColors?.dark || colors.licorice500,
           icon: themePrimary.contrast,
           label: themePrimary.contrast,
         },

--- a/modules/button/react/lib/OutlineButton.tsx
+++ b/modules/button/react/lib/OutlineButton.tsx
@@ -83,6 +83,8 @@ export const getOutlineButtonColors = (
     canvas: {
       palette: {primary: themePrimary},
     },
+    // TODO: Remove this support after AB test is complete
+    ABTest: {secondaryOutlineButton: ABTestColors},
   } = theme;
 
   switch (variant) {
@@ -122,25 +124,25 @@ export const getOutlineButtonColors = (
       return {
         default: {
           background: 'transparent',
-          border: colors.soap500,
+          border: ABTestColors.main || colors.soap500,
           icon: colors.licorice200,
           label: colors.blackPepper400,
         },
         hover: {
-          background: colors.licorice500,
-          border: colors.licorice500,
+          background: ABTestColors.dark || colors.licorice500,
+          border: ABTestColors.dark || colors.licorice500,
           icon: themePrimary.contrast,
           label: themePrimary.contrast,
         },
         active: {
-          background: colors.licorice600,
-          border: colors.licorice600,
+          background: ABTestColors.darkest || colors.licorice600,
+          border: ABTestColors.darkest || colors.licorice600,
           icon: themePrimary.contrast,
           label: themePrimary.contrast,
         },
         focus: {
-          background: colors.licorice500,
-          border: colors.licorice500,
+          background: ABTestColors.dark || colors.licorice500,
+          border: ABTestColors.dark || colors.licorice500,
           icon: themePrimary.contrast,
           label: themePrimary.contrast,
         },

--- a/modules/button/react/lib/OutlineButton.tsx
+++ b/modules/button/react/lib/OutlineButton.tsx
@@ -84,7 +84,7 @@ export const getOutlineButtonColors = (
       palette: {primary: themePrimary},
     },
     // TODO: Remove this support after AB test is complete
-    ABTest: {secondaryOutlineButton: ABTestColors},
+    ABTest: {secondaryOutlineButton: ABTestColors = {}} = {},
   } = theme;
 
   switch (variant) {

--- a/modules/button/react/stories/visual-testing/theming/stories_OutlineButton.tsx
+++ b/modules/button/react/stories/visual-testing/theming/stories_OutlineButton.tsx
@@ -1,5 +1,15 @@
 /// <reference path="../../../../../../typings.d.ts" />
-import {customColorTheme, withSnapshotsEnabled} from '../../../../../../utils/storybook';
+/** @jsx jsx */
+import {jsx} from '@emotion/core';
+import {CanvasProvider} from '@workday/canvas-kit-react-common';
+import {StaticStates} from '@workday/canvas-kit-labs-react-core';
+import {
+  ComponentStatesTable,
+  permutateProps,
+  customColorTheme,
+  withSnapshotsEnabled,
+} from '../../../../../../utils/storybook';
+import {stateTableColumnProps} from '../utils';
 import {OutlineButton} from '../../../';
 import {OutlineButtonStates} from '../stories_OutlineButton';
 
@@ -13,3 +23,38 @@ export default withSnapshotsEnabled({
   },
 });
 export const OutlineButtonThemedStates = OutlineButtonStates;
+
+// TODO: Remove this support after AB test is complete
+export const ABTestOutlineButton = () => (
+  <CanvasProvider
+    theme={{
+      canvas: customColorTheme,
+      ABTest: {
+        secondaryOutlineButton: {
+          main: 'orange', //colors.licorice300,
+          dark: 'blue', //colors.licorice500,
+          darkest: 'red', //colors.licorice600,
+        },
+      },
+    }}
+  >
+    <StaticStates>
+      <ComponentStatesTable
+        rowProps={permutateProps({
+          size: [
+            {value: OutlineButton.Size.Small, label: 'Small'},
+            {value: OutlineButton.Size.Medium, label: 'Medium'},
+            {value: OutlineButton.Size.Large, label: 'Large'},
+          ],
+        })}
+        columnProps={stateTableColumnProps}
+      >
+        {props => (
+          <OutlineButton variant={OutlineButton.Variant.Secondary} {...props}>
+            Test
+          </OutlineButton>
+        )}
+      </ComponentStatesTable>
+    </StaticStates>
+  </CanvasProvider>
+);

--- a/modules/common/react/lib/theming/types.ts
+++ b/modules/common/react/lib/theming/types.ts
@@ -62,5 +62,11 @@ type RecursivePartial<T> = {
 
 export type PartialCanvasTheme = RecursivePartial<CanvasTheme>;
 export type PartialCanvasThemePalette = RecursivePartial<CanvasThemePalette>;
-export type PartialEmotionCanvasTheme = {canvas?: PartialCanvasTheme};
-export type EmotionCanvasTheme = {canvas: CanvasTheme};
+export type PartialEmotionCanvasTheme = {
+  canvas?: PartialCanvasTheme;
+  [key: string]: any;
+};
+export type EmotionCanvasTheme = {
+  canvas: CanvasTheme;
+  [key: string]: any;
+};

--- a/utils/storybook/CanvasProviderDecorator.tsx
+++ b/utils/storybook/CanvasProviderDecorator.tsx
@@ -4,7 +4,6 @@ import {
   CanvasProvider,
   PartialEmotionCanvasTheme,
 } from '@workday/canvas-kit-react-common';
-import {colors} from '@workday/canvas-kit-react-core';
 import {object} from '@storybook/addon-knobs';
 
 const label = 'theme';
@@ -17,6 +16,7 @@ export default makeDecorator({
   wrapper: (storyFn, context, {parameters = {}}) => {
     const theme: PartialEmotionCanvasTheme = {
       canvas: object(label, parameters.theme || defaultCanvasTheme),
+      // TODO: Remove this support after AB test is complete
       ABTest: {
         secondaryOutlineButton: {
           main: 'orange', //colors.licorice300,

--- a/utils/storybook/CanvasProviderDecorator.tsx
+++ b/utils/storybook/CanvasProviderDecorator.tsx
@@ -4,6 +4,7 @@ import {
   CanvasProvider,
   PartialEmotionCanvasTheme,
 } from '@workday/canvas-kit-react-common';
+import {colors} from '@workday/canvas-kit-react-core';
 import {object} from '@storybook/addon-knobs';
 
 const label = 'theme';
@@ -16,6 +17,13 @@ export default makeDecorator({
   wrapper: (storyFn, context, {parameters = {}}) => {
     const theme: PartialEmotionCanvasTheme = {
       canvas: object(label, parameters.theme || defaultCanvasTheme),
+      ABTest: {
+        secondaryOutlineButton: {
+          main: 'orange', //colors.licorice300,
+          dark: 'blue', //colors.licorice500,
+          darkest: 'red', //colors.licorice600,
+        },
+      },
     };
     return <CanvasProvider theme={theme}>{storyFn(context)}</CanvasProvider>;
   },

--- a/utils/storybook/CanvasProviderDecorator.tsx
+++ b/utils/storybook/CanvasProviderDecorator.tsx
@@ -16,14 +16,6 @@ export default makeDecorator({
   wrapper: (storyFn, context, {parameters = {}}) => {
     const theme: PartialEmotionCanvasTheme = {
       canvas: object(label, parameters.theme || defaultCanvasTheme),
-      // TODO: Remove this support after AB test is complete
-      ABTest: {
-        secondaryOutlineButton: {
-          main: 'orange', //colors.licorice300,
-          dark: 'blue', //colors.licorice500,
-          darkest: 'red', //colors.licorice600,
-        },
-      },
     };
     return <CanvasProvider theme={theme}>{storyFn(context)}</CanvasProvider>;
   },


### PR DESCRIPTION
# Summary

We are going to be AB testing a small color change to our secondary outline buttons, and we need to add some way to override the existing colors. Originally the plan was to add support for the `neutral` palette field in the theme object within the `OutlineButton` component. However, I ran into an issue with this approach:

- The current defaults from `defaultCanvasTheme.palette.neutral` do not map to the colors we currently use within the outline button. 
- If I replace the hardcoded colors within `OutlineButton` (e.g. https://github.com/Workday/canvas-kit/blob/master/modules/button/react/lib/OutlineButton.tsx#L125) with a theme reference (e.g. `theme.canvas.palette.neutral.main`, it would then use the wrong color by default.
- Since the theme has already been "filled" with the default value by this point, there isn't really a clean way to do a check and default to the original hardcoded value.
- **I did not want to update the `neutral` values in the `defaultCanvasTheme` object. While we do not currently use this in any of our components, if another team were using it, it would be a breaking change.**

As an alternative solution, I made use of the scoping we added to our Emotion theme in https://github.com/Workday/canvas-kit/pull/593. I've added hidden support in the secondary outline button for `theme.ABTest.secondaryOutlineButton.*`. This is outside the `canvas` theme scope and is not typed, so consumers should not notice the support unless they're looking at the source code of `OutlineButton`. The maintenance impact is minimal, and it avoids the problems noted above. This can be stripped out once the AB test is complete.