### PR TITLE
ci: Add Chromatic baseline to support branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,14 @@ jobs:
           branch: master
 
   - stage: support
+    script:
+      - >- # Chromatic relies on a built Storybook, so exit early if build-storybook fails
+        yarn build-storybook --quiet &&
+        yarn chromatic --quiet --auto-accept-changes --exit-once-uploaded --storybook-build-dir docs &&
+    after_failure:
+      - node utils/report-failure.js
+    env:
+      - CHROMATIC_APP_CODE="dlpro96xybh"
     deploy:
       - provider: script
         script: npm config set //registry.npmjs.org/:_authToken=$NPM_PUBLISH_TOKEN && node utils/publish-canary.js


### PR DESCRIPTION
This PR will enable automatic rebaselining in support branches. Without this change, every PR set to be merged to a support branch will have to re-accept the same changes in every PR after a visual change.