### PR TITLE
fix: Add crossorigin to font preloads

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -24,24 +24,29 @@
   href="https://design.workdaycdn.com/beta/assets/fonts@1.0.0/roboto/ttf/Roboto-Light.ttf"
   as="font"
   type="font/ttf"
+  crossorigin
 /><link
   rel="preload"
   href="https://design.workdaycdn.com/beta/assets/fonts@1.0.0/roboto/ttf/Roboto-Regular.ttf"
   as="font"
   type="font/ttf"
+  crossorigin
 /><link
   rel="preload"
   href="https://design.workdaycdn.com/beta/assets/fonts@1.0.0/roboto/ttf/Roboto-Medium.ttf"
   as="font"
   type="font/ttf"
+  crossorigin
 /><link
   rel="preload"
   href="https://design.workdaycdn.com/beta/assets/fonts@1.0.0/roboto/ttf/Roboto-Bold.ttf"
   as="font"
   type="font/ttf"
+  crossorigin
 /><link
   rel="preload"
   href="https://design.workdaycdn.com/beta/assets/fonts@1.0.0/roboto/ttf/RobotoMono-Regular.ttf"
   as="font"
   type="font/ttf"
+  crossorigin
 />

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -24,29 +24,29 @@
   href="https://design.workdaycdn.com/beta/assets/fonts@1.0.0/roboto/ttf/Roboto-Light.ttf"
   as="font"
   type="font/ttf"
-  crossorigin
+  crossorigin="anonymous"
 /><link
   rel="preload"
   href="https://design.workdaycdn.com/beta/assets/fonts@1.0.0/roboto/ttf/Roboto-Regular.ttf"
   as="font"
   type="font/ttf"
-  crossorigin
+  crossorigin="anonymous"
 /><link
   rel="preload"
   href="https://design.workdaycdn.com/beta/assets/fonts@1.0.0/roboto/ttf/Roboto-Medium.ttf"
   as="font"
   type="font/ttf"
-  crossorigin
+  crossorigin="anonymous"
 /><link
   rel="preload"
   href="https://design.workdaycdn.com/beta/assets/fonts@1.0.0/roboto/ttf/Roboto-Bold.ttf"
   as="font"
   type="font/ttf"
-  crossorigin
+  crossorigin="anonymous"
 /><link
   rel="preload"
   href="https://design.workdaycdn.com/beta/assets/fonts@1.0.0/roboto/ttf/RobotoMono-Regular.ttf"
   as="font"
   type="font/ttf"
-  crossorigin
+  crossorigin="anonymous"
 />


### PR DESCRIPTION
Fonts aren't preloading with the following warnings:
> A preload for 'https://design.workdaycdn.com/beta/assets/fonts@1.0.0/roboto/ttf/Roboto-Regular.ttf' is found, but is not used because the request credentials mode does not match. Consider taking a look at crossorigin attribute.

Since preloads are failing, we're also getting the following warnings:
> The resource https://design.workdaycdn.com/beta/assets/fonts@1.0.0/roboto/ttf/RobotoMono-Regular.ttf was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it has an appropriate `as` value and it is preloaded intentionally.

This fixes both warnings and makes sure Chromatic is correctly preloading fonts.
