### PR TITLE
fix(tokens): Fixes color token exports

### DIFF
--- a/modules/react/tokens/index.ts
+++ b/modules/react/tokens/index.ts
@@ -1,4 +1,15 @@
-import * as canvasColorsWeb from '@workday/canvas-colors-web';
+import {
+  buttonColors,
+  chartingColorOffsets,
+  chartingColors,
+  colors,
+  commonColors,
+  gradients,
+  iconColors,
+  inputColors,
+  statusColors,
+  typeColors,
+} from '@workday/canvas-colors-web';
 
 import {borderRadius, CanvasBorderRadius, CanvasBorderRadiusKeys, CanvasBorderRadiusValues} from './lib/radius';
 import {BrandingColor, CanvasColor} from './lib/colors.types';
@@ -22,15 +33,21 @@ import {type,
 } from './lib/type';
 import {CSSProperties} from './lib/types';
 
-const {default: colors, gradients, ...semanticColors} = canvasColorsWeb;
 const canvas = {
+  buttonColors,
+  chartingColorOffsets,
+  chartingColors,
   colors,
+  commonColors,
   depth,
-  space,
-  type,
   fontFamily,
+  iconColors,
+  inputColors,
   monoFontFamily,
-  ...semanticColors,
+  space,
+  statusColors,
+  type,
+  typeColors,
 };
 
 export * from '@workday/canvas-colors-web';

--- a/modules/react/tokens/index.ts
+++ b/modules/react/tokens/index.ts
@@ -41,6 +41,7 @@ const canvas = {
   commonColors,
   depth,
   fontFamily,
+  gradients,
   iconColors,
   inputColors,
   monoFontFamily,


### PR DESCRIPTION
## Summary

Resolves #1109

Previously we were parsing out colors from `canvas-colors-web` like this:

```ts
const {default: colors, gradients, ...semanticColors} = canvasColorsWeb;
```

And exporting them from a default `canvas` object like this:

```ts
const canvas = {
  colors,
  depth,
  space,
  type,
  fontFamily,
  monoFontFamily,
  ...semanticColors,
};
```

TS throws an error because `...semanticColors` has a `color` key which is overwrites the default export. This happened to work because the colors in the default export and the `colors` key were identical.

To resolve this, we're removing the default export and explicitly import each color key.

## Checklist

- [ ] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [ ] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../modules/docs/mdx/API_PATTERN_GUIDELINES.mdx)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
