### PR TITLE
build: Fix slash imports build pathing

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,12 +19,6 @@
     "allowSyntheticDefaultImports": true,
     "types": [],
     "incremental": true,
-    "baseUrl": "./",
-    "paths": {
-      "@workday/canvas-kit-react*": ["modules/react*"],
-      "@workday/canvas-kit-labs-react*": ["modules/labs-react*"],
-      "@workday/canvas-kit-preview-react*": ["modules/preview-react*"]
-    }
   },
   "ts-node": {
     "transpileOnly": true,


### PR DESCRIPTION
## Summary

In #1029, the following was added to our root tsconfig:

```
    "baseUrl": "./",
    "paths": {
      "@workday/canvas-kit-react*": ["modules/react*"],
      "@workday/canvas-kit-labs-react*": ["modules/labs-react*"],
      "@workday/canvas-kit-preview-react*": ["modules/preview-react*"]
    }
```

Since we're using labs components (e.g. `Box`) inside of our main module, this causes the `tsc` build to compile files from both `labs-react` and `react`. Because of this, the dist folder now looks like this:

```
dist/
  commonjs/
    labs-react/
      box/
    react/
      action-bar/
      avatar/
      ...
  es6/
    (the same as above)
```
instead of:

```
dist/
  commonjs/
    action-bar/
    avatar/
    ...
  es6/
    (the same as above)
```

### What is happening

- `@workday/canvas-kit-react` package.json references `"module": "/dist/es6/index.js"` (and similarly for main/commonjs)
- This file actually lives in `/dist/es6/react/index.js` now.
- Storybook/build process fails to find the `index.js` file, so it loads the `/index.ts` (source code)

### What I did

After talking with @NicholasBoll I found out he only added `paths` in the TS config so that auto import envious code would use the module name instead of a relative path. We should be fine to remove it and experiment with this later. So that's what I did 🙂 