### PR TITLE
feat(button): Update SecondaryButton for v6

### DIFF
--- a/modules/docs/mdx/6.0-MIGRATION-GUIDE.mdx
+++ b/modules/docs/mdx/6.0-MIGRATION-GUIDE.mdx
@@ -26,6 +26,12 @@ any questions about the update.
     - [Primary Medium](#primary-medium)
     - [Primary Small](#primary-small)
     - [Primary Extra Small](#primary-extra-small)
+  - [Secondary Button](#secondary-button)
+    - [Secondary Disabled](#secondary-disabled)
+    - [Secondary Large](#secondary-large)
+    - [Secondary Medium](#secondary-medium)
+    - [Secondary Small](#secondary-small)
+    - [Secondary Extra Small](#secondary-extra-small)
 
 ## Codemod
 
@@ -428,4 +434,28 @@ We now support icons for small `PrimaryButton`s. The icons are `20px` x `20xpx`.
 #### Primary Extra Small
 
 We added a new size, `extraSmall` to our `PrimaryButton`s. These are particularly helpful for use
+cases where you have dense UI or tight layout constraints such as tables.
+
+### Secondary Button
+
+#### Secondary Large
+
+The padding for large `SecondaryButton`s has been slightly adjusted for more visual balance and to
+take up a bit less layout space. Specifically we:
+
+- decreased the space between the button icon and text from `12px` to `8px`
+- decreased the space between the button container and the icon from `28px` to `24px`
+
+#### Secondary Medium
+
+The icon size for medium `SecondaryButton`s has been decreased from `24px` to `20px`, but the overall
+height of the button will remain the same.
+
+#### Secondary Small
+
+We now support icons for small `SecondaryButton`s. The icons are `20px` x `20xpx`.
+
+#### Secondary Extra Small
+
+We added a new size, `extraSmall` to our `SecondaryButton`s. These are particularly helpful for use
 cases where you have dense UI or tight layout constraints such as tables.

--- a/modules/react/button/lib/SecondaryButton.tsx
+++ b/modules/react/button/lib/SecondaryButton.tsx
@@ -10,7 +10,7 @@ import {
   focusRing,
 } from '@workday/canvas-kit-react/common';
 import {CanvasSystemIcon} from '@workday/design-assets-types';
-import {ButtonColors} from './types';
+import {ButtonColors, ButtonSizes, IconPositions} from './types';
 import {ButtonContainer, ButtonLabel, ButtonLabelData, ButtonLabelIcon} from './parts';
 
 export interface SecondaryButtonProps extends Themeable, GrowthBehavior {
@@ -20,10 +20,12 @@ export interface SecondaryButtonProps extends Themeable, GrowthBehavior {
    */
   variant?: 'inverse' | undefined;
   /**
-   * The size of the Button.
+   * There are four button sizes: `extraSmall`, `small`, `medium`, and `large`.
+   * If no size is provided, it will default to `medium`.
+   *
    * @default 'medium'
    */
-  size?: 'small' | 'medium' | 'large';
+  size?: ButtonSizes;
   /**
    * The data label of the Button.
    * Note: not displayed at `small` size
@@ -35,10 +37,11 @@ export interface SecondaryButtonProps extends Themeable, GrowthBehavior {
    */
   icon?: CanvasSystemIcon;
   /**
-   * The position of the TertiaryButton icon.
+   * Button icon positions can either be `left` or `right`.
+   * If no value is provided, it defaults to `left`.
    * @default 'left'
    */
-  iconPosition?: 'left' | 'right';
+  iconPosition?: IconPositions;
   /**
    * If set to `true`, transform the icon's x-axis to mirror the graphic
    * @default false
@@ -46,6 +49,16 @@ export interface SecondaryButtonProps extends Themeable, GrowthBehavior {
   shouldMirrorIcon?: boolean;
   children?: React.ReactNode;
 }
+
+// Button sizes where data labels are enabled
+const dataLabelSizes = ['medium', 'large'];
+// All disabled buttons are set to 40% opacity.
+// This will eventually live in the ButtonContainer styles, but for now we're scoping it to Primary, Secondary, and Tertiary buttons.
+const disabledButtonOpacity = {
+  '&:disabled, &:disabled:active': {
+    opacity: 0.4,
+  },
+};
 
 export const SecondaryButton = createComponent('button')({
   displayName: 'SecondaryButton',
@@ -71,9 +84,10 @@ export const SecondaryButton = createComponent('button')({
       as={Element}
       colors={getSecondaryButtonColors(variant, theme)}
       size={size}
+      extraStyles={disabledButtonOpacity}
       {...elemProps}
     >
-      {icon && size !== 'small' && iconPosition === 'left' && (
+      {icon && iconPosition === 'left' && (
         <ButtonLabelIcon
           size={size}
           iconPosition={iconPosition}
@@ -82,8 +96,8 @@ export const SecondaryButton = createComponent('button')({
         />
       )}
       <ButtonLabel>{children}</ButtonLabel>
-      {dataLabel && size !== 'small' && <ButtonLabelData>{dataLabel}</ButtonLabelData>}
-      {icon && size !== 'small' && iconPosition === 'right' && (
+      {dataLabel && dataLabelSizes.includes(size) && <ButtonLabelData>{dataLabel}</ButtonLabelData>}
+      {icon && iconPosition === 'right' && (
         <ButtonLabelIcon
           size={size}
           iconPosition={iconPosition}
@@ -136,12 +150,13 @@ export const getSecondaryButtonColors = (
           label: colors.blackPepper400,
           labelData: colors.blackPepper400,
         },
+        // Identical to 'default' styles. ButtonContainer will set opacity to 40%
         disabled: {
           background: 'transparent',
-          border: 'rgba(30, 30, 30, 0.4)', // Black Pepper 400 @ 40%
-          icon: 'rgba(30, 30, 30, 0.4)', // Black Pepper 400 @ 40%
-          label: 'rgba(30, 30, 30, 0.4)', // Black Pepper 400 @ 40%
-          labelData: 'rgba(30, 30, 30, 0.4)', // Black Pepper 400 @ 40%
+          border: colors.blackPepper400,
+          icon: colors.blackPepper400,
+          label: colors.blackPepper400,
+          labelData: colors.blackPepper400,
         },
       };
     case 'inverse':
@@ -180,12 +195,12 @@ export const getSecondaryButtonColors = (
             theme
           ),
         },
+        // Identical to inverse 'default' styles. ButtonContainer will set opacity to 40%
         disabled: {
           background: 'transparent',
-          border: 'rgba(255, 255, 255, 0.4)', // French Vanilla 400 @ 40%
-          icon: 'rgba(255, 255, 255, 0.4)', // French Vanilla 400 @ 40%
-          label: 'rgba(255, 255, 255, 0.4)', // French Vanilla 400 @ 40%
-          labelData: 'rgba(255, 255, 255, 0.4)', // French Vanilla 400 @ 40%
+          border: colors.frenchVanilla100,
+          icon: colors.frenchVanilla100,
+          label: colors.frenchVanilla100,
         },
       };
   }

--- a/modules/react/button/stories/visual-testing/stories_SecondaryButton.tsx
+++ b/modules/react/button/stories/visual-testing/stories_SecondaryButton.tsx
@@ -16,29 +16,41 @@ export default withSnapshotsEnabled({
 export const SecondaryButtonStates = (props: {theme?: PartialEmotionCanvasTheme}) => (
   <StaticStates theme={props.theme}>
     <ComponentStatesTable
-      rowProps={permutateProps({
-        variant: [
-          {value: undefined, label: ''},
-          {value: 'inverse', label: 'Inverse'},
-        ],
-        size: [
-          {value: 'small', label: 'Small'},
-          {value: 'medium', label: 'Medium'},
-          {value: 'large', label: 'Large'},
-        ],
-        icon: [
-          {value: undefined, label: ''},
-          {value: playCircleIcon, label: 'w/ Icon'},
-        ],
-        iconPosition: [
-          {value: 'left', label: 'Left Icon'},
-          {value: 'right', label: 'right Icon'},
-        ],
-        dataLabel: [
-          {value: undefined, label: ''},
-          {value: '1:23', label: 'w/ Data Label'},
-        ],
-      })}
+      rowProps={permutateProps(
+        {
+          variant: [
+            {value: undefined, label: ''},
+            {value: 'inverse', label: 'Inverse'},
+          ],
+          size: [
+            {value: 'extraSmall', label: 'Extra Small'},
+            {value: 'small', label: 'Small'},
+            {value: 'medium', label: 'Medium'},
+            {value: 'large', label: 'Large'},
+          ],
+          icon: [
+            {value: undefined, label: ''},
+            // We don't need a label here, because `iconPosition` provides it
+            {value: playCircleIcon, label: ''},
+          ],
+          iconPosition: [
+            {value: undefined, label: ''},
+            {value: 'left', label: '& Left Icon'},
+            {value: 'right', label: '& Right Icon'},
+          ],
+          dataLabel: [
+            {value: undefined, label: ''},
+            {value: '1:23', label: '& Data Label'},
+          ],
+        },
+        // Filter out permutations where `iconPosition` is provided and not `icon`, and vice versa
+        props => {
+          if ((props.iconPosition && !props.icon) || (props.icon && !props.iconPosition)) {
+            return false;
+          }
+          return true;
+        }
+      )}
       columnProps={stateTableColumnProps}
     >
       {props => (


### PR DESCRIPTION
## Summary

Resolves: #1322 

![category](https://img.shields.io/badge/release_category-Components-blue)

### BREAKING CHANGES

This change updates our `SecondaryButton` styles. For more information, please see the V6 migration guide.

---

## Note

#1331 Should be reviewed and merged before this PR.

## Checklist

Below is a list of all relevant changes:

#### Migration Guide

- Update the v6 migration guide

#### Secondary Large

- Decrease padding between icon and text (12px to 8px)
- Decrease container padding outside the icon (28px to 24px)

#### Secondary Medium

- Decrease icon size (24px to 20px) - button container height will be the same

#### Secondary Small

- Add icon support – icons should be 20 x 20px

#### Secondary Extra Small

- Create a new extra small size - view specs for details
