### PR TITLE
feat: Add compound component utility functions

### DIFF
--- a/modules/common/react/lib/utils/components.ts
+++ b/modules/common/react/lib/utils/components.ts
@@ -28,7 +28,7 @@ export type Component<T extends React.ElementType, P> = {
 interface RefForwardingComponent<T, P = {}> {
   (
     props: React.PropsWithChildren<P> & {as?: React.ReactElement<any>},
-    ref: T extends undefined
+    ref: T extends null
       ? never
       : React.Ref<T extends keyof ElementTagNameMap ? ElementTagNameMap[T] : T>,
     as: T extends undefined ? never : T
@@ -36,12 +36,21 @@ interface RefForwardingComponent<T, P = {}> {
 }
 
 /**
+ * If no element is passed to `createComponent`, a `NulLElement` will be returned indicating there
+ * is no element type.
+ */
+type NullElement = () => null;
+
+/**
  * Factory function that creates components to be exported. It enforces React ref forwarding, `as`
  * prop, display name, and sub-components, and handles proper typing without much boiler plate. The
  * return type is `Component<element, Props>` which looks like `Component<'div', Props>` which is a
  * clean interface that tells you the default element that is used.
  */
-export const createComponent = <T extends React.ElementType>(as?: T) => <P, SubComponents = {}>({
+export const createComponent = <T extends React.ElementType = NullElement>(as?: T) => <
+  P,
+  SubComponents = {}
+>({
   displayName,
   Component,
   subComponents,
@@ -64,15 +73,16 @@ export const createComponent = <T extends React.ElementType>(as?: T) => <P, SubC
    */
   subComponents?: SubComponents;
 }) => {
-  const ReturnedComponent = (React.forwardRef<T, P>((props, ref) => {
-    return Component(
-      props,
-      //@ts-ignore Problems with type constraints of T and T extends ElementTagName ? ... This doesn't cause a problem, not sure it is worth fixing
-      ref,
-      (props as any).as || as
-    );
-    // Component({as, ...props}, ref)
-  }) as any) as Component<T, P> & SubComponents;
+  const ReturnedComponent = (React.forwardRef<T, P & {as?: React.ElementType}>(
+    ({as: asOverride, ...props}, ref) => {
+      return Component(
+        props as P,
+        //@ts-ignore Problems with type constraints of T and T extends ElementTagName ? ... This doesn't cause a problem, not sure it is worth fixing
+        ref,
+        asOverride || as
+      );
+    }
+  ) as any) as Component<T, P> & SubComponents;
 
   Object.keys(subComponents || {}).forEach((key: any) => {
     // @ts-ignore Not worth typing correctly
@@ -157,7 +167,7 @@ export function useDefaultModel<T, C>(
 }
 
 /**
- * Returns a model, or returns a model context. Clever way around the conditional React hood ESLint
+ * Returns a model, or returns a model context. Clever way around the conditional React hook ESLint
  * rule
  * @param model A model, if provided
  * @param context The context of a model
@@ -168,7 +178,7 @@ export function useDefaultModel<T, C>(
  *   // ...
  * }
  */
-export function useModelContext<T>(context: React.Context<T>, model?: T) {
+export function useModelContext<T>(context: React.Context<T>, model?: T): T {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   return model || React.useContext(context);
 }

--- a/modules/common/react/lib/utils/components.ts
+++ b/modules/common/react/lib/utils/components.ts
@@ -136,13 +136,24 @@ export function useForkRef<T>(ref1: React.Ref<T>, ref2: React.Ref<T>): (instance
 }
 
 /**
- * This function is the same as calling `React.useRef(null)` with the added benefit of extracting
- * the type from the ref passed to it. This means you don't have to provide a generic to the
- * `useRef` function
+ * This functions handles the common use case where a component needs a local ref and needs to
+ * forward a ref to an element.
  * @param ref The React ref passed from the `createComponent` factory function
+ *
+ * @example
+ * const MyComponent = ({children, ...elemProps}: MyProps, ref, Element) => {
+ *   const { localRef, elementRef } = useLocalRef(ref);
+ *
+ *   // do something with `localRef` which is a `RefObject` with a `current` property
+ *
+ *   return <Element ref={elementRef} {...elemProps} />
+ * }
  */
-export function useComponentRef<T>(ref: React.Ref<T>) {
-  return React.useRef<T>(null);
+export function useLocalRef<T>(ref: React.Ref<T>) {
+  const localRef = React.useRef<T>(null);
+  const elementRef = useForkRef(ref, localRef);
+
+  return {localRef, elementRef};
 }
 
 /**

--- a/modules/common/react/lib/utils/components.ts
+++ b/modules/common/react/lib/utils/components.ts
@@ -1,0 +1,174 @@
+import React from 'react';
+
+/**
+ * Adds the `as` to the style interface to support `as` in styled components
+ * This type and usage should be removed with Emotion 11
+ */
+export type StyledType = {
+  as?: React.ElementType;
+};
+
+/**
+ * Generic component props with "as" prop
+ * @template P Additional props
+ * @template T React component or string element
+ */
+export type PropsWithAs<P, T extends React.ElementType> = P &
+  Omit<React.ComponentProps<T>, 'as' | 'state' | keyof P>;
+
+/**
+ * Component type that allows for `as` to change the element or component type.
+ * Passing `as` will correctly change the allowed interface of the JSX element
+ */
+export type Component<T extends React.ElementType, P> = {
+  <TT extends React.ElementType>(props: PropsWithAs<P, TT> & {as: TT}): JSX.Element;
+  (props: PropsWithAs<P, T>): JSX.Element;
+  displayName?: string;
+};
+interface RefForwardingComponent<T, P = {}> {
+  (
+    props: React.PropsWithChildren<P> & {as?: React.ReactElement<any>},
+    ref: T extends undefined
+      ? never
+      : React.Ref<T extends keyof ElementTagNameMap ? ElementTagNameMap[T] : T>,
+    as: T extends undefined ? never : T
+  ): React.ReactElement | null;
+}
+
+/**
+ * Factory function that creates components to be exported. It enforces React ref forwarding, `as`
+ * prop, display name, and sub-components, and handles proper typing without much boiler plate. The
+ * return type is `Component<element, Props>` which looks like `Component<'div', Props>` which is a
+ * clean interface that tells you the default element that is used.
+ */
+export const createComponent = <T extends React.ElementType>(as?: T) => <P, SubComponents = {}>({
+  displayName,
+  Component,
+  subComponents,
+}: {
+  /** This is what the component will look like in the React dev tools. Encouraged to more easily
+   * understand the component tree */
+  displayName?: string;
+  /** The component function. The function looks like:
+   * @example
+   * Component: ({children}, ref, Element) {
+   *   // `Element` is what's passed to the `as` of your component. It will be 'div' or even a another Component!
+   *   return (
+   *     <Element ref={ref}>{children}</Element>
+   *   )
+   * }
+   */
+  Component: RefForwardingComponent<T, P>;
+  /**
+   * Used in container components
+   */
+  subComponents?: SubComponents;
+}) => {
+  const ReturnedComponent = (React.forwardRef<T, P>((props, ref) => {
+    return Component(
+      props,
+      //@ts-ignore Problems with type constraints of T and T extends ElementTagName ? ... This doesn't cause a problem, not sure it is worth fixing
+      ref,
+      (props as any).as || as
+    );
+    // Component({as, ...props}, ref)
+  }) as any) as Component<T, P> & SubComponents;
+
+  Object.keys(subComponents || {}).forEach((key: any) => {
+    // @ts-ignore Not worth typing correctly
+    ReturnedComponent[key] = subComponents[key];
+  });
+  ReturnedComponent.displayName = displayName;
+
+  return ReturnedComponent;
+};
+
+function setRef<T>(ref: React.Ref<T>, value: T): void {
+  if (ref) {
+    if (typeof ref === 'function') {
+      ref(value);
+    } else {
+      // @ts-ignore Refs are readonly, but we can technically write to it without issue
+      ref.current = value;
+    }
+  }
+}
+
+/**
+ * This function will create a new forked ref out of two input Refs. This is useful for components
+ * that use `React.forwardRef`, but also need internal access to a Ref.
+ *
+ * This function is inspired by https://www.npmjs.com/package/@rooks/use-fork-ref
+ *
+ * @example
+ * React.forwardRef((props, ref) => {
+ *   // Returns a RefObject with a `current` property
+ *   const myRef = React.useRef(ref)
+ *
+ *   // Returns a forked Ref function to pass to an element.
+ *   // This forked ref will update both `myRef` and `ref` when React updates the element ref
+ *   const elementRef = useForkRef(ref, myRef)
+ *
+ *   useEffect(() => {
+ *     console.log(myRef.current) // `current` is the DOM instance
+ *     // `ref` might be null since it depends on if someone passed a `ref` to your component
+ *     // `elementRef` is a function and we cannot get a current value out of it
+ *   })
+ *
+ *   return <div ref={elementRef}/>
+ * })
+ */
+export function useForkRef<T>(ref1: React.Ref<T>, ref2: React.Ref<T>): (instance: T) => void {
+  return (value: T) => {
+    setRef(ref1, value);
+    setRef(ref2, value);
+  };
+}
+
+/**
+ * This function is the same as calling `React.useRef(null)` with the added benefit of extracting
+ * the type from the ref passed to it. This means you don't have to provide a generic to the
+ * `useRef` function
+ * @param ref The React ref passed from the `createComponent` factory function
+ */
+export function useComponentRef<T>(ref: React.Ref<T>) {
+  return React.useRef<T>(null);
+}
+
+/**
+ * Returns a model, or calls the model hook with config. Clever way around the conditional React
+ * hook ESLint rule.
+ * @param model A model, if provided
+ * @param config Config for a model
+ * @param modelHook A model hook that takes valid config
+ * @example
+ * const ContainerComponent = ({children, model, ...config}: ContainerProps) => {
+ *   const value = useDefaultModel(model, config, useContainerModel);
+ *
+ *   // ...
+ * }
+ */
+export function useDefaultModel<T, C>(
+  model: T | undefined,
+  config: C,
+  modelHook: (config: C) => T
+) {
+  return model || modelHook(config);
+}
+
+/**
+ * Returns a model, or returns a model context. Clever way around the conditional React hood ESLint
+ * rule
+ * @param model A model, if provided
+ * @param context The context of a model
+ * @example
+ * const SubComponent = ({children, model, ...elemProps}: SubComponentProps, ref, Element) => {
+ *   const {state, events} = useModelContext(model, SubComponentModelContext);
+ *
+ *   // ...
+ * }
+ */
+export function useModelContext<T>(context: React.Context<T>, model?: T) {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  return model || React.useContext(context);
+}

--- a/modules/common/react/lib/utils/index.ts
+++ b/modules/common/react/lib/utils/index.ts
@@ -2,4 +2,8 @@ export * from './colorUtils';
 export * from './getTranslateFromOrigin';
 export * from './makeMq';
 export * from './mergeCallback';
+export * from './mergeCallbacks';
 export * from './useUniqueId';
+export * from './useMount';
+export * from './components';
+export * from './models';

--- a/modules/common/react/lib/utils/mergeCallbacks.ts
+++ b/modules/common/react/lib/utils/mergeCallbacks.ts
@@ -1,0 +1,16 @@
+import {mergeCallback} from './mergeCallback';
+
+export function mergeCallbacks<T extends {[key: string]: any}>(
+  elemProps: {[key: string]: any},
+  componentProps: T,
+  keys: (keyof T)[] = Object.keys(componentProps)
+) {
+  return (keys as string[]).reduce((mergedProps, key) => {
+    if (typeof elemProps[key] === 'function') {
+      mergedProps[key] = mergeCallback(componentProps[key], elemProps[key]);
+    } else {
+      mergedProps[key] = componentProps[key];
+    }
+    return mergedProps;
+  }, {} as {[key: string]: any});
+}

--- a/modules/common/react/lib/utils/models.ts
+++ b/modules/common/react/lib/utils/models.ts
@@ -1,0 +1,177 @@
+import React from 'react';
+
+export type Model<State, Events> = {
+  state: State;
+  events: Events;
+};
+
+/**
+ * A mapping of guards and callbacks and what events they relate to.
+ * @template TEvents The model events
+ * @template TGuardMap A mapping of guards to events they're associated with
+ * @template TCallbackMap A mapping of callbacks to events they're associated with
+ */
+type EventMap<
+  TEvents extends Record<string, (data: object) => void>,
+  TGuardMap extends Record<string, keyof TEvents>,
+  TCallbackMap extends Record<string, keyof TEvents>
+> = {
+  guards: TGuardMap;
+  callbacks: TCallbackMap;
+};
+
+type ToGuardConfig<
+  TState extends Record<string, any>,
+  TEvents extends Record<string, (data: object) => void>,
+  TGuardMap extends Record<string, keyof TEvents>
+> = {
+  [K in keyof TGuardMap]: (event: {
+    data: Parameters<TEvents[TGuardMap[K]]>[0];
+    state: TState;
+  }) => boolean;
+};
+
+type ToCallbackConfig<
+  TState extends Record<string, any>,
+  TEvents extends Record<string, (data: object) => void>,
+  TGuardMap extends Record<string, keyof TEvents>
+> = {
+  [K in keyof TGuardMap]: (event: {
+    data: Parameters<TEvents[TGuardMap[K]]>[0];
+    state: TState;
+  }) => void;
+};
+
+/**
+ * Takes the State and Events of a model along with the event map and creates a model config type that is used
+ * to configure the model.
+ *
+ * @example
+ * type ModelConfig = {
+ *   // additional config your model requires goes here
+ *   id?: string
+ * } & Partial<ToModelConfig<State, Events, typeof eventMap>>
+ */
+export type ToModelConfig<
+  TState extends Record<string, any>,
+  TEvents extends Record<string, (data: object) => void>,
+  TEventMap extends EventMap<TEvents, any, any>
+> = ToGuardConfig<TState, TEvents, TEventMap['guards']> &
+  ToCallbackConfig<TState, TEvents, TEventMap['callbacks']>;
+
+/**
+ * Convenience factory function that extracts type information and encodes it for use with model
+ * config and `useEventMap`. Under the hood, it returns the config that was passed in. The real
+ * magic is in type extraction and encoding which reduces boilerplate.
+ *
+ * `createEventMap` is a function that takes an `Events` generic and will return a function that
+ * takes in a config object to configure all guards and callbacks. The empty function is used because
+ * Typescript does not allow partial specification of generics (either you specify all generics or
+ * none of them). Since `Events` cannot be inferred, it is passed to the first function.
+ *
+ * @example
+ * type Events = {
+ *   open(data: { eventData: string }): void
+ * }
+ *
+ * const eventMap = createEventMap<Events>()({
+ *   guards: {
+ *     shouldOpen: 'open'
+ *   },
+ *   callbacks: {
+ *     onOpen: 'open'
+ *   }
+ * })
+ */
+export const createEventMap = <TEvents extends Record<string, (data: object) => void>>() => <
+  TGuardMap extends Record<string, keyof TEvents>,
+  TCallbackMap extends Record<string, keyof TEvents>
+>(
+  config: EventMap<TEvents, TGuardMap, TCallbackMap>
+) => {
+  return config;
+};
+
+// small wrapper to get `keyof T` instead of `string | number | symbol`
+const keys = <T extends object>(input: T) => Object.keys(input) as (keyof T)[];
+
+/**
+ * This hook creates a stable reference events object to be used in a model. The reference is stable
+ * by the use of `React.Memo` and uses React Refs to make sure there are no stale closure values. It
+ * takes in an event map, state, model config, and an events object. It will map over each event and
+ * add guards and callbacks to the event as configured in the event map.
+ *
+ * @param eventMap
+ * @param state
+ * @param config
+ * @param events
+ *
+ * @example
+ * const useDiscloseModel = (config: ModelConfig = {}): DiscloseModel => {
+ *   const events = useEventMap(eventMap, state, config, {
+ *     open() {
+ *       // do something
+ *     }
+ *   }
+ * })
+ */
+export const useEventMap = <
+  TEvents extends Record<string, (data: object) => void>,
+  TState extends Record<string, any>,
+  TGuardMap extends Record<string, keyof TEvents>,
+  TCallbackMap extends Record<string, keyof TEvents>,
+  TConfig extends Partial<
+    ToModelConfig<TState, TEvents, EventMap<TEvents, TGuardMap, TCallbackMap>>
+  >
+>(
+  eventMap: EventMap<TEvents, TGuardMap, TCallbackMap>,
+  state: TState,
+  config: TConfig,
+  events: TEvents
+): TEvents => {
+  // use refs so we can memoize the returned `events` object
+  const eventMapRef = React.useRef(eventMap);
+  const stateRef = React.useRef(state);
+  const configRef = React.useRef(config);
+  const eventsRef = React.useRef(events);
+
+  // update all the refs with current values
+  eventMapRef.current = eventMap;
+  stateRef.current = state;
+  configRef.current = config;
+  eventsRef.current = events;
+
+  return React.useMemo(() => {
+    return keys(eventsRef.current).reduce((result, key) => {
+      result[key] = (data => {
+        // Invoke the configured guard if there is one
+        const guardFn = keys(eventMapRef.current.guards || {}).find(k => {
+          return (eventMapRef.current.guards || {})[k] === key;
+        });
+
+        if (
+          guardFn &&
+          configRef.current[guardFn] &&
+          //@ts-ignore Typescript doesn't like that the call signatures are different
+          !configRef.current[guardFn]({data, state: stateRef.current})
+        ) {
+          return;
+        }
+
+        // call the event (setter)
+        eventsRef.current[key](data);
+
+        // Invoke the configured callback if there is one
+        const callbackFn = keys(eventMapRef.current.callbacks || {}).find(k => {
+          return (eventMapRef.current.callbacks || {})[k] === key;
+        });
+
+        if (callbackFn && configRef.current[callbackFn]) {
+          //@ts-ignore Typescript doesn't like that the call signatures are different
+          configRef.current[callbackFn]({data, state: stateRef.current});
+        }
+      }) as TEvents[keyof TEvents]; // this cast keeps Typescript happy
+      return result;
+    }, {} as TEvents);
+  }, []);
+};

--- a/modules/common/react/lib/utils/models.ts
+++ b/modules/common/react/lib/utils/models.ts
@@ -12,17 +12,17 @@ export type Model<State, Events> = {
  * @template TCallbackMap A mapping of callbacks to events they're associated with
  */
 type EventMap<
-  TEvents extends Record<string, (data: object) => void>,
+  TEvents extends Record<string, (data?: object) => void>,
   TGuardMap extends Record<string, keyof TEvents>,
   TCallbackMap extends Record<string, keyof TEvents>
 > = {
-  guards: TGuardMap;
-  callbacks: TCallbackMap;
+  guards?: TGuardMap;
+  callbacks?: TCallbackMap;
 };
 
 type ToGuardConfig<
   TState extends Record<string, any>,
-  TEvents extends Record<string, (data: object) => void>,
+  TEvents extends Record<string, (data?: object) => void>,
   TGuardMap extends Record<string, keyof TEvents>
 > = {
   [K in keyof TGuardMap]: (event: {
@@ -33,7 +33,7 @@ type ToGuardConfig<
 
 type ToCallbackConfig<
   TState extends Record<string, any>,
-  TEvents extends Record<string, (data: object) => void>,
+  TEvents extends Record<string, (data?: object) => void>,
   TGuardMap extends Record<string, keyof TEvents>
 > = {
   [K in keyof TGuardMap]: (event: {
@@ -54,7 +54,7 @@ type ToCallbackConfig<
  */
 export type ToModelConfig<
   TState extends Record<string, any>,
-  TEvents extends Record<string, (data: object) => void>,
+  TEvents extends Record<string, (data?: object) => void>,
   TEventMap extends EventMap<TEvents, any, any>
 > = ToGuardConfig<TState, TEvents, TEventMap['guards']> &
   ToCallbackConfig<TState, TEvents, TEventMap['callbacks']>;
@@ -83,7 +83,8 @@ export type ToModelConfig<
  *   }
  * })
  */
-export const createEventMap = <TEvents extends Record<string, (data: object) => void>>() => <
+
+export const createEventMap = <TEvents extends Record<string, (data?: object) => void>>() => <
   TGuardMap extends Record<string, keyof TEvents>,
   TCallbackMap extends Record<string, keyof TEvents>
 >(
@@ -116,7 +117,7 @@ const keys = <T extends object>(input: T) => Object.keys(input) as (keyof T)[];
  * })
  */
 export const useEventMap = <
-  TEvents extends Record<string, (data: object) => void>,
+  TEvents extends Record<string, (data?: object) => void>,
   TState extends Record<string, any>,
   TGuardMap extends Record<string, keyof TEvents>,
   TCallbackMap extends Record<string, keyof TEvents>,
@@ -151,7 +152,7 @@ export const useEventMap = <
 
         if (
           guardFn &&
-          configRef.current[guardFn] &&
+          configRef.current?.[guardFn] &&
           //@ts-ignore Typescript doesn't like that the call signatures are different
           !configRef.current[guardFn]({data, state: stateRef.current})
         ) {
@@ -166,7 +167,7 @@ export const useEventMap = <
           return (eventMapRef.current.callbacks || {})[k] === key;
         });
 
-        if (callbackFn && configRef.current[callbackFn]) {
+        if (callbackFn && configRef.current?.[callbackFn]) {
           //@ts-ignore Typescript doesn't like that the call signatures are different
           configRef.current[callbackFn]({data, state: stateRef.current});
         }

--- a/modules/common/react/lib/utils/useMount.ts
+++ b/modules/common/react/lib/utils/useMount.ts
@@ -1,0 +1,17 @@
+import React from 'react';
+
+/**
+ * Alias to `useEffect` with the intention to only run on mount/unmount.
+ * Avoids the React lint errors and encodes intent.
+ */
+export const useMount = (callback: () => (() => void) | void) => {
+  React.useEffect(callback, []);
+};
+
+/**
+ * Alias to `useLayoutEffect` with the intention to only run on mount/unmount
+ * Avoids the React lint errors and encodes intent.
+ */
+export const useMountLayout = (callback: () => (() => void) | void) => {
+  React.useLayoutEffect(callback, []);
+};

--- a/modules/common/react/lib/utils/useUniqueId.ts
+++ b/modules/common/react/lib/utils/useUniqueId.ts
@@ -1,13 +1,15 @@
 import * as React from 'react';
 import uuid from 'uuid/v4';
 
+export const generateUniqueId = () => uuid().replace(/^[0-9]*/gi, '');
+
 /**
  * Generate a unique ID if one is not provided. The generated ID will be stable across renders
  * @param id Optional ID provided that will be used instead of a unique ID
  */
 export const useUniqueId = (id?: string) => {
   // https://codesandbox.io/s/react-functional-component-ids-p2ndq
-  const [generatedId] = React.useState(() => uuid().replace(/^[0-9]*/gi, ''));
+  const [generatedId] = React.useState(generateUniqueId);
   return id || generatedId;
 };
 

--- a/modules/common/react/spec/components.spec.tsx
+++ b/modules/common/react/spec/components.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {screen, render, fireEvent, act} from '@testing-library/react';
 
-import {createComponent, useForkRef} from '../lib/utils/components';
+import {createComponent, useForkRef, useLocalRef} from '../lib/utils/components';
 
 describe('createEventMap', () => {
   it('create assign a displayName', () => {
@@ -117,5 +117,24 @@ describe('useForkRef', () => {
 
     expect(ref1).toHaveBeenCalledWith('bar');
     expect(ref2).toHaveBeenCalledWith('bar');
+  });
+});
+
+describe.only('useLocalRef', () => {
+  it('should return a localRef and an elementRef', () => {
+    let localRefTest, elementRefTest;
+    const CustomComponent = React.forwardRef<HTMLDivElement>((_, ref) => {
+      const {localRef, elementRef} = useLocalRef(ref);
+
+      localRefTest = localRef;
+      elementRefTest = elementRef;
+
+      return <div ref={ref} />;
+    });
+
+    render(<CustomComponent />);
+
+    expect(localRefTest).toHaveProperty('current');
+    expect(elementRefTest).toEqual(expect.any(Function));
   });
 });

--- a/modules/common/react/spec/components.spec.tsx
+++ b/modules/common/react/spec/components.spec.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import {screen, render, fireEvent, act} from '@testing-library/react';
+
+import {createComponent, useForkRef} from '../lib/utils/components';
+
+describe('createEventMap', () => {
+  it('create assign a displayName', () => {
+    const Component = createComponent('div')({
+      displayName: 'Test',
+      Component: () => null,
+    });
+
+    expect(Component).toHaveProperty('displayName', 'Test');
+  });
+
+  it('should assign sub components', () => {
+    const SubComponent = () => null;
+    const Component = createComponent('div')({
+      Component: () => null,
+      subComponents: {
+        SubComponent,
+      },
+    });
+
+    expect(Component).toHaveProperty('SubComponent', SubComponent);
+  });
+
+  it('should forward the ref', () => {
+    const ref = {current: null};
+
+    const Component = createComponent('div')({
+      displayName: 'Test',
+      Component: (props, ref) => <div id="test" ref={ref} />,
+    });
+
+    render(<Component ref={ref} />);
+
+    expect(ref.current).toHaveAttribute('id', 'test');
+  });
+
+  it('should render whatever element is passed through the "as" prop', () => {
+    const Component = createComponent('div')({
+      displayName: 'Test',
+      Component: (props, ref, Element) => <Element data-testid="test" />,
+    });
+
+    render(<Component as="button" />);
+
+    expect(screen.getByTestId('test')).toHaveProperty('tagName', 'BUTTON');
+  });
+});
+
+describe('useForkRef', () => {
+  it('should set the current value of the second ref if the first ref is undefined', () => {
+    const ref1 = undefined;
+    const ref2 = {current: null};
+
+    const ref = useForkRef(ref1, ref2);
+
+    ref('bar');
+
+    expect(ref2).toHaveProperty('current', 'bar');
+  });
+
+  it('should set the current value of the first ref if the second ref is undefined', () => {
+    const ref1 = {current: null};
+    const ref2 = undefined;
+
+    const ref = useForkRef(ref1, ref2);
+
+    ref('bar');
+
+    expect(ref1).toHaveProperty('current', 'bar');
+  });
+
+  it('should set the current value of both refs if both refs are RefObjects', () => {
+    const ref1 = {current: null};
+    const ref2 = {current: null};
+
+    const ref = useForkRef(ref1, ref2);
+
+    ref('bar');
+
+    expect(ref1).toHaveProperty('current', 'bar');
+    expect(ref2).toHaveProperty('current', 'bar');
+  });
+
+  it('should call the ref function of the second ref if the first ref is undefined', () => {
+    const ref1 = undefined;
+    const ref2 = jest.fn();
+
+    const ref = useForkRef(ref1, ref2);
+
+    ref('bar');
+
+    expect(ref2).toHaveBeenCalledWith('bar');
+  });
+
+  it('should call the ref function of the first ref if the second ref is undefined', () => {
+    const ref1 = jest.fn();
+    const ref2 = undefined;
+
+    const ref = useForkRef(ref1, ref2);
+
+    ref('bar');
+
+    expect(ref1).toHaveBeenCalledWith('bar');
+  });
+
+  it('should call the ref function of both refs if both refs are ref functions', () => {
+    const ref1 = jest.fn();
+    const ref2 = jest.fn();
+
+    const ref = useForkRef(ref1, ref2);
+
+    ref('bar');
+
+    expect(ref1).toHaveBeenCalledWith('bar');
+    expect(ref2).toHaveBeenCalledWith('bar');
+  });
+});

--- a/modules/common/react/spec/models.spec.tsx
+++ b/modules/common/react/spec/models.spec.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import {screen, render, fireEvent, act} from '@testing-library/react';
+
+import {createEventMap, useEventMap} from '../lib/utils/models';
+
+describe('createEventMap', () => {
+  it('should return the original config object', () => {
+    expect(
+      createEventMap()({
+        guards: {},
+        callbacks: {},
+      })
+    ).toEqual({
+      guards: {},
+      callbacks: {},
+    });
+  });
+});
+
+describe('useEventMap', () => {
+  type Events = {
+    foo(data: {}): void;
+  };
+  const eventMap = createEventMap<Events>()({
+    guards: {
+      shouldFoo: 'foo',
+    },
+    callbacks: {
+      onFoo: 'foo',
+    },
+  });
+
+  const useModel = (config = {}) => {
+    const [foo, setFoo] = React.useState('bar');
+    const state = {
+      foo,
+    };
+
+    const events = useEventMap(eventMap, state, config, {
+      foo(data) {
+        setFoo('baz');
+      },
+    });
+
+    return {state, events};
+  };
+
+  const TestComponent = config => {
+    const model = useModel(config);
+
+    return (
+      <div data-testid="test" onClick={() => model.events.foo({value: 'baz'})}>
+        {model.state.foo}
+      </div>
+    );
+  };
+
+  it('should call a guard if defined', () => {
+    const guard = jest.fn();
+
+    render(<TestComponent shouldFoo={guard} />);
+    fireEvent.click(screen.getByTestId('test'));
+
+    expect(guard).toBeCalledTimes(1);
+  });
+
+  it('should call a guard with data and state', () => {
+    const guard = jest.fn();
+
+    render(<TestComponent shouldFoo={guard} />);
+    fireEvent.click(screen.getByTestId('test'));
+
+    expect(guard).toBeCalledWith({data: {value: 'baz'}, state: {foo: 'bar'}});
+  });
+
+  it('should call a callback if defined', () => {
+    const callback = jest.fn();
+
+    render(<TestComponent onFoo={callback} />);
+    fireEvent.click(screen.getByTestId('test'));
+
+    expect(callback).toBeCalledTimes(1);
+  });
+
+  it('should call a callback with data and state', () => {
+    const callback = jest.fn();
+
+    render(<TestComponent onFoo={callback} />);
+    fireEvent.click(screen.getByTestId('test'));
+
+    expect(callback).toBeCalledWith({data: {value: 'baz'}, state: {foo: 'bar'}});
+  });
+
+  it('should call a callback if a guard returns true', () => {
+    const callback = jest.fn();
+
+    render(<TestComponent onFoo={callback} shouldFoo={() => true} />);
+    fireEvent.click(screen.getByTestId('test'));
+
+    expect(callback).toBeCalledTimes(1);
+  });
+
+  it('should not call a callback if a guard returns false', () => {
+    const callback = jest.fn();
+
+    render(<TestComponent onFoo={callback} shouldFoo={() => false} />);
+    fireEvent.click(screen.getByTestId('test'));
+
+    expect(callback).not.toBeCalled();
+  });
+});

--- a/utils/create-component/createReactModule.js
+++ b/utils/create-component/createReactModule.js
@@ -4,11 +4,14 @@ const {exec} = require('child_process');
 require('colors');
 
 const writeModuleFiles = require('./writeModuleFiles');
-const getPascalCaseName = require('./nameUtils').getPascalCaseName;
-const getTitleCaseName = require('./nameUtils').getTitleCaseName;
+
+const {getCamelCaseName, getPascalCaseName, getTitleCaseName} = require('./nameUtils');
 
 const packageJson = require('./templates/react/packageJson');
+const model = require('./templates/react/model');
 const component = require('./templates/react/component');
+const componentTarget = require('./templates/react/component.target');
+const componentContent = require('./templates/react/component.content');
 const index = require('./templates/react/index');
 const stories = require('./templates/react/stories');
 const testingStories = require('./templates/react/stories_VisualTesting');
@@ -25,6 +28,7 @@ module.exports = (modulePath, name, description, unstable, public, category) => 
 
   mkdirp.sync(modulePath);
 
+  const camelCaseName = getCamelCaseName(name);
   const pascalCaseName = getPascalCaseName(name);
   const titleCaseName = getTitleCaseName(name);
   const rootPath = unstable ? '../../../..' : '../../..';
@@ -36,9 +40,21 @@ module.exports = (modulePath, name, description, unstable, public, category) => 
       path: 'package.json',
       contents: packageJson(name, moduleName, description, unstable, public),
     },
+    model: {
+      path: `lib/use${pascalCaseName}Model.tsx`,
+      contents: model(camelCaseName, pascalCaseName),
+    },
     component: {
       path: `lib/${pascalCaseName}.tsx`,
       contents: component(pascalCaseName),
+    },
+    componentTarget: {
+      path: `lib/${pascalCaseName}.Target.tsx`,
+      contents: componentTarget(camelCaseName, pascalCaseName),
+    },
+    componentContent: {
+      path: `lib/${pascalCaseName}.Content.tsx`,
+      contents: componentContent(pascalCaseName),
     },
     index: {
       path: 'index.ts',
@@ -46,11 +62,11 @@ module.exports = (modulePath, name, description, unstable, public, category) => 
     },
     stories: {
       path: 'stories/stories.tsx',
-      contents: stories(storyPath, pascalCaseName, rootPath),
+      contents: stories(moduleName, storyPath, pascalCaseName, rootPath),
     },
     testingStories: {
       path: 'stories/stories_VisualTesting.tsx',
-      contents: testingStories(testingStoryPath, pascalCaseName, rootPath, unstable),
+      contents: testingStories(moduleName, testingStoryPath, pascalCaseName, rootPath),
     },
     ssr: {
       path: 'spec/SSR.spec.tsx',

--- a/utils/create-component/nameUtils.js
+++ b/utils/create-component/nameUtils.js
@@ -9,16 +9,24 @@ const getTitleCaseName = string => {
 };
 
 /**
+ * Converts kebab-case to camelCase.
+ */
+const getCamelCaseName = string => {
+  return string.replace(/-(\w)/g, function(m) {
+    return m[1].toUpperCase();
+  });
+};
+
+/**
  * Converts kebab-case to PascalCase.
  */
 const getPascalCaseName = string => {
-  const result = string.replace(/-(\w)/g, function(m) {
-    return m[1].toUpperCase();
-  });
+  const result = getCamelCaseName(string);
   return result.charAt(0).toUpperCase() + result.slice(1);
 };
 
 module.exports = {
   getTitleCaseName,
+  getCamelCaseName,
   getPascalCaseName,
 };

--- a/utils/create-component/templates/react/SSR.js
+++ b/utils/create-component/templates/react/SSR.js
@@ -10,7 +10,12 @@ import {${pascalCaseName}} from '../';
 
 describe('${pascalCaseName}', () => {
   it('should render on a server without crashing', () => {
-    const ssrRender = () => renderToString(<${pascalCaseName} />);
+    const ssrRender = () => renderToString(
+      <${pascalCaseName}>
+        <${pascalCaseName}.Target>Target</${pascalCaseName}.Target>
+        <${pascalCaseName}.Content>Content</${pascalCaseName}.Content>
+      </${pascalCaseName}>
+    );
     expect(ssrRender).not.toThrow();
   });
 });

--- a/utils/create-component/templates/react/SSR.js
+++ b/utils/create-component/templates/react/SSR.js
@@ -6,7 +6,7 @@ module.exports = pascalCaseName => `
  */
 import React from 'react';
 import {renderToString} from 'react-dom/server';
-import ${pascalCaseName} from '../';
+import {${pascalCaseName}} from '../';
 
 describe('${pascalCaseName}', () => {
   it('should render on a server without crashing', () => {

--- a/utils/create-component/templates/react/component.content.js
+++ b/utils/create-component/templates/react/component.content.js
@@ -1,0 +1,32 @@
+module.exports = pascalCaseName => `import React from 'react';
+
+import {colors, spacing} from '@workday/canvas-kit-react-core';
+import {createComponent, styled, StyledType, useModelContext} from '@workday/canvas-kit-react-common';
+
+import {${pascalCaseName}ModelContext} from './${pascalCaseName}';
+import { ${pascalCaseName}Model } from './use${pascalCaseName}Model';
+
+export interface ${pascalCaseName}ContentProps {
+  model?: ${pascalCaseName}Model;
+  children: React.ReactNode;
+}
+
+const Container = styled('div')<StyledType>({
+  background: colors.frenchVanilla600,
+  padding: spacing.s,
+  border: \`1px solid \${colors.licorice600}\`,
+});
+
+export const ${pascalCaseName}Content = createComponent('div')({
+  displayName: '${pascalCaseName}.Content',
+  Component: ({children, model, ...elemProps}: ${pascalCaseName}ContentProps, ref, Element) => {
+    const {state} = useModelContext(${pascalCaseName}ModelContext, model);
+
+    return state.open ? (
+      <Container as={Element} ref={ref} {...elemProps}>
+        {children}
+      </Container>
+    ) : null;
+  },
+});
+`;

--- a/utils/create-component/templates/react/component.js
+++ b/utils/create-component/templates/react/component.js
@@ -1,24 +1,37 @@
 module.exports = pascalCaseName => `
-import * as React from 'react'
-import styled from '@emotion/styled';
+import React from 'react';
 
-export interface ${pascalCaseName}Props extends React.HTMLAttributes<HTMLDivElement> {
+import {createComponent, useDefaultModel} from '@workday/canvas-kit-react-common';
 
+import {
+  use${pascalCaseName}Model,
+  ${pascalCaseName}Model,
+  ${pascalCaseName}ModelConfig,
+} from './use${pascalCaseName}Model';
+import {${pascalCaseName}Target} from './${pascalCaseName}.Target';
+import {${pascalCaseName}Content} from './${pascalCaseName}.Content';
+
+export const ${pascalCaseName}ModelContext = React.createContext<${pascalCaseName}Model>({} as any);
+
+export interface ${pascalCaseName}Props extends ${pascalCaseName}ModelConfig {
+  model?: ${pascalCaseName}Model;
+  children: React.ReactNode;
 }
 
-const Container = styled('div')<${pascalCaseName}Props>({
-
-});
-
-export default class ${pascalCaseName} extends React.Component<${pascalCaseName}Props, {}> {
-  public render() {
-    const {...elemProps} = this.props;
+export const ${pascalCaseName} = createComponent('div')({
+  displayName: '${pascalCaseName}',
+  Component: ({children, model, ...config}: ${pascalCaseName}Props) => {
+    const value = useDefaultModel(model, config, use${pascalCaseName}Model);
 
     return (
-      <Container {...elemProps}>
-        ${pascalCaseName}
-      </Container>
-    )
-  }
-}
+      <${pascalCaseName}ModelContext.Provider value={value}>
+        {children}
+      </${pascalCaseName}ModelContext.Provider>
+    );
+  },
+  subComponents: {
+    Target: ${pascalCaseName}Target,
+    Content: ${pascalCaseName}Content,
+  },
+});
 `;

--- a/utils/create-component/templates/react/component.js
+++ b/utils/create-component/templates/react/component.js
@@ -18,7 +18,7 @@ export interface ${pascalCaseName}Props extends ${pascalCaseName}ModelConfig {
   children: React.ReactNode;
 }
 
-export const ${pascalCaseName} = createComponent('div')({
+export const ${pascalCaseName} = createComponent()({
   displayName: '${pascalCaseName}',
   Component: ({children, model, ...config}: ${pascalCaseName}Props) => {
     const value = useDefaultModel(model, config, use${pascalCaseName}Model);

--- a/utils/create-component/templates/react/component.target.js
+++ b/utils/create-component/templates/react/component.target.js
@@ -1,0 +1,44 @@
+module.exports = (camelCaseName, pascalCaseName) => `import React from 'react';
+
+import {createComponent, useModelContext} from '@workday/canvas-kit-react-common';
+
+import {${pascalCaseName}ModelContext} from './${pascalCaseName}';
+import { ${pascalCaseName}Model } from './use${pascalCaseName}Model';
+
+export interface ${pascalCaseName}TargetProps {
+  model?: ${pascalCaseName}Model;
+  children: React.ReactNode;
+}
+
+const useDiscloseTarget = (
+  {state, events}: ${pascalCaseName}Model,
+  elemProps: Partial<React.HTMLAttributes<HTMLElement>> = {}
+) => {
+  return {
+    onClick(event: React.MouseEvent<HTMLElement>) {
+      elemProps.onClick?.(event);
+
+      if (state.open) {
+        events.close({});
+      } else {
+        events.open({});
+      }
+    },
+  };
+};
+
+export const ${pascalCaseName}Target = createComponent('button')({
+  displayName: '${pascalCaseName}.Target',
+  Component: ({children, model, ...elemProps}: ${pascalCaseName}TargetProps, ref, Element) => {
+    const ${camelCaseName}Model = useModelContext(${pascalCaseName}ModelContext, model);
+
+    const target = useDiscloseTarget(${camelCaseName}Model, elemProps);
+
+    return (
+      <Element ref={ref} {...target}>
+        {children}
+      </Element>
+    );
+  },
+});
+`;

--- a/utils/create-component/templates/react/index.js
+++ b/utils/create-component/templates/react/index.js
@@ -1,7 +1,4 @@
 module.exports = pascalCaseName => `
-import ${pascalCaseName} from './lib/${pascalCaseName}';
-
-export default ${pascalCaseName};
-export {${pascalCaseName}};
 export * from './lib/${pascalCaseName}';
+export * from './lib/use${pascalCaseName}Model'
 `;

--- a/utils/create-component/templates/react/model.js
+++ b/utils/create-component/templates/react/model.js
@@ -1,0 +1,54 @@
+module.exports = (camelCaseName, pascalCaseName) => `import React from 'react';
+
+import {createEventMap, Model, ToModelConfig, useEventMap} from '@workday/canvas-kit-react-common';
+
+type ${pascalCaseName}State = {
+  open: boolean;
+};
+
+type ${pascalCaseName}Events = {
+  open(data: {}): void;
+  close(data: {}): void;
+};
+
+export type ${pascalCaseName}Model = Model<${pascalCaseName}State, ${pascalCaseName}Events>;
+
+const ${camelCaseName}EventMap = createEventMap<${pascalCaseName}Events>()({
+  guards: {
+    shouldOpen: 'open',
+    shouldClose: 'close',
+  },
+  callbacks: {
+    onOpen: 'open',
+    onClose: 'close',
+  },
+});
+
+export type ${pascalCaseName}ModelConfig = {
+  initialOpen?: boolean;
+} & Partial<ToModelConfig<${pascalCaseName}State, ${pascalCaseName}Events, typeof ${camelCaseName}EventMap>>;
+
+export const use${pascalCaseName}Model = (
+  config: ${pascalCaseName}ModelConfig = {}
+): ${pascalCaseName}Model => {
+  const [open, setOpen] = React.useState(config.initialOpen || false);
+
+  const state = {
+    open,
+  };
+
+  const events = useEventMap(${camelCaseName}EventMap, state, config, {
+    open(data) {
+      setOpen(true);
+    },
+    close(data) {
+      setOpen(false);
+    },
+  });
+
+  return {
+    state,
+    events,
+  };
+};
+`;

--- a/utils/create-component/templates/react/stories.js
+++ b/utils/create-component/templates/react/stories.js
@@ -1,11 +1,16 @@
 // React stories template
 
-module.exports = (storyPath, pascalCaseName, rootPath) => `
-/// <reference path="${rootPath}/../typings.d.ts" />
-import * as React from 'react';
+module.exports = (
+  modulePath,
+  storyPath,
+  pascalCaseName,
+  rootPath
+) => `/// <reference path="${rootPath}/../typings.d.ts" />
+import React from 'react';
 import withReadme from 'storybook-readme/with-readme';
 
-import ${pascalCaseName} from '../index';
+import {${pascalCaseName}} from '${modulePath}';
+import {Button} from '@workday/canvas-kit-react-button';
 import README from '../README.md';
 
 export default {
@@ -14,5 +19,9 @@ export default {
   component: ${pascalCaseName},
 };
 
-export const Default = () => <${pascalCaseName} />
-`;
+export const Default = () => (
+  <${pascalCaseName}>
+    <${pascalCaseName}.Target as={Button}>Toggle</${pascalCaseName}.Target>
+    <${pascalCaseName}.Content>Content</${pascalCaseName}.Content>
+  </${pascalCaseName}>
+);`;

--- a/utils/create-component/templates/react/stories_VisualTesting.js
+++ b/utils/create-component/templates/react/stories_VisualTesting.js
@@ -1,56 +1,47 @@
 // React stories template
 
-module.exports = (storyPath, pascalCaseName, rootPath, unstable) => `
-/// <reference path="${rootPath}/../typings.d.ts" />
-/** @jsx jsx */
-import {jsx} from '@emotion/core';
+module.exports = (modulePath, storyPath, pascalCaseName, rootPath) => `import React from 'react';
+
 import {StaticStates} from '@workday/canvas-kit-labs-react-core';
-import {ComponentStatesTable, permutateProps, withSnapshotsEnabled} from '../../../../${unstable ? '../' : ''}utils/storybook';
-import ${pascalCaseName} from '../index';
+import {ComponentStatesTable, withSnapshotsEnabled} from '../${rootPath}/utils/storybook';
+
+import {${pascalCaseName}, use${pascalCaseName}Model} from '${modulePath}';
 
 export default withSnapshotsEnabled({
   title: '${storyPath}',
   component: ${pascalCaseName},
 });
 
-export const ${pascalCaseName}States = () => (
-  <StaticStates>
-    <ComponentStatesTable
-      rowProps={permutateProps(
-        {
-          prop1: [{value: true, label: 'Prop one on'}, {value: false, label: 'Prop one off'}],
-          prop2: [
-            {value: undefined, label: ''},
-            {value: 'alert', label: 'Alert'},
-            {value: 'error', label: 'Error'},
-          ],
-        }
-      )}
-      columnProps={permutateProps(
-        {
-          className: [
-            {label: 'Default', value: ''},
-            {label: 'Hover', value: 'hover'},
-            {label: 'Focus', value: 'focus'},
-            {label: 'Focus Hover', value: 'focus hover'},
-            {label: 'Active', value: 'active'},
-            {label: 'Active Hover', value: 'active hover'},
-          ],
-          disabled: [{label: '', value: false}, {label: 'Disabled', value: true}],
-        },
-        props => {
-          if (props.disabled && !['', 'hover'].includes(props.className)) {
-            return false;
-          }
-          return true;
-        }
-      )}
-    >
-      {props => (
-        <${pascalCaseName} {...props} />
-      )}
-    </ComponentStatesTable>
-  </StaticStates>
-);
+export const ${pascalCaseName}States = () => {
+  const model = use${pascalCaseName}Model();
 
+  return (
+    <StaticStates>
+      <ComponentStatesTable
+        rowProps={[{label: 'Default', props: {}}]}
+        columnProps={[
+          {
+            label: 'Closed',
+            props: {open: false},
+          },
+          {
+            label: 'Opened',
+            props: {open: true},
+          },
+        ]}
+      >
+        {props => {
+          const state = {open: props.open};
+
+          return (
+            <${pascalCaseName} model={{...model, state}}>
+              <${pascalCaseName}.Target>Toggle</${pascalCaseName}.Target>
+              <${pascalCaseName}.Content>Content</${pascalCaseName}.Content>
+            </${pascalCaseName}>
+          );
+        }}
+      </ComponentStatesTable>
+    </StaticStates>
+  );
+};
 `;

--- a/utils/custom-lint-rules/restricted-imports.js
+++ b/utils/custom-lint-rules/restricted-imports.js
@@ -19,7 +19,7 @@ module.exports = {
         if (pathRegex.test(value)) {
           context.report({
             node,
-            message: `The /lib directory isn't available in production. Import from '@workday/${packageName}'.`,
+            message: `The /lib directory isn't available in production. Import from '@workday/${packageName}' instead.`,
           });
         }
       },

--- a/utils/custom-lint-rules/restricted-imports.spec.ts
+++ b/utils/custom-lint-rules/restricted-imports.spec.ts
@@ -16,7 +16,7 @@ ruleTester.run('restricted-imports', rule, {
       errors: [
         {
           message:
-            "The /lib directory isn't available in production. Import from '@workday/canvas-kit-react-color-picker'.",
+            "The /lib directory isn't available in production. Import from '@workday/canvas-kit-react-color-picker' instead.",
         },
       ],
     },
@@ -25,7 +25,7 @@ ruleTester.run('restricted-imports', rule, {
       errors: [
         {
           message:
-            "The /lib directory isn't available in production. Import from '@workday/canvas-kit-react-core'.",
+            "The /lib directory isn't available in production. Import from '@workday/canvas-kit-react-core' instead.",
         },
       ],
     },


### PR DESCRIPTION
* Add `createComponent` helper functions
* Add model types and helper functions
* Update new component templates to use Compound Component helper functions

This PR adds compound component helper functions to help with creating compound components. These utility functions take care of complexity around Typescript, enforce ref forwarding, enable element remapping, etc. Documentation for creating compound components will follow.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [x] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

Still to be done:
- [ ] Update API pattern guidelines MD file 
- [x] Add documentation for creating compound components #950
