### PR TITLE
feat: Deprecate Header and Global Header

### DIFF
--- a/modules/codemod/lib/v6/deprecateHeader.ts
+++ b/modules/codemod/lib/v6/deprecateHeader.ts
@@ -1,0 +1,135 @@
+import {API, FileInfo, Identifier, ImportDeclaration} from 'jscodeshift';
+import {
+  filterImportDefaultSpecifiers,
+  filterImportSpecifiers,
+  renameImportDefaultSpecifiers,
+  renameImportSpecifiers,
+  RenameMap,
+} from './utils';
+
+const mainPackage = '@workday/canvas-kit-labs-react';
+const headerPackage = '@workday/canvas-kit-labs-react/header';
+
+const headerComponents = ['DubLogoTitle', 'Header', 'GlobalHeader', 'WorkdayLogoTitle'];
+const headerUtils = ['themes'];
+const headerTypes = ['Themes', 'ThemeAttributes', 'HeaderTheme', 'HeaderVariant', 'HeaderHeight'];
+
+const headerImportSpecifiers = [...headerComponents, ...headerUtils, ...headerTypes];
+
+const headerDefaultImportSpecifiers = ['Header'];
+
+const headerRenameMap: RenameMap = {
+  DubLogoTitle: 'DeprecatedDubLogoTitle',
+  GlobalHeader: 'DeprecatedGlobalHeader',
+  Header: 'DeprecatedHeader',
+  HeaderHeight: 'DeprecatedHeaderHeight',
+  HeaderTheme: 'DeprecatedHeaderTheme',
+  HeaderVariant: 'DeprecatedHeaderVariant',
+  ThemeAttributes: 'DeprecatedHeaderThemeAttributes',
+  Themes: 'DeprecatedHeaderThemes',
+  WorkdayLogoTitle: 'DeprecatedWorkdayLogoTitle',
+  themes: 'deprecatedHeaderThemes',
+};
+
+export default function transformer(file: FileInfo, api: API) {
+  const j = api.jscodeshift;
+
+  const root = j(file.source);
+  let hasHeaderImports = false;
+
+  root.find(j.ImportDeclaration, (nodePath: ImportDeclaration) => {
+    const value = nodePath.source.value;
+    // if importing from the header package, set the failsafe to true
+    if (value === headerPackage) {
+      hasHeaderImports = true;
+      return;
+    }
+    // if importing from the main package, check for header imports and toggle the failsafe if any are found
+    if (value === mainPackage) {
+      const importSpecifiers = nodePath.specifiers || [];
+      const headerSpecifiers = filterImportSpecifiers(importSpecifiers, headerImportSpecifiers);
+      if (headerSpecifiers.length) {
+        hasHeaderImports = true;
+      }
+    }
+  });
+
+  // Failsafe to skip transforms unless a header import is detected
+  if (!hasHeaderImports) {
+    return root.toSource();
+  }
+
+  // Rename header named imports from @workday/canvas-kit-labs-react
+  // e.g. `import { Header } from '@workday/canvas-kit-labs-react';`
+  // becomes `import { DeprecatedHeader } from '@workday/canvas-kit-labs-react';`
+  root.find(j.ImportDeclaration, {source: {value: mainPackage}}).forEach(nodePath => {
+    const importSpecifiers = nodePath.value.specifiers || [];
+    // filter header imports
+    const headerImports = filterImportSpecifiers(importSpecifiers, headerImportSpecifiers);
+    renameImportSpecifiers(headerImports, headerRenameMap);
+  });
+
+  // Rename default and named header imports from @workday/canvas-kit-labs-react/header
+  // e.g. `import Header, { GlobalHeader } from '@workday/canvas-kit-labs-react/header';`
+  // becomes `import DeprecatedHeader, { DeprecatedGlobalHeader } from '@workday/canvas-kit-labs-react/header';`
+  root.find(j.ImportDeclaration, {source: {value: headerPackage}}).forEach(nodePath => {
+    const importSpecifiers = nodePath.value.specifiers || [];
+    // filter header named imports
+    const headerImports = filterImportSpecifiers(importSpecifiers, headerImportSpecifiers);
+    // rename header import specifiers
+    // e.g import { Header } becomes import { DeprecatedHeader }
+    renameImportSpecifiers(headerImports, headerRenameMap);
+    // filter header default imports
+    const headerDefaultImports = filterImportDefaultSpecifiers(
+      importSpecifiers,
+      headerDefaultImportSpecifiers
+    );
+    // rename header import default specifiers
+    // e.g import Header becomes import DeprecatedHeader
+    renameImportDefaultSpecifiers(headerDefaultImports, headerRenameMap);
+  });
+
+  // Transform header type references
+  // e.g. `type CustomThemeAttributes = ThemeAttributes;` becomes `type CustomThemeAttributes = DeprecatedCThemeAttributes;`
+  root.find(j.TSTypeReference, {typeName: {type: 'Identifier'}}).forEach(nodePath => {
+    const identifier = nodePath.value.typeName as Identifier;
+    if (headerTypes.includes(identifier.name)) {
+      identifier.name = headerRenameMap[identifier.name];
+    }
+  });
+
+  // Transform header type interface declaration references
+  // e.g. `interface CustomThemeAttributes extends ThemeAttributes {}`
+  // becomes `interface CustomThemeAttributes extends DeprecatedHeaderThemeAttributes {}`
+  root.find(j.TSInterfaceDeclaration).forEach(nodePath => {
+    // If the interface is extending header type, transform the extension name,
+    nodePath.node.extends?.forEach(typeExtension => {
+      if (
+        typeExtension.expression.type === 'Identifier' &&
+        headerTypes.includes(typeExtension.expression.name)
+      ) {
+        typeExtension.expression.name = headerRenameMap[typeExtension.expression.name];
+      }
+    });
+  });
+
+  // Transform header JSXElements
+  // e.g. `<Header>` becomes `<DeprecatedHeader>`
+  root.find(j.JSXIdentifier).forEach(nodePath => {
+    const identifierName = nodePath.node.name;
+    if (headerComponents.includes(identifierName)) {
+      nodePath.node.name = headerRenameMap[identifierName];
+    }
+  });
+
+  // Transform header MemberExpressions
+  // e.g. `HeaderHeight.Small` becomes `DeprecatedHeaderHeight.Small`
+  root.find(j.MemberExpression, {object: {type: 'Identifier'}}).forEach(nodePath => {
+    const identifier = nodePath.value.object as Identifier;
+    if (identifier.name in headerRenameMap) {
+      identifier.name = headerRenameMap[identifier.name];
+    }
+  });
+
+  return root.toSource();
+}

--- a/modules/codemod/lib/v6/index.ts
+++ b/modules/codemod/lib/v6/index.ts
@@ -5,11 +5,18 @@ import deprecatePageHeader from './deprecatePageHeader';
 import deprecateCookieBanner from './deprecateCookieBanner';
 // move and rename SearchBar
 import moveAndRenameSearchBar from './moveAndRenameSearchBar';
+// deprecate header imports
+import deprecateHeader from './deprecateHeader';
 
 export default function transformer(file: FileInfo, api: API, options: Options) {
-  // These will run in order. If your transform depends on others, place yours after dependent
-  // transforms
-  const fixes = [deprecatePageHeader, deprecateCookieBanner, moveAndRenameSearchBar];
+  // These will run in order. If your transform depends on others, place yours after dependent transforms
+  const fixes = [
+    deprecatePageHeader,
+    deprecateCookieBanner,
+    moveAndRenameSearchBar,
+    // needs to run after `moveAndRenameSearchBar`
+    deprecateHeader,
+  ];
 
   return fixes.reduce((source, fix) => fix({...file, source}, api, options), file.source);
 }

--- a/modules/codemod/lib/v6/spec/deprecateHeader.spec.ts
+++ b/modules/codemod/lib/v6/spec/deprecateHeader.spec.ts
@@ -1,0 +1,146 @@
+import {expectTransformFactory} from './expectTransformFactory';
+import transformer from '../deprecateHeader';
+const context = describe;
+
+const expectTransform = expectTransformFactory(transformer);
+
+describe('Canvas Kit Deprecate Header Codemod', () => {
+  context('when transforming header imports', () => {
+    it('should ignore non-canvas-kit imports', () => {
+      const input = `import Header, {GlobalHeader} from "@workday/some-other-library";`;
+      const expected = `import Header, {GlobalHeader} from "@workday/some-other-library";`;
+
+      expectTransform(input, expected);
+    });
+
+    it('should transform named imports from @workday/canvas-kit-labs-react', () => {
+      const input = `import {Header, GlobalHeader} from '@workday/canvas-kit-labs-react';`;
+      const expected = `import {DeprecatedHeader, DeprecatedGlobalHeader} from '@workday/canvas-kit-labs-react';`;
+
+      expectTransform(input, expected);
+    });
+
+    it('should transform named imports from @workday/canvas-kit-labs-react/header', () => {
+      const input = `import {Header, GlobalHeader} from '@workday/canvas-kit-labs-react/header';`;
+      const expected = `import {DeprecatedHeader, DeprecatedGlobalHeader} from '@workday/canvas-kit-labs-react/header';`;
+
+      expectTransform(input, expected);
+    });
+
+    it('should transform default imports from @workday/canvas-kit-labs-react/header', () => {
+      const input = `import Header from '@workday/canvas-kit-labs-react/header';`;
+      const expected = `import DeprecatedHeader from '@workday/canvas-kit-labs-react/header';`;
+
+      expectTransform(input, expected);
+    });
+
+    it('should transform mixed imports from @workday/canvas-kit-labs-react/header', () => {
+      const input = `import Header, {Themes} from '@workday/canvas-kit-labs-react/header';`;
+      const expected = `import DeprecatedHeader, {DeprecatedHeaderThemes} from '@workday/canvas-kit-labs-react/header';`;
+
+      expectTransform(input, expected);
+    });
+  });
+
+  context('when transforming identifiers', () => {
+    it('should transform JSX identifiers', () => {
+      const input = `
+        import Header, {DubLogoTitle, GlobalHeader} from '@workday/canvas-kit-labs-react/header';
+
+        const CustomHeader = (props) => {
+          return <Header {...props}/>;
+        }
+
+        const CustomGlobalHeader = (props) => {
+          return (
+            <GlobalHeader
+              brand={
+                <a href="#">
+                  <DubLogoTitle themeColor={Header.Theme.White} />
+                </a>
+              }
+              {...props}
+            />
+          );
+        }
+        `;
+      const expected = `
+        import DeprecatedHeader, {DeprecatedDubLogoTitle, DeprecatedGlobalHeader} from '@workday/canvas-kit-labs-react/header';
+
+        const CustomHeader = (props) => {
+          return <DeprecatedHeader {...props}/>;
+        }
+
+        const CustomGlobalHeader = (props) => {
+          return (
+            <DeprecatedGlobalHeader
+              brand={
+                <a href="#">
+                  <DeprecatedDubLogoTitle themeColor={DeprecatedHeader.Theme.White} />
+                </a>
+              }
+              {...props}
+            />
+          );
+        }
+      `;
+
+      expectTransform(input, expected);
+    });
+
+    it('should transform type reference identifiers', () => {
+      const input = `
+        import {Themes} from '@workday/canvas-kit-labs-react/header';
+    
+        type CustomThemes = Themes;
+      `;
+      const expected = `
+        import {DeprecatedHeaderThemes} from '@workday/canvas-kit-labs-react/header';
+    
+        type CustomThemes = DeprecatedHeaderThemes;
+      `;
+
+      expectTransform(input, expected);
+    });
+
+    it('should transform type interface declaration identifiers', () => {
+      const input = `
+        import {ThemeAttributes} from '@workday/canvas-kit-labs-react/header';
+    
+        interface CustomThemeAttributes extends ThemeAttributes {
+          specialAttribute?: string;
+        }
+      `;
+      const expected = `
+        import {DeprecatedHeaderThemeAttributes} from '@workday/canvas-kit-labs-react/header';
+    
+        interface CustomThemeAttributes extends DeprecatedHeaderThemeAttributes {
+          specialAttribute?: string;
+        }
+      `;
+    });
+
+    it('should transform member expression identifiers', () => {
+      const input = `
+        import Header, {HeaderHeight, HeaderTheme, HeaderVariant, themes} from '@workday/canvas-kit-labs-react/header';
+
+        const height = HeaderHeight.Small;
+        const theme = HeaderTheme.White;
+        const variant = HeaderVariant.Full;
+        const blueTheme = themes.Blue;
+        const headerVariant = Header.Variant.Global;
+      `;
+      const expected = `
+        import DeprecatedHeader, {DeprecatedHeaderHeight, DeprecatedHeaderTheme, DeprecatedHeaderVariant, deprecatedHeaderThemes} from '@workday/canvas-kit-labs-react/header';
+
+        const height = DeprecatedHeaderHeight.Small;
+        const theme = DeprecatedHeaderTheme.White;
+        const variant = DeprecatedHeaderVariant.Full;
+        const blueTheme = deprecatedHeaderThemes.Blue;
+        const headerVariant = DeprecatedHeader.Variant.Global;
+      `;
+
+      expectTransform(input, expected);
+    });
+  });
+});

--- a/modules/codemod/lib/v6/utils/index.ts
+++ b/modules/codemod/lib/v6/utils/index.ts
@@ -1,9 +1,4 @@
-import {
-  ImportDeclaration,
-  ImportSpecifier,
-  ImportDefaultSpecifier,
-  ImportNamespaceSpecifier,
-} from 'jscodeshift';
+import {ImportSpecifier, ImportDefaultSpecifier, ImportNamespaceSpecifier} from 'jscodeshift';
 
 export type ImportSpecifierArray = (
   | ImportSpecifier
@@ -79,16 +74,12 @@ export function renameImportSpecifiers(importSpecifiers: ImportSpecifier[], rena
  * }
  */
 export function filterImportDefaultSpecifiers(
-  importDeclaration: ImportDeclaration,
+  importSpecifiers: ImportSpecifierArray,
   importNames?: string[]
 ) {
   const filteredSpecifiers = [] as ImportDefaultSpecifier[];
 
-  if (!importDeclaration.specifiers) {
-    return filteredSpecifiers;
-  }
-
-  importDeclaration.specifiers.forEach(specifier => {
+  importSpecifiers.forEach(specifier => {
     if (specifier.type === 'ImportDefaultSpecifier') {
       const localName = specifier.local?.name || '';
       if (importNames && importNames.includes(localName)) {

--- a/modules/docs/mdx/6.0-MIGRATION-GUIDE.mdx
+++ b/modules/docs/mdx/6.0-MIGRATION-GUIDE.mdx
@@ -10,10 +10,11 @@ any questions about the update.
 
 - [Codemod](#codemod)
 - [Component Deprecations](#component-deprecations)
-  - [CookieBanner](#cookie-banner)
-  - [PageHeader](#page-header)
+  - [Cookie Banner](#cookie-banner)
+  - [Header & Global Header](#header--global-header)
+  - [Page Header](#page-header)
 - [Component Migrations](#component-migrations)
-  - [SearchBar](#search-bar)
+  - [Search Bar](#search-bar)
 
 ## Codemod
 
@@ -113,6 +114,88 @@ export const CustomCookieBanner = (props: CustomCookieBannerProps) => {
 };
 ```
 
+### Header & Global Header
+
+We are [soft deprecating](#soft-deprecation) `Header` and `GlobalHeader` and their related exports.
+They has been renamed to `DeprecatedHeader` and `DeprecatedGlobalHeader`, respectively. You may
+continue to use these components exactly as you did in v5, but note that we plan to
+[hard-deprecate](#hard-deprecation) this package in Canvas Kit v7.
+
+> Note: `SearchBar` is not being deprecated but will instead move to its own dedictated package. You
+> can read more [here](#search-bar).
+
+🤖 The codemod will handle all these changes automatically:
+
+- Rename import specifiers
+  - `DubLogoTitle` becomes `DeprecatedDubLogoTitle`
+  - `GlobalHeader` becomes `DeprecatedGlobalHeader`
+  - `Header` becomes `DeprecatedHeader`
+  - `HeaderHeight` becomes `DeprecatedHeaderHeight`
+  - `HeaderTheme` becomes `DeprecatedHeaderTheme`
+  - `HeaderVariant` becomes `DeprecatedHeaderVariant`
+  - `ThemeAttributes` becomes `DeprecatedHeaderThemeAttributes`
+  - `Themes` becomes `DeprecatedHeaderThemes`
+  - `WorkdayLogoTitle` becomes `DeprecatedWorkdayLogoTitle`
+  - `themes` becomes `deprecatedHeaderThemes`
+- Rename JSX identifiers
+  - `<DubLogoTitle>` becomes `<DeprecatedDubLogoTitle>`
+  - `<GlobalHeader>` becomes `<DeprecatedGlobalHeader>`
+  - `<Header>` becomes `<DeprecatedHeader>`
+  - `<WorkdayLogoTitle>` becomes `<DeprecatedWorkdayLogoTitle>`
+- Rename type references and interface declarations
+  - `type CustomHeaderHeight = HeaderHeight;` becomes
+    `type CustomHeaderHeight = DeprecatedHeaderHeight;`
+  - `type CustomHeaderTheme = HeaderTheme;` becomes
+    `type CustomHeaderTheme = DeprecatedHeaderTheme;`
+  - `type CustomHeaderVariant = HeaderVariant;` becomes
+    `type CustomHeaderVariant = DeprecatedHeaderVariant;`
+  - `type CustomThemeAttributes = ThemeAttributes;` becomes
+    `type CustomThemeAttributes = DeprecatedHeaderThemeAttributes;`
+  - `type CustomThemes = Themes;` becomes `type CustomThemes = DeprecatedHeaderThemes;`
+- Rename member expressions
+  - `HeaderHeight.Small` becomes `DeprecatedHeaderHeight.Small`
+  - `HeaderTheme.White` becomes `DeprecatedHeaderTheme.White`
+  - `HeaderVariant.Full` becomes `DeprecatedHeaderVariant.Full`
+  - `themes.Blue` becomes `deprecatedHeaderThemes.Blue`
+  - `Header.Variant.Global` becomes `DeprecatedHeader.Variant.Global`
+
+```tsx
+// v5
+import Header, {DubLogoTitle, GlobalHeader} from '@workday/canvas-kit-labs-react/header';
+
+const CustomGlobalHeader = props => {
+  return (
+    <GlobalHeader
+      brand={
+        <a href="#">
+          <DubLogoTitle themeColor={Header.Theme.White} />
+        </a>
+      }
+      {...props}
+    />
+  );
+};
+
+// v6
+import DeprecatedHeader, {
+  DeprecatedDubLogoTitle,
+  DeprecatedGlobalHeader,
+} from '@workday/canvas-kit-labs-react/header';
+
+const CustomGlobalHeader = props => {
+  return (
+    <DeprecatedGlobalHeader
+      brand={
+        <a href="#">
+          <DeprecatedDubLogoTitle themeColor={DeprecatedHeader.Theme.White} />
+        </a>
+      }
+      {...props}
+    />
+  );
+};
+```
+
 ### Page Header
 
 We are [soft-deprecating](#soft-deprecation) `PageHeader`. It has been renamed to
@@ -185,7 +268,8 @@ continue to use this component exactly as you did in v5.
   - `<SearchBar>` becomes `<SearchForm>`
 - Rename type references and interface declarations
   - `type CustomSearchProps = SearchBarProps;` becomes `type CustomSearchProps = SearchFormProps;`
-  - `interface CustomSearchProps extends SearchBarProps` becomes `interface CustomSearchProps extends SearchFormProps`
+  - `interface CustomSearchProps extends SearchBarProps` becomes
+    `interface CustomSearchProps extends SearchFormProps`
 
 ```tsx
 // v5

--- a/modules/labs-react/header/README.md
+++ b/modules/labs-react/header/README.md
@@ -1,4 +1,4 @@
-# Canvas Kit Labs React Header
+# Canvas Kit Labs React Header (Deprecated)
 
 <a href="https://github.com/Workday/canvas-kit/tree/master/modules/labs-react/README.md">
   <img src="https://img.shields.io/badge/LABS-alpha-orange" alt="LABS: Alpha" />
@@ -7,10 +7,6 @@
 A set of components to create headers for various Workday applications and sites.
 
 For a full suite of examples, have a look at the [Header Stories](./stories.tsx).
-
-## Coming Soon
-
-- Mobile Expanded Nav
 
 ## Installation
 
@@ -26,13 +22,13 @@ This component renders a responsive, Canvas-style header.
 
 ```tsx
 import * as React from 'react';
-import {Header} from '@workday/canvas-kit-labs-react/header';
+import {DeprecatedHeader} from '@workday/canvas-kit-labs-react/header';
 import {IconButton} from '@workday/canvas-kit-react/button';
 import {Avatar} from '@workday/canvas-kit-react/avatar';
 import {notificationsIcon} from '@workday/canvas-system-icons-web';
 import {PrimaryButton} from '@workday/canvas-kit-react/button';
 
-<Header title="Header" brandUrl="#">
+<DeprecatedHeader title="Header" brandUrl="#">
   <nav>
     <ul>
       <li className="current">
@@ -62,7 +58,7 @@ import {PrimaryButton} from '@workday/canvas-kit-react/button';
     altText="Profile"
   />
   <PrimaryButton>Sign Up</PrimaryButton>
-</Header>;
+</DeprecatedHeader>;
 ```
 
 ## Special Children
@@ -88,18 +84,18 @@ _Deprecated (but supported) - please use `IconButton` instead._
 
 ## Static Properties
 
-#### `Theme: HeaderTheme`
+#### `Theme: DeprecatedHeaderTheme`
 
 ```tsx
-<Header title="Blue Header" themeColor={Header.Theme.Blue} />
+<DeprecatedHeader title="Blue Header" themeColor={DeprecatedHeader.Theme.Blue} />
 ```
 
 ---
 
-#### `Variant: HeaderVariant`
+#### `Variant: DeprecatedHeaderVariant`
 
 ```tsx
-<Header title="Marketing Header" variant={Header.Variant.Full} />
+<DeprecatedHeader title="Marketing Header" variant={DeprecatedHeader.Variant.Full} />
 ```
 
 ## Component Props
@@ -118,7 +114,7 @@ Default: `''`
 
 ---
 
-#### `themeColor: HeaderTheme`
+#### `themeColor: DeprecatedHeaderTheme`
 
 > The theme of the header (White, Blue, or Transparent).
 
@@ -128,11 +124,11 @@ Default: `''`
 | Blue        | Dark blue gradient background with white text, white system icons.                               |
 | Transparent | Transparent background (intended for dark-colored overlays) with white text, white system icons. |
 
-Default: `HeaderTheme.White`
+Default: `DeprecatedHeaderTheme.White`
 
 ---
 
-#### `variant: HeaderVariant`
+#### `variant: DeprecatedHeaderVariant`
 
 > Specifies the variation of the header.
 
@@ -141,7 +137,7 @@ Default: `HeaderTheme.White`
 | Dub     | "Dub" headers have a singular "Dub" logo and a title, separated by a equivalent-height divider. It is shorter in height (64px) than the "Full" variant.                                                |
 | Full    | "Full" headers have the full Workday logo and an optional title at minimum, separated by an equivalent-height divider (when a title is defined). It is taller in height (80px) than the "Dub" variant. |
 
-Default: `HeaderVariant.Dub`
+Default: `DeprecatedHeaderVariant.Dub`
 
 ---
 
@@ -156,7 +152,7 @@ Default: `HeaderVariant.Dub`
 > If specified, this replaces the contents of the Dub logo and title. Used for replacing Dub + title
 > with a `contained lockup` and/or for adding custon design elements next to the Dub + title lockup.
 
-Default: `DubLogoTitle` (for "Dub" variants) or `WorkdayLogoTitle` (for "Full" variants)
+Default: `DeprecatedDubLogoTitle` (for "Dub" variants) or `DeprecatedWorkdayLogoTitle` (for "Full" variants)
 
 ---
 
@@ -183,7 +179,7 @@ Default: `DubLogoTitle` (for "Dub" variants) or `WorkdayLogoTitle` (for "Full" v
 
 > A React element for the left of the header, this is typically a search bar component
 
-# Global Header
+# Global Header (Deprecated)
 
 The Global Header (or App Header) is used for Workday applications.
 
@@ -191,13 +187,13 @@ The Global Header (or App Header) is used for Workday applications.
 
 ```tsx
 import {Avatar} from '@workday/canvas-kit-react/avatar';
-import {GlobalHeader, DubLogoTitle} from '@workday/canvas-kit-labs-react/header';
+import {DeprecatedGlobalHeader, DeprecatedDubLogoTitle} from '@workday/canvas-kit-labs-react/header';
 import {SearchForm} from '@workday/canvas-kit-labs-react/search-form';
 import {Avatar} from '@workday/canvas-kit-react/avatar';
 import {IconButton} from '@workday/canvas-kit-react/button';
 import {notificationsIcon, inboxIcon} from '@workday/canvas-system-icons-web';
 
-const HeaderBrand = () => <DubLogoTitle themeColor={Header.Theme.White} />
+const HeaderBrand = () => <DeprecatedDubLogoTitle themeColor={Header.Theme.White} />
 const HeaderAvatar = () => <Avatar onClick={handleMenuClick} url="https://my.cdn.amazonaws.com/assets/avatar_pic.png" />
 const handleSearchSubmit = event => {
   const query = (event.target as HTMLFormElement).getElementsByTagName('input')[0].value;
@@ -206,11 +202,11 @@ const handleSearchSubmit = event => {
 const openMenu = e => console.log("Menu opened")
 
 /**
- * In this instance, the right-most child will be an Avatar component, when the GlobalHeader
+ * In this instance, the right-most child will be an Avatar component, when the DeprecatedGlobalHeader
  * shrinks below the specified breakpoint (720 in this case), the children get replaced by a menuToggle.
- * For most GlobalHeader implementations, the menuToggle is also the Avatar component.
+ * For most DeprecatedGlobalHeader implementations, the menuToggle is also the Avatar component.
  */
-<GlobalHeader
+<DeprecatedGlobalHeader
   brand={<HeaderBrand />}
   menuToggle={<HeaderAvatar />}
   onMenuClick={openMenu}
@@ -224,7 +220,7 @@ const openMenu = e => console.log("Menu opened")
   <IconButton icon={notificationsIcon} variant={IconButton.Variant.Circle} />
   <IconButton icon={inboxIcon} variant={IconButton.Variant.Circle} />
   <HeaderAvatar />
-</GlobalHeader>
+</DeprecatedGlobalHeader>
 ```
 
 ## Static Properties
@@ -244,13 +240,13 @@ const openMenu = e => console.log("Menu opened")
 > If specified, this replaces the contents of the Dub logo and title. Used for replacing Dub + title
 > with a branded element and/or for adding custon design elements next to the Dub + title lockup.
 
-Default: `<DubLogoTitle />`
+Default: `<DeprecatedDubLogoTitle />`
 
 #### `menuToggle: React.ReactNode`
 
 > _Note: This `menuToggle` slot only appears when the screen size shrinks below the `breakpoint`._
 >
-> For most `GlobalHeader` implementations, this is generally the same as the users' `Avatar`. If not
+> For most `DeprecatedGlobalHeader` implementations, this is generally the same as the users' `Avatar`. If not
 > specified, `menuToggle` defaults to a "hamburger" menu icon or "justify" icon.
 
 Default: `justifyIcon` from `@workday/canvas-system-icons-web`
@@ -259,7 +255,7 @@ Default: `justifyIcon` from `@workday/canvas-system-icons-web`
 
 > A click handler for when the user clicks the `menuToggle` element.
 
-Default: `<DubLogoTitle />`
+Default: `<DeprecatedDubLogoTitle />`
 
 #### `leftSlot: React.ReactElement`
 
@@ -271,7 +267,7 @@ Default: `<DubLogoTitle />`
 
 # "Dub" Logo and Title
 
-_Intended to be used in conjunction with the `Header` component_
+_Intended to be used in conjunction with the `DeprecatedHeader` component_
 
 A component that encapsulates the 'Dub' logo and a title (we call this the contained lockup). This
 is used whenever you want to override the contained lockup that comes default with a header, or if
@@ -281,11 +277,11 @@ background color of the contained lockup
 ## Usage
 
 ```tsx
-import {Header, DubLogoTitle} from '@workday/canvas-kit-labs-react/header';
+import {DeprecatedHeader, DeprecatedDubLogoTitle} from '@workday/canvas-kit-labs-react/header';
 import {colors} from '@workday/canvas-kit-react/tokens';
 
-<Header
-  brand={<DubLogoTitle title="This title will show up instead" bgColor={colors.blueberry600} />}
+<DeprecatedHeader
+  brand={<DeprecatedDubLogoTitle title="This title will show up instead" bgColor={colors.blueberry600} />}
 />;
 ```
 
@@ -305,11 +301,11 @@ Default: `''`
 
 ### Optional
 
-#### `themeColor: HeaderTheme`
+#### `themeColor: DeprecatedHeaderTheme`
 
 > The theme of the header (White, Blue, or Transparent).
 
-Default: `HeaderTheme.White`
+Default: `DeprecatedHeaderTheme.White`
 
 ---
 
@@ -321,7 +317,7 @@ Default: `'none'`
 
 # Workday Logo and Title
 
-_Intended to be used in conjunction with the `Header` component_
+_Intended to be used in conjunction with the `DeprecatedHeader` component_
 
 A component that contains the full Workday logo and a title. This is used whenever you want to
 override the contained lockup that comes default with a header, or if you want to add more elements
@@ -330,9 +326,9 @@ next to the title with custom components or markup.
 ## Usage
 
 ```tsx
-import {Header, WorkdayLogoTitle} from '@workday/canvas-kit-labs-react/header';
+import {DeprecatedHeader, DeprecatedWorkdayLogoTitle} from '@workday/canvas-kit-labs-react/header';
 
-<Header brand={<WorkdayLogoTitle title="Display Title" />} />;
+<DeprecatedHeader brand={<DeprecatedWorkdayLogoTitle title="Display Title" />} />;
 ```
 
 ## Static Properties
@@ -347,12 +343,12 @@ import {Header, WorkdayLogoTitle} from '@workday/canvas-kit-labs-react/header';
 
 ### Optional
 
-#### `themeColor: HeaderTheme`
+#### `themeColor: DeprecatedHeaderTheme`
 
 > The theme of the header (White, Blue, or Transparent). See the
-> [`themeColor`](#themecolor-headertheme) prop on the `Header` component.
+> [`themeColor`](#themecolor-headertheme) prop on the `DeprecatedHeader` component.
 
-Default: `HeaderTheme.White`
+Default: `DeprecatedHeaderTheme.White`
 
 ---
 

--- a/modules/labs-react/header/index.ts
+++ b/modules/labs-react/header/index.ts
@@ -1,9 +1,9 @@
-import Header from './lib/Header';
-import GlobalHeader from './lib/GlobalHeader';
+import DeprecatedHeader from './lib/Header';
+import DeprecatedGlobalHeader from './lib/GlobalHeader';
 
-export default Header;
-export {Header};
-export {GlobalHeader};
+export default DeprecatedHeader;
+export {DeprecatedHeader};
+export {DeprecatedGlobalHeader};
 export * from './lib/parts';
 export * from './lib/shared/themes';
 export * from './lib/shared/types';

--- a/modules/labs-react/header/lib/GlobalHeader.tsx
+++ b/modules/labs-react/header/lib/GlobalHeader.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import Header from './Header';
-import {HeaderVariant} from './shared/types';
-import {DubLogoTitle} from './parts';
+import DeprecatedHeader from './Header';
+import {DeprecatedHeaderVariant} from './shared/types';
+import {DeprecatedDubLogoTitle} from './parts';
 
 export interface GlobalHeaderProps {
   /**
@@ -28,10 +28,27 @@ export interface GlobalHeaderProps {
   leftSlot?: React.ReactElement;
 }
 
-export default class GlobalHeader extends React.Component<GlobalHeaderProps> {
+/**
+ * ### Deprecated Global Header
+ *
+ * As of Canvas Kit v6, this component is being soft-deprecated.
+ * It will be hard-deprecated (completely removed) in v7. Please see the
+ * [migration guide](https://workday.github.io/canvas-kit/?path=/story/welcome-migration-guides-v6-0--page)
+ * for more information.
+ */
+export default class DeprecatedGlobalHeader extends React.Component<GlobalHeaderProps> {
+  componentDidMount() {
+    console.warn(
+      `GlobalHeader is being deprecated and will be removed in Canvas Kit V7.\n
+      For more information, please see the V6 migration guide:\n
+      https://workday.github.io/canvas-kit/?path=/story/welcome-migration-guides-v6-0--page
+      `
+    );
+  }
+
   public render() {
     const {
-      brand = <DubLogoTitle />,
+      brand = <DeprecatedDubLogoTitle />,
       menuToggle,
       onMenuClick,
       isCollapsed,
@@ -40,17 +57,17 @@ export default class GlobalHeader extends React.Component<GlobalHeaderProps> {
       ...elemProps
     } = this.props;
     return (
-      <Header
+      <DeprecatedHeader
         brand={brand}
         menuToggle={menuToggle}
         leftSlot={leftSlot}
         onMenuClick={onMenuClick}
-        variant={HeaderVariant.Global}
+        variant={DeprecatedHeaderVariant.Global}
         isCollapsed={isCollapsed}
         {...elemProps}
       >
         {children}
-      </Header>
+      </DeprecatedHeader>
     );
   }
 }

--- a/modules/labs-react/header/lib/Header.tsx
+++ b/modules/labs-react/header/lib/Header.tsx
@@ -2,9 +2,13 @@ import * as React from 'react';
 import {css} from '@emotion/core';
 import styled from '@emotion/styled';
 import {borderRadius, space, type} from '@workday/canvas-kit-react/tokens';
-import {DubLogoTitle, WorkdayLogoTitle} from './parts';
-import {themes} from './shared/themes';
-import {HeaderHeight, HeaderTheme, HeaderVariant} from './shared/types';
+import {DeprecatedDubLogoTitle, DeprecatedWorkdayLogoTitle} from './parts';
+import {deprecatedHeaderThemes} from './shared/themes';
+import {
+  DeprecatedHeaderHeight,
+  DeprecatedHeaderTheme,
+  DeprecatedHeaderVariant,
+} from './shared/types';
 import {Hyperlink, IconButton, IconButtonProps} from '@workday/canvas-kit-react/button';
 import {SystemIcon, SystemIconProps} from '@workday/canvas-kit-react/icon';
 import {justifyIcon} from '@workday/canvas-system-icons-web';
@@ -17,14 +21,14 @@ export interface HeaderProps extends React.HTMLAttributes<HTMLDivElement> {
   menuToggle?: React.ReactNode;
   /**
    * The theme of the Header. Accepts `White`, `Blue`, or `Transparent`.
-   * @default HeaderTheme.White
+   * @default DeprecatedHeaderTheme.White
    */
-  themeColor?: HeaderTheme;
+  themeColor?: DeprecatedHeaderTheme;
   /**
    * The variant of the Header. Accepts `Dub` (small) or `Full` (large).
-   * @default HeaderVariant.Dub
+   * @default DeprecatedHeaderVariant.Dub
    */
-  variant?: HeaderVariant;
+  variant?: DeprecatedHeaderVariant;
   /**
    * The text of the Header title. Not used if `brand` is provided.
    */
@@ -71,10 +75,13 @@ const HeaderShell = styled('div')<PickRequired<HeaderProps, 'themeColor', 'varia
   },
   ({variant, themeColor}) => ({
     // Only the variant Full has a large header, all the other one (Dub, Global) have a small header height
-    height: variant === HeaderVariant.Full ? HeaderHeight.Large : HeaderHeight.Small,
-    background: themes[themeColor].background,
-    ...themes[themeColor].depth,
-    color: themes[themeColor].color,
+    height:
+      variant === DeprecatedHeaderVariant.Full
+        ? DeprecatedHeaderHeight.Large
+        : DeprecatedHeaderHeight.Small,
+    background: deprecatedHeaderThemes[themeColor].background,
+    ...deprecatedHeaderThemes[themeColor].depth,
+    color: deprecatedHeaderThemes[themeColor].color,
   })
 );
 
@@ -98,7 +105,7 @@ const BrandLink = styled(Hyperlink)({
 });
 
 const navStyle = ({themeColor}: PickRequired<HeaderProps, 'themeColor', 'css'>) => {
-  const theme = themes[themeColor];
+  const theme = deprecatedHeaderThemes[themeColor];
 
   return css({
     nav: {
@@ -211,24 +218,31 @@ class Brand extends React.Component<
   Pick<HeaderProps, 'variant' | 'brand' | 'title' | 'themeColor'>
 > {
   render() {
-    const {variant = HeaderVariant.Dub, brand, themeColor = HeaderTheme.White, title} = this.props;
+    const {
+      variant = DeprecatedHeaderVariant.Dub,
+      brand,
+      themeColor = DeprecatedHeaderTheme.White,
+      title,
+    } = this.props;
 
     switch (variant) {
-      case HeaderVariant.Global: {
+      case DeprecatedHeaderVariant.Global: {
         return <span>{brand}</span>;
       }
-      case HeaderVariant.Full: {
+      case DeprecatedHeaderVariant.Full: {
         return (
           <span>
-            {brand || <WorkdayLogoTitle title={title ? title : ''} themeColor={themeColor} />}
+            {brand || (
+              <DeprecatedWorkdayLogoTitle title={title ? title : ''} themeColor={themeColor} />
+            )}
           </span>
         );
       }
-      // HeaderVariant.Dub is default
+      // DeprecatedHeaderVariant.Dub is default
       default: {
         return (
           <span>
-            {brand || <DubLogoTitle title={title ? title : ''} themeColor={themeColor} />}
+            {brand || <DeprecatedDubLogoTitle title={title ? title : ''} themeColor={themeColor} />}
           </span>
         );
       }
@@ -240,7 +254,7 @@ class MenuIconButton extends React.Component<
   Pick<HeaderProps, 'themeColor' | 'menuToggle' | 'onMenuClick'>
 > {
   render() {
-    const {themeColor = HeaderTheme.White, menuToggle, onMenuClick} = this.props;
+    const {themeColor = DeprecatedHeaderTheme.White, menuToggle, onMenuClick} = this.props;
     if (menuToggle) {
       const menuToggleElement = menuToggle as React.ReactElement<any>;
       const onClick = menuToggleElement.props.onClick
@@ -255,7 +269,7 @@ class MenuIconButton extends React.Component<
 
     return (
       <IconButton
-        variant={themeColor === HeaderTheme.White ? 'circle' : 'inverse'}
+        variant={themeColor === DeprecatedHeaderTheme.White ? 'circle' : 'inverse'}
         icon={justifyIcon}
         className={'canvas-header--menu-icon'}
         aria-label="Open Menu"
@@ -265,9 +279,26 @@ class MenuIconButton extends React.Component<
   }
 }
 
+/**
+ * ### Deprecated Header
+ *
+ * As of Canvas Kit v6, this component is being soft-deprecated.
+ * It will be hard-deprecated (completely removed) in v7. Please see the
+ * [migration guide](https://workday.github.io/canvas-kit/?path=/story/welcome-migration-guides-v6-0--page)
+ * for more information.
+ */
 export default class Header extends React.Component<HeaderProps, {}> {
-  static Theme = HeaderTheme;
-  static Variant = HeaderVariant;
+  static Theme = DeprecatedHeaderTheme;
+  static Variant = DeprecatedHeaderVariant;
+
+  componentDidMount() {
+    console.warn(
+      `Header is being deprecated and will be removed in Canvas Kit V7.\n
+      For more information, please see the V6 migration guide:\n
+      https://workday.github.io/canvas-kit/?path=/story/welcome-migration-guides-v6-0--page
+      `
+    );
+  }
 
   /**
    * Helper that recursively maps ReactNodes to their theme-based equivalent.
@@ -293,7 +324,8 @@ export default class Header extends React.Component<HeaderProps, {}> {
       const propsChildren = (child as React.ReactElement<Props>).props.children;
       const singleChild =
         React.Children.count(propsChildren) === 1 && (propsChildren as React.ReactElement<any>);
-      const iconButtonVariant = this.props.themeColor === HeaderTheme.White ? 'circle' : 'inverse';
+      const iconButtonVariant =
+        this.props.themeColor === DeprecatedHeaderTheme.White ? 'circle' : 'inverse';
 
       // Convert old method of SystemIcon into IconButton. If SystemIcon is within a link, make sure it's passed through
       if (child.type === 'a' && singleChild && singleChild.type === SystemIcon) {
@@ -339,8 +371,8 @@ export default class Header extends React.Component<HeaderProps, {}> {
   render() {
     const {
       menuToggle,
-      themeColor = HeaderTheme.White,
-      variant = HeaderVariant.Dub,
+      themeColor = DeprecatedHeaderTheme.White,
+      variant = DeprecatedHeaderVariant.Dub,
       centeredNav,
       title,
       brand,

--- a/modules/labs-react/header/lib/parts/DubLogoTitle.tsx
+++ b/modules/labs-react/header/lib/parts/DubLogoTitle.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react';
 import styled from '@emotion/styled';
 import {colors, space} from '@workday/canvas-kit-react/tokens';
-import {HeaderHeight, HeaderTheme} from '../shared/types';
+import {DeprecatedHeaderHeight, DeprecatedHeaderTheme} from '../shared/types';
 import chroma from 'chroma-js';
 import {dubLogoWhite, dubLogoBlue} from '@workday/canvas-kit-react/common';
 
 export type DubTitleProps = {
   /**
    * The theme of the DubLogoTitle. Accepts `White`, `Blue`, or `Transparent`.
-   * @default HeaderTheme.White
+   * @default DeprecatedHeaderTheme.White
    */
-  themeColor?: HeaderTheme;
+  themeColor?: DeprecatedHeaderTheme;
   /**
    * The text of the DubLogoTitle. Not used if `brand` is provided.
    */
@@ -29,7 +29,7 @@ const Lockup = styled('div')<DubTitleProps>(
   {
     display: 'flex',
     alignItems: 'center',
-    height: HeaderHeight.Small,
+    height: DeprecatedHeaderHeight.Small,
     paddingLeft: space.m,
   },
   ({bgColor}) => ({
@@ -47,9 +47,10 @@ const Title = styled('h3')<DubTitleProps>(
     whiteSpace: 'nowrap',
   },
   ({themeColor}) => ({
-    color: themeColor === HeaderTheme.White ? colors.blueberry500 : colors.frenchVanilla100,
+    color:
+      themeColor === DeprecatedHeaderTheme.White ? colors.blueberry500 : colors.frenchVanilla100,
     borderLeft: `1px solid ${
-      themeColor === HeaderTheme.White
+      themeColor === DeprecatedHeaderTheme.White
         ? colors.soap400
         : chroma(colors.frenchVanilla100)
             .alpha(0.3)
@@ -62,16 +63,32 @@ const DubLogo = styled('div')<DubTitleProps>({
   lineHeight: 0,
 });
 
-export class DubLogoTitle extends React.Component<DubTitleProps> {
+/**
+ * ### Deprecated Dub Logo Title
+ *
+ * As of Canvas Kit v6, this component is being soft-deprecated.
+ * It will be hard-deprecated (completely removed) in v7. Please see the
+ * [migration guide](https://workday.github.io/canvas-kit/?path=/story/welcome-migration-guides-v6-0--page)
+ * for more information.
+ */
+export class DeprecatedDubLogoTitle extends React.Component<DubTitleProps> {
+  componentDidMount() {
+    console.warn(
+      `DubLogoTitle is being deprecated and will be removed in Canvas Kit V7.\n
+      For more information, please see the V6 migration guide:\n
+      https://workday.github.io/canvas-kit/?path=/story/welcome-migration-guides-v6-0--page
+      `
+    );
+  }
   render() {
-    const {themeColor = HeaderTheme.White, title} = this.props;
+    const {themeColor = DeprecatedHeaderTheme.White, title} = this.props;
     return (
       <LockupContainer>
         <Lockup {...this.props}>
           <DubLogo
             {...this.props}
             dangerouslySetInnerHTML={{
-              __html: themeColor === HeaderTheme.White ? dubLogoBlue : dubLogoWhite,
+              __html: themeColor === DeprecatedHeaderTheme.White ? dubLogoBlue : dubLogoWhite,
             }}
           />
           {title && <Title {...this.props}>{title}</Title>}

--- a/modules/labs-react/header/lib/parts/WorkdayLogoTitle.tsx
+++ b/modules/labs-react/header/lib/parts/WorkdayLogoTitle.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import styled from '@emotion/styled';
-import {HeaderHeight, HeaderTheme, HeaderVariant} from '../shared/types';
+import {
+  DeprecatedHeaderHeight,
+  DeprecatedHeaderTheme,
+  DeprecatedHeaderVariant,
+} from '../shared/types';
 import {miniWdayLogoBlue, wdayLogoWhite, wdayLogoBlue} from '@workday/canvas-kit-react/common';
 import {colors, space} from '@workday/canvas-kit-react/tokens';
 import chroma from 'chroma-js';
@@ -8,9 +12,9 @@ import chroma from 'chroma-js';
 export type WorkdayLogoTitleProps = {
   /**
    * The theme of the WorkdayLogoTitle. Accepts `White`, `Blue`, or `Transparent`.
-   * @default HeaderTheme.White
+   * @default DeprecatedHeaderTheme.White
    */
-  themeColor?: HeaderTheme;
+  themeColor?: DeprecatedHeaderTheme;
   /**
    * The text of the WorkdayLogoTitle. Not used if `brand` is provided.
    * @default ''
@@ -19,7 +23,7 @@ export type WorkdayLogoTitleProps = {
   /**
    * The variant of the WorkdayLogoTitle.
    */
-  variant?: HeaderVariant;
+  variant?: DeprecatedHeaderVariant;
 };
 
 const LockupContainer = styled('div')({
@@ -33,7 +37,10 @@ const Lockup = styled('div')<WorkdayLogoTitleProps>(
     justifyContent: 'center',
   },
   ({variant}) => ({
-    height: variant === HeaderVariant.Global ? HeaderHeight.Small : HeaderHeight.Large,
+    height:
+      variant === DeprecatedHeaderVariant.Global
+        ? DeprecatedHeaderHeight.Small
+        : DeprecatedHeaderHeight.Large,
   })
 );
 
@@ -49,9 +56,10 @@ const Title = styled('h3')<WorkdayLogoTitleProps>(
     display: 'initial',
   },
   ({themeColor}) => ({
-    color: themeColor === HeaderTheme.White ? colors.blueberry500 : colors.frenchVanilla100,
+    color:
+      themeColor === DeprecatedHeaderTheme.White ? colors.blueberry500 : colors.frenchVanilla100,
     borderLeft: `1px solid ${
-      themeColor === HeaderTheme.White
+      themeColor === DeprecatedHeaderTheme.White
         ? colors.soap400
         : chroma(colors.soap400)
             .alpha(0.4)
@@ -65,9 +73,30 @@ const WorkdayLogo = styled('span')<WorkdayLogoTitleProps>({
   lineHeight: 0,
 });
 
-export class WorkdayLogoTitle extends React.Component<WorkdayLogoTitleProps> {
+/**
+ * ### Deprecated Workday Logo Title
+ *
+ * As of Canvas Kit v6, this component is being soft-deprecated.
+ * It will be hard-deprecated (completely removed) in v7. Please see the
+ * [migration guide](https://workday.github.io/canvas-kit/?path=/story/welcome-migration-guides-v6-0--page)
+ * for more information.
+ */
+export class DeprecatedWorkdayLogoTitle extends React.Component<WorkdayLogoTitleProps> {
+  componentDidMount() {
+    console.warn(
+      `WorkdayLogoTitle is being deprecated and will be removed in Canvas Kit V7.\n
+      For more information, please see the V6 migration guide:\n
+      https://workday.github.io/canvas-kit/?path=/story/welcome-migration-guides-v6-0--page
+      `
+    );
+  }
   public render() {
-    const {themeColor = HeaderTheme.White, title = '', variant, ...elemProps} = this.props;
+    const {
+      themeColor = DeprecatedHeaderTheme.White,
+      title = '',
+      variant,
+      ...elemProps
+    } = this.props;
 
     return (
       <LockupContainer>
@@ -76,8 +105,8 @@ export class WorkdayLogoTitle extends React.Component<WorkdayLogoTitleProps> {
             {...this.props}
             dangerouslySetInnerHTML={{
               __html:
-                themeColor === HeaderTheme.White
-                  ? variant === HeaderVariant.Global
+                themeColor === DeprecatedHeaderTheme.White
+                  ? variant === DeprecatedHeaderVariant.Global
                     ? miniWdayLogoBlue
                     : wdayLogoBlue
                   : wdayLogoWhite,

--- a/modules/labs-react/header/lib/parts/index.ts
+++ b/modules/labs-react/header/lib/parts/index.ts
@@ -1,2 +1,2 @@
-export {DubLogoTitle} from './DubLogoTitle';
-export {WorkdayLogoTitle} from './WorkdayLogoTitle';
+export {DeprecatedDubLogoTitle} from './DubLogoTitle';
+export {DeprecatedWorkdayLogoTitle} from './WorkdayLogoTitle';

--- a/modules/labs-react/header/lib/shared/themes.tsx
+++ b/modules/labs-react/header/lib/shared/themes.tsx
@@ -6,9 +6,17 @@ import {
   CSSProperties,
 } from '@workday/canvas-kit-react/tokens';
 import chroma from 'chroma-js';
-import {HeaderTheme} from './types';
+import {DeprecatedHeaderTheme} from './types';
 
-export interface ThemeAttributes {
+/**
+ * ### Deprecated Header Theme Attributes Interface
+ *
+ * As of Canvas Kit v6, this type interface is being soft-deprecated along with the rest of the labs/header package.
+ * It will be hard-deprecated (completely removed) in v7. Please see the
+ * [migration guide](https://workday.github.io/canvas-kit/?path=/story/welcome-migration-guides-v6-0--page)
+ * for more information.
+ */
+export interface DeprecatedHeaderThemeAttributes {
   color: string;
   background: string;
   depth: CSSProperties;
@@ -22,12 +30,28 @@ export interface ThemeAttributes {
   chipColor: string;
 }
 
-export interface Themes {
-  [key: string]: ThemeAttributes;
+/**
+ * ### Deprecated Header Themes Interface
+ *
+ * As of Canvas Kit v6, this type interface is being soft-deprecated along with the rest of the labs/header package.
+ * It will be hard-deprecated (completely removed) in v7. Please see the
+ * [migration guide](https://workday.github.io/canvas-kit/?path=/story/welcome-migration-guides-v6-0--page)
+ * for more information.
+ */
+export interface DeprecatedHeaderThemes {
+  [key: string]: DeprecatedHeaderThemeAttributes;
 }
 
-export const themes: Themes = {
-  [HeaderTheme.White]: {
+/**
+ * ### Deprecated Header Themes
+ *
+ * As of Canvas Kit v6, this theme object is being soft-deprecated along with the rest of the labs/header package.
+ * It will be hard-deprecated (completely removed) in v7. Please see the
+ * [migration guide](https://workday.github.io/canvas-kit/?path=/story/welcome-migration-guides-v6-0--page)
+ * for more information.
+ */
+export const deprecatedHeaderThemes: DeprecatedHeaderThemes = {
+  [DeprecatedHeaderTheme.White]: {
     color: colors.blackPepper400,
     background: colors.frenchVanilla100,
     depth: depth['1'],
@@ -40,7 +64,7 @@ export const themes: Themes = {
     currentLinkColor: colors.blueberry500,
     chipColor: colors.blueberry400,
   },
-  [HeaderTheme.Blue]: {
+  [DeprecatedHeaderTheme.Blue]: {
     color: colors.frenchVanilla100,
     background: gradients.blueberry,
     depth: depth['3'],
@@ -55,7 +79,7 @@ export const themes: Themes = {
     currentLinkColor: colors.frenchVanilla100,
     chipColor: colors.frenchVanilla100,
   },
-  [HeaderTheme.Transparent]: {
+  [DeprecatedHeaderTheme.Transparent]: {
     color: colors.frenchVanilla100,
     background: 'transparent',
     depth: {boxShadow: 'none'},

--- a/modules/labs-react/header/lib/shared/types.tsx
+++ b/modules/labs-react/header/lib/shared/types.tsx
@@ -1,16 +1,16 @@
-export enum HeaderTheme {
+export enum DeprecatedHeaderTheme {
   White,
   Blue,
   Transparent,
 }
 
-export enum HeaderVariant {
+export enum DeprecatedHeaderVariant {
   Dub,
   Full,
   Global,
 }
 
-export enum HeaderHeight {
+export enum DeprecatedHeaderHeight {
   Small = '64px',
   Large = '80px',
 }

--- a/modules/labs-react/header/spec/GlobalHeader.spec.tsx
+++ b/modules/labs-react/header/spec/GlobalHeader.spec.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import GlobalHeader from '../lib/GlobalHeader';
+import DeprecatedGlobalHeader from '../lib/GlobalHeader';
 import {shallow} from 'enzyme';
-import Header from '../lib/Header';
+import DeprecatedHeader from '../lib/Header';
 import {SearchForm} from '@workday/canvas-kit-labs-react/search-form';
-import {DubLogoTitle} from '../lib/parts';
-import {HeaderTheme, HeaderVariant} from '../lib/shared/types';
+import {DeprecatedDubLogoTitle} from '../lib/parts';
+import {DeprecatedHeaderTheme, DeprecatedHeaderVariant} from '../lib/shared/types';
 
 declare global {
   interface Window {
@@ -40,7 +40,7 @@ window.resizeBy = (x: number, y: number) => {
 // @ts-ignore
 window.requestAnimationFrame = cbFn => cbFn();
 
-describe('GlobalHeader', () => {
+describe('DeprecatedGlobalHeader', () => {
   const cb = jest.fn();
   beforeEach(() => {
     window.resizeBy(1280, 1024);
@@ -50,23 +50,25 @@ describe('GlobalHeader', () => {
     cb.mockReset();
   });
 
-  describe('How GlobalHeader children render', () => {
+  describe('How DeprecatedGlobalHeader children render', () => {
     beforeEach(() => {
       window.resizeBy(1280, 1024);
     });
 
     test('Renders non-React child elements as is', () => {
       const text = 'not a react element';
-      const wrapper = shallow<GlobalHeader>(<GlobalHeader>{text}</GlobalHeader>);
+      const wrapper = shallow<DeprecatedGlobalHeader>(
+        <DeprecatedGlobalHeader>{text}</DeprecatedGlobalHeader>
+      );
 
       expect(wrapper.contains(text));
     });
 
     test('Renders a div element as is', () => {
-      const wrapper = shallow<GlobalHeader>(
-        <GlobalHeader>
+      const wrapper = shallow<DeprecatedGlobalHeader>(
+        <DeprecatedGlobalHeader>
           <div>Test</div>
-        </GlobalHeader>
+        </DeprecatedGlobalHeader>
       );
       expect(
         wrapper
@@ -87,19 +89,19 @@ describe('GlobalHeader', () => {
       const propsHeader2 = {
         menuToggle: 'abcde',
         isCollapsed: false,
-        themeColor: HeaderTheme.White,
+        themeColor: DeprecatedHeaderTheme.White,
       };
       const defaultProps = {
-        brand: <DubLogoTitle />,
-        variant: HeaderVariant.Global,
+        brand: <DeprecatedDubLogoTitle />,
+        variant: DeprecatedHeaderVariant.Global,
         children: undefined,
       };
 
-      const childPropsHeader1 = shallow(<GlobalHeader {...propsHeader1} />)
-        .find(Header)
+      const childPropsHeader1 = shallow(<DeprecatedGlobalHeader {...propsHeader1} />)
+        .find(DeprecatedHeader)
         .props();
-      const childPropsHeader2 = shallow(<GlobalHeader {...propsHeader2} />)
-        .find(Header)
+      const childPropsHeader2 = shallow(<DeprecatedGlobalHeader {...propsHeader2} />)
+        .find(DeprecatedHeader)
         .props();
 
       expect(childPropsHeader1).toEqual({...defaultProps, ...propsHeader1});

--- a/modules/labs-react/header/spec/SSR.spec.tsx
+++ b/modules/labs-react/header/spec/SSR.spec.tsx
@@ -3,18 +3,18 @@
  */
 import React from 'react';
 import {renderToString} from 'react-dom/server';
-import {Header, GlobalHeader} from '../';
+import {DeprecatedHeader, DeprecatedGlobalHeader} from '../';
 
-describe('Header', () => {
+describe('Deprecated Header', () => {
   it('should render on a server without crashing', () => {
-    const ssrRender = () => renderToString(<Header />);
+    const ssrRender = () => renderToString(<DeprecatedHeader />);
     expect(ssrRender).not.toThrow();
   });
 });
 
-describe('GlobalHeader', () => {
+describe('Deprecated Global Header', () => {
   it('should render on a server without crashing', () => {
-    const ssrRender = () => renderToString(<GlobalHeader />);
+    const ssrRender = () => renderToString(<DeprecatedGlobalHeader />);
     expect(ssrRender).not.toThrow();
   });
 });

--- a/modules/labs-react/header/stories/stories.tsx
+++ b/modules/labs-react/header/stories/stories.tsx
@@ -11,12 +11,17 @@ import chroma from 'chroma-js';
 import {notificationsIcon, inboxIcon} from '@workday/canvas-system-icons-web';
 
 import {Avatar} from '@workday/canvas-kit-react/avatar';
-import {CanvasProvider, ContentDirection} from '@workday/canvas-kit-react';
 import {colors, space, gradients} from '@workday/canvas-kit-react/tokens';
 import {IconButton, PrimaryButton} from '@workday/canvas-kit-react/button';
 import {MenuItem} from '@workday/canvas-kit-preview-react/menu';
 import {SearchForm, SearchFormProps} from '@workday/canvas-kit-labs-react/search-form';
-import {GlobalHeader, Header, DubLogoTitle, WorkdayLogoTitle, HeaderVariant} from '../index';
+import {
+  DeprecatedGlobalHeader,
+  DeprecatedHeader,
+  DeprecatedDubLogoTitle,
+  DeprecatedWorkdayLogoTitle,
+  DeprecatedHeaderVariant,
+} from '../index';
 
 import README from '../README.md';
 import bgImg from '../static/workday-bg.jpg';
@@ -117,16 +122,16 @@ class SearchWithAutoComplete extends React.Component<
 }
 
 storiesOf('Labs/Header/React', module)
-  .addParameters({component: Header})
+  .addParameters({component: DeprecatedHeader})
   .addDecorator(withReadme(README))
   .addDecorator(withKnobs)
   .add('Global Header', () => (
     <div className="story">
       <div css={containerStyle}>
-        <GlobalHeader
+        <DeprecatedGlobalHeader
           brand={
             <a href="#">
-              <DubLogoTitle themeColor={Header.Theme.White} />
+              <DeprecatedDubLogoTitle themeColor={DeprecatedHeader.Theme.White} />
             </a>
           }
           menuToggle={
@@ -156,11 +161,11 @@ storiesOf('Labs/Header/React', module)
             url="https://s3-us-west-2.amazonaws.com/design-assets-internal/avatars/lmcneil.png"
             altText="Profile"
           />
-        </GlobalHeader>
+        </DeprecatedGlobalHeader>
       </div>
       <div css={containerStyle}>
-        <GlobalHeader
-          brand={<WorkdayLogoTitle variant={HeaderVariant.Global} />}
+        <DeprecatedGlobalHeader
+          brand={<DeprecatedWorkdayLogoTitle variant={DeprecatedHeaderVariant.Global} />}
           menuToggle={<Avatar onClick={handleMenuClickTest} />}
           leftSlot={
             <SearchForm
@@ -178,10 +183,10 @@ storiesOf('Labs/Header/React', module)
           />
           <IconButton icon={inboxIcon} variant="circle" title="Inbox" aria-label="Inbox" />
           <Avatar onClick={handleAvatarClickTest} altText="Profile" />
-        </GlobalHeader>
+        </DeprecatedGlobalHeader>
       </div>
       <div css={containerStyle}>
-        <GlobalHeader
+        <DeprecatedGlobalHeader
           leftSlot={
             <SearchForm
               isCollapsed={boolean('isCollapsed', false)}
@@ -199,14 +204,14 @@ storiesOf('Labs/Header/React', module)
           />
           <IconButton icon={inboxIcon} variant="circle" title="Inbox" aria-label="Inbox" />
           <Avatar onClick={handleAvatarClickTest} altText="Profile" />
-        </GlobalHeader>
+        </DeprecatedGlobalHeader>
       </div>
     </div>
   ))
   .add('Dub Header', () => (
     <div className="story">
       <div css={containerStyle}>
-        <Header
+        <DeprecatedHeader
           title="Required"
           leftSlot={
             <SearchForm
@@ -220,7 +225,7 @@ storiesOf('Labs/Header/React', module)
         />
       </div>
       <div css={containerStyle}>
-        <Header
+        <DeprecatedHeader
           title="Icons Only"
           brandUrl="#"
           leftSlot={
@@ -239,13 +244,13 @@ storiesOf('Labs/Header/React', module)
           />
           <IconButton variant="circle" icon={inboxIcon} title="Inbox" aria-label="Inbox" />
           <Avatar onClick={handleAvatarClickTest} altText="Profile" />
-        </Header>
+        </DeprecatedHeader>
       </div>
       <br />
       <div css={containerStyle}>
-        <Header
+        <DeprecatedHeader
           title="Kitchen Sink"
-          themeColor={Header.Theme.Blue}
+          themeColor={DeprecatedHeader.Theme.Blue}
           brandUrl="#"
           onMenuClick={handleMenuClickTest}
           leftSlot={<SearchWithAutoComplete searchTheme={SearchForm.Theme.Dark} />}
@@ -261,18 +266,18 @@ storiesOf('Labs/Header/React', module)
           />
           <Avatar onClick={handleAvatarClickTest} altText="Profile" />
           <PrimaryButton>Download</PrimaryButton>
-        </Header>
+        </DeprecatedHeader>
       </div>
       <br />
       <div css={containerStyle}>
-        <Header
-          variant={Header.Variant.Dub}
+        <DeprecatedHeader
+          variant={DeprecatedHeader.Variant.Dub}
           title="Ignored when brand prop exists..."
-          themeColor={Header.Theme.White}
+          themeColor={DeprecatedHeader.Theme.White}
           brand={
-            <DubLogoTitle
+            <DeprecatedDubLogoTitle
               title="Contained Lockup"
-              themeColor={Header.Theme.Blue}
+              themeColor={DeprecatedHeader.Theme.Blue}
               bgColor={gradients.blueberry}
             />
           }
@@ -295,14 +300,14 @@ storiesOf('Labs/Header/React', module)
           />
           <IconButton variant="circle" icon={inboxIcon} title="Inbox" aria-label="Inbox" />
           <PrimaryButton>Logout</PrimaryButton>
-        </Header>
+        </DeprecatedHeader>
       </div>
       <br />
       <div css={containerStyle}>
-        <Header
-          variant={Header.Variant.Dub}
+        <DeprecatedHeader
+          variant={DeprecatedHeader.Variant.Dub}
           title="Centered Menu"
-          themeColor={Header.Theme.White}
+          themeColor={DeprecatedHeader.Theme.White}
           centeredNav={true}
           brandUrl="#"
           leftSlot={
@@ -323,14 +328,14 @@ storiesOf('Labs/Header/React', module)
           />
           <IconButton variant="circle" icon={inboxIcon} title="Inbox" aria-label="Inbox" />
           <PrimaryButton>Logout</PrimaryButton>
-        </Header>
+        </DeprecatedHeader>
       </div>
       <br />
       <div css={containerStyle}>
-        <Header
-          variant={Header.Variant.Dub}
+        <DeprecatedHeader
+          variant={DeprecatedHeader.Variant.Dub}
           title="Centered Menu Without Search"
-          themeColor={Header.Theme.White}
+          themeColor={DeprecatedHeader.Theme.White}
           centeredNav={true}
           brandUrl="#"
           isCollapsed={boolean('isCollapsed', false)}
@@ -344,14 +349,14 @@ storiesOf('Labs/Header/React', module)
           />
           <IconButton variant="circle" icon={inboxIcon} title="Inbox" aria-label="Inbox" />
           <PrimaryButton>Logout</PrimaryButton>
-        </Header>
+        </DeprecatedHeader>
       </div>
       <br />
       <div css={[containerStyle, backgroundStyle]}>
-        <Header
-          variant={Header.Variant.Dub}
+        <DeprecatedHeader
+          variant={DeprecatedHeader.Variant.Dub}
           title="Transparent"
-          themeColor={Header.Theme.Transparent}
+          themeColor={DeprecatedHeader.Theme.Transparent}
           brandUrl="#"
           leftSlot={
             <SearchForm
@@ -372,32 +377,35 @@ storiesOf('Labs/Header/React', module)
           />
           <IconButton variant="inverse" icon={inboxIcon} title="Inbox" aria-label="Inbox" />
           <PrimaryButton>Logout</PrimaryButton>
-        </Header>
+        </DeprecatedHeader>
       </div>
     </div>
   ))
   .add('Full Header', () => (
     <div className="story">
       <div css={containerStyle}>
-        <Header variant={Header.Variant.Full} isCollapsed={boolean('isCollapsed', false)} />
+        <DeprecatedHeader
+          variant={DeprecatedHeader.Variant.Full}
+          isCollapsed={boolean('isCollapsed', false)}
+        />
       </div>
       <div css={containerStyle}>
-        <Header
-          variant={Header.Variant.Full}
+        <DeprecatedHeader
+          variant={DeprecatedHeader.Variant.Full}
           title="Design"
-          themeColor={Header.Theme.White}
+          themeColor={DeprecatedHeader.Theme.White}
           brandUrl="#"
           isCollapsed={boolean('isCollapsed', false)}
         >
           {nav}
-        </Header>
+        </DeprecatedHeader>
       </div>
       <br />
       <div css={containerStyle}>
-        <Header
-          variant={Header.Variant.Full}
+        <DeprecatedHeader
+          variant={DeprecatedHeader.Variant.Full}
           title="Kitchen Sink"
-          themeColor={Header.Theme.Blue}
+          themeColor={DeprecatedHeader.Theme.Blue}
           brandUrl="#"
           onMenuClick={handleMenuClickTest}
           isCollapsed={boolean('isCollapsed', false)}
@@ -411,14 +419,14 @@ storiesOf('Labs/Header/React', module)
           />
           <Avatar onClick={handleAvatarClickTest} altText="Profile" />
           <PrimaryButton>Download</PrimaryButton>
-        </Header>
+        </DeprecatedHeader>
       </div>
       <br />
       <div css={containerStyle}>
-        <Header
-          variant={Header.Variant.Full}
+        <DeprecatedHeader
+          variant={DeprecatedHeader.Variant.Full}
           title=""
-          themeColor={Header.Theme.Blue}
+          themeColor={DeprecatedHeader.Theme.Blue}
           brandUrl="#"
           isCollapsed={boolean('isCollapsed', false)}
         >
@@ -430,14 +438,14 @@ storiesOf('Labs/Header/React', module)
             aria-label="Notifications"
           />
           <Avatar onClick={handleAvatarClickTest} />
-        </Header>
+        </DeprecatedHeader>
       </div>
       <br />
       <div css={[containerStyle, backgroundStyle]}>
-        <Header
-          variant={Header.Variant.Full}
+        <DeprecatedHeader
+          variant={DeprecatedHeader.Variant.Full}
           title="Transparent"
-          themeColor={Header.Theme.Transparent}
+          themeColor={DeprecatedHeader.Theme.Transparent}
           brandUrl="#"
           isCollapsed={boolean('isCollapsed', false)}
         >
@@ -449,14 +457,14 @@ storiesOf('Labs/Header/React', module)
             aria-label="Notifications"
           />
           <Avatar onClick={handleAvatarClickTest} altText="Profile" />
-        </Header>
+        </DeprecatedHeader>
       </div>
       <br />
       <div css={containerStyle}>
-        <Header
-          variant={Header.Variant.Full}
+        <DeprecatedHeader
+          variant={DeprecatedHeader.Variant.Full}
           title=""
-          themeColor={Header.Theme.White}
+          themeColor={DeprecatedHeader.Theme.White}
           centeredNav={true}
           brandUrl="#"
           isCollapsed={boolean('isCollapsed', false)}
@@ -470,7 +478,7 @@ storiesOf('Labs/Header/React', module)
           />
           <IconButton variant="circle" icon={inboxIcon} title="Inbox" aria-label="Inbox" />
           <PrimaryButton>Logout</PrimaryButton>
-        </Header>
+        </DeprecatedHeader>
       </div>
     </div>
   ));

--- a/modules/react/side-panel/stories/stories.tsx
+++ b/modules/react/side-panel/stories/stories.tsx
@@ -11,7 +11,7 @@ import {select, number} from '@storybook/addon-knobs';
 import {colors, type} from '@workday/canvas-kit-react/tokens';
 import README from '../README.md';
 import {SystemIcon} from '@workday/canvas-kit-react/icon';
-import {Header} from '@workday/canvas-kit-labs-react/header';
+import {DeprecatedHeader} from '@workday/canvas-kit-labs-react/header';
 import {IconButton, PrimaryButton} from '@workday/canvas-kit-react/button';
 import {Avatar} from '@workday/canvas-kit-react/avatar';
 import {SidePanel} from '@workday/canvas-kit-react/side-panel';
@@ -168,14 +168,14 @@ storiesOf('Components/Containers/Side Panel/React', module)
   .add('Configurable', () => (
     <div className="story">
       <div style={{height: '67vh', position: 'relative'}}>
-        <Header brandUrl="#">
+        <DeprecatedHeader brandUrl="#">
           <Avatar
             onClick={() => {
               alert('clicked avatar');
             }}
           />
           <PrimaryButton>Sign Up</PrimaryButton>
-        </Header>
+        </DeprecatedHeader>
         <SidePanelWrapper />
       </div>
     </div>


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Resolves #1190

Deprecate Header exports

![category](https://img.shields.io/badge/release_category-Components-blue)

## BREAKING CHANGES

This update soft-deprecates all exports from `canvas-kit-labs-react/header`. These changes are handled automatically by the codemod transform included in this PR. Please refer to the v6 migration guide for more information.

---

This PR:

- Adds a codemod to update header exports
- Updates the v6 migration guide
- Deprecates header components
  - Adds console warnings to `DubLogoTitle`, `GlobalHeader`, `Header`, and `WorkdayLogoTitle`
  - Adds deprecation JSDoc notes for all labs/header exports
  - Renames Header and related exports
    - `DubLogoTitle` => `DeprecatedDubLogoTitle`
    - `GlobalHeader` => `DeprecatedGlobalHeader`
    - `Header` => `DeprecatedHeader`
    - `HeaderHeight` => `DeprecatedHeaderHeight`
    - `HeaderTheme` => `DeprecatedHeaderTheme`
    - `HeaderVariant` => `DeprecatedHeaderVariant`
    - `ThemeAttributes` => `DeprecatedHeaderThemeAttributes`
    - `Themes` => `DeprecatedHeaderThemes`
    - `WorkdayLogoTitle` => `DeprecatedWorkdayLogoTitle`
    - `themes` => `deprecatedHeaderThemes`
- Updates Header README
- Updates Header stories
- Updates Header tests (where relevant)
- Updates `SidePanel` story that imported `Header`

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] code has been documented
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](https://workday.github.io/canvas-kit/?path=/story/welcome-dev-docs-api-pattern-guidelines--page)
