### PR TITLE
Popup adapter transfer ownership

### DIFF
--- a/modules/popup-stack/lib/PopupStack.ts
+++ b/modules/popup-stack/lib/PopupStack.ts
@@ -350,10 +350,9 @@ export const PopupStack = {
    * @param staleItems the items that will now be handled by the current adapter.
    */
   transferOwnership(staleItems: PopupStackItem[]): void {
-    if (stack._adapter?.transferOwnership) {
-      return stack._adapter.transferOwnership(staleItems);
-    }
-
+    // This only handles the default PopupStack behavior. If you have your own adapter,
+    // it is recommended to override this method to avoid any possible stale popup references
+    // when createAdapter() is called.
     staleItems.forEach(item => {
       stack.items.push(item);
     });

--- a/modules/popup-stack/lib/PopupStack.ts
+++ b/modules/popup-stack/lib/PopupStack.ts
@@ -344,6 +344,30 @@ export const PopupStack = {
     }
     return false;
   },
+
+  /**
+   * Converts the given popup stack items over to the adapter calling transferOwnership.
+   * @param staleItems the items that will now be handled by the current adapter.
+   */
+  transferOwnership(staleItems: PopupStackItem[]): void {
+    if (stack._adapter?.transferOwnership) {
+      return stack._adapter.transferOwnership(staleItems);
+    }
+
+    staleItems.forEach(item => {
+      stack.items.push(item);
+    });
+  },
+
+  /**
+   * @returns the list of popup stack items associated with the current adapter.
+   */
+  getPopupStackItems(): PopupStackItem[] {
+    if (stack._adapter?.getPopupStackItems) {
+      return stack._adapter.getPopupStackItems();
+    }
+    return stack.items;
+  },
 };
 
 /**
@@ -359,5 +383,10 @@ export function resetStack() {
  * @param adapter The parts of the PopupStack that we want to override
  */
 export const createAdapter = (adapter: Partial<typeof PopupStack>) => {
+  // If there are any stale popup items that belong to the old adapter, transfer them over to the new adapter to handle.
+  if (adapter && adapter.transferOwnership) {
+    adapter.transferOwnership(PopupStack.getPopupStackItems());
+  }
+
   stack._adapter = adapter;
 };

--- a/modules/popup-stack/spec/PopupStack.spec.ts
+++ b/modules/popup-stack/spec/PopupStack.spec.ts
@@ -1,4 +1,4 @@
-import {PopupStack, PopupStackItem, resetStack, getValue} from '../lib/PopupStack';
+import {PopupStack, PopupStackItem, resetStack, getValue, createAdapter} from '../lib/PopupStack';
 
 describe('PopupStack', () => {
   afterEach(() => {
@@ -144,6 +144,98 @@ describe('PopupStack', () => {
 
       expect(PopupStack.contains(element, eventTarget)).toEqual(false);
     });
+  });
+
+  describe('createAdapter()', () => {
+    let adapterItems: PopupStackItem[] = [];
+
+    const customAdapter = {
+      transferOwnership: (items: PopupStackItem[]) => {
+        if (items) {
+          items.forEach((item, index) => {
+            console.log('transfer item ', index);
+            adapterItems.push(item);
+          });
+        }
+      },
+      getPopupStackItems: () => {
+        return adapterItems;
+      },
+    };
+
+    afterEach(() => {
+      adapterItems = [];
+
+      // Reset the adapter with the default adapter.
+      createAdapter({});
+    });
+
+    describe('without items', () => {
+      it('should not call transfer any items to the new adapter', () => {
+        createAdapter(customAdapter);
+
+        expect(PopupStack.getPopupStackItems().length).toEqual(0);
+      });
+    });
+
+    describe('with items', () => {
+      it('should move item ownership from the old adapter to the new adapter', () => {
+        // Add one popup so it exists in the old adapter.
+        PopupStack.add({
+          element: document.createElement('div'),
+          owner: document.createElement('button'),
+        });
+
+        expect(PopupStack.getPopupStackItems().length).toEqual(1);
+
+        createAdapter(customAdapter);
+
+        expect(PopupStack.getPopupStackItems().length).toEqual(1);
+      });
+    });
+  });
+
+  describe('transferOwnership()', () => {
+    describe('without items', () => {
+      it('should not transfer any items to the new adapter', () => {
+        PopupStack.transferOwnership([]);
+        expect(PopupStack.getPopupStackItems().length).toEqual(0);
+      });
+    });
+
+    describe('with items', () => {
+      it('should move item ownership from the old adapter to the new adapter', () => {
+        PopupStack.transferOwnership([
+          {
+            element: document.createElement('div'),
+            owner: document.createElement('button'),
+          },
+          {
+            element: document.createElement('div'),
+            owner: document.createElement('span'),
+          },
+        ]);
+
+        expect(PopupStack.getPopupStackItems().length).toEqual(2);
+      });
+    });
+  });
+
+  it('getPopupStackItems() should return a list of popup stack items', () => {
+    PopupStack.add({
+      element: document.createElement('div'),
+      owner: document.createElement('input'),
+    });
+    PopupStack.add({
+      element: document.createElement('div'),
+      owner: document.createElement('h2'),
+    });
+    PopupStack.add({
+      element: document.createElement('div'),
+      owner: document.createElement('button'),
+    });
+
+    expect(PopupStack.getPopupStackItems().length).toEqual(3);
   });
 
   describe('defaultGetValue()', () => {


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


Previously, if a new adapter is used and there happened to be existing popups on the page, the new adapter loses reference of those existing popups and has no way to interact with them. This fix allows a transfer of ownership from the old adapter to the new one.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../modules/docs/mdx/API_PATTERN_GUIDELINES.mdx)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
