### PR TITLE
ci: Use exec instead of node-cmd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - "10"
+  - "12"
 
 cache:
   npm: false # Caching npm makes yarn install faster but downloading and packaging up the cache makes this slower when enabled

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "lint-staged": "8.0.5",
     "markdown-to-jsx": "^6.10.3",
     "mkdirp": "^1.0.3",
-    "node-cmd": "^3.0.0",
     "node-fetch": "^2.1.2",
     "node-sass": "^4.13.1",
     "npm-run-all": "^4.1.5",

--- a/utils/create-component/createComponent.js
+++ b/utils/create-component/createComponent.js
@@ -6,7 +6,6 @@ const path = require('path');
 const mkdirp = require('mkdirp');
 const inquirer = require('inquirer');
 const cmd = require('node-cmd');
-const colors = require('colors');
 
 const createReactModule = require('./createReactModule');
 const createCssModule = require('./createCssModule');

--- a/utils/create-component/createReactModule.js
+++ b/utils/create-component/createReactModule.js
@@ -1,7 +1,5 @@
-const path = require('path');
 const mkdirp = require('mkdirp');
 const cmd = require('node-cmd');
-const colors = require('colors');
 
 const writeModuleFiles = require('./writeModuleFiles');
 const getPascalCaseName = require('./nameUtils').getPascalCaseName;

--- a/utils/promote-component.js
+++ b/utils/promote-component.js
@@ -3,10 +3,9 @@
 
 const fs = require('fs');
 const {promisify} = require('util');
-const cmd = promisify(require('node-cmd').get);
+const exec = promisify(require('child_process').exec);
 const mkdirp = require('mkdirp');
 const path = require('path');
-const colors = require('colors');
 const inquirer = require('inquirer');
 const glob = require('glob');
 const replaceInFiles = require('replace-in-files');
@@ -68,8 +67,8 @@ inquirer.prompt(questions).then(answers => {
         `modules/${component}`.cyan
     );
 
-    cmd(`git mv ${srcPath}/${target} ${destPath}`)
-      .then(output => {
+    exec(`git mv ${srcPath}/${target} ${destPath}`)
+      .then(() => {
         glob(`${destPath}/${target}/**/*`, async (err, files) => {
           if (err) {
             console.log('Error', err);

--- a/yarn.lock
+++ b/yarn.lock
@@ -13114,11 +13114,6 @@ node-ask@^1.0.1:
   resolved "https://registry.yarnpkg.com/node-ask/-/node-ask-1.0.1.tgz#caaa1076cc58e0364267a0903e3eadfac158396b"
   integrity sha1-yqoQdsxY4DZCZ6CQPj6t+sFYOWs=
 
-node-cmd@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/node-cmd/-/node-cmd-3.0.0.tgz#38fff70a4aaa4f659d203eb57862737018e24f6f"
-  integrity sha1-OP/3CkqqT2WdID61eGJzcBjiT28=
-
 node-dir@^0.1.10, node-dir@^0.1.17:
   version "0.1.17"
   resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.17.tgz#5f5665d93351335caabef8f1c554516cf5f1e4e5"


### PR DESCRIPTION
Swap `node-cmd` for `child_process.exec` (it's the same underlying function). Clean up unused require statements and update to Node 12 to polish off #903, this increases the buffer size as part of Node updates so we removed that option arg in the codebase.