### PR TITLE
fix(tooltip): Fix findEllipsisElement IE11

### DIFF
--- a/cypress/integration/Tooltip.spec.ts
+++ b/cypress/integration/Tooltip.spec.ts
@@ -302,4 +302,19 @@ describe('Tooltip', () => {
       });
     });
   });
+  context('given the [Testing/React/Popups/Tooltip, Overflow] example is rendered', () => {
+    beforeEach(() => {
+      h.stories.load('Testing/React/Popups/Tooltip', 'Overflow');
+    });
+
+    context('when the = button is hovered', () => {
+      beforeEach(() => {
+        cy.findByTestId('overflow-tooltip').trigger('mouseover');
+      });
+
+      it('should open the tooltip', () => {
+        cy.findByRole('tooltip').should('be.visible');
+      });
+    });
+  });
 });

--- a/modules/react/tooltip/lib/OverflowTooltip.tsx
+++ b/modules/react/tooltip/lib/OverflowTooltip.tsx
@@ -10,7 +10,7 @@ import {useTooltip} from './useTooltip';
  * Look for an element within the tree for an overflow element (auto, scroll, clip, or hidden).
  * This could be the passed element, or a descendant. If no element is found, `null` is returned.
  */
-const findOverflowElement = (element: Element): Element | null => {
+export const findOverflowElement = (element: Element): Element | null => {
   const style = getComputedStyle(element);
   if (
     style.overflow === 'auto' ||
@@ -36,11 +36,12 @@ const findOverflowElement = (element: Element): Element | null => {
  * Look for an element within the tree for a `text-overflow` CSS property of `ellipsis`.
  * This could be the passed element, or a descendant. If no element is found, `null` is returned.
  */
-const findEllipsisElement = (element: Element): Element | null => {
+export const findEllipsisElement = (element: Element): Element | null => {
   const style = getComputedStyle(element);
   if (style.textOverflow === 'ellipsis' || Number(style.webkitLineClamp) > 0) {
     return element;
-  } else {
+  } else if (element.children) {
+    // `children` is not defined for SVGElement in IE11
     for (let i = 0; i < element.children.length; i++) {
       const overflowElement = findEllipsisElement(element.children[i]);
       if (overflowElement) {
@@ -49,6 +50,7 @@ const findEllipsisElement = (element: Element): Element | null => {
     }
     return null;
   }
+  return null;
 };
 
 const isOverflowed = (element: Element) => {

--- a/modules/react/tooltip/spec/OverflowTooltip.spec.tsx
+++ b/modules/react/tooltip/spec/OverflowTooltip.spec.tsx
@@ -1,0 +1,15 @@
+import {findEllipsisElement, findOverflowElement} from '..';
+
+describe('findEllipsisElement', () => {
+  it('returns null if element has no children attribute [SVG in IE 11]', () => {
+    const el = document.createElement('svg');
+    expect(findEllipsisElement(el)).toBeNull();
+  });
+});
+
+describe('findOverflowElement', () => {
+  it('returns null if element has no children attribute [SVG in IE 11]', () => {
+    const el = document.createElement('svg');
+    expect(findOverflowElement(el)).toBeNull();
+  });
+});

--- a/modules/react/tooltip/stories/examples/Ellipsis.tsx
+++ b/modules/react/tooltip/stories/examples/Ellipsis.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {SecondaryButton} from '@workday/canvas-kit-react/button';
 import {OverflowTooltip} from '@workday/canvas-kit-react/tooltip';
 import {space} from '@workday/canvas-kit-react/tokens';
+import {resetIcon} from '@workday/canvas-system-icons-web';
 
 const CustomContent = ({...elemProps}) => (
   <button
@@ -28,6 +29,11 @@ export const Ellipsis = () => {
       <OverflowTooltip>
         <SecondaryButton style={{maxWidth: 200}}>
           Super Mega Ultra Long Content With Max Width On The Button
+        </SecondaryButton>
+      </OverflowTooltip>
+      <OverflowTooltip>
+        <SecondaryButton icon={resetIcon} style={{maxWidth: 200}}>
+          Super Mega Ultra Long Content With Max Width On The Button with Icon
         </SecondaryButton>
       </OverflowTooltip>
       <OverflowTooltip>

--- a/modules/react/tooltip/stories/stories_testing.tsx
+++ b/modules/react/tooltip/stories/stories_testing.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {Popper, Placement} from '@workday/canvas-kit-react/popup';
-import {TooltipContainer, Tooltip} from '@workday/canvas-kit-react/tooltip';
+import {TooltipContainer, Tooltip, OverflowTooltip} from '@workday/canvas-kit-react/tooltip';
+import {resetIcon} from '@workday/canvas-system-icons-web';
 import {Card} from '@workday/canvas-kit-react/card';
 import {SecondaryButton} from '@workday/canvas-kit-react/button';
 import {StaticStates} from '@workday/canvas-kit-react/common';
@@ -18,6 +19,16 @@ export const NonInteractive = () => {
     <Tooltip title="Test">
       <span data-testid="non-interactive">Non-interactive Tooltip</span>
     </Tooltip>
+  );
+};
+
+export const Overflow = () => {
+  return (
+    <OverflowTooltip>
+      <SecondaryButton data-testid="overflow-tooltip" icon={resetIcon} style={{maxWidth: 200}}>
+        Super Mega Ultra Long Content With Max Width On The Button with Icon
+      </SecondaryButton>
+    </OverflowTooltip>
   );
 };
 


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary


Previous fix for OverflowTooltip issue in IE 11 only partially solved the problem:
https://github.com/Workday/canvas-kit/pull/1263

Fixes: IE11 OverflowTooltip <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, and Documentation -->
![category](https://img.shields.io/badge/release_category-Components-blue)


---

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests are changed or added
- [x] code adheres to the [API & Pattern guidelines](https://workday.github.io/canvas-kit/?path=/story/welcome-dev-docs-api-pattern-guidelines--page)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->



