### PR TITLE
chore: Update peerDependencies to support React 17

### DIFF
--- a/modules/_canvas-kit-react/package.json
+++ b/modules/_canvas-kit-react/package.json
@@ -43,7 +43,7 @@
     "workday"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@workday/canvas-kit-react-action-bar": "^4.5.0",

--- a/modules/_canvas-kit-react/package.json
+++ b/modules/_canvas-kit-react/package.json
@@ -43,7 +43,7 @@
     "workday"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@workday/canvas-kit-react-action-bar": "^4.5.0",

--- a/modules/_labs/breadcrumbs/react/package.json
+++ b/modules/_labs/breadcrumbs/react/package.json
@@ -35,7 +35,7 @@
     "breadcrumbs"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/_labs/breadcrumbs/react/package.json
+++ b/modules/_labs/breadcrumbs/react/package.json
@@ -35,7 +35,7 @@
     "breadcrumbs"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/_labs/color-picker/react/package.json
+++ b/modules/_labs/color-picker/react/package.json
@@ -57,6 +57,6 @@
     "@workday/canvas-system-icons-web": "1.0.41"
   },
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   }
 }

--- a/modules/_labs/color-picker/react/package.json
+++ b/modules/_labs/color-picker/react/package.json
@@ -57,6 +57,6 @@
     "@workday/canvas-system-icons-web": "1.0.41"
   },
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   }
 }

--- a/modules/_labs/combobox/react/package.json
+++ b/modules/_labs/combobox/react/package.json
@@ -45,7 +45,7 @@
     "combobox"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/_labs/combobox/react/package.json
+++ b/modules/_labs/combobox/react/package.json
@@ -45,7 +45,7 @@
     "combobox"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/_labs/core/react/package.json
+++ b/modules/_labs/core/react/package.json
@@ -44,7 +44,7 @@
     "core"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/_labs/core/react/package.json
+++ b/modules/_labs/core/react/package.json
@@ -44,7 +44,7 @@
     "core"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/_labs/drawer/react/package.json
+++ b/modules/_labs/drawer/react/package.json
@@ -51,7 +51,7 @@
     "@workday/canvas-system-icons-web": "1.0.41"
   },
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "devDependencies": {
     "@workday/canvas-kit-labs-react-core": "^4.5.0"

--- a/modules/_labs/drawer/react/package.json
+++ b/modules/_labs/drawer/react/package.json
@@ -51,7 +51,7 @@
     "@workday/canvas-system-icons-web": "1.0.41"
   },
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "devDependencies": {
     "@workday/canvas-kit-labs-react-core": "^4.5.0"

--- a/modules/_labs/header/react/package.json
+++ b/modules/_labs/header/react/package.json
@@ -45,7 +45,7 @@
     "header"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/_labs/header/react/package.json
+++ b/modules/_labs/header/react/package.json
@@ -45,7 +45,7 @@
     "header"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/_labs/pagination/react/package.json
+++ b/modules/_labs/pagination/react/package.json
@@ -44,7 +44,7 @@
     "pagination"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/_labs/pagination/react/package.json
+++ b/modules/_labs/pagination/react/package.json
@@ -44,7 +44,7 @@
     "pagination"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/_labs/select/react/package.json
+++ b/modules/_labs/select/react/package.json
@@ -35,7 +35,7 @@
     "select"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/_labs/select/react/package.json
+++ b/modules/_labs/select/react/package.json
@@ -35,7 +35,7 @@
     "select"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/_labs/side-panel/react/package.json
+++ b/modules/_labs/side-panel/react/package.json
@@ -60,6 +60,6 @@
     "@workday/canvas-kit-react-avatar": "^4.5.0"
   },
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   }
 }

--- a/modules/_labs/side-panel/react/package.json
+++ b/modules/_labs/side-panel/react/package.json
@@ -60,6 +60,6 @@
     "@workday/canvas-kit-react-avatar": "^4.5.0"
   },
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   }
 }

--- a/modules/_labs/tabs/react/package.json
+++ b/modules/_labs/tabs/react/package.json
@@ -44,6 +44,6 @@
     "@workday/canvas-kit-labs-react-core": "^4.5.0"
   },
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   }
 }

--- a/modules/_labs/tabs/react/package.json
+++ b/modules/_labs/tabs/react/package.json
@@ -44,6 +44,6 @@
     "@workday/canvas-kit-labs-react-core": "^4.5.0"
   },
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   }
 }

--- a/modules/action-bar/react/package.json
+++ b/modules/action-bar/react/package.json
@@ -45,7 +45,7 @@
     "action-bar"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/action-bar/react/package.json
+++ b/modules/action-bar/react/package.json
@@ -45,7 +45,7 @@
     "action-bar"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/avatar/react/package.json
+++ b/modules/avatar/react/package.json
@@ -45,7 +45,7 @@
     "avatar"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/avatar/react/package.json
+++ b/modules/avatar/react/package.json
@@ -45,7 +45,7 @@
     "avatar"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/badge/react/package.json
+++ b/modules/badge/react/package.json
@@ -39,7 +39,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/badge/react/package.json
+++ b/modules/badge/react/package.json
@@ -39,7 +39,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/banner/react/package.json
+++ b/modules/banner/react/package.json
@@ -45,7 +45,7 @@
     "banner"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@workday/canvas-kit-react-common": "^4.5.0",

--- a/modules/banner/react/package.json
+++ b/modules/banner/react/package.json
@@ -45,7 +45,7 @@
     "banner"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@workday/canvas-kit-react-common": "^4.5.0",

--- a/modules/button/react/package.json
+++ b/modules/button/react/package.json
@@ -44,7 +44,7 @@
     "button"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/button/react/package.json
+++ b/modules/button/react/package.json
@@ -44,7 +44,7 @@
     "button"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/card/react/package.json
+++ b/modules/card/react/package.json
@@ -45,7 +45,7 @@
     "card"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/card/react/package.json
+++ b/modules/card/react/package.json
@@ -45,7 +45,7 @@
     "card"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/checkbox/react/package.json
+++ b/modules/checkbox/react/package.json
@@ -45,7 +45,7 @@
     "checkbox"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@workday/canvas-kit-react-common": "^4.5.0",

--- a/modules/checkbox/react/package.json
+++ b/modules/checkbox/react/package.json
@@ -45,7 +45,7 @@
     "checkbox"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@workday/canvas-kit-react-common": "^4.5.0",

--- a/modules/color-picker/react/package.json
+++ b/modules/color-picker/react/package.json
@@ -55,6 +55,6 @@
     "chroma-js": "^2.1.0"
   },
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   }
 }

--- a/modules/color-picker/react/package.json
+++ b/modules/color-picker/react/package.json
@@ -55,6 +55,6 @@
     "chroma-js": "^2.1.0"
   },
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   }
 }

--- a/modules/common/react/package.json
+++ b/modules/common/react/package.json
@@ -45,7 +45,7 @@
     "common"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "devDependencies": {
     "@workday/canvas-kit-react-button": "^4.5.0",

--- a/modules/common/react/package.json
+++ b/modules/common/react/package.json
@@ -45,7 +45,7 @@
     "common"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "devDependencies": {
     "@workday/canvas-kit-react-button": "^4.5.0",

--- a/modules/cookie-banner/react/package.json
+++ b/modules/cookie-banner/react/package.json
@@ -45,7 +45,7 @@
     "cookie-banner"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/cookie-banner/react/package.json
+++ b/modules/cookie-banner/react/package.json
@@ -45,7 +45,7 @@
     "cookie-banner"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/core/react/package.json
+++ b/modules/core/react/package.json
@@ -45,7 +45,7 @@
     "core"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/core/react/package.json
+++ b/modules/core/react/package.json
@@ -45,7 +45,7 @@
     "core"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/fonts/react/package.json
+++ b/modules/fonts/react/package.json
@@ -45,7 +45,7 @@
     "fonts"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28"

--- a/modules/fonts/react/package.json
+++ b/modules/fonts/react/package.json
@@ -45,7 +45,7 @@
     "fonts"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28"

--- a/modules/form-field/react/package.json
+++ b/modules/form-field/react/package.json
@@ -45,7 +45,7 @@
     "input-common"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/form-field/react/package.json
+++ b/modules/form-field/react/package.json
@@ -45,7 +45,7 @@
     "input-common"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/icon/react/package.json
+++ b/modules/icon/react/package.json
@@ -45,7 +45,7 @@
     "icon"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/icon/react/package.json
+++ b/modules/icon/react/package.json
@@ -45,7 +45,7 @@
     "icon"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/layout/react/package.json
+++ b/modules/layout/react/package.json
@@ -45,7 +45,7 @@
     "layout"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/layout/react/package.json
+++ b/modules/layout/react/package.json
@@ -45,7 +45,7 @@
     "layout"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/loading-animation/react/package.json
+++ b/modules/loading-animation/react/package.json
@@ -45,7 +45,7 @@
     "loading-animation"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/loading-animation/react/package.json
+++ b/modules/loading-animation/react/package.json
@@ -45,7 +45,7 @@
     "loading-animation"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/modal/react/package.json
+++ b/modules/modal/react/package.json
@@ -45,7 +45,7 @@
     "modal"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/modal/react/package.json
+++ b/modules/modal/react/package.json
@@ -45,7 +45,7 @@
     "modal"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/page-header/react/package.json
+++ b/modules/page-header/react/package.json
@@ -45,7 +45,7 @@
     "page-header"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/page-header/react/package.json
+++ b/modules/page-header/react/package.json
@@ -45,7 +45,7 @@
     "page-header"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/popup/react/package.json
+++ b/modules/popup/react/package.json
@@ -64,6 +64,6 @@
     "lodash": "^4.17.14"
   },
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   }
 }

--- a/modules/popup/react/package.json
+++ b/modules/popup/react/package.json
@@ -64,6 +64,6 @@
     "lodash": "^4.17.14"
   },
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   }
 }

--- a/modules/radio/react/package.json
+++ b/modules/radio/react/package.json
@@ -45,7 +45,7 @@
     "radio"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@workday/canvas-kit-react-common": "^4.5.0",

--- a/modules/radio/react/package.json
+++ b/modules/radio/react/package.json
@@ -45,7 +45,7 @@
     "radio"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@workday/canvas-kit-react-common": "^4.5.0",

--- a/modules/segmented-control/react/package.json
+++ b/modules/segmented-control/react/package.json
@@ -44,7 +44,7 @@
     "segmented-control"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@workday/canvas-kit-react-button": "^4.5.0",

--- a/modules/segmented-control/react/package.json
+++ b/modules/segmented-control/react/package.json
@@ -44,7 +44,7 @@
     "segmented-control"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@workday/canvas-kit-react-button": "^4.5.0",

--- a/modules/select/react/package.json
+++ b/modules/select/react/package.json
@@ -45,7 +45,7 @@
     "select"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@workday/canvas-kit-react-common": "^4.5.0",

--- a/modules/select/react/package.json
+++ b/modules/select/react/package.json
@@ -45,7 +45,7 @@
     "select"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@workday/canvas-kit-react-common": "^4.5.0",

--- a/modules/side-panel/react/package.json
+++ b/modules/side-panel/react/package.json
@@ -54,7 +54,7 @@
     "lodash": "^4.17.14"
   },
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "devDependencies": {
     "@workday/canvas-kit-labs-react-core": "^4.5.0",

--- a/modules/side-panel/react/package.json
+++ b/modules/side-panel/react/package.json
@@ -54,7 +54,7 @@
     "lodash": "^4.17.14"
   },
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "devDependencies": {
     "@workday/canvas-kit-labs-react-core": "^4.5.0",

--- a/modules/skeleton/react/package.json
+++ b/modules/skeleton/react/package.json
@@ -45,7 +45,7 @@
     "skeleton"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/skeleton/react/package.json
+++ b/modules/skeleton/react/package.json
@@ -45,7 +45,7 @@
     "skeleton"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/status-indicator/react/package.json
+++ b/modules/status-indicator/react/package.json
@@ -45,7 +45,7 @@
     "status-indicator"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/status-indicator/react/package.json
+++ b/modules/status-indicator/react/package.json
@@ -45,7 +45,7 @@
     "status-indicator"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/switch/react/package.json
+++ b/modules/switch/react/package.json
@@ -44,7 +44,7 @@
     "switch"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@workday/canvas-kit-react-common": "^4.5.0",

--- a/modules/switch/react/package.json
+++ b/modules/switch/react/package.json
@@ -44,7 +44,7 @@
     "switch"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@workday/canvas-kit-react-common": "^4.5.0",

--- a/modules/table/react/package.json
+++ b/modules/table/react/package.json
@@ -45,7 +45,7 @@
     "table"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/table/react/package.json
+++ b/modules/table/react/package.json
@@ -45,7 +45,7 @@
     "table"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/text-area/react/package.json
+++ b/modules/text-area/react/package.json
@@ -45,7 +45,7 @@
     "text-area"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@workday/canvas-kit-react-common": "^4.5.0",

--- a/modules/text-area/react/package.json
+++ b/modules/text-area/react/package.json
@@ -45,7 +45,7 @@
     "text-area"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@workday/canvas-kit-react-common": "^4.5.0",

--- a/modules/text-input/react/package.json
+++ b/modules/text-input/react/package.json
@@ -45,7 +45,7 @@
     "text-input"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/text-input/react/package.json
+++ b/modules/text-input/react/package.json
@@ -45,7 +45,7 @@
     "text-input"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/toast/react/package.json
+++ b/modules/toast/react/package.json
@@ -45,7 +45,7 @@
     "toast"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "devDependencies": {
     "@workday/canvas-kit-labs-react-core": "^4.5.0"

--- a/modules/toast/react/package.json
+++ b/modules/toast/react/package.json
@@ -45,7 +45,7 @@
     "toast"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "devDependencies": {
     "@workday/canvas-kit-labs-react-core": "^4.5.0"

--- a/modules/tooltip/react/package.json
+++ b/modules/tooltip/react/package.json
@@ -45,7 +45,7 @@
     "tooltip"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/modules/tooltip/react/package.json
+++ b/modules/tooltip/react/package.json
@@ -45,7 +45,7 @@
     "tooltip"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/utils/create-component/templates/react/packageJson.js
+++ b/utils/create-component/templates/react/packageJson.js
@@ -54,7 +54,7 @@ module.exports = (name, moduleName, description, unstable, public) => `
     "${name}"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ~17.0"
   }
 }
 `;

--- a/utils/create-component/templates/react/packageJson.js
+++ b/utils/create-component/templates/react/packageJson.js
@@ -54,7 +54,7 @@ module.exports = (name, moduleName, description, unstable, public) => `
     "${name}"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ~17.0"
+    "react": "^16.8 || ^17.0"
   }
 }
 `;


### PR DESCRIPTION
## Summary

Resolves #938

Before:
```json
"peerDependencies": {
  "react": ">= 16.8 < 17"
},
  ```
  
After:
  ```json
"peerDependencies": {
  "react": "^16.8 || ^17.0"
},
  ```
  
This will allow us to continue to support React 16.8+ along with React 17 (excluding 17.1). You can test this [here](https://semver.npmjs.com/). I'm open to allowing `^17.0` (all future major versions of 17), but as the latest version is at 17.0.1, I thought it was a better idea to be cautious and stick to patches for now.

The only potential issues I could see have to do with [mutable refs in useEffect hooks](https://reactjs.org/blog/2020/08/10/react-v17-rc.html#potential-issues) and _maybe_ the [update to event listeners](https://reactjs.org/blog/2020/08/10/react-v17-rc.html#changes-to-event-delegation). But I'm still thinking about how to test these.

## Checklist

- [ ] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [ ] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

[React 17 Upgrade docs](https://reactjs.org/blog/2020/08/10/react-v17-rc.html#other-breaking-changes)
[Semver testing](https://semver.npmjs.com/)
