### PR TITLE
fix(popup): Remove ref fowarding requirement in Popup.Target

### DIFF
--- a/cypress/integration/Modal.spec.ts
+++ b/cypress/integration/Modal.spec.ts
@@ -619,7 +619,8 @@ describe('Modal', () => {
 
     context('when the "Open" button is clicked', () => {
       beforeEach(() => {
-        cy.findByRole('button', {name: 'Open'}).click();
+        // cy.findByRole('button', {name: 'Open'}) is failing for some reason
+        cy.contains('button', 'Open').click();
       });
 
       it('should show the modal', () => {
@@ -636,7 +637,7 @@ describe('Modal', () => {
         });
 
         it('should move focus back to the "Open" button', () => {
-          cy.findByRole('button', {name: 'Open'}).should('have.focus');
+          cy.contains('button', 'Open').should('have.focus');
         });
       });
     });

--- a/cypress/integration/Modal.spec.ts
+++ b/cypress/integration/Modal.spec.ts
@@ -611,4 +611,34 @@ describe('Modal', () => {
       });
     });
   });
+
+  context(`given the [Components/Popups/Modal/React, CustomTarget] example is rendered`, () => {
+    beforeEach(() => {
+      h.stories.load('Components/Popups/Modal/React', 'CustomTarget');
+    });
+
+    context('when the "Open" button is clicked', () => {
+      beforeEach(() => {
+        cy.findByRole('button', {name: 'Open'}).click();
+      });
+
+      it('should show the modal', () => {
+        cy.findByRole('dialog', {name: 'Modal'}).should('be.visible');
+      });
+
+      context('when the "Close" button is clicked', () => {
+        beforeEach(() => {
+          cy.findByRole('button', {name: 'Close'}).click();
+        });
+
+        it('should hide the modal', () => {
+          cy.findByRole('dialog', {name: 'Modal'}).should('not.be.visible');
+        });
+
+        it('should move focus back to the "Open" button', () => {
+          cy.findByRole('button', {name: 'Open'}).should('have.focus');
+        });
+      });
+    });
+  });
 });

--- a/cypress/integration/Popup.spec.ts
+++ b/cypress/integration/Popup.spec.ts
@@ -331,4 +331,34 @@ describe('Popup', () => {
       });
     });
   });
+
+  context(`given the [Components/Popups/Popup/React, CustomTarget] example is rendered`, () => {
+    beforeEach(() => {
+      h.stories.load('Components/Popups/Popup/React', 'CustomTarget');
+    });
+
+    context('when the "Open" button is clicked', () => {
+      beforeEach(() => {
+        cy.findByRole('button', {name: 'Open'}).click();
+      });
+
+      it('should show the popup', () => {
+        cy.findByRole('dialog', {name: 'Popup'}).should('be.visible');
+      });
+
+      context('when the "Close" button is clicked', () => {
+        beforeEach(() => {
+          cy.findByRole('button', {name: 'Close'}).click();
+        });
+
+        it('should hide the popup', () => {
+          cy.findByRole('dialog', {name: 'Popup'}).should('not.be.visible');
+        });
+
+        it('should move focus back to the "Open" button', () => {
+          cy.findByRole('button', {name: 'Open'}).should('have.focus');
+        });
+      });
+    });
+  });
 });

--- a/modules/react/modal/stories/Modal.stories.mdx
+++ b/modules/react/modal/stories/Modal.stories.mdx
@@ -6,6 +6,7 @@ import {Specifications} from '@workday/canvas-kit-docs';
 import {Basic} from './examples/Basic';
 import {WithoutCloseIcon} from './examples/WithoutCloseIcon';
 import {CustomFocus} from './examples/CustomFocus';
+import {CustomTarget} from './examples/CustomTarget';
 
 <Meta title="Components/Popups/Modal/React" component={Modal} />
 
@@ -51,6 +52,21 @@ different element. The following example shows how `initialFocusRef` can be used
 element receives focus when the modal opens.
 
 <ExampleCodeBlock code={CustomFocus} />
+
+### Custom Target
+
+It is common to have a custom target for your modal. Use the `as` prop to use your custom component.
+The `Modal.Target` element will add `onClick` and `ref` to the provided component. Your provided
+target component must forward the `onClick` to an element for the Modal to open. The `as` will cause
+`Modal.Target` to inherit the interface of your custom target component. This means any props your
+target requires, `Modal.Target` now also requires. The example below has a `MyTarget` component that
+requires a `label` prop.
+
+> **Note**: If your application needs to programmatically open a Modal without the user interacting
+> with the target button first, you'll also need to use `React.forwardRef` in your target component.
+> Without this, the Modal will open at the top-left of the window instead of around the target.
+
+<ExampleCodeBlock code={CustomTarget} />
 
 ## Components
 

--- a/modules/react/modal/stories/examples/CustomTarget.tsx
+++ b/modules/react/modal/stories/examples/CustomTarget.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import {Modal} from '@workday/canvas-kit-react/modal';
+
+interface MyTargetProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  label: string;
+}
+
+const MyTarget = ({label, ...props}: MyTargetProps) => {
+  return <button {...props}>{label}</button>;
+};
+
+export const CustomTarget = () => {
+  return (
+    <Modal>
+      <Modal.Target as={MyTarget} label="Open" />
+      <Modal.Overlay>
+        <Modal.Card>
+          <Modal.CloseIcon aria-label="Close" />
+          <Modal.Heading>Modal</Modal.Heading>
+          <Modal.Body>Contents</Modal.Body>
+        </Modal.Card>
+      </Modal.Overlay>
+    </Modal>
+  );
+};

--- a/modules/react/popup/lib/hooks/usePopupTarget.ts
+++ b/modules/react/popup/lib/hooks/usePopupTarget.ts
@@ -9,6 +9,14 @@ export const usePopupTarget = createHook(({events, state}: PopupModel, ref) => {
   return {
     ref: elementRef,
     onClick: (event: React.MouseEvent) => {
+      // If we're wrapping a target component that doesn't handle ref forwarding, update the
+      // `state.targetRef` manually. This ensures that custom target components don't need to handle
+      // ref forwarding since ref forwarding is only really needed to programmatically open popups
+      // around a target _before_ a user clicks. In that rare case, ref forwarding is required.
+      if (!state.targetRef.current) {
+        (state.targetRef as React.MutableRefObject<any>).current = event.currentTarget;
+      }
+
       if (state.visibility !== 'hidden') {
         events.hide({event});
       } else {

--- a/modules/react/popup/stories/Popup.stories.mdx
+++ b/modules/react/popup/stories/Popup.stories.mdx
@@ -10,6 +10,7 @@ import {NestedPopups} from './examples/NestedPopups';
 import {FocusRedirect} from './examples/FocusRedirect';
 import {FocusTrap} from './examples/FocusTrap';
 import {RTL} from './examples/RTL';
+import {CustomTarget} from './examples/CustomTarget';
 import {PopupModelConfigComponent, PopupStateComponent, PopupEventsComponent} from './PopupModel';
 
 <Meta title="Components/Popups/Popup/React" component={Popup} />
@@ -122,6 +123,21 @@ parameter is props to be merged which will effectively hide both popups. Focus m
 preserved.
 
 <ExampleCodeBlock code={NestedPopups} />
+
+### Custom Target
+
+It is common to have a custom target for your popup. Use the `as` prop to use your custom component.
+The `Popup.Target` element will add `onClick` and `ref` to the provided component. Your provided
+target component must forward the `onClick` to an element for the Popup to open. The `as` will cause
+`Popup.Target` to inherit the interface of your custom target component. This means any props your
+target requires, `Popup.Target` now also requires. The example below has a `MyTarget` component that
+requires a `label` prop.
+
+> **Note**: If your application needs to programmatically open a Popup without the user interacting
+> with the target button first, you'll also need to use `React.forwardRef` in your target component.
+> Without this, the Popup will open at the top-left of the window instead of around the target.
+
+<ExampleCodeBlock code={CustomTarget} />
 
 ### RTL
 

--- a/modules/react/popup/stories/examples/CustomTarget.tsx
+++ b/modules/react/popup/stories/examples/CustomTarget.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import {
+  Popup,
+  usePopupModel,
+  useCloseOnEscape,
+  useCloseOnOutsideClick,
+  useInitialFocus,
+  useReturnFocus,
+} from '@workday/canvas-kit-react/popup';
+
+interface MyTargetProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  label: string;
+}
+
+const MyTarget = ({label, ...props}: MyTargetProps) => {
+  return <button {...props}>{label}</button>;
+};
+
+export const CustomTarget = () => {
+  const model = usePopupModel();
+
+  useCloseOnOutsideClick(model);
+  useCloseOnEscape(model);
+  useInitialFocus(model);
+  useReturnFocus(model);
+
+  return (
+    <Popup model={model}>
+      <Popup.Target as={MyTarget} label="Open" />
+      <Popup.Popper>
+        <Popup.Card>
+          <Popup.CloseIcon aria-label="Close" />
+          <Popup.Heading>Popup</Popup.Heading>
+          <Popup.Body>Contents</Popup.Body>
+        </Popup.Card>
+      </Popup.Popper>
+    </Popup>
+  );
+};


### PR DESCRIPTION
- Remove ref forwarding requirement in `Popup.Target`, `Modal.Target`, and `Dialog.Target`
- Add examples to show using custom targets for `Popup` and `Modal`
- Add Cypress specifications for new examples

Fixes #1114