### PR TITLE
fix: Resolve Breadcrumb MenuItemLink onAction bug

### DIFF
--- a/modules/_labs/breadcrumbs/react/lib/Breadcrumbs/Dropdown/Menu.tsx
+++ b/modules/_labs/breadcrumbs/react/lib/Breadcrumbs/Dropdown/Menu.tsx
@@ -118,7 +118,7 @@ export const DropdownMenu = ({
       case 'Enter':
         event.preventDefault();
         if (item.onAction) {
-          item.onAction(item);
+          item.onAction(item.link);
           resetFocus();
           break;
         }

--- a/modules/_labs/breadcrumbs/react/lib/Breadcrumbs/Dropdown/MenuItemLink.tsx
+++ b/modules/_labs/breadcrumbs/react/lib/Breadcrumbs/Dropdown/MenuItemLink.tsx
@@ -7,6 +7,10 @@ interface DropdownMenuItemLinkProps extends React.HTMLAttributes<HTMLAnchorEleme
    * The href url of the anchor tag
    */
   href: string;
+  /**
+   * A handler function for overriding hard-redirects with links
+   */
+  onAction?: (href: string) => void;
 }
 
 const MenuItemLink = styled('a')({
@@ -32,11 +36,26 @@ const MenuItemLink = styled('a')({
 
 export const DropdownMenuItemLink = forwardRef(
   (
-    {children, href, ...elemProps}: DropdownMenuItemLinkProps,
+    {children, href, onAction, onClick, ...elemProps}: DropdownMenuItemLinkProps,
     ref: React.RefObject<HTMLAnchorElement>
   ) => {
+    const handleClick = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+      event.preventDefault();
+      // allow an override to the hard redirect
+      if (onAction) {
+        onAction(href);
+      } else {
+        // default to hard redirecting
+        window.location.href = href;
+      }
+      // don't block the onClick event if it's provided
+      if (onClick) {
+        onClick(event);
+      }
+    };
+
     return (
-      <MenuItemLink ref={ref} href={href} role="menuitem" {...elemProps}>
+      <MenuItemLink ref={ref} href={href} role="menuitem" onClick={handleClick} {...elemProps}>
         {children}
       </MenuItemLink>
     );

--- a/modules/_labs/breadcrumbs/react/lib/Breadcrumbs/List/Collapsible.tsx
+++ b/modules/_labs/breadcrumbs/react/lib/Breadcrumbs/List/Collapsible.tsx
@@ -39,7 +39,6 @@ export const CollapsibleList = ({
   // behaviors
   const {shouldCollapseList} = useCollapse(listRef, maxWidth);
   const {collapsedItems, collapsedItemIndices} = useBuildCollapsedList(listRef, children, maxWidth);
-
   const {rootItem, collapsibleItems, currentItem} = parseListItems(children);
   return (
     <BreadcrumbsList ref={listRef} {...props}>

--- a/modules/_labs/breadcrumbs/react/lib/Breadcrumbs/types.ts
+++ b/modules/_labs/breadcrumbs/react/lib/Breadcrumbs/types.ts
@@ -3,5 +3,5 @@ export interface Breadcrumb extends React.HTMLAttributes<HTMLAnchorElement> {
   link: string;
   text: string;
   width: number;
-  onAction?: (item: Breadcrumb) => void;
+  onAction?: (href: string) => void;
 }

--- a/modules/_labs/breadcrumbs/react/spec/Breadcrumbs.spec.tsx
+++ b/modules/_labs/breadcrumbs/react/spec/Breadcrumbs.spec.tsx
@@ -1,0 +1,114 @@
+import * as React from 'react';
+import {fireEvent, render, screen} from '@testing-library/react';
+import {Breadcrumbs} from '@workday/canvas-kit-labs-react-breadcrumbs';
+const context = describe;
+
+describe('Breadcrumbs', () => {
+  context('when clicking a link in the breadcrumbs list', () => {
+    it('should return the href for the item to the onAction handler', () => {
+      const href = '/2019_Q2_financial_documents';
+      const onActionHandler = jest.fn();
+
+      render(
+        <Breadcrumbs.Nav aria-label="Breadcrumb">
+          <Breadcrumbs.List>
+            <Breadcrumbs.ListItem>
+              <Breadcrumbs.Link href={href} onAction={onActionHandler}>
+                2019_Q2_financial_documents
+              </Breadcrumbs.Link>
+            </Breadcrumbs.ListItem>
+            <Breadcrumbs.ListItem>
+              <Breadcrumbs.Link href="/mortgage_documents">mortgage_documents</Breadcrumbs.Link>
+            </Breadcrumbs.ListItem>
+            <Breadcrumbs.ListItem>
+              <Breadcrumbs.Link href="/bank_statements">bank_statements</Breadcrumbs.Link>
+            </Breadcrumbs.ListItem>
+            <Breadcrumbs.CurrentItem>assets.pdf</Breadcrumbs.CurrentItem>
+          </Breadcrumbs.List>
+        </Breadcrumbs.Nav>
+      );
+      const breadcrumbLink = screen.queryAllByRole('link')[0];
+      fireEvent.click(breadcrumbLink);
+
+      expect(onActionHandler).toHaveBeenCalledWith(href);
+    });
+  });
+
+  context('when selecting a menu item with a keypress', () => {
+    it('should return the href for the item to the onAction handler', () => {
+      const menuItemHref = '/bank_statements';
+      const onActionHandler = jest.fn();
+      // Not a realistic value, but it ensures the collapsible list renders a dropdown menu
+      const maxWidth = -1;
+      render(
+        <Breadcrumbs.Nav aria-label="Breadcrumb">
+          <Breadcrumbs.CollapsibleList maxWidth={maxWidth} buttonAriaLabel="more links">
+            <Breadcrumbs.ListItem>
+              <Breadcrumbs.Link href="/2019_Q2_financial_documents">
+                2019_Q2_financial_documents
+              </Breadcrumbs.Link>
+            </Breadcrumbs.ListItem>
+            <Breadcrumbs.ListItem>
+              <Breadcrumbs.Link href="/mortgage_documents">mortgage_documents</Breadcrumbs.Link>
+            </Breadcrumbs.ListItem>
+            <Breadcrumbs.ListItem>
+              <Breadcrumbs.Link onAction={onActionHandler} href={menuItemHref}>
+                bank_statements
+              </Breadcrumbs.Link>
+            </Breadcrumbs.ListItem>
+            <Breadcrumbs.CurrentItem>assets.pdf</Breadcrumbs.CurrentItem>
+          </Breadcrumbs.CollapsibleList>
+        </Breadcrumbs.Nav>
+      );
+
+      const dropdownButton = screen.queryByLabelText('more links');
+      const enter = {keyCode: 13, key: 'Enter'};
+
+      // open the dropdown menu
+      fireEvent.click(dropdownButton);
+      const dropdownMenuItem = screen.queryAllByRole('menuitem')[1];
+      fireEvent.keyDown(dropdownMenuItem, enter);
+
+      expect(onActionHandler).toHaveBeenCalledWith(menuItemHref);
+    });
+  });
+
+  context('when selecting a menu item with a click', () => {
+    it('should return the href for the item to the onAction handler', () => {
+      const menuItemHref = '/bank_statements';
+      const onActionHandler = jest.fn();
+      // Not a realistic value, but it ensures the collapsible list renders a dropdown menu
+      const maxWidth = -1;
+      render(
+        <Breadcrumbs.Nav aria-label="Breadcrumb">
+          <Breadcrumbs.CollapsibleList maxWidth={maxWidth} buttonAriaLabel="more links">
+            <Breadcrumbs.ListItem>
+              <Breadcrumbs.Link href="/2019_Q2_financial_documents">
+                2019_Q2_financial_documents
+              </Breadcrumbs.Link>
+            </Breadcrumbs.ListItem>
+            <Breadcrumbs.ListItem>
+              <Breadcrumbs.Link href="/mortgage_documents">mortgage_documents</Breadcrumbs.Link>
+            </Breadcrumbs.ListItem>
+            <Breadcrumbs.ListItem>
+              <Breadcrumbs.Link onAction={onActionHandler} href={menuItemHref}>
+                bank_statements
+              </Breadcrumbs.Link>
+            </Breadcrumbs.ListItem>
+            <Breadcrumbs.CurrentItem>assets.pdf</Breadcrumbs.CurrentItem>
+          </Breadcrumbs.CollapsibleList>
+        </Breadcrumbs.Nav>
+      );
+
+      const dropdownButton = screen.queryByLabelText('more links');
+      const enter = {keyCode: 13, key: 'Enter'};
+
+      // open the dropdown menu
+      fireEvent.click(dropdownButton);
+      const dropdownMenuItem = screen.queryAllByRole('menuitem')[1];
+      fireEvent.click(dropdownMenuItem);
+
+      expect(onActionHandler).toHaveBeenCalledWith(menuItemHref);
+    });
+  });
+});


### PR DESCRIPTION
## Issue

Resolves #1070

## Overview

`onAction` event handlers weren't properly supported in `Breadcrumb.MenuItemLink`s like they were in `Breadcrumb.Link`s. This PR fixes that.

## Where Should the Reviewer Start?

`modules/_labs/breadcrumbs/react/lib/Breadcrumbs/Dropdown/MenuItemLink.tsx`

## Testing Manually

* pull up storybook
* visit `?path=/story/labs-breadcrumbs-react--collapsible`
* click on the `Ledger Account is “4200: Property”` menu item
* see an alert fire
* click on the `2018_08_28_Summary_of_Annual_Recurring_Revenue` menu item
* see the page redirect

## Screenshots

![](http://g.recordit.co/ggi4hkQrA5.gif)

## Thank You Gif

![](https://media.giphy.com/media/fADf4RUs3hUFvHz18o/giphy-downsized.gif)

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [ ] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)
