### PR TITLE
feat: Add closeButtonAriaLabel to Modal Component

### DIFF
--- a/modules/modal/react/README.md
+++ b/modules/modal/react/README.md
@@ -120,3 +120,9 @@ default behavior.
 
 If this ref is not provided the modal will try to use the close icon. If that icon is not available,
 it will make the modal heading focusable and focus on that instead.
+
+#### `closeButtonAriaLabel: string`
+
+> Aria label string for the close icon button
+
+---

--- a/modules/modal/react/lib/ModalContent.tsx
+++ b/modules/modal/react/lib/ModalContent.tsx
@@ -60,6 +60,10 @@ export interface ModalContentProps extends React.HTMLAttributes<HTMLDivElement> 
    * @default document.body
    */
   container?: HTMLElement;
+  /**
+   * The `aria-label` for the Popup close button.
+   */
+  closeButtonAriaLabel?: string;
 }
 
 const fadeIn = keyframes`
@@ -193,6 +197,7 @@ const ModalContent = ({
   children,
   firstFocusRef,
   heading,
+  closeButtonAriaLabel,
   ...elemProps
 }: ModalContentProps) => {
   const centeringRef = React.useRef<HTMLDivElement>(null);
@@ -228,6 +233,7 @@ const ModalContent = ({
           transformOrigin={transformOrigin}
           aria-modal={true}
           ariaLabel={ariaLabel}
+          closeButtonAriaLabel={closeButtonAriaLabel}
         >
           {children}
         </Popup>

--- a/modules/modal/react/spec/Modal.spec.tsx
+++ b/modules/modal/react/spec/Modal.spec.tsx
@@ -26,7 +26,7 @@ describe('Modal', () => {
     );
   });
 
-  test('Modal should forward closeButtonAriaLabel prop tp Popup', () => {
+  test('Modal should forward closeButtonAriaLabel prop to Popup', () => {
     const closeButtonAriaLabel = 'close button aria label';
     const {getByRole} = renderModal({closeButtonAriaLabel});
     expect(getByRole('button')).toHaveAttribute('aria-label', closeButtonAriaLabel);

--- a/modules/modal/react/spec/Modal.spec.tsx
+++ b/modules/modal/react/spec/Modal.spec.tsx
@@ -26,9 +26,9 @@ describe('Modal', () => {
     );
   });
 
-  test('Modal should replace aria-labeldBy with custom aria-label', () => {
-    const customAriaLabel = 'custom aria label';
-    const {getByRole} = renderModal({ariaLabel: customAriaLabel});
-    expect(getByRole('dialog')).toHaveAttribute('aria-label', customAriaLabel);
+  test('Modal should forward closeButtonAriaLabel prop tp Popup', () => {
+    const closeButtonAriaLabel = 'close button aria label';
+    const {getByRole} = renderModal({closeButtonAriaLabel});
+    expect(getByRole('button')).toHaveAttribute('aria-label', closeButtonAriaLabel);
   });
 });

--- a/modules/popup/react/README.md
+++ b/modules/popup/react/README.md
@@ -222,7 +222,7 @@ Default: `PopupPadding.l`
 
 ---
 
-#### `closeLabel: string`
+#### `closeButtonAriaLabel: string`
 
 > Aria label string for the close icon button
 


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Allow for custom aria-label attribute on the close button for the modal.
Fixes #955
## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md
- [x] design approved final implementation
- [x] a11y approved final implementation
- [x] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->

## Example

`<Modal closeButtonAriaLabel="Example Label" />`
