### PR TITLE
fix(popup): Allow tooltips to close alongside modals on click outside

### DIFF
--- a/cypress/integration/Modal.spec.ts
+++ b/cypress/integration/Modal.spec.ts
@@ -262,7 +262,6 @@ describe('Modal', () => {
 
           context(`when clicking outside the modal`, () => {
             beforeEach(() => {
-              // cy.findByRole('dialog', {name: 'Delete Item'}).click();
               cy.get('body').click('top');
             });
 

--- a/cypress/integration/Modal.spec.ts
+++ b/cypress/integration/Modal.spec.ts
@@ -162,6 +162,132 @@ describe('Modal', () => {
     });
   });
 
+  context(`given the 'With Tooltips' story is rendered`, () => {
+    beforeEach(() => {
+      h.stories.load('Components/Popups/Modal/React', 'With Tooltips');
+    });
+
+    context('when the modal is open', () => {
+      beforeEach(() => {
+        cy.findByText('Delete Item').click();
+      });
+
+      it('should open the modal', () => {
+        cy.findByRole('dialog', {name: 'Delete Item'}).should('be.visible');
+      });
+
+      context(`when the 'Cancel' button is focused`, () => {
+        beforeEach(() => {
+          cy.contains('Cancel').focus();
+        });
+
+        it(`should open the 'Cancel' tooltip`, () => {
+          cy.findByRole('tooltip', {name: 'Not so sure'}).should('be.visible');
+        });
+
+        context(`when clicking outside the modal`, () => {
+          beforeEach(() => {
+            cy.get('body').click('top');
+          });
+
+          it(`should close the 'Cancel' tooltip`, () => {
+            cy.findByRole('tooltip', {name: 'Not so sure'}).should('not.be.visible');
+          });
+
+          it(`should close the modal`, () => {
+            cy.findByRole('dialog', {name: 'Delete Item'}).should('not.be.visible');
+          });
+        });
+      });
+
+      context(`when the 'Open Popup to reach Delete button' button is clicked`, () => {
+        beforeEach(() => {
+          cy.findByText('Open Popup to reach Delete button').click();
+        });
+
+        it(`should open the 'Really Delete' popup`, () => {
+          cy.findByRole('dialog', {name: 'Really Delete'}).should('be.visible');
+        });
+
+        context(`when the 'Delete' button is focused`, () => {
+          beforeEach(() => {
+            cy.findByRole('button', {name: 'Delete'}).focus();
+          });
+          it(`should open the 'Delete' tooltip`, () => {
+            cy.findByRole('tooltip', {name: 'Really, Really, Really, Really, Really sure'}).should(
+              'be.visible'
+            );
+          });
+
+          context(`when clicking outside the modal`, () => {
+            beforeEach(() => {
+              cy.get('body').click('top');
+            });
+
+            it(`should close the 'Delete' tooltip`, () => {
+              cy.findByRole('tooltip', {
+                name: 'Really, Really, Really, Really, Really sure',
+              }).should('not.be.visible');
+            });
+
+            it(`should close the 'Really Delete' popup`, () => {
+              cy.findByRole('dialog', {name: 'Really Delete'}).should('not.be.visible');
+            });
+
+            it(`should keep the modal open`, () => {
+              cy.findByRole('dialog', {name: 'Delete Item'}).should('be.visible');
+            });
+          });
+        });
+      });
+
+      context(`when the 'Non-hidable Popup' button is clicked`, () => {
+        beforeEach(() => {
+          cy.findByText('Non-hidable Popup').click();
+        });
+
+        it(`should open the 'Does Not Hide On Click Outside' popup`, () => {
+          cy.findByRole('dialog', {name: 'Does Not Hide On Click Outside'}).should('be.visible');
+        });
+
+        context(`when the 'Delete' button is focused`, () => {
+          beforeEach(() => {
+            cy.findByRole('button', {name: 'Delete'}).focus();
+          });
+          it(`should open the 'Delete' tooltip`, () => {
+            cy.findByRole('tooltip', {name: 'Really, Really, Really, Really, Really sure'}).should(
+              'be.visible'
+            );
+          });
+
+          context(`when clicking outside the modal`, () => {
+            beforeEach(() => {
+              // cy.findByRole('dialog', {name: 'Delete Item'}).click();
+              cy.get('body').click('top');
+            });
+
+            it(`should not close the 'Does Not Hide On Click Outside' popup`, () => {
+              cy.findByRole('dialog', {name: 'Does Not Hide On Click Outside'}).should(
+                'be.visible'
+              );
+            });
+
+            it(`should close the modal`, () => {
+              cy.findByRole('dialog', {name: 'Delete Item'}).should('not.be.visible');
+            });
+
+            // TODO: Manually, this test case works, but cypress click on body does not close the tooltip.
+            it.skip(`should close the 'Delete' tooltip`, () => {
+              cy.findByRole('tooltip', {
+                name: 'Really, Really, Really, Really, Really sure',
+              }).should('not.be.visible');
+            });
+          });
+        });
+      });
+    });
+  });
+
   context(`given the 'With Radio buttons' story is rendered`, () => {
     beforeEach(() => {
       h.stories.load('Components/Popups/Modal/React', 'With Radio buttons');

--- a/cypress/integration/Popup.spec.ts
+++ b/cypress/integration/Popup.spec.ts
@@ -113,8 +113,7 @@ describe('Popup', () => {
           cy.findByRole('dialog', {name: 'Popup 2'}).should('be.visible');
         });
 
-        // TODO Skip for now until we have a systematic approach to fix this issue
-        it.skip('should close Popup 1', () => {
+        it('should close Popup 1', () => {
           cy.findByRole('dialog', {name: 'Popup 1'}).should('not.exist');
         });
 

--- a/modules/modal/react/lib/ModalContent.tsx
+++ b/modules/modal/react/lib/ModalContent.tsx
@@ -217,7 +217,17 @@ const ModalContent = ({
   // special handling for clicking on the overlay
   const onOverlayClick = (event: React.MouseEvent<HTMLElement>) => {
     // Detect clicks only on the centering wrapper element
-    if (event.target === centeringRef.current && PopupStack.isTopmost(stackRef.current!)) {
+    if (!stackRef.current) {
+      return;
+    }
+    const elements = PopupStack.getElements()
+      .sort((a, b) => Number(a.style.zIndex) - Number(b.style.zIndex))
+      .filter(e => e.getAttribute('data-behavior-click-outside-close') === 'topmost');
+    if (
+      elements.length &&
+      elements[elements.length - 1] === stackRef.current &&
+      event.target === centeringRef.current
+    ) {
       onClose();
     }
   };

--- a/modules/modal/react/package.json
+++ b/modules/modal/react/package.json
@@ -57,6 +57,7 @@
   "devDependencies": {
     "@workday/canvas-kit-react-button": "^4.7.0",
     "@workday/canvas-kit-react-form-field": "^4.7.0",
-    "@workday/canvas-kit-react-text-input": "^4.7.0"
+    "@workday/canvas-kit-react-text-input": "^4.7.0",
+    "@workday/canvas-kit-react-tooltip": "^4.7.0"
   }
 }

--- a/modules/modal/react/stories/stories.tsx
+++ b/modules/modal/react/stories/stories.tsx
@@ -8,9 +8,11 @@ import {FormField} from '@workday/canvas-kit-react-form-field';
 import {TextInput} from '@workday/canvas-kit-react-text-input';
 import {Modal, useModal} from '@workday/canvas-kit-react-modal';
 import {Radio, RadioGroup} from '@workday/canvas-kit-react-radio';
+import {Tooltip} from '@workday/canvas-kit-react-tooltip';
 
 import README from '../README.md';
 import {controlComponent} from '../../../../utils/storybook';
+import Popup, {Popper, useCloseOnOutsideClick, usePopup} from '@workday/canvas-kit-react-popup';
 
 export default {
   title: 'Components/Popups/Modal/React',
@@ -33,6 +35,58 @@ export const Default = () => {
           Cancel
         </Button>
       </Modal>
+    </>
+  );
+};
+
+export const WithTooltips = () => {
+  const {targetProps, modalProps, closeModal} = useModal();
+  const popup1 = usePopup();
+  const popup2 = usePopup();
+
+  useCloseOnOutsideClick(popup1.stackRef, popup1.closePopup);
+
+  return (
+    <>
+      <DeleteButton {...targetProps}>Delete Item</DeleteButton>
+      <Modal data-testid="TestModal" heading={'Delete Item'} {...modalProps}>
+        <p>Are you sure you'd like to delete the item titled 'My Item'?</p>
+        <Button {...popup1.targetProps}>Open Popup to reach Delete button</Button>
+        <Button {...popup2.targetProps}>Non-hidable Popup</Button>
+        <Tooltip title={'Not so sure'} type={'muted'}>
+          <Button onClick={closeModal} variant={Button.Variant.Secondary}>
+            Cancel
+          </Button>
+        </Tooltip>
+      </Modal>
+      <Popper {...popup1.popperProps}>
+        <Popup heading="Really Delete" handleClose={popup1.closePopup}>
+          Pressing 'Delete' will close the modal
+          <Tooltip
+            placement="left"
+            title={'Really, Really, Really, Really, Really sure'}
+            type={'muted'}
+          >
+            <DeleteButton style={{marginRight: '16px'}} onClick={closeModal}>
+              Delete
+            </DeleteButton>
+          </Tooltip>
+        </Popup>
+      </Popper>
+      <Popper {...popup2.popperProps}>
+        <Popup heading="Does Not Hide On Click Outside" handleClose={popup2.closePopup}>
+          Pressing 'Delete' will close the modal
+          <Tooltip
+            placement="left"
+            title={'Really, Really, Really, Really, Really sure'}
+            type={'muted'}
+          >
+            <DeleteButton style={{marginRight: '16px'}} onClick={closeModal}>
+              Delete
+            </DeleteButton>
+          </Tooltip>
+        </Popup>
+      </Popper>
     </>
   );
 };


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Before the fix, when a tooltip is opened on top of a modal, it required two clicks to close the tooltip and then the modal. With the fix, a single click will close a tooltip and the modal underneath. 

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
