### PR TITLE
docs: Standardize README badges for Labs components

### DIFF
--- a/modules/_labs/README.md
+++ b/modules/_labs/README.md
@@ -47,7 +47,7 @@ ultimately performing a migration when components are promoted to a stable versi
 2. Change the package name in `package.json` to `@workday/canvas-kit-labs-<TARGET>-<COMPONENT>`
 3. Add a warning to the README:
    > <a href="https://github.com/Workday/canvas-kit/tree/master/modules/_labs/README.md">
-   >   <img src="https://img.shields.io/badge/LABS-alpha-orange" alt="LABS: Alpha" />
+   >   <img src="https://img.shields.io/badge/LABS-beta-orange" alt="LABS: Beta" />
    > </a>  This component is work in progress and currently in pre-release.
 4. Update any necessary paths (links to storybook utils, tsconfig, etc.)
 5. Change the storybook path to add a `Labs` prefix (e.g. `Labs/Menu/Default`)

--- a/modules/_labs/README.md
+++ b/modules/_labs/README.md
@@ -1,6 +1,6 @@
 # Canvas Kit Labs
 
-This is a group of unstable/work-in-progress components. Canvas Kit Labs is an incubator for new and
+This is a group of work-in-progress components. Canvas Kit Labs is an incubator for new and
 experimental components. Since we have a rather rigorous process for getting components in at a
 production level, it can be valuable to make them available earlier while we continuously iterate on
 the API/functionality. The Labs modules allow us to do that as needed.
@@ -36,7 +36,7 @@ ultimately performing a migration when components are promoted to a stable versi
 ## Creating a Canvas Kit Labs Module
 
 1. Run `yarn create-module`
-2. When asked `Is this an unstable component? [Y/n]`, enter `y` or `Y`.
+2. When asked `What category should this component live in?`, select `Labs (beta)`.
 3. Your new module will be generated in accordance with the file structure above. It will get a
    package name of `@workday/canvas-kit-labs-<TARGET>-<COMPONENT>`.
 4. If you had the storybook server running, you may need to restart it.

--- a/modules/_labs/breadcrumbs/react/README.md
+++ b/modules/_labs/breadcrumbs/react/README.md
@@ -1,7 +1,7 @@
 # Canvas Kit React Breadcrumbs
 
 <a href="https://github.com/Workday/canvas-kit/tree/master/modules/_labs/README.md">
-  <img src="https://img.shields.io/badge/LABS-alpha-orange" alt="LABS: Alpha" />
+  <img src="https://img.shields.io/badge/LABS-beta-orange" alt="LABS: Beta" />
 </a>  This component is work in progress and currently in pre-release.
 
 Breadcrumbs provides navigation to previous levels of pages.

--- a/modules/_labs/color-picker/react/README.md
+++ b/modules/_labs/color-picker/react/README.md
@@ -1,7 +1,7 @@
 # Canvas Kit React Color Picker
 
 <a href="https://github.com/Workday/canvas-kit/tree/master/modules/_labs/README.md">
-  <img src="https://img.shields.io/badge/LABS-alpha-orange" alt="LABS: Alpha" />
+  <img src="https://img.shields.io/badge/LABS-beta-orange" alt="LABS: Beta" />
 </a>  This component is work in progress and currently in pre-release.
 
 Color Picker is a popup for selecting a color.

--- a/modules/_labs/combobox/react/README.md
+++ b/modules/_labs/combobox/react/README.md
@@ -1,7 +1,7 @@
 # Canvas Kit Combobox
 
 <a href="https://github.com/Workday/canvas-kit/tree/master/modules/_labs/README.md">
-  <img src="https://img.shields.io/badge/UNSTABLE-alpha-orange" alt="UNSTABLE: Alpha" />
+  <img src="https://img.shields.io/badge/LABS-beta-orange" alt="LABS: Beta" />
 </a>  This component is work in progress and currently in pre-release.
 
 For a full suite of examples, have a look at the [Combobox Stories](./stories/stories.tsx).

--- a/modules/_labs/core/react/README.md
+++ b/modules/_labs/core/react/README.md
@@ -1,7 +1,7 @@
 # Canvas Kit Labs React Core
 
 <a href="https://github.com/Workday/canvas-kit/tree/master/modules/_labs/README.md">
-  <img src="https://img.shields.io/badge/UNSTABLE-alpha-orange" alt="UNSTABLE: Alpha" />
+  <img src="https://img.shields.io/badge/LABS-beta-orange" alt="LABS: Beta" />
 </a>  This component is work in progress and currently in pre-release.
 
 Includes:

--- a/modules/_labs/drawer/react/README.md
+++ b/modules/_labs/drawer/react/README.md
@@ -1,7 +1,7 @@
 # Canvas Kit React Drawer
 
 <a href="https://github.com/Workday/canvas-kit/tree/master/modules/_labs/README.md">
-  <img src="https://img.shields.io/badge/LABS-alpha-orange" alt="LABS: Alpha" />
+  <img src="https://img.shields.io/badge/LABS-beta-orange" alt="LABS: Beta" />
 </a>  This component is work in progress and currently in pre-release.
 
 ## Installation

--- a/modules/_labs/header/react/README.md
+++ b/modules/_labs/header/react/README.md
@@ -1,7 +1,7 @@
 # Canvas Kit Labs React Header
 
 <a href="https://github.com/Workday/canvas-kit/tree/master/modules/_labs/README.md">
-  <img src="https://img.shields.io/badge/UNSTABLE-alpha-orange" alt="UNSTABLE: Alpha" />
+  <img src="https://img.shields.io/badge/LABS-beta-orange" alt="LABS: Beta" />
 </a>  This component is work in progress and currently in pre-release.
 
 A set of components to create headers for various Workday applications and sites.

--- a/modules/_labs/menu/react/README.md
+++ b/modules/_labs/menu/react/README.md
@@ -1,7 +1,7 @@
 # Canvas Kit Labs React Menu
 
 <a href="https://github.com/Workday/canvas-kit/tree/master/modules/_labs/README.md">
-  <img src="https://img.shields.io/badge/LABS-alpha-orange" alt="LABS: Alpha" />
+  <img src="https://img.shields.io/badge/LABS-beta-orange" alt="LABS: Beta" />
 </a>  This component is work in progress and currently in pre-release.
 
 Creates an actions menu of clickable items.

--- a/modules/_labs/pagination/react/README.md
+++ b/modules/_labs/pagination/react/README.md
@@ -1,7 +1,7 @@
 # Canvas Kit React Pagination
 
 <a href="https://github.com/Workday/canvas-kit/tree/master/modules/_labs/README.md">
-  <img src="https://img.shields.io/badge/LABS-alpha-orange" alt="LABS: Alpha" />
+  <img src="https://img.shields.io/badge/LABS-beta-orange" alt="LABS: Beta" />
 </a>  This component is work in progress and currently in pre-release.
 
 Contains a component for a pagination bar and dispatches for page changes

--- a/modules/_labs/select/react/README.md
+++ b/modules/_labs/select/react/README.md
@@ -1,7 +1,7 @@
 # Canvas Kit Select (with Canvas-styled Menu)
 
 <a href="https://github.com/Workday/canvas-kit/tree/master/modules/_labs/README.md">
-  <img src="https://img.shields.io/badge/LABS-alpha-orange" alt="LABS: Alpha" />
+  <img src="https://img.shields.io/badge/LABS-beta-orange" alt="LABS: Beta" />
 </a>  This component is work in progress and currently in pre-release.
 
 A Canvas-styled Select with a Canvas-styled menu. This is a

--- a/modules/_labs/side-panel/react/README.md
+++ b/modules/_labs/side-panel/react/README.md
@@ -1,7 +1,7 @@
 # Canvas Kit React Side Panel
 
 <a href="https://github.com/Workday/canvas-kit/tree/master/modules/_labs/README.md">
-  <img src="https://img.shields.io/badge/LABS-alpha-orange" alt="LABS: Alpha" />
+  <img src="https://img.shields.io/badge/LABS-beta-orange" alt="LABS: Beta" />
 </a>  This component is work in progress and currently in pre-release.
 
 A collapsable side panel

--- a/modules/_labs/tabs/react/README.md
+++ b/modules/_labs/tabs/react/README.md
@@ -1,7 +1,7 @@
 # Canvas Kit React Tabs
 
 <a href="https://github.com/Workday/canvas-kit/tree/master/modules/_labs/README.md">
-  <img src="https://img.shields.io/badge/LABS-alpha-orange" alt="LABS: Alpha" />
+  <img src="https://img.shields.io/badge/LABS-beta-orange" alt="LABS: Beta" />
 </a>  This component is work in progress and currently in pre-release.
 
 Composable tab components

--- a/utils/create-component/createComponent.js
+++ b/utils/create-component/createComponent.js
@@ -44,7 +44,7 @@ const questions = [
     name: 'category',
     message: 'What category should this component live in?:',
     choices: [
-      'Labs (unstable)',
+      'Labs (beta)',
       'Buttons',
       'Containers',
       'Indicators',
@@ -72,7 +72,7 @@ inquirer
     const {name, category, targets} = answers;
     const css = targets.includes('CSS');
     const react = targets.includes('React');
-    const unstable = category == 'Labs (unstable)';
+    const unstable = category == 'Labs (beta)';
     const componentPath = path.join(cwd, unstable ? `modules/_labs/${name}` : `modules/${name}`);
 
     if (!fs.existsSync(componentPath)) {

--- a/utils/create-component/templates/css/readme.js
+++ b/utils/create-component/templates/css/readme.js
@@ -3,7 +3,7 @@ ${
   unstable
     ? `
 <a href="https://github.com/Workday/canvas-kit/tree/master/modules/_labs/README.md">
-  <img src="https://img.shields.io/badge/LABS-alpha-orange" alt="LABS: Alpha" />
+  <img src="https://img.shields.io/badge/LABS-beta-orange" alt="LABS: Beta" />
 </a>  This component is work in progress and currently in pre-release.
 `
     : ''

--- a/utils/create-component/templates/react/readme.js
+++ b/utils/create-component/templates/react/readme.js
@@ -10,7 +10,7 @@ ${
   unstable
     ? `
 <a href="https://github.com/Workday/canvas-kit/tree/master/modules/_labs/README.md">
-  <img src="https://img.shields.io/badge/LABS-alpha-orange" alt="LABS: Alpha" />
+  <img src="https://img.shields.io/badge/LABS-beta-orange" alt="LABS: Beta" />
 </a>  This component is work in progress and currently in pre-release.
 `
     : ''


### PR DESCRIPTION
## Summary

Fixes #674.

## Checklist

- [x] Update README badges in all Labs components to read `LABS|beta`
- [x] Remove use of "unstable" from Labs README
- [x] Remove use of "unstable" from `create-component` CLI prompts
- [x] Update readme templates used by `create-component` scripts to use `LABS|beta` badge
