### PR TITLE
fix(drawer): Add support for word wrapping in IE11

### DIFF
--- a/modules/_labs/drawer/react/lib/Drawer.tsx
+++ b/modules/_labs/drawer/react/lib/Drawer.tsx
@@ -80,6 +80,7 @@ const ChildrenContainer = styled('div')<Pick<DrawerProps, 'padding'>>(
     height: '100%',
     overflowY: 'auto',
     wordBreak: 'break-word',
+    wordWrap: 'break-word', // Needed for IE11
     position: 'relative',
   },
   ({padding}) => ({

--- a/modules/toast/react/lib/Toast.tsx
+++ b/modules/toast/react/lib/Toast.tsx
@@ -69,7 +69,7 @@ const ActionButton = styled('button')({
 
 const Message = styled('div')({
   wordBreak: 'break-word',
-  wordWrap: 'break-word',
+  wordWrap: 'break-word', // Needed for IE11
 });
 
 export default class Toast extends React.Component<ToastProps> {


### PR DESCRIPTION
## Issue

Fixes #878 

## Overview

This PR adds IE11 support for word wrapping in the Drawer component.

## Where Should the Reviewer Start?

`modules/_labs/drawer/react/lib/Drawer.tsx`

## Testing Manually

* Pull down changes
* Run `yarn start`
* visit `http://localhost:9001/?path=/story/testing-react-labs-drawer--drawer-states`
* update the text in one of the drawers
  * I would recommend something like "Note: Internet_Explorer_Eleven was originally released in October 2013"
* See "Internet_Explorer_Eleven" as expected

## New Dependencies

n/a

## Screenshots (if applicable)

See screenshots in #878 

## Thank You Gif
_Share a fun [gif](https://giphy.com) to say thanks to your reviewer:_

![dog wrapping itself up in a blanket](https://media.giphy.com/media/XkxfezUB7Rj4k/giphy.gif)

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [ ] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
