### PR TITLE
fix(popup): Fix Popup icon RTL bug

### DIFF
--- a/modules/popup/react/lib/Popup.tsx
+++ b/modules/popup/react/lib/Popup.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import styled from '@emotion/styled';
 import {keyframes} from '@emotion/core';
 import isPropValid from '@emotion/is-prop-valid';
 import uuid from 'uuid/v4';
@@ -8,6 +7,7 @@ import Card from '@workday/canvas-kit-react-card';
 import {IconButton} from '@workday/canvas-kit-react-button';
 import {CanvasDepthValue, depth as depthValues, spacing} from '@workday/canvas-kit-react-core';
 import {
+  styled,
   TransformOrigin,
   getTranslateFromOrigin,
   PickRequired,

--- a/modules/popup/react/package.json
+++ b/modules/popup/react/package.json
@@ -47,7 +47,6 @@
   "dependencies": {
     "@emotion/core": "^10.0.28",
     "@emotion/is-prop-valid": "^0.8.2",
-    "@emotion/styled": "^10.0.27",
     "@popperjs/core": "^2.1.1",
     "@workday/canvas-kit-popup-stack": "^4.5.0",
     "@workday/canvas-kit-react-button": "^4.5.0",

--- a/modules/popup/react/stories/stories.tsx
+++ b/modules/popup/react/stories/stories.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import withReadme from 'storybook-readme/with-readme';
 
 import {Button, DeleteButton} from '@workday/canvas-kit-react-button';
+import {CanvasProvider, ContentDirection} from '@workday/canvas-kit-react-common';
 import {
   Popper,
   Popup,
@@ -61,5 +62,20 @@ export const Open = () => {
       </DeleteButton>
       <Button onClick={() => null}>Cancel</Button>
     </Popup>
+  );
+};
+
+export const RTL = () => {
+  return (
+    <CanvasProvider theme={{canvas: {direction: ContentDirection.RTL}}}>
+      <Popup width={400} heading="למחוק פריט" padding={Popup.Padding.s} handleClose={() => null}>
+        <div style={{marginBottom: '24px'}}>האם ברצונך למחוק פריט זה</div>
+
+        <DeleteButton style={{marginLeft: '16px'}} onClick={() => null}>
+          לִמְחוֹק
+        </DeleteButton>
+        <Button onClick={() => null}>לְבַטֵל</Button>
+      </Popup>
+    </CanvasProvider>
   );
 };

--- a/modules/popup/react/stories/stories_VisualTesting.tsx
+++ b/modules/popup/react/stories/stories_VisualTesting.tsx
@@ -2,19 +2,34 @@
 /** @jsx jsx */
 import {jsx} from '@emotion/core';
 import {StaticStates} from '@workday/canvas-kit-labs-react-core';
+import {depth} from '@workday/canvas-kit-react-core';
+import {CanvasProvider, ContentDirection} from '@workday/canvas-kit-react-common';
 import {action} from '@storybook/addon-actions';
+
 import {ComponentStatesTable, withSnapshotsEnabled} from '../../../../utils/storybook';
 import {Popup} from '../index';
 import {PopupPadding} from '../lib/Popup';
-import {depth} from '@workday/canvas-kit-react-core';
 
 export const PopupStates = withSnapshotsEnabled(() => (
   <StaticStates>
     <ComponentStatesTable
       rowProps={[
-        {label: 'Default', props: {}},
-        {label: 'On Close', props: {handleClose: action('close button clicked')}},
-        {label: 'With Heading', props: {heading: 'Delete Item'}},
+        {
+          label: 'Default',
+          props: {},
+        },
+        {
+          label: 'On Close',
+          props: {
+            handleClose: action('close button clicked'),
+          },
+        },
+        {
+          label: 'With Heading',
+          props: {
+            heading: 'Delete Item',
+          },
+        },
         {
           label: 'With zero padding',
           props: {
@@ -90,5 +105,31 @@ export const PopupStates = withSnapshotsEnabled(() => (
         </Popup>
       )}
     </ComponentStatesTable>
+  </StaticStates>
+));
+
+export const PopupStatesRTL = withSnapshotsEnabled(() => (
+  <StaticStates>
+    <CanvasProvider theme={{canvas: {direction: ContentDirection.RTL}}}>
+      <ComponentStatesTable
+        rowProps={[
+          {
+            label: 'With RTL',
+            props: {
+              heading: 'למחוק פריט',
+              handleClose: action('לחצן סגור לחץ'),
+              width: 300,
+            },
+          },
+        ]}
+        columnProps={[{label: 'Default', props: {}}]}
+      >
+        {({body, ...props}) => (
+          <Popup transformOrigin={null} {...props}>
+            האם ברצונך למחוק פריט זה
+          </Popup>
+        )}
+      </ComponentStatesTable>
+    </CanvasProvider>
   </StaticStates>
 ));


### PR DESCRIPTION
## Summary

The close icon in Popup wasn't responding to RTL. So now we're using updating our internal styled function.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [ ] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
