### PR TITLE
fix(menu): Update MenuItem icon styles

### DIFF
--- a/modules/_labs/menu/react/lib/MenuItem.tsx
+++ b/modules/_labs/menu/react/lib/MenuItem.tsx
@@ -137,11 +137,14 @@ const Divider = styled('hr')({
 const iconSize = 24;
 const iconPadding = 16;
 const StyledSystemIcon = styled(SystemIcon)({
-  flex: `${iconSize + iconPadding}px 0`, // gives padding between LabelContainer, no matter the direction
+  flexShrink: 0,
+  flexBasis: iconSize + iconPadding, // gives padding between LabelContainer, no matter the direction
 });
 
-const SecondaryStyledSystemIcon = styled(StyledSystemIcon)({
+const SecondaryStyledSystemIcon = styled(SystemIcon)({
   display: `flex`,
+  flexShrink: 0,
+  flexBasis: iconSize + iconPadding, // gives padding between LabelContainer, no matter the direction
   justifyContent: `flex-end`,
 });
 

--- a/modules/_labs/menu/react/lib/MenuItem.tsx
+++ b/modules/_labs/menu/react/lib/MenuItem.tsx
@@ -137,14 +137,12 @@ const Divider = styled('hr')({
 const iconSize = 24;
 const iconPadding = 16;
 const StyledSystemIcon = styled(SystemIcon)({
-  flexShrink: 0,
-  flexBasis: iconSize + iconPadding, // gives padding between LabelContainer, no matter the direction
+  minWidth: iconSize + iconPadding, // gives padding between LabelContainer, no matter the direction
 });
 
 const SecondaryStyledSystemIcon = styled(SystemIcon)({
   display: `flex`,
-  flexShrink: 0,
-  flexBasis: iconSize + iconPadding, // gives padding between LabelContainer, no matter the direction
+  minWidth: iconSize + iconPadding, // gives padding between LabelContainer, no matter the direction
   justifyContent: `flex-end`,
 });
 

--- a/modules/_labs/menu/react/stories/stories.tsx
+++ b/modules/_labs/menu/react/stories/stories.tsx
@@ -33,7 +33,7 @@ const createMenuItems = (hasIcons?: boolean): StoryMenuItemProps[] => {
       icon: hasIcons ? uploadCloudIcon : undefined,
     },
     {
-      text: `Second Item with really really really long label`,
+      text: `Second Item (with a really really really long label)`,
       icon: hasIcons ? setupIcon : undefined,
     },
     {

--- a/modules/_labs/menu/react/stories/stories_visualTesting.tsx
+++ b/modules/_labs/menu/react/stories/stories_visualTesting.tsx
@@ -33,11 +33,20 @@ const createMenuItems = (hasIcons?: boolean, isFocused?: boolean): StoryMenuItem
       isFocused: isFocused,
     },
     {
-      text: `Second Item with really really really long label`,
+      text: `Second Item (with a really really really long label)`,
       icon: undefined,
     },
     {
-      text: `Third Item (disabled)`,
+      text: `Third Item (with a really really really long label)`,
+      icon: hasIcons ? uploadCloudIcon : undefined,
+    },
+    {
+      text: `Fourth Item (with a really really really long label)`,
+      icon: hasIcons ? uploadCloudIcon : undefined,
+      secondaryIcon: hasIcons ? extLinkIcon : undefined,
+    },
+    {
+      text: `Fifth Item (disabled)`,
       icon: undefined,
       secondaryIcon: hasIcons ? extLinkIcon : undefined,
       isDisabled: true,
@@ -47,14 +56,14 @@ const createMenuItems = (hasIcons?: boolean, isFocused?: boolean): StoryMenuItem
         ''
       ) : (
         <em>
-          Fourth Item (<b>with markup</b>)
+          Sixth Item (<b>with markup</b>)
         </em>
       ),
       icon: undefined,
       'aria-label': hasIcons ? `I am a label for screen readers` : undefined,
     },
     {
-      text: `Fifth Item (with divider)`,
+      text: `Seventh Item (with divider)`,
       icon: undefined,
       hasDivider: true,
     },
@@ -81,10 +90,11 @@ export const MenuItemStates = () => (
       rowProps={[
         {label: 'Default', props: {}},
         {label: 'With Icons', props: {hasIcons: true}},
+        {label: 'With Icons and Custom Width', props: {hasIcons: true, width: 200}},
       ]}
       columnProps={[{label: 'Default', props: {}}]}
     >
-      {props => <Menu>{createMenuItems(props.hasIcons).map(buildItem)}</Menu>}
+      {props => <Menu width={props.width}>{createMenuItems(props.hasIcons).map(buildItem)}</Menu>}
     </ComponentStatesTable>
   </StaticStates>
 );

--- a/modules/_labs/menu/react/stories/stories_visualTesting.tsx
+++ b/modules/_labs/menu/react/stories/stories_visualTesting.tsx
@@ -3,7 +3,7 @@
 import {jsx} from '@emotion/core';
 import {StaticStates} from '@workday/canvas-kit-labs-react-core';
 import {ComponentStatesTable, withSnapshotsEnabled} from '../../../../../utils/storybook';
-import {uploadCloudIcon, extLinkIcon} from '@workday/canvas-system-icons-web';
+import {uploadCloudIcon, extLinkIcon, userIcon} from '@workday/canvas-system-icons-web';
 import {Menu, MenuItem, MenuItemProps} from '../index';
 
 // @ts-ignore: Cannot find module error
@@ -59,7 +59,7 @@ const createMenuItems = (hasIcons?: boolean, isFocused?: boolean): StoryMenuItem
           Sixth Item (<b>with markup</b>)
         </em>
       ),
-      icon: undefined,
+      icon: hasIcons ? userIcon : undefined,
       'aria-label': hasIcons ? `I am a label for screen readers` : undefined,
     },
     {

--- a/modules/menu/css/stories.tsx
+++ b/modules/menu/css/stories.tsx
@@ -23,7 +23,7 @@ class WithIconsDemo extends Component {
             <li role="menuitem">
               <i className="wdc-icon" data-icon="setup" data-category="system" />
               <span className="wdc-menu-item-label">
-                Second Item with a really really really long label
+                Second Item (with a really really really long label)
               </span>
             </li>
             <li role="menuitem" className="wdc-menu-item-disabled" aria-disabled="true">
@@ -56,7 +56,7 @@ storiesOf('Components|Popups/Menu/CSS', module)
             <li role="menuitem" className="wdc-menu-item-focused">
               <a href="#">First Item</a>
             </li>
-            <li role="menuitem">Second Item with a really really really long label</li>
+            <li role="menuitem">Second Item (with a really really really long label)</li>
             <li role="menuitem" className="wdc-menu-item-disabled" aria-disabled="true">
               Third Item (disabled)
             </li>

--- a/modules/menu/css/stories.tsx
+++ b/modules/menu/css/stories.tsx
@@ -23,7 +23,7 @@ class WithIconsDemo extends Component {
             <li role="menuitem">
               <i className="wdc-icon" data-icon="setup" data-category="system" />
               <span className="wdc-menu-item-label">
-                Second Item with really really really long label
+                Second Item with a really really really long label
               </span>
             </li>
             <li role="menuitem" className="wdc-menu-item-disabled" aria-disabled="true">
@@ -56,7 +56,7 @@ storiesOf('Components|Popups/Menu/CSS', module)
             <li role="menuitem" className="wdc-menu-item-focused">
               <a href="#">First Item</a>
             </li>
-            <li role="menuitem">Second Item with really really really long label</li>
+            <li role="menuitem">Second Item with a really really really long label</li>
             <li role="menuitem" className="wdc-menu-item-disabled" aria-disabled="true">
               Third Item (disabled)
             </li>


### PR DESCRIPTION
## Issue

Fixes #851 

## Overview

This PR updates the MenuItem styles in the Labs Menu component to keep consistent spacing around icons. I also updated and added a visual test. And I verified that the CSS version of the Menu component does not have this issue.

## Where Should the Reviewer Start?

`modules/_labs/menu/react/lib/MenuItem.tsx`

## Testing Manually

* pull down this branch locally
* run `yarn start`
* visit `http://localhost:9001/?path=/story/labs-menu-react--with-icons`
* visit `http://localhost:9001/?path=/story/testing-react-labs-menu--menu-item-states`

## New Dependencies

n/a

## Screenshots (if applicable)

### Before 😿 

![Screen Shot 2020-10-14 at 3 41 12 PM](https://user-images.githubusercontent.com/4818182/96050607-24e66080-0e37-11eb-93ae-3c37c68dd910.png)

### After 🥳 

![Screen Shot 2020-10-14 at 4 12 24 PM](https://user-images.githubusercontent.com/4818182/96051133-219fa480-0e38-11eb-91e6-37deb3d0bf41.png)

## Thank You Gif
_Share a fun [gif](https://giphy.com) to say thanks to your reviewer:_

![](https://media.giphy.com/media/sRIXt1e9dQRjEjxnMk/giphy-downsized.gif)

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [ ] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
