### PR TITLE
docs: Fixed broken link in pagination.stories.mdx

### DIFF
--- a/modules/react/pagination/stories/pagination.stories.mdx
+++ b/modules/react/pagination/stories/pagination.stories.mdx
@@ -563,7 +563,7 @@ need static child elements, this component will support it.
 > **Note:** The model and compound component pattern presented here will be updated and solidified
 > in v5 of canvas-kit. While the general concepts are the same, there will be some breaking changes
 > in v5. If you'd like to learn about models and compound components in v5, please refer to
-> [this doc](https://github.com/Workday/canvas-kit/blob/master/COMPOUND_COMPONENTS.mdx).
+> [this doc](https://github.com/Workday/canvas-kit/blob/master/modules/docs/mdx/COMPOUND_COMPONENTS.mdx).
 
 The `PaginationModel` is the core of the `Pagination` component. That said, if you're using the
 higher-level context API components and following the basic usage guidelines, you shouldn't need to


### PR DESCRIPTION
This commit fixes a broken link in the `pagination.stories.mdx` file.

## Summary

This commit fixes a broken link in the `pagination.stories.mdx` file.