### PR TITLE
fix: Fix Checkbox width bug

### DIFF
--- a/modules/checkbox/react/lib/Checkbox.tsx
+++ b/modules/checkbox/react/lib/Checkbox.tsx
@@ -84,7 +84,7 @@ const CheckboxContainer = styled('div')({
 const CheckboxInputWrapper = styled('div')<Pick<CheckboxProps, 'disabled'>>({
   display: 'flex',
   height: checkboxHeight,
-  width: checkboxWidth,
+  minWidth: checkboxWidth,
   marginTop: '3px',
   alignSelf: 'flex-start',
 });


### PR DESCRIPTION
## Summary

Resolves #1134

When really long text was added as the checkbox label, the space between the box and the label overlapped. This PR fixes that.

## Screenshots 

### Before

![Screen Shot 2021-07-08 at 4 10 40 PM](https://user-images.githubusercontent.com/4818182/124997224-79ee8600-e007-11eb-9345-b9214a18a21d.png)

### After

![Screen Shot 2021-07-08 at 4 11 05 PM](https://user-images.githubusercontent.com/4818182/124997256-87a40b80-e007-11eb-8784-8aa8242afa7e.png)


## Checklist

- [ ] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [ ] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../modules/docs/mdx/API_PATTERN_GUIDELINES.mdx)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
