### PR TITLE
chore: Fix create component scripts

### DIFF
--- a/utils/create-component/createComponent.js
+++ b/utils/create-component/createComponent.js
@@ -5,7 +5,9 @@ const fs = require('fs');
 const path = require('path');
 const mkdirp = require('mkdirp');
 const inquirer = require('inquirer');
-const cmd = require('node-cmd');
+const exec = require('child_process');
+
+require('colors');
 
 const createReactModule = require('./createReactModule');
 const createCssModule = require('./createCssModule');
@@ -99,7 +101,7 @@ const createModule = (componentPath, target, moduleGenerator, answers, unstable)
     moduleGenerator(modulePath, name, description, unstable, publicModule, category);
 
     console.log('\nBootstrapping dependencies.');
-    cmd.run('yarn');
+    exec('yarn');
 
     if (!unstable) {
       console.log('\nAdding dependency to ' + `@workday/canvas-kit-${target}.`.cyan);

--- a/utils/create-component/createCssModule.js
+++ b/utils/create-component/createCssModule.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const mkdirp = require('mkdirp');
-const cmd = require('node-cmd');
+const exec = require('child_process');
+require('colors');
 
 const writeModuleFiles = require('./writeModuleFiles');
 const getTitleCaseName = require('./nameUtils').getTitleCaseName;
@@ -49,5 +50,5 @@ module.exports = (modulePath, name, description, unstable, public, category) => 
   writeModuleFiles(files, modulePath);
 
   console.log('Copying License file to ' + `.${modulePath.replace(cwd, '')}/LICENSE`.cyan);
-  cmd.run(`cp ${cwd}/LICENSE ${modulePath}/LICENSE`);
+  exec(`cp ${cwd}/LICENSE ${modulePath}/LICENSE`);
 };

--- a/utils/create-component/createReactModule.js
+++ b/utils/create-component/createReactModule.js
@@ -1,5 +1,6 @@
 const mkdirp = require('mkdirp');
-const cmd = require('node-cmd');
+const exec = require('child_process');
+require('colors');
 
 const writeModuleFiles = require('./writeModuleFiles');
 const getPascalCaseName = require('./nameUtils').getPascalCaseName;
@@ -75,5 +76,5 @@ module.exports = (modulePath, name, description, unstable, public, category) => 
   writeModuleFiles(files, modulePath);
 
   console.log('Copying License file to ' + `.${modulePath.replace(cwd, '')}/LICENSE`.cyan);
-  cmd.run(`cp ${cwd}/LICENSE ${modulePath}/LICENSE`);
+  exec(`cp ${cwd}/LICENSE ${modulePath}/LICENSE`);
 };


### PR DESCRIPTION
## Summary
The create component scripts were still dependent on `node-cmd` which was removed here: https://github.com/Workday/canvas-kit/commit/bc2f1f499736d6b792c3eccc05e7bca93b83c817#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L95

Also, we still need to use the `colors` module for our cli coloring which was removed here: 
https://github.com/Workday/canvas-kit/commit/bc2f1f499736d6b792c3eccc05e7bca93b83c817#diff-cf53da1297de5bd1a9a1f27c12e693097fcad3810a132ab41d49b4a469c0fdf6L4