### PR TITLE
fix: Fix breadcrumbs spec deps

### DIFF
--- a/modules/_labs/breadcrumbs/react/spec/Breadcrumbs.spec.tsx
+++ b/modules/_labs/breadcrumbs/react/spec/Breadcrumbs.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {fireEvent, render, screen} from '@testing-library/react';
-import {Breadcrumbs} from '@workday/canvas-kit-labs-react-breadcrumbs';
+import {Breadcrumbs} from '../lib/Breadcrumbs';
 const context = describe;
 
 describe('Breadcrumbs', () => {


### PR DESCRIPTION
## Summary

There's a dependency issue in the `support/4.x` branch that our checkdep script caught.

```sh
@workday/canvas-kit-labs-react-breadcrumbs is missing from /home/runner/work/canvas-kit/canvas-kit/modules/_labs/breadcrumbs/react/package.json  check-dependencies-exist
```

 I'm not sure why it wasn't flagged in the initial PR, but here's a fix for it.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [ ] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../modules/docs/mdx/API_PATTERN_GUIDELINES.mdx)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
