### PR TITLE
docs: Remove universal selector for section elements

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -8,7 +8,6 @@
     font-family: sans-serif;
   }
 
-  section > *,
   .story > * {
     margin: 12px !important;
   }

--- a/modules/_labs/core/react/stories/stories.tsx
+++ b/modules/_labs/core/react/stories/stories.tsx
@@ -21,7 +21,7 @@ export default {
 };
 
 export const Type = () => (
-  <section>
+  <section className="story">
     <h1 style={type.brand1}>Brand 1 Header</h1>
     <h2 style={type.brand2}>Brand 2 header</h2>
     <h1 style={type.h1}>H1 Header</h1>

--- a/modules/_labs/core/react/stories/stories_visualTesting.tsx
+++ b/modules/_labs/core/react/stories/stories_visualTesting.tsx
@@ -27,7 +27,7 @@ export const TypeAndSpace = () => {
 
   return (
     <div>
-      <section>
+      <section className="story">
         <h1 style={type.brand1}>Brand 1 Header</h1>
         <h2 style={type.brand2}>Brand 2 header</h2>
         <h1 style={type.h1}>H1 Header</h1>
@@ -36,7 +36,7 @@ export const TypeAndSpace = () => {
         <h4 style={type.h4}>H4 Header</h4>
         <h5 style={type.h5}>H5 Header</h5>
       </section>
-      <section>
+      <section className="story">
         <h2 style={type.h2}>Body Text</h2>
         <p style={type.body}>
           <strong>Body: </strong> Tacos chartreuse raclette single-origin coffee ethical tilde
@@ -63,7 +63,7 @@ export const TypeAndSpace = () => {
           bird on it occaecat
         </p>
       </section>
-      <section>
+      <section className="story">
         <h2 style={type.h2}>Text Variants</h2>
         <span css={[type.body, type.variant.button]}>Button Text</span>
         <br />
@@ -83,7 +83,7 @@ export const TypeAndSpace = () => {
         <br />
         <span css={[type.body, type.variant.mono]}>Mono Text</span>
       </section>
-      <section>
+      <section className="story">
         <h2 style={type.h2}>Spacing</h2>
         <Box m={spacing.m} p={spacing.m}>
           medium margin and padding

--- a/modules/banner/css/stories.scss
+++ b/modules/banner/css/stories.scss
@@ -6,6 +6,6 @@
   }
 }
 
-.story>* {
+.banner-story > * {
   margin-top: 0px !important;
 }

--- a/modules/banner/css/stories.tsx
+++ b/modules/banner/css/stories.tsx
@@ -8,7 +8,7 @@ import './stories.scss';
 storiesOf('Components|Indicators/Banner/CSS/Alert ', module)
   .addDecorator(withReadme(README))
   .add('Full', () => (
-    <div className="story">
+    <div className="banner-story">
       <a className="wdc-banner" href="#">
         <span className="wdc-banner-text">3 Alerts</span>
         <span className="wdc-banner-link">View All</span>
@@ -16,7 +16,7 @@ storiesOf('Components|Indicators/Banner/CSS/Alert ', module)
     </div>
   ))
   .add('Sticky  ', () => (
-    <div className="story">
+    <div className="banner-story">
       <a className="wdc-banner wdc-banner-sticky" href="#">
         <span className="wdc-banner-text">3 Alerts</span>
       </a>
@@ -26,7 +26,7 @@ storiesOf('Components|Indicators/Banner/CSS/Alert ', module)
 storiesOf('Components|Indicators/Banner/CSS/Error ', module)
   .addDecorator(withReadme(README))
   .add('Full', () => (
-    <div className="story">
+    <div className="banner-story">
       <a className="wdc-banner wdc-banner-error" href="#">
         <span className="wdc-banner-text">3 Errors</span>
         <span className="wdc-banner-link">View All</span>
@@ -34,7 +34,7 @@ storiesOf('Components|Indicators/Banner/CSS/Error ', module)
     </div>
   ))
   .add('Sticky', () => (
-    <div className="story">
+    <div className="banner-story">
       <a className="wdc-banner wdc-banner-error wdc-banner-sticky" href="#">
         <span className="wdc-banner-text">3 Errors</span>
       </a>

--- a/modules/button/css/stories.tsx
+++ b/modules/button/css/stories.tsx
@@ -45,7 +45,7 @@ storiesOf('Components|Buttons/Button/CSS', module)
   .addDecorator(withReadme(README))
   .add('Primary', () => (
     <div className="story">
-      <section>
+      <section className="story">
         <h3>Large Primary</h3>
         <IconDemo>
           <button className="wdc-btn wdc-btn-primary wdc-btn-size-l">Primary</button>
@@ -62,7 +62,7 @@ storiesOf('Components|Buttons/Button/CSS', module)
         </button>
       </section>
 
-      <section>
+      <section className="story">
         <h3>Medium Primary</h3>
         <IconDemo>
           <button className="wdc-btn wdc-btn-primary">Primary</button>
@@ -76,7 +76,7 @@ storiesOf('Components|Buttons/Button/CSS', module)
         </button>
       </section>
 
-      <section>
+      <section className="story">
         <h3>Small Primary</h3>
         <button className="wdc-btn wdc-btn-primary wdc-btn-size-s">Primary</button>
         <button disabled={true} className="wdc-btn wdc-btn-primary wdc-btn-size-s">
@@ -87,7 +87,7 @@ storiesOf('Components|Buttons/Button/CSS', module)
   ))
   .add('Secondary', () => (
     <div>
-      <section>
+      <section className="story">
         <h3>Large Secondary</h3>
         <IconDemo>
           <button className="wdc-btn wdc-btn-size-l">Secondary</button>
@@ -101,7 +101,7 @@ storiesOf('Components|Buttons/Button/CSS', module)
         </button>
       </section>
 
-      <section>
+      <section className="story">
         <h3>Medium Secondary</h3>
         <IconDemo>
           <button className="wdc-btn">Secondary</button>
@@ -115,7 +115,7 @@ storiesOf('Components|Buttons/Button/CSS', module)
         </button>
       </section>
 
-      <section>
+      <section className="story">
         <h3>Small Secondary</h3>
         <button className="wdc-btn wdc-btn-size-s">Secondary</button>
         <button disabled={true} className="wdc-btn wdc-btn-size-s">
@@ -126,7 +126,7 @@ storiesOf('Components|Buttons/Button/CSS', module)
   ))
   .add('Delete', () => (
     <div>
-      <section>
+      <section className="story">
         <h3>Large Delete</h3>
         <button className="wdc-btn wdc-btn-delete wdc-btn-size-l">Delete</button>
         <button disabled={true} className="wdc-btn wdc-btn-delete wdc-btn-size-l">
@@ -134,7 +134,7 @@ storiesOf('Components|Buttons/Button/CSS', module)
         </button>
       </section>
 
-      <section>
+      <section className="story">
         <h3>Medium Delete</h3>
         <button className="wdc-btn wdc-btn-delete">Delete</button>
         <button disabled={true} className="wdc-btn wdc-btn-delete">
@@ -142,7 +142,7 @@ storiesOf('Components|Buttons/Button/CSS', module)
         </button>
       </section>
 
-      <section>
+      <section className="story">
         <h3>Small Delete</h3>
         <button className="wdc-btn wdc-btn-delete wdc-btn-size-s">Delete</button>
         <button disabled={true} className="wdc-btn wdc-btn-delete wdc-btn-size-s">
@@ -156,7 +156,7 @@ storiesOf('Components|Buttons/Button/CSS/Dropdown', module)
   .addDecorator(withReadme(README))
   .add('Default', () => (
     <div className="story">
-      <section>
+      <section className="story">
         <h3>Primary Large</h3>
         <button
           className="wdc-btn wdc-btn-primary wdc-btn-size-l wdc-btn-dropdown"
@@ -361,14 +361,14 @@ storiesOf('Components|Buttons/Button/CSS/Deprecated', module)
   ))
   .add('Dropdown', () => (
     <div className="story">
-      <section>
+      <section className="story">
         <button className="wdc-btn-deprecated wdc-btn-dropdown">Dropdown</button>
       </section>
     </div>
   ))
   .add('Split', () => (
     <div className="story">
-      <section>
+      <section className="story">
         <div className="wdc-btn-split">
           <button className="wdc-btn-deprecated wdc-btn-primary wdc-btn-split-text">
             Split Button

--- a/modules/card/css/stories.tsx
+++ b/modules/card/css/stories.tsx
@@ -9,7 +9,7 @@ storiesOf('Components|Containers/Card/CSS', module)
   .add('All', () => (
     <div className="story">
       <h2>Default</h2>
-      <section>
+      <section className="story">
         <div className="wdc-card">
           <h3 className="wdc-card-heading">Card Header</h3>
           <div className="wdc-card-body">.wdc-card</div>
@@ -68,7 +68,7 @@ storiesOf('Components|Containers/Card/CSS', module)
 
       <h2>Positioning</h2>
 
-      <section>
+      <section className="story">
         <div className="wdc-card-container wdc-card-container-around">
           <div className="wdc-card-3">
             <h3 className="wdc-card-heading">Card Header</h3>
@@ -143,7 +143,7 @@ storiesOf('Components|Containers/Card/CSS', module)
 
       <h2>No Padding</h2>
 
-      <section>
+      <section className="story">
         <div className="wdc-card-container">
           <div className="wdc-card-6 wdc-card-no-padding">
             <h3 className="wdc-card-heading">Card Header</h3>
@@ -158,7 +158,7 @@ storiesOf('Components|Containers/Card/CSS', module)
 
       <h2>Different Depths</h2>
 
-      <section>
+      <section className="story">
         <div className="wdc-card-container">
           <div className="wdc-card-3 wdc-depth-1">
             <h3 className="wdc-card-heading">Card Header</h3>

--- a/modules/common/react/stories/stories_direction.tsx
+++ b/modules/common/react/stories/stories_direction.tsx
@@ -19,7 +19,7 @@ storiesOf('Tokens|Common/Theming', module)
   .addDecorator(withReadme(README))
   .add('Direction', () => (
     <div className="story">
-      <section>
+      <section className="story">
         <CanvasProvider theme={{canvas: {direction: ContentDirection.RTL}}}>
           <Card heading="مشغل وسائط" style={{width: '186px'}}>
             <CanvasProvider theme={{canvas: {direction: ContentDirection.LTR}}}>

--- a/modules/core/css/stories.tsx
+++ b/modules/core/css/stories.tsx
@@ -19,7 +19,7 @@ storiesOf('Tokens|Core/CSS', module)
       <div className="story">
         <h3>Type Hierarchy</h3>
 
-        <section className="wdc-type">
+        <section className="story wdc-type">
           <h1 className="wdc-type-data-viz-1">Data Viz 1</h1>
           <h1 className="wdc-type-data-viz-2">Data Viz 2</h1>
           <h1 className="wdc-type-h1">H1 Header</h1>
@@ -55,7 +55,7 @@ storiesOf('Tokens|Core/CSS', module)
 
         <h3>Type Variations</h3>
 
-        <section className="wdc-type">
+        <section className="story wdc-type">
           <div>
             <p className="wdc-type-variant-label">Label</p>
             <p className="wdc-type-variant-button">Button</p>


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
In Storybook, we are doing a universal selector for children of a `<section>` and adding a margin. This was probably for convenience purposes. However, this means that any `section` rendered in a story would universally apply a margin to their children.

For something like `SidePanel` (#866), **it is a section** by default so this would have unintentional layout behaviors in a story.

The fix is to remove the universal selector for `section` and apply the class name `.story` to whatever stories used `section` for this convenience since it does the same thing. All-in-all this smells like some legacy stuff that we just need to get rid of.

Definitely would like to merge this before #866 if possible so I'm going to mark that PR "blocked by" this one.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [ ] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
