### PR TITLE
docs: Remove travis badge [skip release]

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ implement user experiences consistent with
 
 ---
 
-**:white_check_mark: For a list of available react modules see [Canvas Kit Component Status](./modules/docs/mdx/COMPONENT_STATUS.mdx)**
+**:white_check_mark: For a list of available react modules see
+[Canvas Kit Component Status](./modules/docs/mdx/COMPONENT_STATUS.mdx)**
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ implement user experiences consistent with
 <a href="https://lerna.js.org">
   <img src="https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg" alt="Maintained with Lerna" />
 </a>
+[![Release](https://github.com/Workday/canvas-kit/actions/workflows/release.yml/badge.svg)](https://github.com/Workday/canvas-kit/actions/workflows/release.yml)
 <a href="./modules/docs/mdx/CONTRIBUTING.mdx">
   <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome" />
 </a>
@@ -142,4 +143,4 @@ The Workday Canvas Kits are licensed under the Apache 2.0 License.
 
 Visual Testing by [ChromaticQA](https://www.chromaticqa.com/)
 
-Builds by [TravisCI](https://www.chromaticqa.com/)
+Builds by [Github Actions](https://docs.github.com/en/actions)

--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@ implement user experiences consistent with
 <a href="./LICENSE">
   <img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="Workday Canvas Kit is released under the Apache-2.0 license" />
 </a>
-<a href="https://travis-ci.org/Workday/canvas-kit">
-  <img src="https://travis-ci.com/Workday/canvas-kit.svg?token=oZpr7hcrwxtuCsrBb5dT&branch=master" alt="Travis CI">
-</a>
 <a href="https://lerna.js.org">
   <img src="https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg" alt="Maintained with Lerna" />
 </a>

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ implement user experiences consistent with
 
 ---
 
-**:white_check_mark: For a list of available react modules see
-[Canvas Kit Component Status](./modules/docs/mdx/COMPONENT_STATUS.mdx)**
+**:white_check_mark: For a list of available react modules see [Canvas Kit Component Status](./modules/docs/mdx/COMPONENT_STATUS.mdx)**
 
 ## Getting started
 


### PR DESCRIPTION
Seems like you're not using travis anymore for builds?

or at least I can't find it, in which case we should close this PR and update the link and the badge image instead

lmk

## Summary

Remove Travis badge since Travis is no longer used.

![category](https://img.shields.io/badge/release_category-Documentation-blue)