### PR TITLE
fix(tooltip): Update OverflowTooltip to support non-elements

### DIFF
--- a/cypress/integration/Tooltip.spec.ts
+++ b/cypress/integration/Tooltip.spec.ts
@@ -221,6 +221,21 @@ describe('Tooltip', () => {
       }
     );
 
+    context(
+      'when the "Super Mega Ultra Long Content With Max Width Custom" button is hovered',
+      () => {
+        beforeEach(() => {
+          cy.findByRole('button', {
+            name: 'Super Mega Ultra Long Content With Max Width Custom',
+          }).trigger('mouseover');
+        });
+
+        it('should show the tooltip', () => {
+          cy.findByRole('tooltip').should('be.visible');
+        });
+      }
+    );
+
     context('when the "Short Content" button is focused', () => {
       beforeEach(() => {
         cy.findByRole('button', {name: 'Short Content'}).focus();
@@ -237,6 +252,21 @@ describe('Tooltip', () => {
         beforeEach(() => {
           cy.findByRole('button', {
             name: 'Super Mega Ultra Long Content With Max Width On The Button',
+          }).focus();
+        });
+
+        it('should show the tooltip', () => {
+          cy.findByRole('tooltip').should('be.visible');
+        });
+      }
+    );
+
+    context(
+      'when the "Super Mega Ultra Long Content With Max Width Custom" button is focused',
+      () => {
+        beforeEach(() => {
+          cy.findByRole('button', {
+            name: 'Super Mega Ultra Long Content With Max Width Custom',
           }).focus();
         });
 

--- a/modules/react/tooltip/lib/OverflowTooltip.tsx
+++ b/modules/react/tooltip/lib/OverflowTooltip.tsx
@@ -99,15 +99,17 @@ export const OverflowTooltip = ({
   children,
   ...elemProps
 }: OverflowTooltipProps) => {
-  const titleText = innerText(children);
-  const {targetProps, popperProps, tooltipProps} = useTooltip({type: 'label', titleText});
+  const [titleText, setTitleText] = React.useState('');
+  const {targetProps, popperProps, tooltipProps} = useTooltip({type: 'muted'});
 
   const onMouseEnter = (event: React.MouseEvent<HTMLElement>) => {
+    setTitleText(event.currentTarget.innerText);
     if (isOverflowed(event.currentTarget)) {
       targetProps.onMouseEnter(event);
     }
   };
   const onFocus = (event: React.FocusEvent<HTMLElement>) => {
+    setTitleText(event.currentTarget.innerText);
     if (isOverflowed(event.currentTarget)) {
       targetProps.onFocus(event);
     }

--- a/modules/react/tooltip/lib/OverflowTooltip.tsx
+++ b/modules/react/tooltip/lib/OverflowTooltip.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import innerText from 'react-innertext';
 
 import {getTransformFromPlacement, Placement, Popper} from '@workday/canvas-kit-react/popup';
 import {mergeCallback} from '@workday/canvas-kit-react/common';

--- a/modules/react/tooltip/stories/examples/Ellipsis.tsx
+++ b/modules/react/tooltip/stories/examples/Ellipsis.tsx
@@ -4,6 +4,21 @@ import {SecondaryButton} from '@workday/canvas-kit-react/button';
 import {OverflowTooltip} from '@workday/canvas-kit-react/tooltip';
 import {space} from '@workday/canvas-kit-react/tokens';
 
+const CustomContent = ({...elemProps}) => (
+  <button
+    style={{
+      marginTop: space.xs,
+      maxWidth: 200,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    }}
+    {...elemProps}
+  >
+    Super Mega Ultra Long Content With Max Width Custom
+  </button>
+);
+
 export const Ellipsis = () => {
   return (
     <React.Fragment>
@@ -27,6 +42,9 @@ export const Ellipsis = () => {
         >
           Super Mega Ultra Long Content With Max Width
         </button>
+      </OverflowTooltip>
+      <OverflowTooltip>
+        <CustomContent />
       </OverflowTooltip>
     </React.Fragment>
   );


### PR DESCRIPTION
This change adds support for the following use case:

```tsx
<OverflowTooltip>
  <SomeCustomComponent />
</OverflowTooltip>
```

The problem was `react-innertext` was used to determine the text of the content inside the `OverflowTooltip`. `react-innertext` uses VDOM `children` to determine text. But in this case, `children` has no text, just a single child of type `SomeCustomComponent`. Therefore calculated `titleText` is `''` and the tooltip will never show. The fix is to use [DOM innerText](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/innerText) instead which should work regardless of React JSX structure. This should be safe because the text is always calculated based on `onFocus` or `onMouseEnter` events; the same time that overflow is calculated.

The `Ellipsis` example was updated with this use case as well as a Cypress test ensuring it works properly.