### PR TITLE
ci: Use `support` dist tags for for support branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ stages:
 - name: trunk
   if: (branch = master OR branch =~ /^prerelease\//) AND type != pull_request
 
+- name: support
+  if: (branch =~ /^support\//) AND type != pull_request
+
 - name: tag
   if: branch =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND tag IS present
 
@@ -59,6 +62,14 @@ jobs:
         github_token: "$GH_STORYBOOK_TOKEN"
         on:
           branch: master
+
+  - stage: support
+    deploy:
+      - provider: script
+        script: npm config set //registry.npmjs.org/:_authToken=$NPM_PUBLISH_TOKEN && node utils/publish-canary.js
+        skip_cleanup: true
+        on:
+          all_branches: true
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,13 @@ stages:
   if: (branch = master OR branch =~ /^prerelease\//) AND type != pull_request
 
 - name: support
-  if: (branch =~ /^support\//) AND type != pull_request
+  if: branch =~ /^support\// AND type != pull_request
 
-- name: tag
-  if: branch =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND tag IS present
+- name: release
+  if: tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND tag IS present
+
+- name: support-release
+  if: branch =~ /^support\// AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND tag IS present
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.15.2
@@ -29,12 +32,22 @@ install:
 
 jobs:
   include:
-  - stage: tag
+  - stage: release
     script:
       - yarn build
     deploy:
       provider: script
       script: npm config set //registry.npmjs.org/:_authToken=$NPM_PUBLISH_TOKEN && yarn lerna publish from-package --yes --pre-dist-tag prerelease
+      skip_cleanup: true
+      on:
+        tags: true
+
+  - stage: support-release
+    script:
+      - yarn build
+    deploy:
+      provider: script
+      script: npm config set //registry.npmjs.org/:_authToken=$NPM_PUBLISH_TOKEN && yarn lerna publish from-package --yes --dist-tag support
       skip_cleanup: true
       on:
         tags: true

--- a/utils/publish-canary.js
+++ b/utils/publish-canary.js
@@ -14,6 +14,7 @@ const {
 } = process.env;
 
 const isPrerelease = TRAVIS_BRANCH.match(/^prerelease\/v\d*$/g);
+const isSupport = TRAVIS_BRANCH.match(/^support\/v\d*$/g);
 const data = {};
 
 let distTag;
@@ -23,8 +24,8 @@ if (TRAVIS_BRANCH === 'master') {
   distTag = 'next';
 } else if (isPrerelease) {
   distTag = 'prerelease-next';
-  console.error('Prerelease canary builds disabled.');
-  process.exit(0);
+} else if (isSupport) {
+  distTag = 'support-next';
 } else {
   console.error('No travis branch provided');
   process.exit(1);
@@ -44,7 +45,7 @@ const slackAnnouncement = attachment => {
         ],
       },
     },
-    (error) => {
+    error => {
       if (error) {
         throw error;
       }
@@ -91,10 +92,7 @@ exec('git diff --name-only HEAD HEAD^')
   .then(({stdout}) => {
     console.log(stdout);
 
-    const regex = new RegExp(
-      `@workday\\/[a-z-]*@(\\d*.\\d*.\\d*-${preid}.\\d*\\+\\w*)`,
-      'g'
-    );
+    const regex = new RegExp(`@workday\\/[a-z-]*@(\\d*.\\d*.\\d*-${preid}.\\d*\\+\\w*)`, 'g');
     data.packages = stdout.match(regex);
     data.version = regex.exec(data.packages[0])[1];
 


### PR DESCRIPTION
Closes #1119. 

- Adds support for canary builds on `support/v*` branches under the dist tag `support-next`.
- Adds a new release stage for support releases that uses the `support` dist tag so we don't temporarily take over `latest`