### PR TITLE
feat(cookie-banner): Deprecate CookieBanner

### DIFF
--- a/modules/codemod/lib/v6/deprecateCookieBanner.ts
+++ b/modules/codemod/lib/v6/deprecateCookieBanner.ts
@@ -1,0 +1,124 @@
+import {API, FileInfo, Identifier, ImportDeclaration, Options} from 'jscodeshift';
+
+const mainPackage = '@workday/canvas-kit-react';
+const cookieBannerPackage = '@workday/canvas-kit-react/cookie-banner';
+
+export default function transformer(file: FileInfo, api: API, options: Options) {
+  const j = api.jscodeshift;
+
+  const root = j(file.source);
+  let hasCookieBannerImports = false;
+
+  // This toggles the failsafe that prevents us from accidentally transforming something unintentionally.
+  root.find(j.ImportDeclaration, (nodePath: ImportDeclaration) => {
+    const value = nodePath.source.value;
+    // If there's an import from the cookie-banner package, set the import boolean check to true
+    if (value === cookieBannerPackage) {
+      hasCookieBannerImports = true;
+      return;
+    }
+    // If there's an import from the main package, check to see if CookieBanner or CookieBannerProps are among the named imports
+    // e.g. import {CookieBanner} from '@workday/canvas-kit-react';
+    if (value === mainPackage) {
+      (nodePath.specifiers || []).forEach(specifier => {
+        if (specifier.type === 'ImportSpecifier') {
+          const specifierName = specifier.imported.name;
+          if (specifierName === 'CookieBanner' || specifierName === 'CookieBannerProps') {
+            hasCookieBannerImports = true;
+          }
+        }
+      });
+    }
+  });
+
+  // Failsafe to skip transforms unless a CookieBanner import is detected
+  if (!hasCookieBannerImports) {
+    return root.toSource();
+  }
+
+  // Transform CookieBanner named import statements from the main package
+  // e.g. import { CookieBanner, CookieBannerProps } from '@workday/canvas-kit-react';
+  // becomes import { DeprecatedCookieBanner, DeprecatedCookieBannerProps } from '@workday/canvas-kit-react';
+  root
+    .find(j.ImportDeclaration, {source: {value: '@workday/canvas-kit-react'}})
+    .forEach(nodePath => {
+      nodePath.value.specifiers?.forEach(specifier => {
+        if (specifier.type === 'ImportSpecifier') {
+          //  `import {CookieBanner}` becomes `import {DeprecatedCookieBanner}`
+          if (specifier.imported.name === 'CookieBanner') {
+            specifier.imported.name = 'DeprecatedCookieBanner';
+          }
+
+          if (specifier.imported.name === 'CookieBannerProps') {
+            specifier.imported.name = 'DeprecatedCookieBannerProps';
+          }
+        }
+        return specifier;
+      });
+    });
+
+  // Transform CookieBanner default and named import statements from the cookie-banner package
+  root
+    .find(j.ImportDeclaration, {source: {value: '@workday/canvas-kit-react/cookie-banner'}})
+    .forEach(nodePath => {
+      nodePath.value.specifiers?.forEach(specifier => {
+        if (specifier.type === 'ImportDefaultSpecifier') {
+          //  `import CookieBanner` becomes `import DeprecatedCookieBanner`
+          if (specifier.local?.name === 'CookieBanner') {
+            specifier.local.name = 'DeprecatedCookieBanner';
+          }
+        }
+        if (specifier.type === 'ImportSpecifier') {
+          //  `import {CookieBanner}` becomes `import {DeprecatedCookieBanner}`
+          if (specifier.imported.name === 'CookieBanner') {
+            specifier.imported.name = 'DeprecatedCookieBanner';
+          }
+          //  `import {CookieBannerProps}` becomes `import {DeprecatedCookieBannerProps}`
+          if (specifier.imported.name === 'CookieBannerProps') {
+            specifier.imported.name = 'DeprecatedCookieBannerProps';
+          }
+        }
+        return specifier;
+      });
+    });
+
+  // Transform CookieBannerProps type references
+  // e.g. `type CustomProps = CookieBannerProps;` becomes `type CustomProps = DeprecatedCookieBannerProps;`
+  root
+    .find(j.TSTypeReference, {typeName: {type: 'Identifier', name: 'CookieBannerProps'}})
+    .forEach(nodePath => {
+      const identifier = nodePath.value.typeName as Identifier;
+      identifier.name = 'DeprecatedCookieBannerProps';
+    });
+
+  // Transform CookieBannerProps type interface declaration references
+  // e.g. `interface CustomProps extends CookieBannerProps` becomes `interface CustomProps extends DeprecatedCookieBannerProps`
+  root.find(j.TSInterfaceDeclaration).forEach(nodePath => {
+    // If the interface is extending CookieBannerProps, transform the extension name to DeprecatedCookieBannerProps
+    nodePath.node.extends?.forEach(typeExtension => {
+      if (
+        typeExtension.expression.type === 'Identifier' &&
+        typeExtension.expression.name === 'CookieBannerProps'
+      ) {
+        typeExtension.expression.name = 'DeprecatedCookieBannerProps';
+      }
+    });
+  });
+
+  // Transform CookieBanner JSXElements
+  // e.g. `<CookieBanner>` becomes `<DeprecatedCookieBanner>`
+  root.find(j.JSXIdentifier, {name: 'CookieBanner'}).forEach(nodePath => {
+    nodePath.node.name = 'DeprecatedCookieBanner';
+  });
+
+  // Transform CookieBanner MemberExpressions
+  // e.g. `CookieBanner.DefaultNotice` becomes `DeprecatedCookieBanner.DefaultNotice`
+  root
+    .find(j.MemberExpression, {object: {type: 'Identifier', name: 'CookieBanner'}})
+    .forEach(nodePath => {
+      const identifier = nodePath.value.object as Identifier;
+      identifier.name = 'DeprecatedCookieBanner';
+    });
+
+  return root.toSource();
+}

--- a/modules/codemod/lib/v6/index.ts
+++ b/modules/codemod/lib/v6/index.ts
@@ -1,11 +1,13 @@
 import {API, FileInfo, Options} from 'jscodeshift';
 // deprecate PageHeader
 import deprecatePageHeader from './deprecatePageHeader';
+// deprecate CookieBanner
+import deprecateCookieBanner from './deprecateCookieBanner';
 
 export default function transformer(file: FileInfo, api: API, options: Options) {
   // These will run in order. If your transform depends on others, place yours after dependent
   // transforms
-  const fixes = [deprecatePageHeader];
+  const fixes = [deprecatePageHeader, deprecateCookieBanner];
 
   return fixes.reduce((source, fix) => fix({...file, source}, api, options), file.source);
 }

--- a/modules/codemod/lib/v6/spec/deprecateCookieBanner.spec.ts
+++ b/modules/codemod/lib/v6/spec/deprecateCookieBanner.spec.ts
@@ -1,0 +1,108 @@
+import {expectTransformFactory} from './expectTransformFactory';
+import transformer from '../deprecateCookieBanner';
+const context = describe;
+
+const expectTransform = expectTransformFactory(transformer);
+
+describe('Canvas Kit Deprecate CookieBanner Codemod', () => {
+  context('when transforming CookieBanner imports', () => {
+    it('should ignore non-canvas-kit imports', () => {
+      const input = `import {CookieBanner} from '@workday/some-other-library'`;
+      const expected = `import {CookieBanner} from '@workday/some-other-library'`;
+
+      expectTransform(input, expected);
+    });
+
+    it('should properly transform named imports from @workday/canvas-kit-react', () => {
+      const input = `import {CookieBanner, CookieBannerProps} from '@workday/canvas-kit-react'`;
+      const expected = `import {DeprecatedCookieBanner, DeprecatedCookieBannerProps} from '@workday/canvas-kit-react'`;
+
+      expectTransform(input, expected);
+    });
+
+    it('should properly transform named imports from @workday/canvas-kit-react/cookie-banner', () => {
+      const input = `import {CookieBanner} from '@workday/canvas-kit-react/cookie-banner'`;
+      const expected = `import {DeprecatedCookieBanner} from '@workday/canvas-kit-react/cookie-banner'`;
+
+      expectTransform(input, expected);
+    });
+
+    it('should properly transform default imports from @workday/canvas-kit-react/cookie-banner', () => {
+      const input = `import CookieBanner from '@workday/canvas-kit-react/cookie-banner'`;
+      const expected = `import DeprecatedCookieBanner from '@workday/canvas-kit-react/cookie-banner'`;
+
+      expectTransform(input, expected);
+    });
+
+    it('should properly transform mixed imports from @workday/canvas-kit-react/cookie-banner', () => {
+      const input = `import CookieBanner, { CookieBannerProps } from '@workday/canvas-kit-react/cookie-banner'`;
+      const expected = `import DeprecatedCookieBanner, { DeprecatedCookieBannerProps } from '@workday/canvas-kit-react/cookie-banner'`;
+
+      expectTransform(input, expected);
+    });
+  });
+
+  context('when transforming identifiers', () => {
+    it('should properly transform CookieBanner JSX identifiers', () => {
+      const input = `
+      import {CookieBanner} from '@workday/canvas-kit-react/cookie-banner';
+  
+      const CustomCookieBanner = () => {
+        return (
+          <CookieBanner
+            onAccept={() => console.log('accecpted')}
+            notice={CookieBanner.DefaultNotice}
+          >
+            Hello World
+          </CookieBanner>
+        );
+      };
+
+      const AnotherCookieBanner = (props) => {
+        return <CookieBanner {...props} />;
+      }
+      `;
+      const expected = `
+      import {DeprecatedCookieBanner} from '@workday/canvas-kit-react/cookie-banner';
+  
+      const CustomCookieBanner = () => {
+        return (
+          <DeprecatedCookieBanner
+            onAccept={() => console.log('accecpted')}
+            notice={DeprecatedCookieBanner.DefaultNotice}
+          >
+            Hello World
+          </DeprecatedCookieBanner>
+        );
+      };
+
+      const AnotherCookieBanner = (props) => {
+        return <DeprecatedCookieBanner {...props} />;
+      }
+      `;
+
+      expectTransform(input, expected);
+    });
+
+    it('should properly transform type reference identifiers', () => {
+      const input = `
+      import { CookieBannerProps } from '@workday/canvas-kit-react/cookie-banner';
+  
+      type CustomCookieBannerProps = CookieBannerProps;
+      interface AnotherCookieBannerProps extends CookieBannerProps {
+        specialProp?: boolean;
+      }
+      `;
+      const expected = `
+      import { DeprecatedCookieBannerProps } from '@workday/canvas-kit-react/cookie-banner';
+  
+      type CustomCookieBannerProps = DeprecatedCookieBannerProps;
+      interface AnotherCookieBannerProps extends DeprecatedCookieBannerProps {
+        specialProp?: boolean;
+      }
+      `;
+
+      expectTransform(input, expected);
+    });
+  });
+});

--- a/modules/codemod/lib/v6/spec/deprecateCookieBanner.spec.ts
+++ b/modules/codemod/lib/v6/spec/deprecateCookieBanner.spec.ts
@@ -8,7 +8,7 @@ describe('Canvas Kit Deprecate CookieBanner Codemod', () => {
   context('when transforming CookieBanner imports', () => {
     it('should ignore non-canvas-kit imports', () => {
       const input = `import {CookieBanner} from '@workday/some-other-library'`;
-      const expected = `import {CookieBanner} from '@workday/some-other-library'`;
+      const expected = input;
 
       expectTransform(input, expected);
     });

--- a/modules/docs/mdx/6.0-MIGRATION-GUIDE.mdx
+++ b/modules/docs/mdx/6.0-MIGRATION-GUIDE.mdx
@@ -111,7 +111,6 @@ export const CustomCookieBanner = (props: CustomCookieBannerProps) => {
 };
 ```
 
-🤖 These updates will be handled automatically by the codemod.
 
 ### Page Header
 

--- a/modules/docs/mdx/6.0-MIGRATION-GUIDE.mdx
+++ b/modules/docs/mdx/6.0-MIGRATION-GUIDE.mdx
@@ -10,6 +10,7 @@ any questions about the update.
 
 - [Codemod](#codemod)
 - [Component Deprecations](#component-deprecations)
+  - [CookieBanner](#cookie-banner)
   - [PageHeader](#page-header)
 
 ## Codemod
@@ -58,6 +59,59 @@ warning.
 A hard-deprecated component or package is no longer available. You will need to follow the method
 prescribed in our migration guide to update your application. Please reach out to our team directly
 if you need additional help.
+
+### Cookie Banner
+
+We are [soft deprecating](#soft-deprecation) `CookieBanner`. It has been renamed to
+`DeprecatedCookieBanner`. Similarly, `CookieBannerProps` has been renamed to
+`DeprecatedCookieBannerProps`. You may continue to use this component exactly as you did in v5, but
+note that we plan to [hard-deprecate](#hard-deprecation) it in Canvas Kit v7.
+
+🤖 The codemod will rename `CookieBanner` and `CookieBannerProps` to their deprecated names:
+
+```tsx
+// v5
+import CookieBanner, {CookieBannerProps} from '@workday/canvas-kit-react/cookie-banner';
+
+export const CustomCookieBanner = (props: CookieBannerProps) => {
+  return <CookieBanner notice={CookieBanner.DefaultNotice} {...props} />;
+};
+
+// v6
+import DeprecatedCookieBanner, {
+  DeprecatedCookieBannerProps,
+} from '@workday/canvas-kit-react/cookie-banner';
+
+export const CustomCookieBanner = (props: DeprecatedCookieBannerProps) => {
+  return <DeprecatedCookieBanner notice={DeprecatedCookieBanner.DefaultNotice} {...props} />;
+};
+```
+
+```tsx
+// v5
+import {CookieBanner, CookieBannerProps} from '@workday/canvas-kit-react';
+
+interface CustomCookieBannerProps extends CookieBannerProps {
+  // custom page header props
+}
+
+export const CustomCookieBanner = (props: CustomCookieBannerProps) => {
+  return <CookieBanner notice={CookieBanner.DefaultNotice} {...props} />;
+};
+
+// v6
+import {DeprecatedCookieBanner, DeprecatedCookieBannerProps} from '@workday/canvas-kit-react';
+
+interface CustomCookieBannerProps extends DeprecatedCookieBannerProps {
+  // custom page header props
+}
+
+export const CustomCookieBanner = (props: CustomCookieBannerProps) => {
+  return <DeprecatedCookieBanner notice={DeprecatedCookieBanner.DefaultNotice} {...props} />;
+};
+```
+
+🤖 These updates will be handled automatically by the codemod.
 
 ### Page Header
 

--- a/modules/react/cookie-banner/README.md
+++ b/modules/react/cookie-banner/README.md
@@ -1,4 +1,9 @@
-# Canvas Kit Cookie Banner
+# Canvas Kit Cookie Banner (Deprecated)
+
+> Note: As of Canvas Kit v6, CookieBanner is being soft-deprecated. It will be hard-deprecated
+> (completely removed) in v7. Please see the
+> [migration guide](https://workday.github.io/canvas-kit/?path=/story/welcome-migration-guides-v6-0--page)
+> for more information.
 
 Cookie banner component.
 
@@ -15,28 +20,28 @@ Fixes a cookie banner to the bottom of the web page.
 Can be configured with a "Cookie Settings" element and a custom notice.
 
 ```tsx
-import CookieBanner from '@workday/canvas-kit-react/cookie-banner'
+import DeprecatedCookieBanner from '@workday/canvas-kit-react/cookie-banner'
 
-<CookieBanner
+<DeprecatedCookieBanner
   onAccept={this.onAccept}
   isClosed={this.state.acceptedCookies}
 />
 
-<CookieBanner
+<DeprecatedCookieBanner
   onAccept={this.onAccept}
   isClosed={this.state.acceptedCookies}
   onClickSettings={this.openSettings}
   notice="Custom notice"
 />
 
-<CookieBanner
+<DeprecatedCookieBanner
   onAccept={this.onAccept}
   isClosed={this.state.acceptedCookies}
   onClickSettings={this.openSettings}
-  notice={`${CookieBanner.DefaultNotice} This is appended.`}
+  notice={`${DeprecatedCookieBanner.DefaultNotice} This is appended.`}
 />
 
-<CookieBanner
+<DeprecatedCookieBanner
   onAccept={this.onAccept}
   isClosed={this.state.acceptedCookies}
   notice={<Component />}
@@ -51,11 +56,11 @@ import CookieBanner from '@workday/canvas-kit-react/cookie-banner'
 > without changing your settings, we’ll assume that you are willing to receive cookies.
 
 ```tsx
-<CookieBanner
+<DeprecatedCookieBanner
   onAccept={this.onAccept}
   isClosed={this.state.acceptedCookies}
   onClickSettings={this.openSettings}
-  notice={`${CookieBanner.DefaultNotice} This is appended.`}
+  notice={`${DeprecatedCookieBanner.DefaultNotice} This is appended.`}
 />
 ```
 
@@ -90,7 +95,7 @@ Default: `undefined`
 
 > Custom cookie notice text or element to display.
 
-Default: `CookieBanner.DefaultNotice`
+Default: `DeprecatedCookieBanner.DefaultNotice`
 
 #### `settingsLabel: string`
 

--- a/modules/react/cookie-banner/index.ts
+++ b/modules/react/cookie-banner/index.ts
@@ -1,5 +1,5 @@
-import CookieBanner from './lib/CookieBanner';
+import DeprecatedCookieBanner from './lib/CookieBanner';
 
-export default CookieBanner;
-export {CookieBanner};
+export default DeprecatedCookieBanner;
+export {DeprecatedCookieBanner};
 export * from './lib/CookieBanner';

--- a/modules/react/cookie-banner/lib/CookieBanner.tsx
+++ b/modules/react/cookie-banner/lib/CookieBanner.tsx
@@ -5,7 +5,15 @@ import styled from '@emotion/styled';
 import {colors, commonColors, type, space} from '@workday/canvas-kit-react/tokens';
 import {Hyperlink, HyperlinkProps, PrimaryButton} from '@workday/canvas-kit-react/button';
 
-export interface CookieBannerProps {
+/**
+ * ### Deprecated Cookie Banner Props
+ *
+ * As of Canvas Kit v6, CookieBanner is being soft-deprecated.
+ * It will be hard-deprecated (completely removed) in v7. Please see the
+ * [migration guide](https://workday.github.io/canvas-kit/?path=/story/welcome-migration-guides-v6-0--page)
+ * for more information.
+ */
+export interface DeprecatedCookieBannerProps {
   /**
    * If true, set the CookieBanner to the closed state.
    * @default false
@@ -57,7 +65,7 @@ const Banner = styled('div')(
       padding: `${space.s} 0`,
     },
   },
-  ({isClosed}: Pick<CookieBannerProps, 'isClosed'>) =>
+  ({isClosed}: Pick<DeprecatedCookieBannerProps, 'isClosed'>) =>
     isClosed ? {transform: 'translateY(100%)'} : null
 );
 
@@ -95,13 +103,30 @@ const CookieSettings = (props: CookieSettingsProps) => {
   return <Hyperlink as="button" css={cookieSettingsStyles} {...props} />;
 };
 
-export default class CookieBanner extends React.Component<CookieBannerProps> {
+/**
+ * ### Deprecated Cookie Banner
+ *
+ * As of Canvas Kit v6, this component is being soft-deprecated.
+ * It will be hard-deprecated (completely removed) in v7. Please see the
+ * [migration guide](https://workday.github.io/canvas-kit/?path=/story/welcome-migration-guides-v6-0--page)
+ * for more information.
+ */
+export default class DeprecatedCookieBanner extends React.Component<DeprecatedCookieBannerProps> {
+  componentDidMount() {
+    console.warn(
+      `This component is being deprecated and will be removed in Canvas Kit V7.\n
+      For more information, please see the V6 migration guide:\n
+      https://workday.github.io/canvas-kit/?path=/story/welcome-migration-guides-v6-0--page
+      `
+    );
+  }
+
   public static DefaultNotice =
     'We use cookies to ensure that we give you the best experience on our website. If you continue without changing your settings, we’ll assume that you are willing to receive cookies.';
 
   public render(): React.ReactNode {
     const {
-      notice = CookieBanner.DefaultNotice,
+      notice = DeprecatedCookieBanner.DefaultNotice,
       settingsLabel = 'Cookie Settings',
       isClosed,
       onAccept,

--- a/modules/react/cookie-banner/stories/stories.tsx
+++ b/modules/react/cookie-banner/stories/stories.tsx
@@ -8,7 +8,7 @@ import {action} from '@storybook/addon-actions';
 import styled from '@emotion/styled';
 
 import {Hyperlink, SecondaryButton} from '../../button';
-import CookieBanner from '../index';
+import DeprecatedCookieBanner from '../index';
 import README from '../README.md';
 
 interface Props {
@@ -50,7 +50,7 @@ class BannerContainer extends React.Component<Props, State> {
     return (
       <Container>
         <SecondaryButton onClick={this.reset}>Reset Banner</SecondaryButton>
-        <CookieBanner
+        <DeprecatedCookieBanner
           onAccept={this.onAccept}
           isClosed={this.state.acceptedCookies}
           {...bannerProps}
@@ -61,7 +61,7 @@ class BannerContainer extends React.Component<Props, State> {
 }
 
 storiesOf('Components/Indicators/Cookie Banner/React', module)
-  .addParameters({component: CookieBanner})
+  .addParameters({component: DeprecatedCookieBanner})
   .addDecorator(withReadme(README))
   .add('Default', () => (
     <div className="story">
@@ -79,7 +79,7 @@ storiesOf('Components/Indicators/Cookie Banner/React', module)
           onClickSettings: action('click-settings'),
           notice: (
             <React.Fragment>
-              {CookieBanner.DefaultNotice} Please review our{' '}
+              {DeprecatedCookieBanner.DefaultNotice} Please review our{' '}
               <Hyperlink href="https://www.workday.com/en-us/privacy.html" target="__blank">
                 Privacy Policy
               </Hyperlink>


### PR DESCRIPTION
## Summary

Resolves #1214

Deprecate CookieBanner

![category](https://img.shields.io/badge/release_category-Components-blue)

## BREAKING CHANGES

This update soft-deprecates all exports from `canvas-kit-labs-react/cookie-banner`. These changes are handled automatically by the v6 codemod. Please refer to the v6 migration guide for more information.

---

This PR:

- Updates `CookieBanner` to `DeprecatedCookieBanner`
- Updates `CookieBannerProps` to `DeprecatedCookieBannerProps`
- Updates the `CookieBanner` README
- Adds deprecation information to the V6 migration guide
- Adds a soft-deprecation codemod for `CookieBanner`
- Adds a test for the codemod

## Where Should the Reviewer Start?

`modules/react/cookie-banner/lib/CookieBanner.tsx`

## Thank You Gif
_Share a fun [gif](https://giphy.com) to say thanks to your reviewer:_

![a dog jumps up to the kitchen counter trying to get cookies](https://media.giphy.com/media/l3nWl5bhBoim7glNu/source.gif?cid=ecf05e473t3au5n6pm0gi71lyq8ytd0h9csj0roawdv8p661&rid=source.gif&ct=g)

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] branch has been rebased on the latest master commit
- [ ] tests are changed or added
- [ ] `yarn test` passes
- [ ] all (dev)dependencies that the module needs is added to its `package.json`
- [ ] code has been documented and, if applicable, usage described in README.md
- [ ] module has been added to `canvas-kit-react` and/or `canvas-kit-css` universal modules, if
      applicable
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](../modules/docs/mdx/API_PATTERN_GUIDELINES.mdx)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
