### PR TITLE
fix(popup): Fix RTL rendering for popups

### DIFF
--- a/modules/popup/react/lib/usePopupStack.ts
+++ b/modules/popup/react/lib/usePopupStack.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {PopupStack} from '@workday/canvas-kit-popup-stack';
+import {useIsRTL} from '@workday/canvas-kit-react-common';
 
 /**
  * This hook should not be used directly. Use the `Popper` component instead.
@@ -45,6 +46,7 @@ export const usePopupStack = <E extends HTMLElement>(
 ): React.RefObject<HTMLDivElement> => {
   const internalRef = React.useRef<HTMLDivElement>(null);
   const ref = (forwardRef || internalRef) as React.RefObject<HTMLDivElement>;
+  const isRTL = useIsRTL();
 
   // useState function input ensures we only create a container once.
   const [popupRef] = React.useState(() => {
@@ -72,6 +74,16 @@ export const usePopupStack = <E extends HTMLElement>(
       PopupStack.remove(element);
     };
   }, [ref, target, popupRef]);
+
+  // The direction will properly follow the theme via React context, but portals lose the `dir`
+  // hierarchy, so we'll add it back here.
+  React.useLayoutEffect(() => {
+    if (isRTL) {
+      ref.current?.setAttribute('dir', 'rtl');
+    } else {
+      ref.current?.removeAttribute('dir');
+    }
+  }, [ref, isRTL]);
 
   return ref;
 };

--- a/modules/popup/react/stories/stories_Popper_testing.tsx
+++ b/modules/popup/react/stories/stories_Popper_testing.tsx
@@ -3,6 +3,8 @@ import * as React from 'react';
 
 import {Button} from '@workday/canvas-kit-react-button';
 import {Popup, Popper, Placement} from '@workday/canvas-kit-react-popup';
+import {withSnapshotsEnabled} from '../../../../utils/storybook';
+import {CanvasProvider, ContentDirection} from '@workday/canvas-kit-react-common';
 
 export default {
   title: 'Testing/React/Popups/Popper',
@@ -53,3 +55,18 @@ export const UpdateOptions = () => {
     </>
   );
 };
+
+export const PopperRTL = withSnapshotsEnabled(() => (
+  <CanvasProvider theme={{canvas: {direction: ContentDirection.RTL}}}>
+    <Popper open={true}>
+      <Popup
+        transformOrigin={null}
+        heading="למחוק פריט"
+        width={300}
+        handleClose={() => console.log('close clicked')}
+      >
+        האם ברצונך למחוק פריט זה
+      </Popup>
+    </Popper>
+  </CanvasProvider>
+));


### PR DESCRIPTION
Fixes #1158
- Add `dir` to `usePopupStack` to automatically set direction for portalled popups

Before:
![bug: RTL Popup with LTR content](https://user-images.githubusercontent.com/338257/127037627-3dcbc0b3-df7e-42a9-a918-20e031f4a755.png)

After:
![fix: RTL Popup with RTL content](https://user-images.githubusercontent.com/338257/127037662-b36bff1e-5ccc-4037-b742-26aa1932a95e.png)
