### PR TITLE
chore: Update @workday/canvas-system-icons-web dependency

### DIFF
--- a/modules/_labs/breadcrumbs/react/package.json
+++ b/modules/_labs/breadcrumbs/react/package.json
@@ -45,7 +45,7 @@
     "@workday/canvas-kit-react-icon": "^4.4.2",
     "@workday/canvas-kit-react-popup": "^4.4.2",
     "@workday/canvas-kit-react-tooltip": "^4.4.2",
-    "@workday/canvas-system-icons-web": "^1.0.20",
+    "@workday/canvas-system-icons-web": "1.0.41",
     "@workday/design-assets-types": "^0.2.4"
   },
   "devDependencies": {

--- a/modules/_labs/color-picker/react/package.json
+++ b/modules/_labs/color-picker/react/package.json
@@ -54,7 +54,7 @@
     "@workday/canvas-kit-react-icon": "^4.4.2",
     "@workday/canvas-kit-react-popup": "^4.4.2",
     "@workday/canvas-kit-react-text-input": "^4.4.2",
-    "@workday/canvas-system-icons-web": "^1.0.20"
+    "@workday/canvas-system-icons-web": "1.0.41"
   },
   "peerDependencies": {
     "react": ">= 16.8 < 17"

--- a/modules/_labs/combobox/react/package.json
+++ b/modules/_labs/combobox/react/package.json
@@ -56,7 +56,7 @@
     "@workday/canvas-kit-react-common": "^4.4.2",
     "@workday/canvas-kit-react-core": "^4.4.2",
     "@workday/canvas-kit-react-text-input": "^4.4.2",
-    "@workday/canvas-system-icons-web": "^1.0.20",
+    "@workday/canvas-system-icons-web": "1.0.41",
     "lodash.flatten": "^4.4.0",
     "uuid": "^3.3.3"
   },

--- a/modules/_labs/drawer/react/package.json
+++ b/modules/_labs/drawer/react/package.json
@@ -48,7 +48,7 @@
     "@emotion/styled": "^10.0.27",
     "@workday/canvas-kit-react-button": "^4.4.2",
     "@workday/canvas-kit-react-core": "^4.4.2",
-    "@workday/canvas-system-icons-web": "^1.0.20"
+    "@workday/canvas-system-icons-web": "1.0.41"
   },
   "peerDependencies": {
     "react": ">= 16.8 < 17"

--- a/modules/_labs/header/react/package.json
+++ b/modules/_labs/header/react/package.json
@@ -58,7 +58,7 @@
     "@workday/canvas-kit-react-form-field": "^4.4.2",
     "@workday/canvas-kit-react-icon": "^4.4.2",
     "@workday/canvas-kit-react-text-input": "^4.4.2",
-    "@workday/canvas-system-icons-web": "^1.0.20",
+    "@workday/canvas-system-icons-web": "1.0.41",
     "chroma-js": "^2.1.0",
     "uuid": "^3.3.3"
   }

--- a/modules/_labs/menu/react/package.json
+++ b/modules/_labs/menu/react/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@material-ui/core": "^4.9.7",
     "@workday/canvas-kit-react-popup": "^4.4.2",
-    "@workday/canvas-system-icons-web": "^1.0.20"
+    "@workday/canvas-system-icons-web": "1.0.41"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/_labs/pagination/react/package.json
+++ b/modules/_labs/pagination/react/package.json
@@ -53,7 +53,7 @@
     "@workday/canvas-kit-react-button": "^4.4.2",
     "@workday/canvas-kit-react-core": "^4.4.2",
     "@workday/canvas-kit-react-text-input": "^4.4.2",
-    "@workday/canvas-system-icons-web": "^1.0.20",
+    "@workday/canvas-system-icons-web": "1.0.41",
     "lodash": "^4.17.14",
     "uuid": "^3.3.3"
   }

--- a/modules/_labs/select/react/package.json
+++ b/modules/_labs/select/react/package.json
@@ -44,7 +44,7 @@
     "@workday/canvas-kit-react-core": "^4.4.2",
     "@workday/canvas-kit-react-icon": "^4.4.2",
     "@workday/canvas-kit-react-popup": "^4.4.2",
-    "@workday/canvas-system-icons-web": "^1.0.20",
+    "@workday/canvas-system-icons-web": "1.0.41",
     "uuid": "^3.3.3"
   }
 }

--- a/modules/_labs/side-panel/react/package.json
+++ b/modules/_labs/side-panel/react/package.json
@@ -53,7 +53,7 @@
     "@workday/canvas-kit-react-common": "^4.4.2",
     "@workday/canvas-kit-react-core": "^4.4.2",
     "@workday/canvas-kit-react-icon": "^4.4.2",
-    "@workday/canvas-system-icons-web": "^1.0.20"
+    "@workday/canvas-system-icons-web": "1.0.41"
   },
   "devDependencies": {
     "@workday/canvas-kit-labs-react-core": "^4.4.2",

--- a/modules/avatar/react/package.json
+++ b/modules/avatar/react/package.json
@@ -53,7 +53,7 @@
     "@workday/canvas-kit-react-common": "^4.4.2",
     "@workday/canvas-kit-react-core": "^4.4.2",
     "@workday/canvas-kit-react-icon": "^4.4.2",
-    "@workday/canvas-system-icons-web": "^1.0.20"
+    "@workday/canvas-system-icons-web": "1.0.41"
   },
   "devDependencies": {
     "@workday/canvas-kit-labs-react-core": "^4.4.2"

--- a/modules/banner/css/package.json
+++ b/modules/banner/css/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@workday/canvas-kit-css-core": "^4.4.2",
-    "@workday/canvas-system-icons-web": "^1.0.20"
+    "@workday/canvas-system-icons-web": "1.0.41"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/modules/banner/react/package.json
+++ b/modules/banner/react/package.json
@@ -51,6 +51,6 @@
     "@workday/canvas-kit-react-common": "^4.4.2",
     "@workday/canvas-kit-react-core": "^4.4.2",
     "@workday/canvas-kit-react-icon": "^4.4.2",
-    "@workday/canvas-system-icons-web": "^1.0.20"
+    "@workday/canvas-system-icons-web": "1.0.41"
   }
 }

--- a/modules/button/css/package.json
+++ b/modules/button/css/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@workday/canvas-kit-css-core": "^4.4.2",
-    "@workday/canvas-system-icons-web": "^1.0.20"
+    "@workday/canvas-system-icons-web": "1.0.41"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/modules/button/react/package.json
+++ b/modules/button/react/package.json
@@ -54,7 +54,7 @@
     "@workday/canvas-kit-react-common": "^4.4.2",
     "@workday/canvas-kit-react-core": "^4.4.2",
     "@workday/canvas-kit-react-icon": "^4.4.2",
-    "@workday/canvas-system-icons-web": "^1.0.20",
+    "@workday/canvas-system-icons-web": "1.0.41",
     "@workday/design-assets-types": "^0.2.4"
   }
 }

--- a/modules/checkbox/react/package.json
+++ b/modules/checkbox/react/package.json
@@ -51,6 +51,6 @@
     "@workday/canvas-kit-react-common": "^4.4.2",
     "@workday/canvas-kit-react-core": "^4.4.2",
     "@workday/canvas-kit-react-icon": "^4.4.2",
-    "@workday/canvas-system-icons-web": "^1.0.20"
+    "@workday/canvas-system-icons-web": "1.0.41"
   }
 }

--- a/modules/color-picker/react/package.json
+++ b/modules/color-picker/react/package.json
@@ -51,7 +51,7 @@
     "@workday/canvas-kit-react-core": "^4.4.2",
     "@workday/canvas-kit-react-icon": "^4.4.2",
     "@workday/canvas-kit-react-text-input": "^4.4.2",
-    "@workday/canvas-system-icons-web": "^1.0.20",
+    "@workday/canvas-system-icons-web": "1.0.41",
     "chroma-js": "^2.1.0"
   },
   "peerDependencies": {

--- a/modules/common/react/package.json
+++ b/modules/common/react/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@workday/canvas-kit-react-button": "^4.4.2",
     "@workday/canvas-kit-react-card": "^4.4.2",
-    "@workday/canvas-system-icons-web": "^1.0.20"
+    "@workday/canvas-system-icons-web": "1.0.41"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/form-field/css/package.json
+++ b/modules/form-field/css/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@workday/canvas-kit-css-common": "^4.4.2",
     "@workday/canvas-kit-css-core": "^4.4.2",
-    "@workday/canvas-system-icons-web": "^1.0.20"
+    "@workday/canvas-system-icons-web": "1.0.41"
   },
   "devDependencies": {
     "@workday/canvas-kit-css-checkbox": "^4.4.2",

--- a/modules/icon/react/package.json
+++ b/modules/icon/react/package.json
@@ -58,6 +58,6 @@
   "devDependencies": {
     "@workday/canvas-accent-icons-web": "^1.0.0",
     "@workday/canvas-applet-icons-web": "^0.17.50",
-    "@workday/canvas-system-icons-web": "^1.0.20"
+    "@workday/canvas-system-icons-web": "1.0.41"
   }
 }

--- a/modules/page-header/react/package.json
+++ b/modules/page-header/react/package.json
@@ -54,6 +54,6 @@
     "@workday/canvas-kit-react-core": "^4.4.2"
   },
   "devDependencies": {
-    "@workday/canvas-system-icons-web": "^1.0.20"
+    "@workday/canvas-system-icons-web": "1.0.41"
   }
 }

--- a/modules/popup/react/package.json
+++ b/modules/popup/react/package.json
@@ -54,7 +54,7 @@
     "@workday/canvas-kit-react-card": "^4.4.2",
     "@workday/canvas-kit-react-common": "^4.4.2",
     "@workday/canvas-kit-react-core": "^4.4.2",
-    "@workday/canvas-system-icons-web": "^1.0.20",
+    "@workday/canvas-system-icons-web": "1.0.41",
     "focus-trap-js": "1.1.0",
     "uuid": "^3.3.3"
   },

--- a/modules/segmented-control/react/package.json
+++ b/modules/segmented-control/react/package.json
@@ -50,7 +50,7 @@
     "@workday/canvas-kit-react-button": "^4.4.2",
     "@workday/canvas-kit-react-common": "^4.4.2",
     "@workday/canvas-kit-react-core": "^4.4.2",
-    "@workday/canvas-system-icons-web": "^1.0.20"
+    "@workday/canvas-system-icons-web": "1.0.41"
   },
   "devDependencies": {
     "@workday/canvas-kit-labs-react-core": "^4.4.2"

--- a/modules/select/react/package.json
+++ b/modules/select/react/package.json
@@ -51,6 +51,6 @@
     "@workday/canvas-kit-react-common": "^4.4.2",
     "@workday/canvas-kit-react-core": "^4.4.2",
     "@workday/canvas-kit-react-icon": "^4.4.2",
-    "@workday/canvas-system-icons-web": "^1.0.20"
+    "@workday/canvas-system-icons-web": "1.0.41"
   }
 }

--- a/modules/side-panel/react/package.json
+++ b/modules/side-panel/react/package.json
@@ -49,7 +49,7 @@
     "@emotion/styled": "^10.0.27",
     "@workday/canvas-kit-react-button": "^4.4.2",
     "@workday/canvas-kit-react-core": "^4.4.2",
-    "@workday/canvas-system-icons-web": "^1.0.20",
+    "@workday/canvas-system-icons-web": "1.0.41",
     "@workday/design-assets-types": "^0.2.4",
     "lodash": "^4.17.14"
   },

--- a/modules/status-indicator/react/package.json
+++ b/modules/status-indicator/react/package.json
@@ -57,6 +57,6 @@
   },
   "devDependencies": {
     "@workday/canvas-kit-labs-react-core": "^4.4.2",
-    "@workday/canvas-system-icons-web": "^1.0.20"
+    "@workday/canvas-system-icons-web": "1.0.41"
   }
 }

--- a/modules/text-input/react/package.json
+++ b/modules/text-input/react/package.json
@@ -53,6 +53,6 @@
     "@workday/canvas-kit-react-common": "^4.4.2",
     "@workday/canvas-kit-react-core": "^4.4.2",
     "@workday/canvas-kit-react-icon": "^4.4.2",
-    "@workday/canvas-system-icons-web": "^1.0.20"
+    "@workday/canvas-system-icons-web": "1.0.41"
   }
 }

--- a/modules/toast/react/package.json
+++ b/modules/toast/react/package.json
@@ -57,7 +57,7 @@
     "@workday/canvas-kit-react-core": "^4.4.2",
     "@workday/canvas-kit-react-icon": "^4.4.2",
     "@workday/canvas-kit-react-popup": "^4.4.2",
-    "@workday/canvas-system-icons-web": "^1.0.20",
+    "@workday/canvas-system-icons-web": "1.0.41",
     "@workday/design-assets-types": "^0.2.4"
   }
 }

--- a/modules/tooltip/react/package.json
+++ b/modules/tooltip/react/package.json
@@ -59,6 +59,6 @@
   "devDependencies": {
     "@workday/canvas-kit-react-button": "^4.4.2",
     "@workday/canvas-kit-react-card": "^4.4.2",
-    "@workday/canvas-system-icons-web": "^1.0.20"
+    "@workday/canvas-system-icons-web": "1.0.41"
   }
 }


### PR DESCRIPTION

## Summary

This PR updates `@workday/canvas-system-icons-web` to the latest (1.0.41) across all packages that have it as a dependency.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [ ] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
