### PR TITLE
Add custom limit to CountBadge

### DIFF
--- a/modules/badge/react/README.md
+++ b/modules/badge/react/README.md
@@ -24,7 +24,7 @@ accessibility concerns you'll want to keep in mind:
 - The live region should be outside the button
 - The live region should be visually hidden and only contain text
 
-### Example
+### Notification Example
 
 ```tsx
 import styled from '@emotion/styled';
@@ -49,21 +49,47 @@ const AccessibleHide = styled('div')({
 </IconButton>
 <AccessibleHide role="status" aria-live="polite" aria-atomic="true">
   New notifications
-</div>
+</AccessibleHide>
 ```
 
 ## Usage
+
+📝 **Note** With all usage examples, please also refer to the accessibility guidelines above.
+
+### Basic Usage
+
+#### Setting the Count
 
 ```tsx
 import * as React from 'react';
 import {CountBadge} from '@workday/canvas-kit-react-badge';
 
-// default CountBadge
-<CountBadge count={3} />
+const CustomCountBadge = () => {
+  return <CountBadge count={3} />;
+};
+```
 
-// inverse CountBadge variant
-<CountBadge variant="inverse" count={3} />
+#### Setting a Variant
 
+```tsx
+import * as React from 'react';
+import {CountBadge} from '@workday/canvas-kit-react-badge';
+
+const InverseCountBadge = () => {
+  return <CountBadge variant="inverse" count={3} />;
+};
+```
+
+#### Setting a Limit
+
+```tsx
+import * as React from 'react';
+import {CountBadge} from '@workday/canvas-kit-react-badge';
+
+const InverseCountBadge = () => {
+  // this will display the count as '99+'
+  return <CountBadge variant="inverse" count={100} limit={100} />;
+};
 ```
 
 ## Static Properties
@@ -99,4 +125,10 @@ Default: `0`
 
 📝 **Note**
 
-Values greater than 999 are formatted to "999+"
+By default, values greater than 999 are formatted to "999+"
+
+#### `limit: number`
+
+> Limit sets when to format the displayed count
+
+Default: `1000`

--- a/modules/badge/react/lib/CountBadge.tsx
+++ b/modules/badge/react/lib/CountBadge.tsx
@@ -5,6 +5,7 @@ import {borderRadius, colors, fontFamily} from '@workday/canvas-kit-react-core';
 
 export interface CountBadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
   count?: number;
+  limit?: number;
   variant?: 'default' | 'inverse';
 }
 
@@ -53,9 +54,9 @@ const Container = styled('span')<CountBadgeProps>(
 );
 
 const CountBadge = (props: CountBadgeProps) => {
-  const {variant = 'default', count = 0, ...elemProps} = props;
+  const {variant = 'default', count = 0, limit = 1000, ...elemProps} = props;
 
-  const formattedCount = count < 1000 ? `${count}` : '999+';
+  const formattedCount = count < limit ? `${count}` : `${limit - 1}+`;
 
   return (
     <Container variant={variant} {...elemProps}>

--- a/modules/badge/react/spec/CountBadge.spec.tsx
+++ b/modules/badge/react/spec/CountBadge.spec.tsx
@@ -1,32 +1,48 @@
 import React from 'react';
 import {render} from '@testing-library/react';
 import {CountBadge, CountBadgeProps} from '../index';
+const context = describe;
 
 describe('CountBadge', () => {
   const renderCountBadge = (props = {} as Partial<CountBadgeProps>) => {
     return render(<CountBadge {...props} />);
   };
 
-  it('should default to 0 if no count is provided', () => {
-    const expected = '0';
-    const {container} = renderCountBadge();
+  context('when the default count is set', () => {
+    it('should default to 0 if no count is provided', () => {
+      const expected = '0';
+      const {container} = renderCountBadge();
 
-    expect(container.textContent).toEqual(expected);
+      expect(container.textContent).toEqual(expected);
+    });
   });
 
-  it('should render the count for numbers under 1000', () => {
-    const count = 999;
-    const expected = count.toString();
-    const {container} = renderCountBadge({count});
+  context('when the default limit is set', () => {
+    it('should render the count for numbers under 1000', () => {
+      const count = 999;
+      const expected = count.toString();
+      const {container} = renderCountBadge({count});
 
-    expect(container.textContent).toEqual(expected);
+      expect(container.textContent).toEqual(expected);
+    });
+
+    it('should render 999+ for numbers 1000 and above', () => {
+      const count = 1000;
+      const expected = '999+';
+      const {container} = renderCountBadge({count});
+
+      expect(container.textContent).toEqual(expected);
+    });
   });
 
-  it('should render 999+ for numbers 1000 and above', () => {
-    const count = 1000;
-    const expected = '999+';
-    const {container} = renderCountBadge({count});
+  context('when a custom limit is set', () => {
+    it('should render a formatted number if the count exceeds the limit', () => {
+      const count = 100;
+      const limit = 100;
+      const expected = '99+';
+      const {container} = renderCountBadge({count, limit});
 
-    expect(container.textContent).toEqual(expected);
+      expect(container.textContent).toEqual(expected);
+    });
   });
 });

--- a/modules/badge/react/stories/stories.tsx
+++ b/modules/badge/react/stories/stories.tsx
@@ -28,3 +28,13 @@ export const Inverse = () => (
     />
   </div>
 );
+
+export const CustomLimit = () => (
+  <div className="story">
+    <CountBadge
+      count={number('Count', 100)}
+      limit={number('Number', 100)}
+      variant={select('Variant', ['default', 'inverse'], 'default')}
+    />
+  </div>
+);

--- a/modules/badge/react/stories/stories_visualTesting.tsx
+++ b/modules/badge/react/stories/stories_visualTesting.tsx
@@ -24,6 +24,7 @@ export const CountBadgeStates = () => {
           label: 'Greater than 999',
           props: {count: 1000},
         },
+        {label: 'Custom Limit', props: {count: 100, limit: 100}},
       ]}
       rowProps={[
         {label: 'Default', props: {}},


### PR DESCRIPTION
## Summary

Resolves #936 

This PR adds functionality for custom limits to format the displayed count in `CountBadge`. I also added a test and updated the docs.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md
- [x] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

![Screen Shot 2021-01-07 at 10 36 49 AM](https://user-images.githubusercontent.com/4818182/103925114-496b7500-50d4-11eb-9acc-65d463464c1c.png)
