### PR TITLE
fix: Update toast to properly render rtl

### DIFF
--- a/modules/react/toast/lib/Toast.tsx
+++ b/modules/react/toast/lib/Toast.tsx
@@ -1,14 +1,13 @@
 /** @jsx jsx */
 import {jsx} from '@emotion/core';
 import * as React from 'react';
-import styled from '@emotion/styled';
 
 import {Popup} from '@workday/canvas-kit-react/popup';
 import {space, colors, type, CanvasColor} from '@workday/canvas-kit-react/tokens';
 import {SystemIcon} from '@workday/canvas-kit-react/icon';
 import {checkIcon} from '@workday/canvas-system-icons-web';
 import {CanvasSystemIcon} from '@workday/design-assets-types';
-import {createComponent, ExtractProps} from '@workday/canvas-kit-react/common';
+import {createComponent, ExtractProps, styled} from '@workday/canvas-kit-react/common';
 import {Hyperlink, HyperlinkProps} from '@workday/canvas-kit-react/button';
 
 export interface ToastProps extends ExtractProps<typeof Popup.Card, never> {

--- a/modules/react/toast/stories/examples/RTL.tsx
+++ b/modules/react/toast/stories/examples/RTL.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
-import Toast from '../../index';
-import {ContentDirection, StaticStates} from '../../../common';
+import {Toast} from '@workday/canvas-kit-react/toast';
+import {CanvasProvider, ContentDirection} from '@workday/canvas-kit-react/common';
 
 export const RTL = () => {
   const handleClose = () => {
     console.log('close button clicked');
   };
   return (
-    <StaticStates theme={{canvas: {direction: ContentDirection.RTL}}}>
+    <CanvasProvider theme={{canvas: {direction: ContentDirection.RTL}}}>
       <Toast onClose={handleClose}>Your workbook was successfully processed.</Toast>
-    </StaticStates>
+    </CanvasProvider>
   );
 };

--- a/modules/react/toast/stories/examples/RTL.tsx
+++ b/modules/react/toast/stories/examples/RTL.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import Toast from '../../index';
+import {ContentDirection, StaticStates} from '../../../common';
+
+export const RTL = () => {
+  const handleClose = () => {
+    console.log('close button clicked');
+  };
+  return (
+    <StaticStates theme={{canvas: {direction: ContentDirection.RTL}}}>
+      <Toast onClose={handleClose}>Your workbook was successfully processed.</Toast>
+    </StaticStates>
+  );
+};

--- a/modules/react/toast/stories/stories_visualTesting.tsx
+++ b/modules/react/toast/stories/stories_visualTesting.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import {colors} from '@workday/canvas-kit-react/tokens';
-import {StaticStates} from '@workday/canvas-kit-react/common';
+import {ContentDirection, StaticStates} from '@workday/canvas-kit-react/common';
 import {action} from '@storybook/addon-actions';
 import {exclamationCircleIcon} from '@workday/canvas-system-icons-web';
 import {Toast} from '@workday/canvas-kit-react/toast';
@@ -14,8 +14,8 @@ export default withSnapshotsEnabled({
   component: Toast,
 });
 
-export const ToastStates = () => (
-  <StaticStates>
+const ToastStates = ({direction = ContentDirection.LTR}) => (
+  <StaticStates theme={{canvas: {direction}}}>
     <ComponentStatesTable
       rowProps={[
         {label: 'Default', props: {}},
@@ -51,3 +51,21 @@ export const ToastStates = () => (
     </ComponentStatesTable>
   </StaticStates>
 );
+
+export const ToastStatesLeftToRight = () => {
+  return (
+    <>
+      <h2>Left-To-Right Toast</h2>
+      <ToastStates />
+    </>
+  );
+};
+
+export const ToastStatesRightToLeft = () => {
+  return (
+    <>
+      <h2>Right-To-Left Toast</h2>
+      <ToastStates direction={ContentDirection.RTL} />
+    </>
+  );
+};

--- a/modules/react/toast/stories/toast.stories.mdx
+++ b/modules/react/toast/stories/toast.stories.mdx
@@ -7,6 +7,7 @@ import {WithCloseButton} from './examples/WithCloseButton';
 import {WithActionLink} from './examples/WithActionLink';
 import {WithActionLinkAndCloseIcon} from './examples/WithActionLinkAndCloseIcon';
 import {WithPopper} from './examples/WithPopper';
+import {RTL} from './examples/RTL';
 
 <Meta title="Components/Popups/Toast/React" component={Toast} />
 
@@ -68,6 +69,12 @@ We use Popper to position Toast. Here's an example of how to use them together.
 #### With an Action Link and CloseIcon
 
 <ExampleCodeBlock code={WithActionLinkAndCloseIcon} />
+
+---
+
+#### With RTL
+
+<ExampleCodeBlock code={RTL} />
 
 ---
 


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using comments. -->

<!-- Make sure that you've linted your files, written and run unit tests, and filled out or updated documentation (README) -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Resolves #1225 

This PR fixes some margins when rendering the toast in RTL, see related issue [#1225](https://github.com/Workday/canvas-kit/issues/1225). The solution was to switch to the `styled` wrapper to take advantage of automatic rtl flipping.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] branch has been rebased on the latest master commit
- [x] tests are changed or added
- [x] `yarn test` passes
- [x] code has been documented and, if applicable, usage described in README.md
- [x] code adheres to the [API & Pattern guidelines](../modules/docs/mdx/API_PATTERN_GUIDELINES.mdx)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->

Before fix:
![Screen Shot 2021-08-17 at 10 45 27 AM](https://user-images.githubusercontent.com/9849619/129784077-017c6e60-71ee-47ed-9b7c-860f1c089c99.png)

After fix:
![Screen Shot 2021-08-17 at 10 46 53 AM](https://user-images.githubusercontent.com/9849619/129784096-49684354-5ea9-460f-a06f-9a5b79f1575d.png)
