### PR TITLE
fix(tooltip): Allow aria-label pass-through in muted tooltips

### DIFF
--- a/modules/tooltip/react/lib/Tooltip.tsx
+++ b/modules/tooltip/react/lib/Tooltip.tsx
@@ -76,6 +76,9 @@ export const Tooltip = ({
       {React.cloneElement(children, {
         ...targetProps,
         ...mergeCallbacks(children.props, targetProps),
+        ...(type === 'muted' && children.props['aria-label']
+          ? {'aria-label': children.props['aria-label']}
+          : {}),
       })}
       <Popper placement={placement} {...popperProps}>
         {({placement}) => {

--- a/modules/tooltip/react/spec/Tooltip.spec.tsx
+++ b/modules/tooltip/react/spec/Tooltip.spec.tsx
@@ -1,44 +1,70 @@
 /// <reference types="@testing-library/jest-dom/extend-expect" />
 
 import * as React from 'react';
-import {render, fireEvent} from '@testing-library/react';
+import {render, fireEvent, screen} from '@testing-library/react';
 
 import {Tooltip} from '..';
 
 describe('Tooltip', () => {
   describe('when "type" is "label"', () => {
     it('should render an aria-label', () => {
-      const {getByText} = render(
+      render(
         <Tooltip title="Add">
           <span>Test Text</span>
         </Tooltip>
       );
 
-      expect(getByText('Test Text')).toHaveAttribute('aria-label', 'Add');
+      expect(screen.getByText('Test Text')).toHaveAttribute('aria-label', 'Add');
     });
   });
 
   describe('when "type" is "describe"', () => {
     it('should render aria-describedby', () => {
-      const {getByText, getByRole} = render(
+      render(
         <Tooltip type="describe" title="This is an extra description">
           <span>Test Text</span>
         </Tooltip>
       );
 
-      fireEvent.mouseEnter(getByText('Test Text')); // triggers the tooltip
+      fireEvent.mouseEnter(screen.getByText('Test Text')); // triggers the tooltip
 
-      expect(getByText('Test Text')).toHaveAttribute('aria-describedby');
+      expect(screen.getByText('Test Text')).toHaveAttribute('aria-describedby');
 
-      const id = getByText('Test Text').getAttribute('aria-describedby');
-      expect(getByRole('tooltip')).toHaveAttribute('id', id);
+      const id = screen.getByText('Test Text').getAttribute('aria-describedby');
+      expect(screen.getByRole('tooltip')).toHaveAttribute('id', id);
     });
   });
 
-  ['onMouseEnter', 'onMouseLeave', 'onFocus', 'onBlur', 'onClick', 'onMouseOver'].forEach(key => {
+  describe('when "type" is "muted"', () => {
+    it('should not render an aria-label', () => {
+      render(
+        <Tooltip type="muted" title="Tooltip Text">
+          <span>Test Text</span>
+        </Tooltip>
+      );
+
+      fireEvent.mouseEnter(screen.getByText('Test Text'));
+
+      expect(screen.getByText('Test Text')).not.toHaveAttribute('aria-label');
+    });
+
+    it('should not override an aria-label', () => {
+      render(
+        <Tooltip type="muted" title="Tooltip Text">
+          <span aria-label="Test Label">Test Text</span>
+        </Tooltip>
+      );
+
+      fireEvent.mouseEnter(screen.getByText('Test Text'));
+
+      expect(screen.getByText('Test Text')).toHaveAttribute('aria-label', 'Test Label');
+    });
+  });
+
+  [('onMouseEnter', 'onMouseLeave', 'onFocus', 'onBlur', 'onClick', 'onMouseOver')].forEach(key => {
     it(`should call the ${key} callback functions provided to the wrapped component`, () => {
       const fn = jest.fn();
-      const {getByText} = render(
+      render(
         <Tooltip title="test">
           <span {...{[key]: fn}}>Test</span>
         </Tooltip>
@@ -50,7 +76,7 @@ describe('Tooltip', () => {
         (_, first, rest) => first.toLowerCase() + rest
       );
 
-      fireEvent[action](getByText('Test'));
+      fireEvent[action](screen.getByText('Test'));
 
       expect(fn).toBeCalled();
     });


### PR DESCRIPTION
Fixes #1036