### PR TITLE
fix: ChangeFocus takes any input and Dialog/Modal accepts model config

### DIFF
--- a/modules/react/common/lib/utils/changeFocus.ts
+++ b/modules/react/common/lib/utils/changeFocus.ts
@@ -2,19 +2,23 @@
  * Programmatically change focus in a way that causes a focus ring around the new element.
  * @param element Element that should be focused
  */
-export const changeFocus = (element: HTMLElement | null) => {
+export const changeFocus = (element: unknown) => {
   // Normally the browser will ignore calls to `focus` on an element that already has focus, but we
   // don't want to accidentally show the focus ring in this case, so we'll detect and bail early.
   // We'll also bail if there is no element
   if (document.activeElement === element || !element) {
     return;
   }
-  // Dispatch an unidentified keyboard event for an input provider prior to a focus change so that
-  // the ring will appear.
-  if (typeof KeyboardEvent === 'function') {
-    const event = new KeyboardEvent('keydown', {bubbles: true, key: 'Unidentified'});
-    element.dispatchEvent(event);
-  }
 
-  element.focus();
+  if (element instanceof HTMLElement) {
+    // Dispatch an unidentified keyboard event for an input provider prior to a focus change so that
+    // the ring will appear.
+    if (typeof KeyboardEvent === 'function') {
+      const event = new KeyboardEvent('keydown', {bubbles: true, key: 'Unidentified'});
+
+      element.dispatchEvent(event);
+    }
+
+    element.focus();
+  }
 };

--- a/modules/react/dialog/lib/Dialog.tsx
+++ b/modules/react/dialog/lib/Dialog.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
 
 import {createComponent, useDefaultModel} from '@workday/canvas-kit-react/common';
-import {Popup, PopupModelContext, PopupModel} from '@workday/canvas-kit-react/popup';
+import {
+  Popup,
+  PopupModelContext,
+  PopupModel,
+  PopupModelConfig,
+} from '@workday/canvas-kit-react/popup';
 
 import {DialogPopper} from './DialogPopper';
 import {DialogCard} from './DialogCard';
 import {useDialogModel} from './hooks';
 
-export interface DialogProps {
+export interface DialogProps extends PopupModelConfig {
   /**
    * The contents of the Dialog. Can be `Dialog` children or any valid elements.
    */


### PR DESCRIPTION
- Update `changeFocus` to take any input and explicitly test for `HTMLElement`
- Update `Dialog` and `Modal` types to take optional model config.
