### PR TITLE
fix(side-panel): Update Toggle spacing

### DIFF
--- a/modules/_labs/side-panel/react/lib/SidePanel.tsx
+++ b/modules/_labs/side-panel/react/lib/SidePanel.tsx
@@ -229,7 +229,7 @@ const ToggleButton = ({
   // Note: Depending on the collapsed width, the button could "jump" to it's final position.
   const buttonStyle = css({
     position: 'absolute',
-    top: spacing.l,
+    top: spacing.m,
     right: context.state === 'collapsed' ? 0 : context.origin === 'left' ? spacing.s : undefined,
     left: context.state === 'collapsed' ? 0 : context.origin === 'right' ? spacing.s : undefined,
     margin: context.state === 'collapsed' ? 'auto' : 0, // to override the -8px margin for IconButton.Plain


### PR DESCRIPTION
This PR addresses a simple alteration to the specs that change the top spacing of the IconButton from 32px to 24px.