### PR TITLE
fix: Fix create component scripts

### DIFF
--- a/utils/create-component/createComponent.js
+++ b/utils/create-component/createComponent.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const mkdirp = require('mkdirp');
 const inquirer = require('inquirer');
-const exec = require('child_process');
+const {exec} = require('child_process');
 
 require('colors');
 
@@ -95,7 +95,7 @@ const createModule = (componentPath, target, moduleGenerator, answers, unstable)
   const modulePath = path.join(componentPath, target);
 
   if (fs.existsSync(modulePath)) {
-    const moduleName = `Module @workday/canvas-kit-${unstable ? 'labs-' : ''}${target}-${name}`;
+    const moduleName = `@workday/canvas-kit-${unstable ? 'labs-' : ''}${target}-${name}`;
     console.log(`\nModule ${moduleName} already exists. Skipping.`.yellow);
   } else {
     moduleGenerator(modulePath, name, description, unstable, publicModule, category);

--- a/utils/create-component/createCssModule.js
+++ b/utils/create-component/createCssModule.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const mkdirp = require('mkdirp');
-const exec = require('child_process');
+const {exec} = require('child_process');
+
 require('colors');
 
 const writeModuleFiles = require('./writeModuleFiles');

--- a/utils/create-component/createReactModule.js
+++ b/utils/create-component/createReactModule.js
@@ -1,5 +1,6 @@
 const mkdirp = require('mkdirp');
-const exec = require('child_process');
+const {exec} = require('child_process');
+
 require('colors');
 
 const writeModuleFiles = require('./writeModuleFiles');

--- a/utils/create-component/createReactModule.js
+++ b/utils/create-component/createReactModule.js
@@ -50,7 +50,7 @@ module.exports = (modulePath, name, description, unstable, public, category) => 
     },
     testingStories: {
       path: 'stories/stories_VisualTesting.tsx',
-      contents: testingStories(testingStoryPath, pascalCaseName, rootPath),
+      contents: testingStories(testingStoryPath, pascalCaseName, rootPath, unstable),
     },
     ssr: {
       path: 'spec/SSR.spec.tsx',

--- a/utils/create-component/templates/react/stories_VisualTesting.js
+++ b/utils/create-component/templates/react/stories_VisualTesting.js
@@ -1,11 +1,11 @@
 // React stories template
 
-module.exports = (storyPath, pascalCaseName, rootPath) => `
+module.exports = (storyPath, pascalCaseName, rootPath, unstable) => `
 /// <reference path="${rootPath}/../typings.d.ts" />
 /** @jsx jsx */
 import {jsx} from '@emotion/core';
 import {StaticStates} from '@workday/canvas-kit-labs-react-core';
-import {ComponentStatesTable, permutateProps, withSnapshotsEnabled} from '../../../../utils/storybook';
+import {ComponentStatesTable, permutateProps, withSnapshotsEnabled} from '../../../../${unstable ? '../' : ''}utils/storybook';
 import ${pascalCaseName} from '../index';
 
 export default withSnapshotsEnabled({


### PR DESCRIPTION
## Summary

Our createComponent script was bombing out with `TypeError: exec is not a function` due to incorrect `require` statements for `exec`. Originally, `node-cmd` was used to run commands, but it was removed as a dependency in favor of `exec` in #908. However, the `require` statements in the createComponent scripts weren't updated to use `exec` until #912. This PR adds the necessary destructuring to get those `require` statements working.

It also fixes a path issue with the `stories_VisualTesting` template.