### PR TITLE
fix: Add support for React 17 in main

### DIFF
--- a/modules/react/package.json
+++ b/modules/react/package.json
@@ -48,7 +48,7 @@
     "workday"
   ],
   "peerDependencies": {
-    "react": ">= 16.8 < 17"
+    "react": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",


### PR DESCRIPTION
## Summary

In 4.x we made a change (#974) to add support for React 17. Somehow, in the #992 Slash Imports PR, this [peer dependency regressed](https://github.com/Workday/canvas-kit/pull/992/files#diff-3be175031a0046a5ad6ec23a2bfdea7e7d8e996dc4e6846a8f8d885ddc4b0edeR46), and we missed it.

This PR fixes the main package to support React 17 again. I also validated the other packages are supporting React 17 as well.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [ ] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../modules/docs/mdx/API_PATTERN_GUIDELINES.mdx)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
