### PR TITLE
ci: Update forward merge to support v6

### DIFF
--- a/.github/workflows/forward-merge.yml
+++ b/.github/workflows/forward-merge.yml
@@ -14,4 +14,4 @@ jobs:
       - uses: NicholasBoll/action-forward-merge-pr@v1.0.0
         with:
           token: ${{secrets.GITHUB_TOKEN}}
-          branches: support/v4.x+master
+          branches: support/v4.x+master,master+prerelease/v6


### PR DESCRIPTION
This change will enable forward merging to the `prerelease/v6` branch