### PR TITLE
ci: Fix canary dist-tag for prerelease canaries in slack message

### DIFF
--- a/utils/publish-canary.js
+++ b/utils/publish-canary.js
@@ -101,7 +101,7 @@ exec('git diff --name-only HEAD HEAD^')
       author_name: `New canary build published (v${data.version})`,
       title: `Merge commit ${data.sha}`,
       title_link: `https://github.com/Workday/canvas-kit/commit/${data.sha}`,
-      text: `\`yarn add @workday/canvas-kit-{module}@${data.version}\`\nor\n\`yarn add @workday/canvas-kit-{module}@next\`\n`,
+      text: `\`yarn add @workday/canvas-kit-{module}@${data.version}\`\nor\n\`yarn add @workday/canvas-kit-{module}@${distTag}\`\n`,
     });
   })
   .catch(err => {


### PR DESCRIPTION
## Summary

Fixes slack update message for new canary builds

Before:
```
New canary build published (v5.0.0-beta.0-next.9+52852d7b)
Merge commit 52852d7b
yarn add @workday/canvas-kit-{module}@5.0.0-beta.0-next.9+52852d7b
or
yarn add @workday/canvas-kit-{module}@next
```

After:
```
New canary build published (v5.0.0-beta.0-next.9+52852d7b)
Merge commit 52852d7b
yarn add @workday/canvas-kit-{module}@5.0.0-beta.0-next.9+52852d7b
or
yarn add @workday/canvas-kit-{module}@prerelease-next
```
(note `next` > `prerelease-next` in last line)