### PR TITLE
Deprecate CKCSS and update migration guide

### DIFF
--- a/5.0-MIGRATION-GUIDE.md
+++ b/5.0-MIGRATION-GUIDE.md
@@ -8,12 +8,17 @@ our React infrastructure and components.
 
 - [Canvas Kit 5.0 Migration Guide](#canvas-kit-50-migration-guide)
   - [General Changes](#general-changes)
+    - [Canvas Kit CSS Maintenance Mode](#canvas-kit-css-maintenance-mode)
     - [Slash Imports](#slash-imports)
     - [Compound Components](#compound-components)
   - [Breaking Component Changes](#breaking-component-changes)
     - [Tabs](#tabs)
 
 ## General Changes
+
+### Canvas Kit CSS Maintenance Mode
+
+Due to the infrequent use of our CSS modules, they will be going into maintenance mode in Canvas Kit v5. We will still support `@workday/canvas-kit-css` with bug fixes and significant visual updates, but it generally won't be receiving new components, additional features, etc. This will allow us to provide more focused support, and dedicate our efforts to making bigger and better improvements to our most used components: Canvas Kit React. If you have questions or concerns, please [let us know](https://github.com/Workday/canvas-kit/issues/new?labels=&template=question.md).
 
 ### Slash Imports
 

--- a/5.0-MIGRATION-GUIDE.md
+++ b/5.0-MIGRATION-GUIDE.md
@@ -6,15 +6,48 @@ about the update.
 CSS users rejoice! :tada: No breaking changes in this release. The following changes all relate to
 our React infrastructure and components.
 
-- [General Changes](#changes)
-- [Breaking Component Changes](#breaking-component-changes)
-  - [Tabs](#tabs)
+- [Canvas Kit 5.0 Migration Guide](#canvas-kit-50-migration-guide)
+  - [General Changes](#general-changes)
+    - [Slash Imports](#slash-imports)
+    - [Compound Components](#compound-components)
+  - [Breaking Component Changes](#breaking-component-changes)
+    - [Tabs](#tabs)
 
 ## General Changes
 
-- Components are transitioning to [Compound Components](./COMPOUND_COMPONENTS.md)
-  - Components will support [forwarded refs](https://reactjs.org/docs/forwarding-refs.html)
-  - The corresponding tag of a component can be changed with the `as` prop
+### Slash Imports
+
+We have moved from a separate module for every component to a slash imports system. All of our react components are now bundled under two packages:
+- `@workday/canvas-kit-react`
+- `@workday/canvas-kit-labs-react`
+
+Due to this change, imports will need to be updated. For example:
+```tsx
+// before
+import canvas from '@workday/canvas-kit-react';
+import Button from '@workday/canvas-kit-react-button';
+
+// after
+import canvas from "@workday/canvas-kit-react/core";
+import { Button } from "@workday/canvas-kit-react/button";
+```
+
+We've provided a [new codemod package](./modules/codemod) that you can use to update the majority of your imports. Simply run:
+
+```sh
+> npx @workday/canvas-kit-codemod v5 [path]
+```
+> Note: This codemod only work on .js, .jsx, .ts, and .tsx extensions. You may need to make some manual changes in other file types (.json, .mdx, .md, etc.).
+
+> Note: You may need to run your linter after executing the codemod, as it's resulting formatting (spacing, quotes, etc.) may not match your project's styling.
+
+Please [let us know](https://github.com/Workday/canvas-kit/issues/new?labels=bug&template=bug.md) if you have any troubles or missed use cases with this codemod. The `@workday/canvas-kit-codemod` package will help us maintain additional codemod transforms to make future migrations easier.
+
+### Compound Components
+
+Components are transitioning to [Compound Components](./COMPOUND_COMPONENTS.md)
+- Components will support [forwarded refs](https://reactjs.org/docs/forwarding-refs.html)
+- The corresponding tag of a component can be changed with the `as` prop
 
 ## Breaking Component Changes
 

--- a/modules/css/README.md
+++ b/modules/css/README.md
@@ -2,6 +2,10 @@
 
 The bundle package containing all modules of the Canvas CSS Kit.
 
+<img src="https://img.shields.io/badge/-maintenance mode-important" alt="Mainenance Mode" />
+
+**In Canvas Kit v5, this package and it's components will be going into maintenance mode due to the infrequent use of our CSS modules. We will still support `@workday/canvas-kit-css` with bug fixes and significant visual updates, but it generally won't be receiving new components, additional features, etc. This will allow us to provide more focused support, and dedicate our efforts to making bigger and better improvements to our most used components: Canvas Kit React. If you have questions or concerns, please [let us know](https://github.com/Workday/canvas-kit/issues/new?labels=&template=question.md).**
+
 ## Usage
 
 Canvas Kit CSS uses tilde `~` imports to resolve imports to your project's node_modules directory.

--- a/modules/css/action-bar/README.md
+++ b/modules/css/action-bar/README.md
@@ -2,6 +2,10 @@
 
 Full width action bar that can be fixed to the bottom of the screen.
 
+<a href="../README.md">
+  <img src="https://img.shields.io/badge/-maintenance mode-important" alt="Mainenance Mode" />
+</a>
+
 ## Installation
 
 ```sh

--- a/modules/css/badge/README.md
+++ b/modules/css/badge/README.md
@@ -2,6 +2,10 @@
 
 The count badge provides a quantity-based summary with dynamic values.
 
+<a href="../README.md">
+  <img src="https://img.shields.io/badge/-maintenance mode-important" alt="Mainenance Mode" />
+</a>
+
 ## Installation
 
 ```sh

--- a/modules/css/banner/README.md
+++ b/modules/css/banner/README.md
@@ -3,6 +3,10 @@
 Errors and Alerts notify users of missteps that happen within a workflow and describe how the user
 can take appropriate action to resolve them.
 
+<a href="../README.md">
+  <img src="https://img.shields.io/badge/-maintenance mode-important" alt="Mainenance Mode" />
+</a>
+
 [> Workday Design Reference](https://design.workday.com/components/indicators/banners)
 
 ## Installation

--- a/modules/css/button/README.md
+++ b/modules/css/button/README.md
@@ -2,6 +2,10 @@
 
 Clickable button elements that extend the native `<button>` element with Canvas styling.
 
+<a href="../README.md">
+  <img src="https://img.shields.io/badge/-maintenance mode-important" alt="Mainenance Mode" />
+</a>
+
 [> Workday Design Reference](https://design.workday.com/components/buttons/buttons)
 
 ## Installation

--- a/modules/css/card/README.md
+++ b/modules/css/card/README.md
@@ -3,6 +3,10 @@
 A card is a flexible and extensible content container that includes options for positioning. The
 card content includes classes for heading and body.
 
+<a href="../README.md">
+  <img src="https://img.shields.io/badge/-maintenance mode-important" alt="Mainenance Mode" />
+</a>
+
 [> Workday Design Reference](https://design.workday.com/components/containers/cards)
 
 ## Installation

--- a/modules/css/checkbox/README.md
+++ b/modules/css/checkbox/README.md
@@ -2,6 +2,10 @@
 
 Checkbox styles
 
+<a href="../README.md">
+  <img src="https://img.shields.io/badge/-maintenance mode-important" alt="Mainenance Mode" />
+</a>
+
 [> Workday Design Reference](https://design.workday.com/components/inputs/checkboxes)
 
 ## Installation

--- a/modules/css/common/README.md
+++ b/modules/css/common/README.md
@@ -2,6 +2,10 @@
 
 Canvas Kit Common contains common utilities shared across the kit.
 
+<a href="../README.md">
+  <img src="https://img.shields.io/badge/-maintenance mode-important" alt="Mainenance Mode" />
+</a>
+
 Includes:
 
 - Errors

--- a/modules/css/core/README.md
+++ b/modules/css/core/README.md
@@ -2,6 +2,10 @@
 
 Canvas Kit Core contains values and base styles that are shared across the kit.
 
+<a href="../README.md">
+  <img src="https://img.shields.io/badge/-maintenance mode-important" alt="Mainenance Mode" />
+</a>
+
 Includes:
 
 - [Colors](#colors)

--- a/modules/css/form-field/README.md
+++ b/modules/css/form-field/README.md
@@ -2,6 +2,10 @@
 
 Form element styles and other common form styles.
 
+<a href="../README.md">
+  <img src="https://img.shields.io/badge/-maintenance mode-important" alt="Mainenance Mode" />
+</a>
+
 ## Installation
 
 ```sh

--- a/modules/css/icon/README.md
+++ b/modules/css/icon/README.md
@@ -3,6 +3,10 @@
 Icon injection and coloring toolkit for Canvas Kit icons. Uses
 [SVGInjector](https://github.com/iconic/SVGInjector).
 
+<a href="../README.md">
+  <img src="https://img.shields.io/badge/-maintenance mode-important" alt="Mainenance Mode" />
+</a>
+
 ## Installation
 
 ```sh

--- a/modules/css/layout/README.md
+++ b/modules/css/layout/README.md
@@ -3,6 +3,10 @@
 Canvas Kit Layout is based on a 12 column grid. It uses the flexbox layout for positioning of
 columns.
 
+<a href="../README.md">
+  <img src="https://img.shields.io/badge/-maintenance mode-important" alt="Mainenance Mode" />
+</a>
+
 ## Installation
 
 ```sh

--- a/modules/css/loading-animation/README.md
+++ b/modules/css/loading-animation/README.md
@@ -2,6 +2,10 @@
 
 Components that display animations while a page or component loads.
 
+<a href="../README.md">
+  <img src="https://img.shields.io/badge/-maintenance mode-important" alt="Mainenance Mode" />
+</a>
+
 [> Workday Design Reference](https://design.workday.com/components/indicators/loading-animation)
 
 ## Installation

--- a/modules/css/menu/README.md
+++ b/modules/css/menu/README.md
@@ -4,6 +4,10 @@ Creates an actions menu of clickable items.
 
 Can be used to implement a menu button, context menu, etc.
 
+<a href="../README.md">
+  <img src="https://img.shields.io/badge/-maintenance mode-important" alt="Mainenance Mode" />
+</a>
+
 [> Workday Design Reference](https://design.workday.com/components/popups/menus)
 
 ## Installation

--- a/modules/css/modal/README.md
+++ b/modules/css/modal/README.md
@@ -2,6 +2,10 @@
 
 A Modal component that allows you to render a Popup with a translucent overlay.
 
+<a href="../README.md">
+  <img src="https://img.shields.io/badge/-maintenance mode-important" alt="Mainenance Mode" />
+</a>
+
 ## Installation
 
 ```sh

--- a/modules/css/page-header/README.md
+++ b/modules/css/page-header/README.md
@@ -2,6 +2,10 @@
 
 The page header for our application.
 
+<a href="../README.md">
+  <img src="https://img.shields.io/badge/-maintenance mode-important" alt="Mainenance Mode" />
+</a>
+
 [> Workday Design Reference](https://design.workday.com/components/navigation/headers)
 
 ## Installation

--- a/modules/css/popup/README.md
+++ b/modules/css/popup/README.md
@@ -2,6 +2,10 @@
 
 A Popup component that allows you to render content in a container on top of a page.
 
+<a href="../README.md">
+  <img src="https://img.shields.io/badge/-maintenance mode-important" alt="Mainenance Mode" />
+</a>
+
 ## Installation
 
 ```sh

--- a/modules/css/radio/README.md
+++ b/modules/css/radio/README.md
@@ -2,6 +2,10 @@
 
 Radio styles
 
+<a href="../README.md">
+  <img src="https://img.shields.io/badge/-maintenance mode-important" alt="Mainenance Mode" />
+</a>
+
 [> Workday Design Reference](https://design.workday.com/components/inputs/radio-buttons)
 
 ## Installation

--- a/modules/css/select/README.md
+++ b/modules/css/select/README.md
@@ -2,6 +2,10 @@
 
 Select styles
 
+<a href="../README.md">
+  <img src="https://img.shields.io/badge/-maintenance mode-important" alt="Mainenance Mode" />
+</a>
+
 [> Workday Design Reference](https://design.workday.com/components/inputs/select-drop-down)
 
 ## Installation

--- a/modules/css/table/README.md
+++ b/modules/css/table/README.md
@@ -2,6 +2,10 @@
 
 Data table styling for Canvas Kit.
 
+<a href="../README.md">
+  <img src="https://img.shields.io/badge/-maintenance mode-important" alt="Mainenance Mode" />
+</a>
+
 [> Workday Design Reference](https://design.workday.com/components/containers/tables)
 
 ## Installation

--- a/modules/css/text-area/README.md
+++ b/modules/css/text-area/README.md
@@ -2,6 +2,10 @@
 
 Text Area styles
 
+<a href="../README.md">
+  <img src="https://img.shields.io/badge/-maintenance mode-important" alt="Mainenance Mode" />
+</a>
+
 [> Workday Design Reference](https://design.workday.com/components/inputs/text-area)
 
 ## Installation

--- a/modules/css/text-input/README.md
+++ b/modules/css/text-input/README.md
@@ -2,6 +2,10 @@
 
 Text Input styles
 
+<a href="../README.md">
+  <img src="https://img.shields.io/badge/-maintenance mode-important" alt="Mainenance Mode" />
+</a>
+
 [> Workday Design Reference](https://design.workday.com/components/inputs/text-input)
 
 ## Installation

--- a/modules/css/tooltip/README.md
+++ b/modules/css/tooltip/README.md
@@ -2,6 +2,10 @@
 
 Tooltips with modifiers and containers implementing display on hover.
 
+<a href="../README.md">
+  <img src="https://img.shields.io/badge/-maintenance mode-important" alt="Mainenance Mode" />
+</a>
+
 [> Workday Design Reference](https://design.workday.com/components/popups/tooltips)
 
 ## Installation


### PR DESCRIPTION
## Summary

Adds deprecation messages to the CSS readmes and updates the migration guide with relative info. Also adds missing info about the slash imports change made in #992 and how consumers should use the codemod.