### PR TITLE
feat(labs): Add convertToStaticStates to useThemeRTL

### DIFF
--- a/modules/labs-react/common/spec/useThemeRTL.spec.ts
+++ b/modules/labs-react/common/spec/useThemeRTL.spec.ts
@@ -1,18 +1,17 @@
-import {css} from '@emotion/core';
+import {css, CSSObject} from '@emotion/core';
 import {renderHook} from '@testing-library/react-hooks';
 import {useThemeRTL} from '../lib/theming';
 
 describe('styles', () => {
   describe(`useThemeRLT hook`, () => {
     const LTRTheme = {
-      canvas: {
-        direction: 'ltr',
-      },
+      direction: {direction: 'ltr'},
     };
     const RTLTheme = {
-      canvas: {
-        direction: 'rtl',
-      },
+      direction: {direction: 'rtl'},
+    };
+    const withStaticStates = {
+      _staticStates: true,
     };
     it('should return styles', () => {
       const expectedHeight = `100px`;
@@ -43,7 +42,7 @@ describe('styles', () => {
       beforeEach(() => {
         (window as any).workday = {
           canvas: {
-            theme: LTRTheme.canvas,
+            theme: LTRTheme.direction,
           },
         };
       });
@@ -57,13 +56,26 @@ describe('styles', () => {
         const cssProp = result.current.themeRTL(style);
         expect(cssProp.paddingLeft).toEqual(expectedPadding);
       });
+      it('should NOT convert static states when _staticStates is undefined', () => {
+        const expectedPadding = `10px`;
+        const style = {
+          '&:hover': {
+            paddingLeft: expectedPadding,
+          },
+        };
+
+        const {result} = renderHook(() => useThemeRTL());
+        const cssProp = result.current.themeRTL(style);
+
+        expect((cssProp['&:hover'] as CSSObject).paddingLeft).toEqual(expectedPadding);
+      });
     });
 
     describe('RTL', () => {
       beforeEach(() => {
         (window as any).workday = {
           canvas: {
-            theme: RTLTheme.canvas,
+            theme: RTLTheme.direction,
           },
         };
       });
@@ -87,6 +99,72 @@ describe('styles', () => {
         const {result} = renderHook(() => useThemeRTL());
         const cssProp = result.current.themeRTL(style);
         expect(cssProp.paddingRight).toEqual(expectedPadding);
+      });
+
+      it('should flip and NOT convert static states when _staticStates is undefined', () => {
+        const expectedPadding = `10px`;
+        const style = {
+          '&:hover': {
+            paddingLeft: expectedPadding,
+          },
+        };
+
+        const {result} = renderHook(() => useThemeRTL());
+        const cssProp = result.current.themeRTL(style);
+
+        expect((cssProp['&:hover'] as CSSObject).paddingRight).toEqual(expectedPadding);
+      });
+    });
+
+    describe('LTR Static States', () => {
+      beforeEach(() => {
+        (window as any).workday = {
+          canvas: {
+            theme: {
+              ...LTRTheme.direction,
+              ...withStaticStates,
+            },
+          },
+        };
+      });
+      it('should NOT flip but convert hover styles', () => {
+        const expectedPadding = `10px`;
+        const style = {
+          '&:hover': {
+            paddingLeft: expectedPadding,
+          },
+        };
+
+        const {result} = renderHook(() => useThemeRTL());
+        const cssProp = result.current.themeRTL(style);
+
+        expect((cssProp['&.hover'] as CSSObject).paddingLeft).toEqual(expectedPadding);
+      });
+    });
+
+    describe('RTL Static States', () => {
+      beforeEach(() => {
+        (window as any).workday = {
+          canvas: {
+            theme: {
+              ...RTLTheme.direction,
+              ...withStaticStates,
+            },
+          },
+        };
+      });
+      it('should flip and convert hover styles', () => {
+        const expectedPadding = `10px`;
+        const style = {
+          '&:hover': {
+            paddingLeft: expectedPadding,
+          },
+        };
+
+        const {result} = renderHook(() => useThemeRTL());
+        const cssProp = result.current.themeRTL(style);
+
+        expect((cssProp['&.hover'] as CSSObject).paddingRight).toEqual(expectedPadding);
       });
     });
   });

--- a/modules/react/common/lib/theming/styled.ts
+++ b/modules/react/common/lib/theming/styled.ts
@@ -1,32 +1,12 @@
 import {default as emotionStyled, CreateStyled, Interpolation, CSSObject} from '@emotion/styled';
 import {useTheme, EmotionCanvasTheme, ContentDirection} from './index';
 import rtlCSSJS from 'rtl-css-js';
+import {convertToStaticStates} from '../utils/StaticStates';
 
 const noop = (styles: any) => styles;
 
 // Pulled from https://github.com/emotion-js/emotion/blob/master/packages/styled-base/src/utils.js#L6 (not exported)
 type Interpolations = Array<any>;
-
-export const convertToStaticStates = (obj?: CSSObject): CSSObject | undefined => {
-  if (!obj) {
-    return obj;
-  }
-
-  return Object.keys(obj).reduce((result, key) => {
-    const newKey = key
-      .replace(/^:/, '&:') // handle shorthand like ":focus"
-      .replace(/,(\s+):/g, ',$1&:') // handle selectors like ":focus, :hover"
-      .replace(/:(focus|hover|active)/g, '.$1')
-      .replace(
-        /\[data\-whatinput=("|')?(mouse|touch|keyboard|pointer)("|')?]/g,
-        '[data-whatinput="noop"]'
-      );
-    const value =
-      typeof obj[key] === 'object' ? convertToStaticStates(obj[key] as CSSObject) : obj[key];
-    const newObj = {...result, [newKey]: value};
-    return newObj;
-  }, {});
-};
 
 function styled<Props>(node: any) {
   return (...args: Interpolation<Props>[]) => {

--- a/modules/react/common/lib/utils/StaticStates.tsx
+++ b/modules/react/common/lib/utils/StaticStates.tsx
@@ -5,6 +5,28 @@ import {
   EmotionCanvasTheme,
   PartialEmotionCanvasTheme,
 } from '@workday/canvas-kit-react/common';
+import {CSSProperties} from '@workday/canvas-kit-react/tokens';
+
+export const convertToStaticStates = (obj?: CSSProperties): CSSProperties | undefined => {
+  if (!obj) {
+    return obj;
+  }
+
+  return Object.keys(obj).reduce((result, key) => {
+    const newKey = key
+      .replace(/^:/, '&:') // handle shorthand like ":focus"
+      .replace(/,(\s+):/g, ',$1&:') // handle selectors like ":focus, :hover"
+      .replace(/:(focus|hover|active)/g, '.$1')
+      .replace(
+        /\[data\-whatinput=("|')?(mouse|touch|keyboard|pointer)("|')?]/g,
+        '[data-whatinput="noop"]'
+      );
+    const value =
+      typeof obj[key] === 'object' ? convertToStaticStates(obj[key] as CSSProperties) : obj[key];
+    const newObj = {...result, [newKey]: value};
+    return newObj;
+  }, {});
+};
 
 export const StaticStates: React.FC<{theme?: PartialEmotionCanvasTheme} & React.HTMLAttributes<
   HTMLElement

--- a/modules/react/common/spec/styled.spec.tsx
+++ b/modules/react/common/spec/styled.spec.tsx
@@ -1,4 +1,4 @@
-import {convertToStaticStates} from '../lib/theming/styled';
+import {convertToStaticStates} from '../lib/utils/StaticStates';
 
 describe('changeToStaticStates', () => {
   it('should convert ":hover" to "&.hover"', () => {


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

Resolves #1212.

Adds feature parity with styled by adding a maybeConvert function to useThemeRTL. Allows for the use of StaticStyle Tables when using css() instead of styled().

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] all (dev)dependencies that the module needs is added to its `package.json`
- [x] code has been documented and, if applicable, usage described in README.md
- [x] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ x design approved final implementation
- [x] a11y approved final implementation
- [x] code adheres to the [API & Pattern guidelines](../modules/docs/mdx/API_PATTERN_GUIDELINES.mdx)

