### PR TITLE
fix: Type cleanup

### DIFF
--- a/modules/codemod/lib/v5/mapTypeTokensToNewHierarchy.ts
+++ b/modules/codemod/lib/v5/mapTypeTokensToNewHierarchy.ts
@@ -437,8 +437,12 @@ export default function transformer(file: FileInfo, api: API) {
         ? j.memberExpression(j.identifier('canvas'), newFontWeightMemberExpression, false)
         : newFontWeightMemberExpression
     );
+
     if (nodePath.parent.parent.value.type === 'ObjectExpression') {
       return nodePath.parent.parent.value.properties.push(fontWeightProperty);
+    } else if (nodePath.parent.value.type === 'CallExpression') {
+      const typeArgIndex = nodePath.parent.value.arguments.indexOf(nodePath.value);
+      return nodePath.parent.value.arguments.splice(typeArgIndex + 1, 0, fontWeightProperty);
     } else if (nodePath.parent.value.type === 'JSXExpressionContainer') {
       return nodePath.replace(
         j.objectExpression([j.spreadElement(nodePath.value), fontWeightProperty])

--- a/modules/codemod/lib/v5/spec/mapTypeTokensToNewHierarchy.spec.ts
+++ b/modules/codemod/lib/v5/spec/mapTypeTokensToNewHierarchy.spec.ts
@@ -1604,6 +1604,26 @@ describe('Canvas Kit Labs Type Tokens Map Codemod', () => {
 
         expectTransform(input, expected);
       });
+
+      it('should add bold styles to former styled headings', () => {
+        const input = `
+          import canvas, {type} from '@workday/canvas-kit-react/tokens';
+
+          const Heading = styled('h3')(type.h3, {
+            marginBottom: space.m,
+          });
+        `;
+
+        const expected = `
+          import canvas, {type} from '@workday/canvas-kit-react/tokens';
+
+          const Heading = styled('h3')(type.levels.body.large, fontWeight: type.properties.fontWeights.bold, {
+            marginBottom: space.m,
+          });
+        `;
+
+        expectTransform(input, expected);
+      });
     });
 
     context('when transforming type variants', () => {

--- a/modules/react/card/lib/CardHeading.tsx
+++ b/modules/react/card/lib/CardHeading.tsx
@@ -13,6 +13,7 @@ export interface CardHeadingProps {
 }
 
 const Heading = styled('h3')<StyledType>(type.levels.body.large, {
+  fontWeight: type.properties.fontWeights.bold,
   marginBottom: space.m,
   marginTop: 0,
 });

--- a/modules/react/tokens/lib/type/levels.ts
+++ b/modules/react/tokens/lib/type/levels.ts
@@ -100,8 +100,6 @@ export const levels: CanvasTypeHierarchy = {
       fontSize: fontSizes[20],
       /** 28px converted to base-16 rem (1.75rem) */
       lineHeight: '1.75rem',
-      /** 0.16px converted to base-16 rem (0.01rem) */
-      letterSpacing: '0.01rem',
       fontWeight: fontWeights.regular,
       color: typeColors.body,
     },
@@ -111,8 +109,6 @@ export const levels: CanvasTypeHierarchy = {
       fontSize: fontSizes[18],
       /** 28px converted to base-16 rem (1.75rem) */
       lineHeight: '1.75rem',
-      /** 0.16px converted to base-16 rem (0.01rem) */
-      letterSpacing: '0.01rem',
       fontWeight: fontWeights.regular,
       color: typeColors.body,
     },
@@ -335,8 +331,6 @@ type CanvasTypeBodyLevel = {
     fontSize: CanvasFontSizes[20];
     /** 28px converted to base-16 rem (1.75rem) */
     lineHeight: '1.75rem';
-    /** 0.16px converted to base-16 rem (0.01rem) */
-    letterSpacing: '0.01rem';
     fontWeight: CanvasFontWeights['regular'];
     color: typeof typeColors.body;
   };
@@ -346,8 +340,6 @@ type CanvasTypeBodyLevel = {
     fontSize: CanvasFontSizes[18];
     /** 28px converted to base-16 rem (1.75rem) */
     lineHeight: '1.75rem';
-    /** 0.16px converted to base-16 rem (0.01rem) */
-    letterSpacing: '0.01rem';
     fontWeight: CanvasFontWeights['regular'];
     color: typeof typeColors.body;
   };

--- a/modules/react/tokens/spec/type.spec.ts
+++ b/modules/react/tokens/spec/type.spec.ts
@@ -134,12 +134,10 @@ describe('Type Tokens', () => {
       const actualLineHeightValue = remToPx(medium.lineHeight);
       const expectedLineHeightValue = typeLevelMap.body.medium.lineHeight;
 
-      const actualLetterSpacingValue = remToPx(medium.letterSpacing);
       const expectedLetterSpacingValue = typeLevelMap.body.medium.letterSpacing;
 
       expect(actualFontSizeValue).toEqual(expectedFontSizeValue);
       expect(actualLineHeightValue).toEqual(expectedLineHeightValue);
-      expect(actualLetterSpacingValue).toEqual(expectedLetterSpacingValue);
     });
 
     it('should return the correct medium size values', () => {
@@ -150,12 +148,10 @@ describe('Type Tokens', () => {
       const actualLineHeightValue = remToPx(large.lineHeight);
       const expectedLineHeightValue = typeLevelMap.body.large.lineHeight;
 
-      const actualLetterSpacingValue = remToPx(large.letterSpacing);
       const expectedLetterSpacingValue = typeLevelMap.body.large.letterSpacing;
 
       expect(actualFontSizeValue).toEqual(expectedFontSizeValue);
       expect(actualLineHeightValue).toEqual(expectedLineHeightValue);
-      expect(actualLetterSpacingValue).toEqual(expectedLetterSpacingValue);
     });
   });
 

--- a/modules/react/tokens/stories/stories.tsx
+++ b/modules/react/tokens/stories/stories.tsx
@@ -76,6 +76,7 @@ export const Type = () => (
 const Shape = styled('div')<{radius?: string | number; size?: string | number}>(
   {
     ...type.levels.body.small,
+    fontWeight: type.properties.fontWeights.bold,
     margin: space.m,
     background: colors.blueberry400,
     color: colors.frenchVanilla100,
@@ -101,10 +102,11 @@ const Shape = styled('div')<{radius?: string | number; size?: string | number}>(
 
 const SizeLabel = styled('div')({
   ...type.levels.body.small,
+  fontWeight: type.properties.fontWeights.bold,
   margin: space.s,
   width: 80,
   '& span': {
-    ...type.levels.subtext.large,
+    ...type.levels.subtext.medium,
     fontFamily: type.properties.fontFamilies.monospace,
     ...type.variants.hint,
     display: 'block',
@@ -160,8 +162,8 @@ const Palette = styled('ul')({
 
 const Swatch = styled('li')<{bg: string; primary?: boolean}>(
   {
-    ...type.levels.body.medium,
-    fontWeight: 700,
+    ...type.levels.subtext.large,
+    fontWeight: type.properties.fontWeights.bold,
     padding: `0 ${space.m}`,
     height: space.xl,
     display: 'flex',
@@ -171,6 +173,7 @@ const Swatch = styled('li')<{bg: string; primary?: boolean}>(
   ({primary, bg}) =>
     primary && {
       ...type.levels.body.large,
+      fontWeight: type.properties.fontWeights.bold,
       height: space.xxxl,
       paddingTop: space.s,
       paddingBottom: space.s,


### PR DESCRIPTION
A few follow-up cleanup items on #1078 to prep us for the v5 release!

- [x] Corrects some of the manual migration done to the tokens stories in #1078 
- [x] Fixes missing logic in type codemod that was preventing the font weight from being preserved for h3 and h4 headings that were specifying the type object in a `styled()` argument
- [x] Run codemod update (or manually update the issues)
- [x] BREAKING: Removes unintended `0.01rem` letter spacing from `body.m` and `body.l`
- [x] Upsize toast text to 14px because 12px was too small