### PR TITLE
feat(button): Update Tertiary Buttons for v6

### DIFF
--- a/modules/docs/mdx/6.0-MIGRATION-GUIDE.mdx
+++ b/modules/docs/mdx/6.0-MIGRATION-GUIDE.mdx
@@ -32,6 +32,12 @@ any questions about the update.
     - [Secondary Medium](#secondary-medium)
     - [Secondary Small](#secondary-small)
     - [Secondary Extra Small](#secondary-extra-small)
+  - [Tertiary Button](#tertiary-button)
+    - [Tertiary Default](#tertiary-default)
+    - [Tertiary Disabled](#tertiary-disabled)
+    - [Tertiary Medium](#tertiary-medium)
+    - [Tertiary Small](#tertiary-small)
+    - [Tertiary Extra Small](#tertiary-extra-small)
 
 ## Codemod
 
@@ -448,8 +454,8 @@ take up a bit less layout space. Specifically we:
 
 #### Secondary Medium
 
-The icon size for medium `SecondaryButton`s has been decreased from `24px` to `20px`, but the overall
-height of the button will remain the same.
+The icon size for medium `SecondaryButton`s has been decreased from `24px` to `20px`, but the
+overall height of the button will remain the same.
 
 #### Secondary Small
 
@@ -458,4 +464,37 @@ We now support icons for small `SecondaryButton`s. The icons are `20px` x `20xpx
 #### Secondary Extra Small
 
 We added a new size, `extraSmall` to our `SecondaryButton`s. These are particularly helpful for use
+cases where you have dense UI or tight layout constraints such as tables.
+
+### Tertiary Button
+
+#### Tertiary Default
+
+We added an underline to the button text for all states to help distinguish it from the
+`SecondaryButton` and create more visual consistency.
+
+#### Tertiary Disabled
+
+As with our other buttons, we updated the disabled state to set the entire button to 40% opacity.
+They were previously using our light theme color at 50% opacity for icons and text.
+
+#### Tertiary Medium
+
+The medium `TertiaryButton` now uses our new type hierarchy and adjusted the padding, but the
+overall size of the button will stay the same. Specifically, we:
+
+- decreased the space between the button icon and text from `8px` to `4px`
+
+#### Tertiary Small
+
+The small `TertiaryButton` now uses our new type hierarchy and adjusted the padding, but the overall
+size of the button will stay the same. Specifically, we:
+
+- decreased the space between the button icon and text from `8px` to `4px`
+- increased the container padding outside the button text when an icon is present from `8px` to
+  `12px`
+
+#### Tertiary Extra Small
+
+We added a new size, `extraSmall` to our `TertiaryButton`s. These are particularly helpful for use
 cases where you have dense UI or tight layout constraints such as tables.

--- a/modules/react/button/lib/TertiaryButton.tsx
+++ b/modules/react/button/lib/TertiaryButton.tsx
@@ -7,9 +7,9 @@ import {
   EmotionCanvasTheme,
   createComponent,
 } from '@workday/canvas-kit-react/common';
-import {colors, space, type, borderRadius} from '@workday/canvas-kit-react/tokens';
+import {colors, space, borderRadius} from '@workday/canvas-kit-react/tokens';
 import {CanvasSystemIcon} from '@workday/design-assets-types';
-import {ButtonColors} from './types';
+import {ButtonColors, TertiaryButtonSizes, IconPositions} from './types';
 import {ButtonContainer, ButtonLabelIcon, ButtonLabel} from './parts';
 
 export interface TertiaryButtonProps extends Themeable {
@@ -19,15 +19,18 @@ export interface TertiaryButtonProps extends Themeable {
    */
   variant?: 'inverse' | undefined;
   /**
-   * The size of the TertiaryButton.
+   * There are three button sizes: `extraSmall`, `small`, and `medium`.
+   * If no size is provided, it will default to `medium`.
+   *
    * @default 'medium'
    */
-  size?: 'small' | 'medium';
+  size?: TertiaryButtonSizes;
   /**
-   * The position of the TertiaryButton icon.
+   * Button icon positions can either be `left` or `right`.
+   * If no value is provided, it defaults to `left`.
    * @default 'left'
    */
-  iconPosition?: 'left' | 'right';
+  iconPosition?: IconPositions;
   /**
    * The icon of the TertiaryButton.
    */
@@ -87,8 +90,8 @@ const getTertiaryButtonColors = (
       },
       disabled: {
         background: 'transparent',
-        icon: 'rgba(255, 255, 255, 0.5)',
-        label: 'rgba(255, 255, 255, 0.5)',
+        icon: colors.frenchVanilla100,
+        label: colors.frenchVanilla100,
       },
     };
   } else {
@@ -113,26 +116,34 @@ const getTertiaryButtonColors = (
         focusRing: focusRing({}, theme),
       },
       disabled: {
-        background: 'transparent',
-        icon: themePrimary.light,
-        label: themePrimary.light,
+        icon: themePrimary.main,
+        label: themePrimary.main,
       },
     };
   }
 };
 
-const containerStyles = {
-  borderRadius: borderRadius.m,
-  border: '0',
-  padding: `0 ${space.xxs}`,
-  minWidth: 'auto',
-  '.wdc-text-button-label': {
-    borderBottom: '2px solid transparent',
-    paddingTop: '2px',
-    transition: 'border-color 0.3s',
-  },
-  '&:hover:not([disabled]) .wdc-text-button-label': {
-    borderBottomColor: 'currentColor',
+const getPaddingStyles = (
+  icon: CanvasSystemIcon | undefined,
+  iconPosition: 'left' | 'right'
+): string => {
+  // if there is an icon on the left, add 4px extra padding to the right for visual balance
+  if (icon && iconPosition === 'left') {
+    return `0 ${space.xs} 0 ${space.xxs}`;
+  }
+  // if there is an icon on the right, add 4px extra padding to the left for visual balance
+  if (icon && iconPosition === 'right') {
+    return `0 ${space.xxs} 0 ${space.xs}`;
+  }
+  // if there is no icon, return the default padding
+  return `0 ${space.xxs}`;
+};
+
+// All disabled buttons are set to 40% opacity.
+// This will eventually live in the ButtonContainer styles, but for now we're scoping it to Primary, Secondary, and Tertiary buttons.
+const disabledButtonOpacity = {
+  '&:disabled, &:disabled:active': {
+    opacity: 0.4,
   },
 };
 
@@ -155,19 +166,17 @@ export const TertiaryButton = createComponent('button')({
     ref,
     Element
   ) => {
-    // Note: We don't use ButtonLabel because the label styles differ from other button types
-    const allContainerStyles: CSSObject = allCaps
-      ? {
-          ...containerStyles,
-          textTransform: 'uppercase',
-          fontWeight: type.properties.fontWeights.bold,
-          fontSize: size === 'medium' ? type.properties.fontSizes[16] : undefined,
-          letterSpacing: '.5px',
-        }
-      : {
-          ...containerStyles,
-          fontSize: size === 'medium' ? type.properties.fontSizes[14] : undefined,
-        };
+    const allContainerStyles: CSSObject = {
+      borderRadius: borderRadius.m,
+      border: '0',
+      padding: getPaddingStyles(icon, iconPosition),
+      minWidth: 'auto',
+      textTransform: allCaps ? 'uppercase' : undefined,
+      '.wdc-text-button-label': {
+        textDecoration: 'underline',
+      },
+      ...disabledButtonOpacity,
+    };
 
     return (
       <ButtonContainer

--- a/modules/react/button/lib/parts/ButtonContainer.tsx
+++ b/modules/react/button/lib/parts/ButtonContainer.tsx
@@ -142,6 +142,8 @@ export const ButtonContainer = styled('button', {
         };
       case 'extraSmall':
         return {
+          ...type.levels.subtext.medium,
+          fontWeight: type.properties.fontWeights.bold,
           height: space.m,
           padding: `0 ${space.xs}`,
           '& > * ': {

--- a/modules/react/button/lib/types.ts
+++ b/modules/react/button/lib/types.ts
@@ -28,5 +28,6 @@ export interface ButtonColors {
  * @default 'medium'
  */
 export type ButtonSizes = 'extraSmall' | 'small' | 'medium' | 'large';
-
+// TODO: Remove TertiaryButtonSizes in favor of button sizes when we add Tertiary large
+export type TertiaryButtonSizes = 'extraSmall' | 'small' | 'medium';
 export type IconPositions = 'left' | 'right';

--- a/modules/react/button/stories/visual-testing/stories_TertiaryButton.tsx
+++ b/modules/react/button/stories/visual-testing/stories_TertiaryButton.tsx
@@ -27,19 +27,26 @@ export const TertiaryButtonStates = (props: {theme?: PartialEmotionCanvasTheme})
             {value: true, label: 'All Caps'},
           ],
           size: [
+            {value: 'extraSmall', label: 'Extra Small'},
             {value: 'small', label: 'Small'},
             {value: 'medium', label: 'Medium'},
           ],
           icon: [
             {value: undefined, label: ''},
-            {value: playCircleIcon, label: 'w/ Icon'},
+            // We don't need a label here, because `iconPosition` provides it
+            {value: playCircleIcon, label: ''},
           ],
           iconPosition: [
-            {value: 'left', label: 'Left Icon'},
-            {value: 'right', label: 'right Icon'},
+            {value: undefined, label: ''},
+            {value: 'left', label: '& Left Icon'},
+            {value: 'right', label: '& Right Icon'},
           ],
         },
+        // Filter out permutations where `iconPosition` is provided and not `icon`, and vice versa
         props => {
+          if ((props.iconPosition && !props.icon) || (props.icon && !props.iconPosition)) {
+            return false;
+          }
           return true;
         }
       )}
@@ -47,7 +54,7 @@ export const TertiaryButtonStates = (props: {theme?: PartialEmotionCanvasTheme})
     >
       {props => (
         <Container blue={props.variant === 'inverse'}>
-          <TertiaryButton {...props}>Test</TertiaryButton>
+          <TertiaryButton {...props}>Tertiary</TertiaryButton>
         </Container>
       )}
     </ComponentStatesTable>


### PR DESCRIPTION
## Summary

Resolves #1323

![category](https://img.shields.io/badge/release_category-Components-blue)

### BREAKING CHANGES

This change updates our `TertiaryButton` styles. For more information, please see the V6 migration guide.

---

## Checklist
### Tertiary (All)

- [ ] Add underline on default and focus states (underline should be on all states)
- [ ] Use 40% opacity for disabled styling on the entire container

### Tertiary Medium

- [ ] Use Subtext Large (14px) + bold (700)
- [ ] Increase container padding outside the text when an icon is present (8px to 12px)

### Tertiary Small

- [ ] Use Subtext Large (14px) + bold (700)
- [ ] Decrease padding between icon and text (8px to 4px)
- [ ] Increase container padding outside the text (8px to 12px)

### Tertiary Extra Small

- [ ] Create a new extra small size - view specs for details
- [ ] Use Subtext Medium (12px) + bold (700)

