### PR TITLE
fix(tooltip): Fix OverflowTooltip with SVG in IE11

### DIFF
--- a/modules/react/tooltip/lib/OverflowTooltip.tsx
+++ b/modules/react/tooltip/lib/OverflowTooltip.tsx
@@ -10,7 +10,7 @@ import {useTooltip} from './useTooltip';
  * Look for an element within the tree for an overflow element (auto, scroll, clip, or hidden).
  * This could be the passed element, or a descendant. If no element is found, `null` is returned.
  */
-const findOverflowElement = (element: HTMLElement): HTMLElement | null => {
+const findOverflowElement = (element: Element): Element | null => {
   const style = getComputedStyle(element);
   if (
     style.overflow === 'auto' ||
@@ -19,28 +19,30 @@ const findOverflowElement = (element: HTMLElement): HTMLElement | null => {
     style.overflow === 'hidden'
   ) {
     return element;
-  } else {
+  } else if (element.children) {
+    // `children` is not defined for SVGElement in IE11
     for (let i = 0; i < element.children.length; i++) {
-      const overflowElement = findOverflowElement(element.children[i] as HTMLElement);
+      const overflowElement = findOverflowElement(element.children[i]);
       if (overflowElement) {
         return overflowElement;
       }
     }
     return null;
   }
+  return null;
 };
 
 /**
  * Look for an element within the tree for a `text-overflow` CSS property of `ellipsis`.
  * This could be the passed element, or a descendant. If no element is found, `null` is returned.
  */
-const findEllipsisElement = (element: HTMLElement): HTMLElement | null => {
+const findEllipsisElement = (element: Element): Element | null => {
   const style = getComputedStyle(element);
   if (style.textOverflow === 'ellipsis' || Number(style.webkitLineClamp) > 0) {
     return element;
   } else {
     for (let i = 0; i < element.children.length; i++) {
-      const overflowElement = findEllipsisElement(element.children[i] as HTMLElement);
+      const overflowElement = findEllipsisElement(element.children[i]);
       if (overflowElement) {
         return overflowElement;
       }
@@ -49,7 +51,7 @@ const findEllipsisElement = (element: HTMLElement): HTMLElement | null => {
   }
 };
 
-const isOverflowed = (element: HTMLElement) => {
+const isOverflowed = (element: Element) => {
   const overflowElement = findEllipsisElement(element) || findOverflowElement(element);
 
   if (overflowElement) {
@@ -101,16 +103,18 @@ export const OverflowTooltip = ({
   const [titleText, setTitleText] = React.useState('');
   const {targetProps, popperProps, tooltipProps} = useTooltip({type: 'muted'});
 
-  const onMouseEnter = (event: React.MouseEvent<HTMLElement>) => {
-    setTitleText(event.currentTarget.innerText);
-    if (isOverflowed(event.currentTarget)) {
-      targetProps.onMouseEnter(event);
+  const onMouseEnter = (event: React.MouseEvent) => {
+    const target = event.currentTarget;
+    setTitleText(target instanceof HTMLElement ? target.innerText : '');
+    if (isOverflowed(target)) {
+      targetProps.onMouseEnter(event as React.MouseEvent);
     }
   };
-  const onFocus = (event: React.FocusEvent<HTMLElement>) => {
-    setTitleText(event.currentTarget.innerText);
-    if (isOverflowed(event.currentTarget)) {
-      targetProps.onFocus(event);
+  const onFocus = (event: React.FocusEvent) => {
+    const target = event.currentTarget;
+    setTitleText(target instanceof HTMLElement ? target.innerText : '');
+    if (isOverflowed(target)) {
+      targetProps.onFocus(event as React.FocusEvent);
     }
   };
 

--- a/modules/react/tooltip/lib/useTooltip.tsx
+++ b/modules/react/tooltip/lib/useTooltip.tsx
@@ -31,7 +31,7 @@ const useIntentTimer = (fn: Function, waitMs: number = 0): {start(): void; clear
   };
 };
 
-const isInteractiveElement = (element: HTMLElement) => {
+const isInteractiveElement = (element: Element) => {
   const tagName = element.tagName.toLowerCase();
   const tabIndex = element.getAttribute('tabindex');
 
@@ -51,7 +51,7 @@ const isInteractiveElement = (element: HTMLElement) => {
  * Convenience hook for creating components with tooltips. It will return an object of properties to mix
  * into a target, popper and tooltip
  */
-export function useTooltip<T extends HTMLElement = HTMLElement>({
+export function useTooltip<T extends Element = Element>({
   type = 'label',
   titleText = '',
 }: {
@@ -89,12 +89,12 @@ export function useTooltip<T extends HTMLElement = HTMLElement>({
     intentTimer.clear();
   };
 
-  const onOpenFromTarget = (event: React.SyntheticEvent<HTMLElement>) => {
+  const onOpenFromTarget = (event: React.SyntheticEvent) => {
     setAnchorElement(event.currentTarget as T);
     onOpen();
   };
 
-  const onFocus = (event: React.FocusEvent<HTMLElement>) => {
+  const onFocus = (event: React.FocusEvent) => {
     if (!mouseDownRef.current) {
       onOpenFromTarget(event);
     }
@@ -102,7 +102,7 @@ export function useTooltip<T extends HTMLElement = HTMLElement>({
     mouseDownRef.current = false;
   };
 
-  const onMouseDown = (event: React.MouseEvent<HTMLElement>) => {
+  const onMouseDown = (event: React.MouseEvent) => {
     mouseDownRef.current = true;
     if (isInteractiveElement(event.currentTarget)) {
       popupModel.events.hide();


### PR DESCRIPTION
IE11 doesn't define the `children` property in `Element`. It defines `children` as part of the `HTMLElement` interface. This means that `findEllipsisElement` will fail if `OverflowTooltip` contains any SVG element. An issue has been filed with MDN to update their docs. The code now does specific testing against an `HTMLElement` for `innerText` (not defined on `SVGElement` in any browser) as well as testing the presence of `.children` to avoid IE11 crashing on SVG elements.

More info here: https://github.com/mdn/content/issues/8890