### PR TITLE
feat(common): Add HTML attribute interface to ExtractProps

### DIFF
--- a/modules/react/common/lib/utils/components.ts
+++ b/modules/react/common/lib/utils/components.ts
@@ -47,21 +47,65 @@ export type PropsWithAs<P, ElementType extends React.ElementType> = P &
   };
 
 /**
- * Extract props from any component that was created using `createComponent`.
+ * Extracts only the HTML attribute interface from `JSX.IntrinsicElements[E]`. This effectively removes `ref` and `key`
+ * without using `Omit` which makes the returned type more difficult to understand.
+ *
+ * For example:
+ * JSX.IntrinsicElements['button'] // React.ClassAttributes<HTMLButtonElement> & React.ButtonHTMLAttributes<HTMLButtonElement>
+ * ExtractHTMLAttributes<JSX.IntrinsicElements['button']> // React.HTMLButtonAttributes<HTMLButtonElement>
+ */
+type ExtractHTMLAttributes<
+  T extends React.DetailedHTMLProps<any, any>
+> = T extends React.DetailedHTMLProps<infer P, any> ? P : T;
+
+// Prettier messes up comments when `ts-ignore` is involved: https://github.com/prettier/prettier/issues/5411
+// prettier-ignore
+/**
+ * Extract props from any component that was created using `createComponent`. It will return the
+ * HTML attribute interface of the default element used with `createComponent`. If you use `as`, the
+ * HTML attribute interface can change, so you can use an override to the element you wish to use.
+ * You can also disable the HTML attribute by passing `never`:
+ *
+ * - `ExtractProps<typeof Card>`: `React.ClassAttributes<HTMLDivElement> &
+ *   React.HTMLAttributes<HTMLDivElement> & CardProps`
+ * - `ExtractProps<typeof Card, 'aside'>`: `React.ClassAttributes<HTMLElement> &
+ *   React.HTMLAttributes<HTMLElement> & CardProps`
+ * - `ExtractProps<typeof Card, never>`: `CardProps`
+ *
+ * @template TComponent The component you wish to extract props from. Needs 'typeof` in front:
+ * `typeof Card`
+ * @template TElement An optional override of the element that will be used. Define this if you use
+ * an `as` on the component
+ *
  * @example
  * interface MyProps extends ExtractProps<typeof Card.Body> {}
+ *
+ * ExtractProps<typeof Card>; // React.ClassAttributes<HTMLDivElement> & React.HTMLAttributes<HTMLDivElement> & CardProps
+ * ExtractProps<typeof Card, 'aside'>; // React.ClassAttributes<HTMLElement> & React.HTMLAttributes<HTMLElement> & CardProps
+ * ExtractProps<typeof Card, never>; // CardProps
  */
-export type ExtractProps<T> = T extends ElementComponent<any, infer P>
-  ? P
-  : T extends Component<infer P>
-  ? P
-  : {};
+export type ExtractProps<
+  TComponent,
+  TElement extends keyof JSX.IntrinsicElements | undefined | never = undefined
+> = TComponent extends ElementComponent<infer E, infer P> // test if `TComponent` is an `ElementComponent`, while inferring both default element and props associated
+  ? E extends keyof JSX.IntrinsicElements // test if the inferred element `E` is in JSX.IntrinsicElements
+    ? [TElement] extends [never] // test if user passed `never` for the `TElement` override. https://github.com/microsoft/TypeScript/issues/23182
+      ? P // if `TElement` was `never`, return only the inferred props `P`
+      : TElement extends undefined // else test if TElement was defined
+      ? ExtractHTMLAttributes<JSX.IntrinsicElements[E]> & P // `TElement` wasn't explicitly defined, so let's fall back to the inferred element's HTML attribute interface + props `P`
+      : // @ts-ignore TS thinks `TElement` cannot be an index type because of the `undefined`, but we've already ensured that can't happen, so we'll ignore that error
+        ExtractHTMLAttributes<JSX.IntrinsicElements[TElement]> & P // `TElement` was defined, so we'll return the HTML attribute interface + inferred `P` props
+    : P // E isn't in JSX.IntrinsicElements, we don't know what it is, so return the inferred props `P`
+  : TComponent extends Component<infer P> // test if `TComponent` is a `Component`, while inferring props `P`
+  ? P // it was a `Component`, return inferred props `P`
+  : {}; // `TComponent` does not extend either `ElementComponent` or `Component`, return an empty object
 
 /**
  * Component type that allows for `as` to change the element or component type.
  * Passing `as` will correctly change the allowed interface of the JSX element
  */
 export type ElementComponent<T extends React.ElementType, P> = {
+  __type: 'ElementComponent'; // used internally to distinguish between `ElementComponent` and `Component`
   <ElementType extends React.ElementType>(
     props: PropsWithAs<P, ElementType> & {
       /**
@@ -77,6 +121,7 @@ export type ElementComponent<T extends React.ElementType, P> = {
 };
 
 export type Component<P> = {
+  __type: 'Component'; // used internally to distinguish between `ElementComponent` and `Component`
   (props: P): JSX.Element;
   displayName?: string;
 };

--- a/modules/react/common/lib/utils/components.ts
+++ b/modules/react/common/lib/utils/components.ts
@@ -93,8 +93,9 @@ export type ExtractProps<
       ? P // if `TElement` was `never`, return only the inferred props `P`
       : TElement extends undefined // else test if TElement was defined
       ? ExtractHTMLAttributes<JSX.IntrinsicElements[E]> & P // `TElement` wasn't explicitly defined, so let's fall back to the inferred element's HTML attribute interface + props `P`
-      : // @ts-ignore TS thinks `TElement` cannot be an index type because of the `undefined`, but we've already ensured that can't happen, so we'll ignore that error
-        ExtractHTMLAttributes<JSX.IntrinsicElements[TElement]> & P // `TElement` was defined, so we'll return the HTML attribute interface + inferred `P` props
+      // TS thinks `TElement` cannot be an index type because of the `undefined`, but we've already ensured that can't happen, so we'll ignore that error
+      // @ts-ignore
+      : ExtractHTMLAttributes<JSX.IntrinsicElements[TElement]> & P // `TElement` was defined, so we'll return the HTML attribute interface + inferred `P` props
     : P // E isn't in JSX.IntrinsicElements, we don't know what it is, so return the inferred props `P`
   : TComponent extends Component<infer P> // test if `TComponent` is a `Component`, while inferring props `P`
   ? P // it was a `Component`, return inferred props `P`

--- a/modules/react/common/spec/components.test-d.tsx
+++ b/modules/react/common/spec/components.test-d.tsx
@@ -1,49 +1,82 @@
 import React from 'react';
 import {expectTypeOf} from 'expect-type';
 
-import {createComponent, ElementComponent} from '../lib/utils/components';
+import {createComponent, ElementComponent, ExtractProps} from '../lib/utils/components';
 
-it('should assign an element-base component as an ElementComponent', () => {
-  const component = createComponent('div')({Component: (props: {foo: 'bar'}) => null});
-  expectTypeOf(component).toEqualTypeOf<ElementComponent<'div', {foo: 'bar'}>>();
-});
-
-it('should add sub-components to the signature', () => {
-  const component = createComponent('div')({
-    Component: (props: {foo: 'bar'}) => null,
-    subComponents: {
-      Foo: 'bar',
-    },
+describe('createComponent', () => {
+  it('should assign an element-base component as an ElementComponent', () => {
+    const component = createComponent('div')({Component: (props: {foo: 'bar'}) => null});
+    expectTypeOf(component).toEqualTypeOf<ElementComponent<'div', {foo: 'bar'}>>();
   });
-  expectTypeOf(component).toEqualTypeOf<ElementComponent<'div', {foo: 'bar'}> & {Foo: string}>();
-});
 
-it('should assign ref and Element correctly for element components', () => {
-  createComponent('div')({
-    Component: (props: {}, ref, Element) => {
-      expectTypeOf(ref).toEqualTypeOf<React.Ref<HTMLDivElement>>();
-      expectTypeOf(Element).toEqualTypeOf<'div'>();
-      return null;
-    },
+  it('should add sub-components to the signature', () => {
+    const component = createComponent('div')({
+      Component: (props: {foo: 'bar'}) => null,
+      subComponents: {
+        Foo: 'bar',
+      },
+    });
+    expectTypeOf(component).toEqualTypeOf<ElementComponent<'div', {foo: 'bar'}> & {Foo: string}>();
+  });
+
+  it('should assign ref and Element correctly for element components', () => {
+    createComponent('div')({
+      Component: (props: {}, ref, Element) => {
+        expectTypeOf(ref).toEqualTypeOf<React.Ref<HTMLDivElement>>();
+        expectTypeOf(Element).toEqualTypeOf<'div'>();
+        return null;
+      },
+    });
+  });
+
+  it('should assign ref and Element correctly for createComponent components', () => {
+    const component = createComponent('article')({Component: (props: {}) => null});
+
+    createComponent(component)({
+      Component: (props: {}, ref, Element) => {
+        expectTypeOf(ref).toEqualTypeOf<React.Ref<HTMLElement>>();
+        expectTypeOf(Element).toEqualTypeOf<ElementComponent<'article', {}>>();
+        return null;
+      },
+    });
+  });
+
+  it('should allow a valid ref when wrapping components', () => {
+    const Component = createComponent('button')({Component: (props: {}) => null});
+    const ref: React.RefObject<HTMLButtonElement> = {current: null};
+
+    // No expectation, but the next line will fail if the ref signature isn't valid and it should be
+    return <Component ref={ref} />;
   });
 });
 
-it('should assign ref and Element correctly for createComponent components', () => {
-  const component = createComponent('article')({Component: (props: {}) => null});
-
-  createComponent(component)({
-    Component: (props: {}, ref, Element) => {
-      expectTypeOf(ref).toEqualTypeOf<React.Ref<HTMLElement>>();
-      expectTypeOf(Element).toEqualTypeOf<ElementComponent<'article', {}>>();
-      return null;
-    },
+describe('ExtractProps', () => {
+  interface Props {
+    foo: string;
+  }
+  const ElementComponent = createComponent('div')({
+    Component: (props: Props) => null,
   });
-});
 
-it('should allow a valid ref when wrapping components', () => {
-  const Component = createComponent('button')({Component: (props: {}) => null});
-  const ref: React.RefObject<HTMLButtonElement> = {current: null};
+  it('should return the props and HTMLDivElement interface when no element is provided on an `ElementComponent`', () => {
+    expectTypeOf<ExtractProps<typeof ElementComponent>>().toEqualTypeOf<
+      Props & React.HTMLAttributes<HTMLDivElement>
+    >();
+  });
 
-  // No expectation, but the next line will fail if the ref signature isn't valid and it should be
-  return <Component ref={ref} />;
+  it('should return the props and HTMLButtonElement when a `button` element is provided on an `ElementComponent`', () => {
+    expectTypeOf<ExtractProps<typeof ElementComponent, 'button'>>().toEqualTypeOf<
+      Props & React.ButtonHTMLAttributes<HTMLButtonElement>
+    >();
+  });
+
+  it('should return only the props when `never` is provided on an `ElementComponent', () => {
+    expectTypeOf<ExtractProps<typeof ElementComponent, never>>().toEqualTypeOf<Props>();
+  });
+
+  it('should return only props on a `Component`', () => {
+    const Component = createComponent()({Component: (props: Props) => null});
+
+    expectTypeOf<ExtractProps<typeof Component>>().toEqualTypeOf<Props>();
+  });
 });

--- a/modules/react/dialog/lib/DialogCard.tsx
+++ b/modules/react/dialog/lib/DialogCard.tsx
@@ -5,7 +5,7 @@ import {Popup, PopupModelContext} from '@workday/canvas-kit-react/popup';
 
 import {useDialogCard} from './hooks';
 
-export interface DialogPopupProps extends ExtractProps<typeof Popup.Popper> {}
+export interface DialogPopupProps extends ExtractProps<typeof Popup.Popper, never> {}
 
 export const DialogCard = createComponent('div')({
   displayName: 'Dialog.Card',

--- a/modules/react/dialog/lib/DialogPopper.tsx
+++ b/modules/react/dialog/lib/DialogPopper.tsx
@@ -5,7 +5,7 @@ import {Popup, PopupModelContext, usePopupPopper, Popper} from '@workday/canvas-
 
 import {useDialogPopper} from './hooks';
 
-export interface DialogPopupProps extends ExtractProps<typeof Popup.Popper> {}
+export interface DialogPopupProps extends ExtractProps<typeof Popup.Popper, never> {}
 
 export const DialogPopper = createComponent('div')({
   displayName: 'Dialog.Popper',

--- a/modules/react/modal/lib/Modal.tsx
+++ b/modules/react/modal/lib/Modal.tsx
@@ -7,7 +7,7 @@ import {ModalCard} from './ModalCard';
 import {useModalModel} from './hooks';
 import {ModalHeading} from './ModalHeading';
 
-export interface ModalProps extends ExtractProps<typeof Dialog> {}
+export interface ModalProps extends ExtractProps<typeof Dialog, never> {}
 
 export const Modal = createComponent()({
   displayName: 'Modal',

--- a/modules/react/modal/lib/ModalCard.tsx
+++ b/modules/react/modal/lib/ModalCard.tsx
@@ -5,7 +5,7 @@ import {Popup, PopupModelContext} from '@workday/canvas-kit-react/popup';
 
 import {useModalCard} from './hooks';
 
-export interface ModalCardProps extends ExtractProps<typeof Popup.Card> {}
+export interface ModalCardProps extends ExtractProps<typeof Popup.Card, never> {}
 
 export const ModalCard = createComponent('div')({
   displayName: 'Modal.Card',

--- a/modules/react/modal/lib/ModalHeading.tsx
+++ b/modules/react/modal/lib/ModalHeading.tsx
@@ -5,7 +5,7 @@ import {Popup, PopupModelContext} from '@workday/canvas-kit-react/popup';
 
 import {useModalHeading} from './hooks';
 
-export interface ModalHeadingProps extends ExtractProps<typeof Popup.Heading> {}
+export interface ModalHeadingProps extends ExtractProps<typeof Popup.Heading, never> {}
 
 export const ModalHeading = createComponent('h2')({
   displayName: 'Modal.Heading',

--- a/modules/react/popup/lib/PopupCard.tsx
+++ b/modules/react/popup/lib/PopupCard.tsx
@@ -16,7 +16,7 @@ import {
 import {getTransformFromPlacement} from './getTransformFromPlacement';
 import {usePopupCard, PopupModel, PopupModelContext} from './hooks';
 
-export interface PopupCardProps extends ExtractProps<typeof Card> {
+export interface PopupCardProps extends ExtractProps<typeof Card, never> {
   /**
    * Optionally pass a model directly to this component. Default is to implicitly use the same
    * model as the container component which uses React context. Only use this for advanced use-cases

--- a/modules/react/popup/lib/PopupCloseIcon.tsx
+++ b/modules/react/popup/lib/PopupCloseIcon.tsx
@@ -15,7 +15,7 @@ import {usePopupCloseButton, PopupModel, PopupModelContext} from './hooks';
 const closeIconSpacing = 11;
 const closeIconSpacingSmall = 9;
 
-export interface PopupCloseIconProps extends ExtractProps<typeof IconButton> {
+export interface PopupCloseIconProps extends ExtractProps<typeof IconButton, never> {
   /**
    * Optionally pass a model directly to this component. Default is to implicitly use the same
    * model as the container component which uses React context. Only use this for advanced use-cases
@@ -23,7 +23,7 @@ export interface PopupCloseIconProps extends ExtractProps<typeof IconButton> {
   model?: PopupModel;
 }
 
-const StyledCloseIcon = styled(IconButton)<StyledType & ExtractProps<typeof IconButton>>(
+const StyledCloseIcon = styled(IconButton)<StyledType & PopupCloseIconProps>(
   {
     position: 'absolute',
   },

--- a/modules/react/toast/lib/Toast.tsx
+++ b/modules/react/toast/lib/Toast.tsx
@@ -11,7 +11,7 @@ import {CanvasSystemIcon} from '@workday/design-assets-types';
 import {createComponent, ExtractProps} from '@workday/canvas-kit-react/common';
 import {Hyperlink, HyperlinkProps} from '@workday/canvas-kit-react/button';
 
-export interface ToastProps extends ExtractProps<typeof Popup.Card> {
+export interface ToastProps extends ExtractProps<typeof Popup.Card, never> {
   /**
    * The icon of the Toast.
    * @default checkIcon


### PR DESCRIPTION

Fixes #1145 

```tsx
ExtractProps<typeof Card>; // React.HTMLAttributes<HTMLDivElement> & CardProps
ExtractProps<typeof Card, 'aside'>; // React.HTMLAttributes<HTMLElement> & CardProps
ExtractProps<typeof Card, never>; // CardProps
```

Usage:
```tsx
import {ExtractProps} from '@workday/canvas-kit-react/common';
import {TextInput} from '@workday/canvas-kit-react/text-input';

export interface MyComponentProps extends ExtractProps<typeof TextInput> {
  myExtraProp: boolean
}

const MyComponent = ({ myExtraProp, ...props}: MyComponentProps) => {
  // do something with `myExtraProp`
  return <TextInput {...props} />
}
```