### PR TITLE
fix(tooltip): Fix overflow ellipsis detection

### DIFF
--- a/modules/tooltip/react/lib/OverflowTooltip.tsx
+++ b/modules/tooltip/react/lib/OverflowTooltip.tsx
@@ -8,7 +8,7 @@ import {TooltipContainer} from './TooltipContainer';
 import {useTooltip} from './useTooltip';
 
 /**
- * Look for an element within the tree for a `text-overflow` CSS property of `ellipsis`.
+ * Look for an element within the tree for an overflow element (auto, scroll, clip, or hidden).
  * This could be the passed element, or a descendant. If no element is found, `null` is returned.
  */
 const findOverflowElement = (element: HTMLElement): HTMLElement | null => {
@@ -31,6 +31,10 @@ const findOverflowElement = (element: HTMLElement): HTMLElement | null => {
   }
 };
 
+/**
+ * Look for an element within the tree for a `text-overflow` CSS property of `ellipsis`.
+ * This could be the passed element, or a descendant. If no element is found, `null` is returned.
+ */
 const findEllipsisElement = (element: HTMLElement): HTMLElement | null => {
   const style = getComputedStyle(element);
   if (style.textOverflow === 'ellipsis' || Number(style.webkitLineClamp) > 0) {

--- a/modules/tooltip/react/lib/OverflowTooltip.tsx
+++ b/modules/tooltip/react/lib/OverflowTooltip.tsx
@@ -37,7 +37,7 @@ const findEllipsisElement = (element: HTMLElement): HTMLElement | null => {
     return element;
   } else {
     for (let i = 0; i < element.children.length; i++) {
-      const overflowElement = findOverflowElement(element.children[i] as HTMLElement);
+      const overflowElement = findEllipsisElement(element.children[i] as HTMLElement);
       if (overflowElement) {
         return overflowElement;
       }


### PR DESCRIPTION
Fixes #1125

The intent of the overflow tooltip is to first find an ellipsis element, then fallback to finding an overflow element if no ellipsis element was found. The `findEllipsisElement` is intended to be a recursive function, but accidentally called `findOverflowElement` instead of `findEllipsisElement`.
