### PR TITLE
feat(icon): Add shouldMirror prop to icons

### DIFF
--- a/modules/react/button/README.md
+++ b/modules/react/button/README.md
@@ -43,7 +43,7 @@ line-height, etc.).
 
 ---
 
-### `as: React.ElementType`
+#### `as: React.ElementType`
 
 > The alternative container type for the button. If `as="a"` is provided, We use Emotion's special
 > `as` prop to render an `a` tag instead of a `button`.
@@ -69,6 +69,7 @@ Default: `undefined`
 import * as React from 'react';
 import {ToolbarIconButton} from '@workday/canvas-kit-react/button';
 import {activityStreamIcon} from '@workday/canvas-system-icons-web';
+
 <ToolbarIconButton icon={activityStreamIcon} aria-label="Activity Stream" />;
 ```
 
@@ -114,9 +115,17 @@ Default: `undefined`
 
 ---
 
-### `icon: CanvasSystemIcon`
+#### `icon: CanvasSystemIcon`
 
 > The icon of the button. Optional because ToolbarIconButton can also wrap a SystemIcon component.
+
+---
+
+#### `shouldMirrorIcon: boolean`
+
+> If set to `true`, transform the SVG's x-axis to mirror the graphic
+
+Default: `false`
 
 ---
 
@@ -162,6 +171,14 @@ import {activityStreamIcon} from '@workday/canvas-system-icons-web';
 
 > The icon of the button. Optional because ToolbarDropdownButton can also wrap a SystemIcon
 > component.
+
+---
+
+#### `shouldMirrorIcon: boolean`
+
+> If set to `true`, transform the SVG's x-axis to mirror the graphic
+
+Default: `false`
 
 ---
 

--- a/modules/react/button/lib/IconButton.tsx
+++ b/modules/react/button/lib/IconButton.tsx
@@ -44,6 +44,11 @@ export interface IconButtonProps extends Themeable {
    */
   icon?: CanvasSystemIcon;
   /**
+   * If set to `true`, transform the icon's x-axis to mirror the graphic
+   * @default false
+   */
+  shouldMirrorIcon?: boolean;
+  /**
    * The function called when the IconButton toggled state changes.
    */
   onToggleChange?: (toggled: boolean | undefined) => void;
@@ -62,6 +67,7 @@ export const IconButton = createComponent('button')({
       size = 'medium',
       onToggleChange,
       icon,
+      shouldMirrorIcon = false,
       toggled,
       children,
       ...elemProps
@@ -108,7 +114,7 @@ export const IconButton = createComponent('button')({
         aria-pressed={toggled}
         {...elemProps}
       >
-        {icon ? <SystemIcon icon={icon} /> : children}
+        {icon ? <SystemIcon icon={icon} shouldMirror={shouldMirrorIcon} /> : children}
       </ButtonContainer>
     );
   },

--- a/modules/react/button/lib/PrimaryButton.tsx
+++ b/modules/react/button/lib/PrimaryButton.tsx
@@ -32,6 +32,11 @@ export interface PrimaryButtonProps extends Themeable, GrowthBehavior {
    * @default 'left'
    */
   iconPosition?: 'left' | 'right';
+  /**
+   * If set to `true`, transform the icon's x-axis to mirror the graphic
+   * @default false
+   */
+  shouldMirrorIcon?: boolean;
   children?: React.ReactNode;
 }
 
@@ -46,6 +51,7 @@ export const PrimaryButton = createComponent('button')({
       iconPosition = 'left',
       dataLabel,
       icon,
+      shouldMirrorIcon = false,
       children,
       ...elemProps
     }: PrimaryButtonProps,
@@ -60,12 +66,22 @@ export const PrimaryButton = createComponent('button')({
       {...elemProps}
     >
       {icon && size !== 'small' && iconPosition === 'left' && (
-        <ButtonLabelIcon size={size} iconPosition={iconPosition} icon={icon} />
+        <ButtonLabelIcon
+          size={size}
+          iconPosition={iconPosition}
+          icon={icon}
+          shouldMirrorIcon={shouldMirrorIcon}
+        />
       )}
       <ButtonLabel>{children}</ButtonLabel>
       {dataLabel && size !== 'small' && <ButtonLabelData>{dataLabel}</ButtonLabelData>}
       {icon && size !== 'small' && iconPosition === 'right' && (
-        <ButtonLabelIcon size={size} iconPosition={iconPosition} icon={icon} />
+        <ButtonLabelIcon
+          size={size}
+          iconPosition={iconPosition}
+          icon={icon}
+          shouldMirrorIcon={shouldMirrorIcon}
+        />
       )}
     </ButtonContainer>
   ),

--- a/modules/react/button/lib/SecondaryButton.tsx
+++ b/modules/react/button/lib/SecondaryButton.tsx
@@ -39,6 +39,11 @@ export interface SecondaryButtonProps extends Themeable, GrowthBehavior {
    * @default 'left'
    */
   iconPosition?: 'left' | 'right';
+  /**
+   * If set to `true`, transform the icon's x-axis to mirror the graphic
+   * @default false
+   */
+  shouldMirrorIcon?: boolean;
   children?: React.ReactNode;
 }
 
@@ -54,6 +59,7 @@ export const SecondaryButton = createComponent('button')({
       variant,
       dataLabel,
       icon,
+      shouldMirrorIcon = false,
       children,
       ...elemProps
     }: SecondaryButtonProps,
@@ -68,12 +74,22 @@ export const SecondaryButton = createComponent('button')({
       {...elemProps}
     >
       {icon && size !== 'small' && iconPosition === 'left' && (
-        <ButtonLabelIcon size={size} iconPosition={iconPosition} icon={icon} />
+        <ButtonLabelIcon
+          size={size}
+          iconPosition={iconPosition}
+          icon={icon}
+          shouldMirrorIcon={shouldMirrorIcon}
+        />
       )}
       <ButtonLabel>{children}</ButtonLabel>
       {dataLabel && size !== 'small' && <ButtonLabelData>{dataLabel}</ButtonLabelData>}
       {icon && size !== 'small' && iconPosition === 'right' && (
-        <ButtonLabelIcon size={size} iconPosition={iconPosition} icon={icon} />
+        <ButtonLabelIcon
+          size={size}
+          iconPosition={iconPosition}
+          icon={icon}
+          shouldMirrorIcon={shouldMirrorIcon}
+        />
       )}
     </ButtonContainer>
   ),

--- a/modules/react/button/lib/TertiaryButton.tsx
+++ b/modules/react/button/lib/TertiaryButton.tsx
@@ -35,6 +35,11 @@ export interface TertiaryButtonProps extends Themeable {
   /**
    * The capitalization of the text in the button.
    */
+  /**
+   * If set to `true`, transform the icon's x-axis to mirror the graphic
+   * @default false
+   */
+  shouldMirrorIcon?: boolean;
   allCaps?: boolean;
   children?: React.ReactNode;
 }
@@ -143,6 +148,7 @@ export const TertiaryButton = createComponent('button')({
       variant,
       children,
       icon,
+      shouldMirrorIcon = false,
       allCaps,
       ...elemProps
     }: TertiaryButtonProps,
@@ -173,11 +179,21 @@ export const TertiaryButton = createComponent('button')({
         {...elemProps}
       >
         {icon && iconPosition === 'left' && (
-          <ButtonLabelIcon size={size} iconPosition={iconPosition} icon={icon} />
+          <ButtonLabelIcon
+            size={size}
+            iconPosition={iconPosition}
+            icon={icon}
+            shouldMirrorIcon={shouldMirrorIcon}
+          />
         )}
         <ButtonLabel className="wdc-text-button-label">{children}</ButtonLabel>
         {icon && iconPosition === 'right' && (
-          <ButtonLabelIcon size={size} iconPosition={iconPosition} icon={icon} />
+          <ButtonLabelIcon
+            size={size}
+            iconPosition={iconPosition}
+            icon={icon}
+            shouldMirrorIcon={shouldMirrorIcon}
+          />
         )}
       </ButtonContainer>
     );

--- a/modules/react/button/lib/ToolbarDropdownButton.tsx
+++ b/modules/react/button/lib/ToolbarDropdownButton.tsx
@@ -48,6 +48,7 @@ export const ToolbarDropdownButton = createComponent('button')({
       // eslint-disable-next-line react-hooks/rules-of-hooks
       theme = useTheme(),
       icon,
+      shouldMirrorIcon = false,
       children,
       ...elemProps
     }: ToolbarDropdownButtonProps,
@@ -63,11 +64,19 @@ export const ToolbarDropdownButton = createComponent('button')({
         {...elemProps}
       >
         {icon ? (
-          <SystemIcon className={'wdc-toolbar-dropdown-btn-custom-icon'} icon={icon} />
+          <SystemIcon
+            className={'wdc-toolbar-dropdown-btn-custom-icon'}
+            icon={icon}
+            shouldMirror={shouldMirrorIcon}
+          />
         ) : (
           children
         )}
-        <SystemIcon className={'wdc-toolbar-dropdown-btn-arrow'} icon={chevronDownSmallIcon} />
+        <SystemIcon
+          className={'wdc-toolbar-dropdown-btn-arrow'}
+          icon={chevronDownSmallIcon}
+          shouldMirror={shouldMirrorIcon}
+        />
       </ButtonContainer>
     );
   },

--- a/modules/react/button/lib/ToolbarIconButton.tsx
+++ b/modules/react/button/lib/ToolbarIconButton.tsx
@@ -39,6 +39,7 @@ export const ToolbarIconButton = createComponent('button')({
       theme = useTheme(),
       onToggleChange,
       icon,
+      shouldMirrorIcon = false,
       toggled,
       children,
       ...elemProps
@@ -70,7 +71,7 @@ export const ToolbarIconButton = createComponent('button')({
         aria-pressed={toggled}
         {...elemProps}
       >
-        {icon ? <SystemIcon icon={icon} /> : children}
+        {icon ? <SystemIcon icon={icon} shouldMirror={shouldMirrorIcon} /> : children}
       </ButtonContainer>
     );
   },

--- a/modules/react/button/lib/parts/ButtonLabelIcon.tsx
+++ b/modules/react/button/lib/parts/ButtonLabelIcon.tsx
@@ -21,6 +21,11 @@ export interface ButtonLabelIconProps {
    * @default 'left'
    */
   iconPosition?: 'left' | 'right';
+  /**
+   * If set to `true`, transform the icon's x-axis to mirror the graphic
+   * @default false
+   */
+  shouldMirrorIcon?: boolean;
 }
 
 const ICON_SIZE = 24;
@@ -42,7 +47,13 @@ const ButtonLabelIconStyled = styled('span', {
   })
 );
 
-export const ButtonLabelIcon = ({icon, size, iconPosition, ...elemProps}: ButtonLabelIconProps) => {
+export const ButtonLabelIcon = ({
+  icon,
+  size,
+  iconPosition,
+  shouldMirrorIcon = false,
+  ...elemProps
+}: ButtonLabelIconProps) => {
   /* istanbul ignore next line for coverage */
   if (icon === undefined) {
     return null;
@@ -52,7 +63,7 @@ export const ButtonLabelIcon = ({icon, size, iconPosition, ...elemProps}: Button
 
   return (
     <ButtonLabelIconStyled iconPosition={iconPosition} size={size} {...elemProps}>
-      <SystemIcon size={iconSize} icon={icon} />
+      <SystemIcon size={iconSize} icon={icon} shouldMirror={shouldMirrorIcon} />
     </ButtonLabelIconStyled>
   );
 };

--- a/modules/react/button/stories/icon-button/IconButton.stories.mdx
+++ b/modules/react/button/stories/icon-button/IconButton.stories.mdx
@@ -7,6 +7,7 @@ import {Circle} from './examples/Circle';
 import {CircleFilled} from './examples/CircleFilled';
 import {Inverse} from './examples/Inverse';
 import {InverseFilled} from './examples/InverseFilled';
+import {MirroredIcon} from './examples/MirroredIcon';
 import {Plain} from './examples/Plain';
 import {Square} from './examples/Square';
 import {SquareFilled} from './examples/SquareFilled';
@@ -78,6 +79,19 @@ InverseFilled Icon Buttons are a higher emphasis version of Inverse, and should 
 backgrounds.
 
 <ExampleCodeBlock code={InverseFilled} />
+
+### Mirroring Icons
+
+Sometimes icons should be mirrored for bidirectional support. Setting the `shouldMirrorIcon` prop to
+`true` will transform the icon's x-axis to mirror the graphic. This is often useful when there is no
+equivalent mirrored icon available. Below is an example of the `unorderedListIcon` being rendered in
+its default state with an icon showing a left-to-right bulleted list. Beside it is the same icon
+that has been mirrored to show a right-to-left bulleted list.
+
+Note that while the `aria-label` text in this example did not need to be updated, if the label
+contains directional descriptors such as "right" and "left," the text should also be updated.
+
+<ExampleCodeBlock code={MirroredIcon} />
 
 ### Toggleability
 

--- a/modules/react/button/stories/icon-button/examples/MirroredIcon.tsx
+++ b/modules/react/button/stories/icon-button/examples/MirroredIcon.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import {IconButton} from '@workday/canvas-kit-react/button';
+import {unorderedListIcon} from '@workday/canvas-system-icons-web';
+
+export const MirroredIcon = () => (
+  <>
+    <IconButton icon={unorderedListIcon} aria-label="create a bulleted list" />
+    <IconButton icon={unorderedListIcon} aria-label="create a bulleted list" shouldMirrorIcon />
+  </>
+);

--- a/modules/react/button/stories/visual-testing/stories_IconButton.tsx
+++ b/modules/react/button/stories/visual-testing/stories_IconButton.tsx
@@ -14,6 +14,11 @@ export default withSnapshotsEnabled({
   component: IconButton,
 });
 
+const columnProps = [
+  ...stateTableColumnProps,
+  {label: 'Mirrored Icon ', props: {shouldMirrorIcon: true, disabled: false}},
+];
+
 export const IconButtonStates = (props: {theme?: PartialEmotionCanvasTheme}) => (
   <React.Fragment>
     {[false, true].map(toggled => (
@@ -32,7 +37,7 @@ export const IconButtonStates = (props: {theme?: PartialEmotionCanvasTheme}) => 
                 {value: 'squareFilled', label: 'Square Filled'},
               ],
             })}
-            columnProps={stateTableColumnProps}
+            columnProps={columnProps}
           >
             {props => (
               <Container blue={['inverse', 'inverseFilled'].includes(props.variant)}>

--- a/modules/react/button/stories/visual-testing/stories_ToolbarDropdownButton.tsx
+++ b/modules/react/button/stories/visual-testing/stories_ToolbarDropdownButton.tsx
@@ -14,15 +14,17 @@ export default withSnapshotsEnabled({
   component: ToolbarDropdownButton,
 });
 
+const columnProps = [
+  ...stateTableColumnProps,
+  {label: 'Mirrored Icon ', props: {shouldMirrorIcon: true, disabled: false}},
+];
+
 export const ToolbarDropdownButtonStates = (props: {theme?: PartialEmotionCanvasTheme}) => (
   <React.Fragment>
     <div>
       <h3>Default</h3>
       <StaticStates theme={props.theme}>
-        <ComponentStatesTable
-          rowProps={[{label: 'Default', props: {}}]}
-          columnProps={stateTableColumnProps}
-        >
+        <ComponentStatesTable rowProps={[{label: 'Default', props: {}}]} columnProps={columnProps}>
           {props => (
             <Container>
               <ToolbarDropdownButton

--- a/modules/react/button/stories/visual-testing/stories_ToolbarIconButton.tsx
+++ b/modules/react/button/stories/visual-testing/stories_ToolbarIconButton.tsx
@@ -14,6 +14,11 @@ export default withSnapshotsEnabled({
   component: ToolbarIconButton,
 });
 
+const columnProps = [
+  ...stateTableColumnProps,
+  {label: 'Mirrored Icon ', props: {shouldMirrorIcon: true, disabled: false}},
+];
+
 export const ToolbarIconButtonStates = (props: {theme?: PartialEmotionCanvasTheme}) => (
   <StaticStates theme={props.theme}>
     <ComponentStatesTable
@@ -21,7 +26,7 @@ export const ToolbarIconButtonStates = (props: {theme?: PartialEmotionCanvasThem
         {label: 'Toggled Off', props: {toggled: false}},
         {label: 'Toggled On', props: {toggled: true}},
       ]}
-      columnProps={stateTableColumnProps}
+      columnProps={columnProps}
     >
       {(props: any) => (
         <Container>

--- a/modules/react/button/stories/visual-testing/utils.tsx
+++ b/modules/react/button/stories/visual-testing/utils.tsx
@@ -31,7 +31,6 @@ export const stateTableColumnProps = [
   {label: 'Focus Hover ', props: {className: 'focus hover', disabled: false}},
   {label: 'Active ', props: {className: 'active', disabled: false}},
   {label: 'Active Hover ', props: {className: 'active hover', disabled: false}},
-  {label: 'Mirrored Icon ', props: {shouldMirrorIcon: true, disabled: false}},
 ];
 
 const isInverseVariant = (variant: IconButtonProps['variant']) => {

--- a/modules/react/button/stories/visual-testing/utils.tsx
+++ b/modules/react/button/stories/visual-testing/utils.tsx
@@ -31,6 +31,7 @@ export const stateTableColumnProps = [
   {label: 'Focus Hover ', props: {className: 'focus hover', disabled: false}},
   {label: 'Active ', props: {className: 'active', disabled: false}},
   {label: 'Active Hover ', props: {className: 'active hover', disabled: false}},
+  {label: 'Mirrored Icon ', props: {shouldMirrorIcon: true, disabled: false}},
 ];
 
 const isInverseVariant = (variant: IconButtonProps['variant']) => {

--- a/modules/react/icon/README.md
+++ b/modules/react/icon/README.md
@@ -34,9 +34,14 @@ import { colors } from '@workday/canvas-kit-react/tokens'
 import { AccentIcon } from '@workday/canvas-kit-react/icon'
 import { shieldIcon } from '@workday/canvas-accent-icons-web'
 
+// Default Accent Icon
 <AccentIcon icon={shieldIcon} />
+// Accent Icon with custom color
 <AccentIcon icon={shieldIcon} color={colors.pomegranate500} />
+// Accent Icon with set size
 <AccentIcon icon={shieldIcon} size={80} />
+// Accent Icon with a mirrored x-axis (helpful for bidirectional support, if needed)
+<AccentIcon icon={shieldIcon} shouldMirror={true} />
 ```
 
 ## Static Properties
@@ -83,6 +88,14 @@ Default: `false`
 
 ---
 
+#### `shouldMirror: boolean`
+
+> If set to `true`, transform the SVG's x-axis to mirror the graphic
+
+Default: `false`
+
+---
+
 # Applet Icons
 
 ## Usage
@@ -93,9 +106,14 @@ Use with `@workday/canvas-applet-icons-web`.
 import { AppletIcon } from '@workday/canvas-kit-react/icon'
 import { benefitsIcon } from '@workday/canvas-applet-icons-web'
 
+// Default Applet Icon
 <AppletIcon icon={benefitsIcon} />
+// Applet Icon with custom color
 <AppletIcon icon={benefitsIcon} color={AppletIcon.Colors.Pomegranate} />
+// Applet Icon with set size
 <AppletIcon icon={benefitsIcon} size={60} />
+// Applet Icon with a mirrored x-axis (helpful for bidirectional support, if needed)
+<AppletIcon icon={benefitsIcon} shouldMirror={true} />
 ```
 
 ## Static Properties
@@ -162,6 +180,14 @@ Default: `92`
 #### `iconRef: React.Ref<HTMLSpanElement>`
 
 > Returns the ref to the rendered icon.
+
+---
+
+#### `shouldMirror: boolean`
+
+> If set to `true`, transform the SVG's x-axis to mirror the graphic
+
+Default: `false`
 
 ---
 
@@ -272,6 +298,14 @@ Default: `'transparent'`
 
 ---
 
+#### `shouldMirror: boolean`
+
+> If set to `true`, transform the SVG's x-axis to mirror the graphic
+
+Default: `false`
+
+---
+
 # System Icon Circle
 
 A system icon with a colored circular background. Icon color will be determined based on contrast
@@ -286,8 +320,12 @@ import { colors } from '@workday/canvas-kit-react/tokens'
 import { SystemIconCircle } from '@workday/canvas-kit-react/icon'
 import { shieldIcon } from '@workday/canvas-accent-icons-web'
 
+// Default System Icon Circle
 <SystemIconCircle icon={shieldIcon} />
+// System Icon Circle with bockground color
 <SystemIconCircle icon={shieldIcon} background={colors.pomegranate500} />
+// System Icon Circle  with a mirrored x-axis (helpful for bidirectional support, if needed)
+<SystemIconCircle icon={shieldIcon} shouldMirror={true} />
 ```
 
 ## Static Properties
@@ -326,6 +364,14 @@ Default: `SystemIconCircleSize.l` (`40`)
 
 ---
 
+#### `shouldMirror: boolean`
+
+> If set to `true`, transform the SVG's x-axis to mirror the graphic
+
+Default: `false`
+
+---
+
 # Graphics
 
 ## Usage
@@ -337,10 +383,16 @@ import { colors } from '@workday/canvas-kit-react/tokens'
 import { Graphic } from '@workday/canvas-kit-react/icon'
 import { badgeAchievementGraphic } from '@workday/canvas-graphics-web'
 
+// Default graphic
 <Graphic src={badgeAchievementGraphic} />
+// Graphic with a set width of 80px
 <Graphic src={badgeAchievementGraphic} width={80}/>
+// Graphic with a set height of 80px
 <Graphic src={badgeAchievementGraphic} height={80}/>
+// Graphic with growth behavior to fit its container
 <Graphic src={badgeAchievementGraphic} grow={true} />
+// Graphic with a mirrored x-axis (helpful for bidirectional support, if needed)
+<Graphic src={badgeAchievementGraphic} shouldMirror={true} />
 ```
 
 ## Static Properties
@@ -394,5 +446,13 @@ Default: `false`
 #### `iconRef: React.Ref<HTMLSpanElement>`
 
 > Returns the ref to the rendered icon.
+
+---
+
+#### `shouldMirror: boolean`
+
+> If set to `true`, transform the SVG's x-axis to mirror the graphic
+
+Default: `false`
 
 ---

--- a/modules/react/icon/lib/AccentIcon.tsx
+++ b/modules/react/icon/lib/AccentIcon.tsx
@@ -43,7 +43,15 @@ export const accentIconStyles = ({
 
 export default class AccentIcon extends React.Component<AccentIconProps> {
   render() {
-    const {transparent = false, size = 56, icon, color, iconRef, ...elemProps} = this.props;
+    const {
+      transparent = false,
+      size = 56,
+      icon,
+      color,
+      iconRef,
+      shouldMirror,
+      ...elemProps
+    } = this.props;
 
     return (
       <Icon
@@ -52,6 +60,7 @@ export default class AccentIcon extends React.Component<AccentIconProps> {
         styles={accentIconStyles({color, transparent})}
         size={size}
         iconRef={iconRef}
+        shouldMirror={shouldMirror}
         {...elemProps}
       />
     );

--- a/modules/react/icon/lib/AppletIcon.tsx
+++ b/modules/react/icon/lib/AppletIcon.tsx
@@ -54,7 +54,9 @@ export const appletIconStyles = ({
   };
 };
 
-export interface AppletIconProps extends AppletIconStyles, Pick<IconProps, 'iconRef'> {
+export interface AppletIconProps
+  extends AppletIconStyles,
+    Pick<IconProps, 'iconRef' | 'shouldMirror'> {
   /**
    * The icon to display from `@workday/canvas-applet-icons-web`.
    */
@@ -70,7 +72,7 @@ export default class AppletIcon extends React.Component<AppletIconProps> {
   public static Colors = BrandingColor;
 
   public render() {
-    const {size = 92, icon, color, iconRef, ...elemProps} = this.props;
+    const {size = 92, icon, color, iconRef, shouldMirror, ...elemProps} = this.props;
 
     return (
       <Icon
@@ -79,6 +81,7 @@ export default class AppletIcon extends React.Component<AppletIconProps> {
         styles={appletIconStyles({color})}
         size={size}
         iconRef={iconRef}
+        shouldMirror={shouldMirror}
         {...elemProps}
       />
     );

--- a/modules/react/icon/lib/Graphic.tsx
+++ b/modules/react/icon/lib/Graphic.tsx
@@ -21,7 +21,7 @@ export interface GraphicStyles {
   grow?: boolean;
 }
 
-export interface GraphicProps extends GraphicStyles, Pick<SvgProps, 'iconRef'> {
+export interface GraphicProps extends GraphicStyles, Pick<SvgProps, 'iconRef' | 'shouldMirror'> {
   /**
    * The graphic to display from `@workday/canvas-graphics-web`.
    */
@@ -60,7 +60,7 @@ export const graphicStyles = ({width, height, grow}: GraphicStyles): CSSObject =
 
 export default class Graphic extends React.Component<GraphicProps> {
   render() {
-    const {grow = false, src, width, height, iconRef, ...elemProps} = this.props;
+    const {grow = false, src, width, height, iconRef, shouldMirror, ...elemProps} = this.props;
 
     return (
       <Svg
@@ -68,6 +68,7 @@ export default class Graphic extends React.Component<GraphicProps> {
         styles={graphicStyles({width, height, grow})}
         type={CanvasIconTypes.Graphic}
         iconRef={iconRef}
+        shouldMirror={shouldMirror}
         {...elemProps}
       />
     );

--- a/modules/react/icon/lib/Icon.tsx
+++ b/modules/react/icon/lib/Icon.tsx
@@ -12,7 +12,7 @@ export interface IconProps extends SvgProps {
 
 export default class Icon extends React.Component<IconProps> {
   public render() {
-    const {src, size, styles, type, iconRef, ...elemProps} = this.props;
+    const {src, size, styles, type, iconRef, shouldMirror, ...elemProps} = this.props;
 
     const iconStyles: CSSObject = {...styles};
 
@@ -23,6 +23,15 @@ export default class Icon extends React.Component<IconProps> {
       };
     }
 
-    return <Svg src={src} type={type} {...elemProps} styles={iconStyles} iconRef={iconRef} />;
+    return (
+      <Svg
+        src={src}
+        type={type}
+        shouldMirror={shouldMirror}
+        {...elemProps}
+        styles={iconStyles}
+        iconRef={iconRef}
+      />
+    );
   }
 }

--- a/modules/react/icon/lib/Svg.tsx
+++ b/modules/react/icon/lib/Svg.tsx
@@ -9,11 +9,16 @@ export interface SvgProps extends React.HTMLAttributes<HTMLSpanElement> {
   styles?: CSSObject;
   type: CanvasIconTypes;
   iconRef?: React.Ref<HTMLSpanElement>;
+  /**
+   * If set to `true`, transform the SVG's x-axis to mirror the graphic
+   * @default false
+   */
+  shouldMirror?: boolean;
 }
 
 export default class Svg extends React.Component<SvgProps> {
   public render() {
-    const {src, styles, type, iconRef, ...elemProps} = this.props;
+    const {src, styles, type, iconRef, shouldMirror, ...elemProps} = this.props;
 
     // Validation for JS
     try {
@@ -35,6 +40,7 @@ export default class Svg extends React.Component<SvgProps> {
               css(styles, {
                 display: 'inline-block',
                 '& svg': {display: 'block'},
+                transform: shouldMirror ? 'scaleX(-1)' : undefined,
               }),
               elemProps.className
             )}

--- a/modules/react/icon/lib/SystemIcon.tsx
+++ b/modules/react/icon/lib/SystemIcon.tsx
@@ -98,6 +98,7 @@ export default class SystemIcon extends React.Component<SystemIconProps> {
       fill,
       fillHover,
       size,
+      shouldMirror,
       ...elemProps
     } = this.props;
 
@@ -119,6 +120,7 @@ export default class SystemIcon extends React.Component<SystemIconProps> {
         size={size}
         styles={style}
         iconRef={iconRef}
+        shouldMirror={shouldMirror}
         {...elemProps}
       />
     );

--- a/modules/react/icon/lib/SystemIconCircle.tsx
+++ b/modules/react/icon/lib/SystemIconCircle.tsx
@@ -15,7 +15,7 @@ export enum SystemIconCircleSize {
   xxl = 120,
 }
 
-export interface SystemIconCircleProps extends Pick<SystemIconProps, 'iconRef'> {
+export interface SystemIconCircleProps extends Pick<SystemIconProps, 'iconRef' | 'shouldMirror'> {
   /**
    * The background color of the SystemIconCircle from `@workday/canvas-colors-web`.
    * @default colors.soap300
@@ -67,6 +67,7 @@ export default class SystemIconCircle extends React.Component<SystemIconCirclePr
       size = SystemIconCircleSize.l,
       icon,
       iconRef,
+      shouldMirror,
       ...elemProps
     } = this.props;
 
@@ -81,6 +82,7 @@ export default class SystemIconCircle extends React.Component<SystemIconCirclePr
           colorHover={iconColor}
           size={iconSize}
           iconRef={iconRef}
+          shouldMirror={shouldMirror}
         />
       </Container>
     );

--- a/modules/react/icon/stories/stories.tsx
+++ b/modules/react/icon/stories/stories.tsx
@@ -39,6 +39,7 @@ storiesOf('Tokens/Icon/React', module)
       </span>
       <br />
       <AccentIcon icon={shieldIcon} size={80} />
+      <AccentIcon icon={shieldIcon} size={80} shouldMirror={true} />
     </div>
   ));
 
@@ -50,6 +51,7 @@ storiesOf('Tokens/Icon/React', module)
       <AppletIcon icon={benefitsIcon} color={AppletIcon.Colors.Pomegranate} />
       <br />
       <AppletIcon icon={benefitsIcon} size={60} />
+      <AppletIcon icon={benefitsIcon} size={60} shouldMirror={true} />
     </div>
   ));
 
@@ -87,7 +89,13 @@ storiesOf('Tokens/Icon/React', module)
       <br />
       <SystemIcon icon={activityStreamIcon} size={48} />
       <SystemIconCircle icon={activityStreamIcon} />
+      <SystemIconCircle icon={activityStreamIcon} shouldMirror={true} />
       <SystemIconCircle icon={activityStreamIcon} background={colors.blueberry400} />
+      <SystemIconCircle
+        icon={activityStreamIcon}
+        background={colors.blueberry400}
+        shouldMirror={true}
+      />
     </div>
   ));
 
@@ -100,6 +108,9 @@ storiesOf('Tokens/Icon/React', module)
       <Graphic src={graphicExample} width={80} />
       <div style={{width: 100}}>
         <Graphic src={graphicExample} grow={true} />
+      </div>
+      <div style={{width: 100}}>
+        <Graphic src={graphicExample} grow={true} shouldMirror={true} />
       </div>
     </div>
   ));


### PR DESCRIPTION
Co-authored-by: Stefan Urosevic <stefanuros@gmail.com>
Co-authored-by: Alan B Smith <a.bax.smith@gmail.com>

## Issue

Resolves #751

## Overview

This PR updates @stefanuros' original PR (#949) to Canvas Kit v5. There were a lot of file changes with buttons, and this was the more simple route to resolve the conflicts. It also makes some minor alterations to the original PR.

- `mirror` and `mirrorIcon` prop names have been updated to `shouldMirror` and `shouldMirrorIcon` respectively
- tests and docs have been updated to reflect this change as well
- small doc tweaks were added


## Where Should the Reviewer Start?

`modules/react/icon/lib/Svg.tsx`

This PR touches quite a few components. I would personally start at the root with `Svg`. Below is a tree view of how these components are related. Each nested component consumes the components higher in the hierarchy.

```
├ Svg
├── Graphic
├── Icon
│   ├── AccentIcon
│   ├── AppletIcon
│   ├── SystemIcon
│   │   ├── DeleteButton
│   │   ├── IconButton
│   │   ├── PrimaryButton
│   │   ├── SecondaryButton
│   │   ├── TertiaryButton
│   │   ├── ToolbarIconButton
│   │   │   └── ToolbarIDropdownButton
│   │   └── SystemIconCircle
```

## Testing Manually

These changes are all visual, so the best way to test is by looking at the rendered output.

I would look at the following Storybook paths:

- `?path=/docs/components-buttons-button-react-icon-button--mirrored-icon`
- `?path=/docs/tokens-icon-react--accent-icon`
-  `?path=/docs/testing-react-buttons-button-icon-button--icon-button-states`

## New Dependencies

n/a

## Screenshots (if applicable)

<img width="1082" alt="Screen Shot 2021-09-07 at 23 10 20" src="https://user-images.githubusercontent.com/4818182/132449991-f71981d7-e729-4802-b85d-a5f724a04a04.png">


## Thank You Gif

![a cat being playful and fascinated with its image in the mirror](https://media.giphy.com/media/1wnZSnmrnwJmnJkd1c/giphy-downsized.gif?cid=ecf05e4715ajg937ap6y1tx1ic7a2s7xgo9w4w001ohidqmu&rid=giphy-downsized.gif&ct=g)
