### PR TITLE
fix(menu): Remove minimum width and collapse around the content

### DIFF
--- a/modules/_labs/menu/react/lib/Menu.tsx
+++ b/modules/_labs/menu/react/lib/Menu.tsx
@@ -46,11 +46,8 @@ export interface MenuState {
   selectedItemIndex: number;
 }
 
-const minWidth = 100;
-
 const List = styled('ul')({
   background: commonColors.background,
-  minWidth: `${minWidth}px`,
   borderRadius: borderRadius.m,
   padding: 0,
   margin: `${spacing.xxs} 0`,
@@ -124,11 +121,7 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
     const cardWidth = grow ? '100%' : width;
 
     return (
-      <Card
-        style={{display: 'inline-block', minWidth: minWidth + 2}}
-        padding={spacing.zero}
-        width={cardWidth}
-      >
+      <Card style={{display: 'inline-block'}} padding={spacing.zero} width={cardWidth}>
         <List
           role="menu"
           tabIndex={0}


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

Closes #859.

Our documentation describes behavior which the Menu component was not following. It should auto-collapse the width based on the content, but it was using an arbitrary minimum width. This PR removes the `min-width` style from being applied.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [ ] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md
- [x] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [x] design approved final implementation
- [x] a11y approved final implementation
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

Before:
![Screen Shot 2020-12-03 at 11 25 18 AM](https://user-images.githubusercontent.com/1075861/101072153-d9108780-355a-11eb-94ee-56ec00d81e4b.png)
![Screen Shot 2020-12-03 at 11 26 50 AM](https://user-images.githubusercontent.com/1075861/101072175-df9eff00-355a-11eb-9fea-942ff058d633.png)

After:
![Screen Shot 2020-12-03 at 11 15 50 AM](https://user-images.githubusercontent.com/1075861/101072192-e6c60d00-355a-11eb-95f5-134dc22928a9.png)
![Screen Shot 2020-12-03 at 11 28 38 AM](https://user-images.githubusercontent.com/1075861/101072202-e9c0fd80-355a-11eb-8b18-7c5fa52029ca.png)

