### PR TITLE
fix(modal): Fix focus trap when Modal contains an iframe

### DIFF
--- a/cypress/integration/Modal.spec.ts
+++ b/cypress/integration/Modal.spec.ts
@@ -620,4 +620,49 @@ describe('Modal', () => {
       });
     });
   });
+
+  context(`given the 'Iframe Test' story is rendered`, () => {
+    beforeEach(() => {
+      h.stories.load('Testing/React/Popups/Modal', 'Iframe Test');
+    });
+
+    context('when the modal is opened', () => {
+      beforeEach(() => {
+        cy.contains('button', 'Delete Item').click();
+      });
+
+      context('when Shift + Tab key is pressed', () => {
+        beforeEach(() => {
+          cy.focused().tab({shift: true});
+        });
+
+        it('should focus in the iframe', () => {
+          cy.get('iframe').should('have.focus');
+        });
+
+        it('should focus on the last button in the iframe', () => {
+          cy.get('iframe')
+            .its('0.contentDocument.body')
+            .then(cy.wrap)
+            .contains('button', 'iframe button 2')
+            .should('have.focus');
+        });
+
+        // skipping because the cy.tab plugin isn't capable of starting inside an iframe. We have to test this manually
+        context.skip('when the Tab key is pressed', () => {
+          beforeEach(() => {
+            cy.get('iframe')
+              .its('0.contentDocument.body')
+              .then(cy.wrap)
+              .focused()
+              .tab();
+          });
+
+          it('should focus on the close button', () => {
+            cy.findByRole('button', {name: 'Close'}).should('have.focus');
+          });
+        });
+      });
+    });
+  });
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -16,7 +16,7 @@ Cypress.Commands.add('injectAxe', () => {
 });
 
 // Add better logging to cy.tab
-Cypress.Commands.overwrite('tab', (originalFn, subject) => {
+Cypress.Commands.overwrite('tab', (originalFn, subject, options) => {
   const prevSubject = cy.$$(subject || (cy as any).state('window').document.activeElement);
 
   const log = Cypress.log({
@@ -30,7 +30,7 @@ Cypress.Commands.overwrite('tab', (originalFn, subject) => {
 
   log.snapshot('before', {next: 'after'});
 
-  return Cypress.Promise.try(() => originalFn(subject))
+  return Cypress.Promise.try(() => originalFn(subject, options))
     .then(value => {
       log.set('$el', value).snapshot();
       return Cypress.$(value);

--- a/modules/docs/utils/get-specifications.js
+++ b/modules/docs/utils/get-specifications.js
@@ -35,6 +35,7 @@ function getSpecifications() {
               cb();
               children = childrenBefore;
             };
+            describe.skip = noop;
             const context = describe;
 
             const it = name => {

--- a/modules/modal/react/stories/stories_testing.tsx
+++ b/modules/modal/react/stories/stories_testing.tsx
@@ -171,3 +171,35 @@ export const ModalWithPopup = () => {
     </>
   );
 };
+
+export const IframeTest = () => {
+  const [open, setOpen] = React.useState(false);
+  const buttonRef = React.useRef<HTMLButtonElement>() as React.RefObject<HTMLButtonElement>; // cast to keep buttonRef happy
+  const openModal = () => {
+    setOpen(true);
+  };
+  const closeModal = () => {
+    setOpen(false);
+    if (buttonRef.current) {
+      buttonRef.current.focus();
+    }
+  };
+
+  return (
+    <>
+      <DeleteButton buttonRef={buttonRef} onClick={openModal}>
+        Delete Item
+      </DeleteButton>
+      <Modal data-testid="TestModal" heading="Delete Item" open={open} handleClose={closeModal}>
+        <p>Are you sure you want to delete the item?</p>
+        <DeleteButton style={{marginRight: '16px'}} onClick={closeModal}>
+          Delete
+        </DeleteButton>
+        <Button onClick={closeModal} variant={Button.Variant.Secondary}>
+          Cancel
+        </Button>
+        <iframe srcDoc="<html><body>Hello, <b>world</b>.<button>iframe button 1</button><button>iframe button 2</button></body></html>" />
+      </Modal>
+    </>
+  );
+};

--- a/modules/popup/react/lib/focus-trap-js.d.ts
+++ b/modules/popup/react/lib/focus-trap-js.d.ts
@@ -1,0 +1,1 @@
+export default function tabTrappingKey(event: Event, element: HTMLElement): null;

--- a/modules/popup/react/lib/focus-trap-js.js
+++ b/modules/popup/react/lib/focus-trap-js.js
@@ -1,0 +1,122 @@
+/* eslint-disable */
+// refactor for v5
+
+var candidateSelectors = [
+  'input',
+  'select',
+  'textarea',
+  'a[href]',
+  'button',
+  'iframe',
+  '[tabindex]',
+  'audio[controls]',
+  'video[controls]',
+  '[contenteditable]:not([contenteditable="false"])',
+];
+
+function isHidden(node) {
+  // offsetParent being null will allow detecting cases where an element is invisible or inside an invisible element,
+  // as long as the element does not use position: fixed. For them, their visibility has to be checked directly as well.
+  return node.offsetParent === null || getComputedStyle(node).visibility === 'hidden';
+}
+
+function getCheckedRadio(nodes, form) {
+  for (var i = 0; i < nodes.length; i++) {
+    if (nodes[i].checked && nodes[i].form === form) {
+      return nodes[i];
+    }
+  }
+}
+
+function isNotRadioOrTabbableRadio(node) {
+  if (node.tagName !== 'INPUT' || node.type !== 'radio' || !node.name) {
+    return true;
+  }
+  var radioScope = node.form || node.ownerDocument;
+  var radioSet = radioScope.querySelectorAll('input[type="radio"][name="' + node.name + '"]');
+  var checked = getCheckedRadio(radioSet, node.form);
+  return checked === node || (checked === undefined && radioSet[0] === node);
+}
+
+function getAllTabbingElements(parentElem) {
+  var currentActiveElement = document.activeElement;
+  var tabbableNodes = parentElem.querySelectorAll(candidateSelectors.join(','));
+  var onlyTabbable = [];
+  for (var i = 0; i < tabbableNodes.length; i++) {
+    var node = tabbableNodes[i];
+    if (
+      currentActiveElement === node ||
+      (!node.disabled &&
+        getTabindex(node) > -1 &&
+        !isHidden(node) &&
+        isNotRadioOrTabbableRadio(node))
+    ) {
+      if (node instanceof HTMLIFrameElement) {
+        var iframeDoc = node.contentWindow.document;
+        var tabbableElementsInIframe = getAllTabbingElements(iframeDoc);
+        const handleKeyEvent = event => {
+          const blocked = tabTrappingKey(event, iframeDoc, onlyTabbable);
+          if (blocked) {
+            iframeDoc.removeEventListener('keydown', handleKeyEvent);
+          }
+        };
+        iframeDoc.addEventListener('keydown', handleKeyEvent);
+        tabbableElementsInIframe.forEach(elem => {
+          onlyTabbable.push(elem);
+        });
+      } else {
+        onlyTabbable.push(node);
+      }
+    }
+  }
+  return onlyTabbable;
+}
+
+function tabTrappingKey(event, parentElem, onlyTabbable) {
+  // check if current event keyCode is tab
+  if (!event || event.key !== 'Tab') return;
+
+  if (!parentElem || !parentElem.contains) {
+    if (process && process.env.NODE_ENV === 'development') {
+      console.warn('focus-trap-js: parent element is not defined');
+    }
+    return false;
+  }
+
+  if (!parentElem.contains(event.target)) {
+    return false;
+  }
+
+  var allTabbingElements = onlyTabbable || getAllTabbingElements(parentElem);
+  var firstFocusableElement = allTabbingElements[0];
+  var lastFocusableElement = allTabbingElements[allTabbingElements.length - 1];
+
+  if (event.shiftKey && event.target === firstFocusableElement) {
+    lastFocusableElement.focus();
+    event.preventDefault();
+    return true;
+  } else if (!event.shiftKey && event.target === lastFocusableElement) {
+    firstFocusableElement.focus();
+    event.preventDefault();
+    return true;
+  }
+  return false;
+}
+
+function getTabindex(node) {
+  var tabindexAttr = parseInt(node.getAttribute('tabindex'), 10);
+
+  if (!isNaN(tabindexAttr)) return tabindexAttr;
+  // Browsers do not return tabIndex correctly for contentEditable nodes;
+  // so if they don't have a tabindex attribute specifically set, assume it's 0.
+
+  if (isContentEditable(node)) return 0;
+  return node.tabIndex;
+}
+
+function isContentEditable(node) {
+  return node.getAttribute('contentEditable');
+}
+
+tabTrappingKey.isNotRadioOrTabbableRadio = isNotRadioOrTabbableRadio;
+module.exports = tabTrappingKey;

--- a/modules/popup/react/lib/useFocusTrap.ts
+++ b/modules/popup/react/lib/useFocusTrap.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import tabTrappingKey from 'focus-trap-js';
+import tabTrappingKey from './focus-trap-js';
 
 export const useKeyDownListener = (onKeyDown: EventListenerOrEventListenerObject) => {
   // `useLayoutEffect` for automation

--- a/modules/popup/react/package.json
+++ b/modules/popup/react/package.json
@@ -54,7 +54,6 @@
     "@workday/canvas-kit-react-common": "^4.8.0",
     "@workday/canvas-kit-react-core": "^4.8.0",
     "@workday/canvas-system-icons-web": "1.0.41",
-    "focus-trap-js": "1.1.0",
     "uuid": "^3.3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #1097

The library code has been copied locally using the code from https://github.com/alexandrzavalii/focus-trap-js/pull/11

This is fine for v4, but will require some rework in v5. v5 introduces `useFocusRedirect` with similar logic. It makes sense to move code from the `focus-trap-js` library into the common module that can handle both focus trapping and focus redirecting.
