### PR TITLE
feat(comboxbox):Added default maxHeight to autocomplete container

### DIFF
--- a/modules/_labs/combobox/react/lib/Combobox.tsx
+++ b/modules/_labs/combobox/react/lib/Combobox.tsx
@@ -105,6 +105,8 @@ const MenuContainer = styled(Card)({
   width: '100%',
   minWidth: 0,
   animation: `${fadeInKeyframes} 200ms ease-out`,
+  maxHeight: 200,
+  overflowY: 'auto',
 });
 
 const ResetButton = styled(IconButton)<{shouldShow: boolean}>(


### PR DESCRIPTION
## Summary

Resolves [1075](https://github.com/Workday/canvas-kit/issues/1075). Added default maxHeight: 200 and overflowY: auto like Drowdown Menu to control the overflow of large items.

## Checklist

- [ ] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [ ] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../API_PATTERN_GUIDELINES.md)

## Additional References

![Screen Shot 2021-05-25 at 11 42 21 AM](https://user-images.githubusercontent.com/530961/119551293-5371d580-bd4e-11eb-9688-7be93bb8e7fb.png)
