### PR TITLE
chore: Fix circular dep in preview module

### DIFF
--- a/modules/preview-react/package.json
+++ b/modules/preview-react/package.json
@@ -54,7 +54,6 @@
     "@emotion/core": "^10.0.28",
     "@emotion/styled": "^10.0.27",
     "@types/uuid": "^3.4.4",
-    "@workday/canvas-kit-labs-react": "^5.0.0",
     "@workday/canvas-kit-react": "^5.0.0",
     "@workday/canvas-system-icons-web": "1.0.41",
     "@workday/design-assets-types": "^0.2.4",
@@ -62,6 +61,7 @@
   },
   "devDependencies": {
     "@material-ui/core": "^4.9.7",
-    "@workday/canvas-accent-icons-web": "^1.0.0"
+    "@workday/canvas-accent-icons-web": "^1.0.0",
+    "@workday/canvas-kit-labs-react": "^5.0.0"
   }
 }


### PR DESCRIPTION
## Summary

It was reported that we have some circular deps in v5. This addresses some* of those.

* We mistakenly had `@workday/canvas-kit-labs-react` as a full dependency of `@workday/canvas-kit-preview-react`. It was only a dev dependency used for one test. This has been updated.

There are two cyclical dependencies remaining:
- `@workday/canvas-kit-labs-react -> @workday/canvas-kit-preview-react -> @workday/canvas-kit-labs-react`
  - This should not cause any issues as `labs` is only a dev dep of `preview  `
- `@workday/canvas-kit-react -> (nested cycle: @workday/canvas-kit-labs-react -> @workday/canvas-kit-preview-react -> @workday/canvas-kit-labs-react) -> @workday/canvas-kit-react`
  - This should not cause any issue because it is just a nested version of the previous cycle.

Unfortunately this is a common scenario for component monorepos and it is [not something lerna will let us configure](https://github.com/lerna/lerna/issues/1198) as it is not a runtime warning, but a bootstrap instability warning. If we were to promote `@workday/canvas-kit-labs-react/layout` to main, it would fix all our dependency cycles.

--- 

**Note: I was not able to reproduce the report of a circular dependency in our main `@workday/canvas-kit-react` package.**