### PR TITLE
fix(common): Fix mouseFocusBehavior type issue

### DIFF
--- a/modules/common/react/lib/styles/hideMouseFocus.ts
+++ b/modules/common/react/lib/styles/hideMouseFocus.ts
@@ -1,4 +1,4 @@
-import {CSSObject} from '@emotion/core';
+import {CSSObject, Interpolation} from '@emotion/core';
 
 /**
  * A utility to hide the default canvas style focus ring when using mouse input.
@@ -14,8 +14,6 @@ export const hideMouseFocus: CSSObject = {
   },
 };
 
-type IndexableObject = {[key: string]: object};
-
 /*
  * A utility that simplifies focus selectors since you can't use nested syntax for some reason. Example:
  * [`[data-whatinput="mouse"],
@@ -26,8 +24,10 @@ type IndexableObject = {[key: string]: object};
        }
    },
  */
-export const mouseFocusBehavior = <T extends IndexableObject = IndexableObject>(selectors: T) => {
-  const output: IndexableObject = {};
+export const mouseFocusBehavior = (
+  selectors: Record<string, Interpolation>
+): Record<string, Interpolation> => {
+  const output: Record<string, Interpolation> = {};
 
   Object.keys(selectors).map((selector, index) => {
     selector.split(',').forEach(selectorPart => {
@@ -39,5 +39,5 @@ export const mouseFocusBehavior = <T extends IndexableObject = IndexableObject>(
     });
   });
 
-  return output as T;
+  return output;
 };


### PR DESCRIPTION
Fixes #925

I went through many iterations testing with the following code:

```ts
const temp = {
  '&:focus': {
    background: 'red',
  },
  ...mouseFocusBehavior({
    '&:focus': {
      backgroundColor: 'blue',
    },
  }),
};

const Div = styled('div');
const Foo = Div(temp);

const styles = css(
  mouseFocusBehavior({
    '&:focus': {
      outline: 'none',
    },
  })
);
```

I made sure that `mouseFocusBehavior` works for both `styled` and `css`.