### PR TITLE
fix(select): Allow a single option

### DIFF
--- a/modules/select/react/lib/Select.tsx
+++ b/modules/select/react/lib/Select.tsx
@@ -25,7 +25,7 @@ export interface SelectProps
   /**
    * The SelectOption children of the Select (must be at least two).
    */
-  children: React.ReactElement<SelectOption>[];
+  children: React.ReactElement<SelectOption> | React.ReactElement<SelectOption>[];
   /**
    * If true, set the Select to the disabled state.
    * @default false

--- a/modules/select/react/spec/Select.spec.tsx
+++ b/modules/select/react/spec/Select.spec.tsx
@@ -12,6 +12,17 @@ describe('Select', () => {
     cb.mockReset();
   });
 
+  describe('when rendered with a single child', () => {
+    it('should not throw an error', () => {
+      const {getAllByRole} = render(
+        <Select onChange={cb}>
+          <SelectOption value="email" label="E-mail" />
+        </Select>
+      );
+      expect(getAllByRole('option')).toHaveLength(1);
+    });
+  });
+
   describe('when rendered with an id', () => {
     it('should render a select with id', () => {
       const id = 'mySelect';


### PR DESCRIPTION
## Summary

A `Select` should support a single `SelectOption` child.

