### PR TITLE
fix(tooltip): Add delay to Tooltip show and hide

### DIFF
--- a/cypress/integration/Popup.spec.ts
+++ b/cypress/integration/Popup.spec.ts
@@ -236,13 +236,12 @@ describe('Popup', () => {
         });
 
         context('when the Escape key is pressed', () => {
-          beforeEach(() => {
+          it('should close the Tooltip', () => {
+            cy.clock();
+            cy.tick(300); // advance the timer by the amount of default delay time
             cy.get('html').trigger('keydown', {
               key: 'Escape',
             });
-          });
-
-          it('should close the Tooltip', () => {
             cy.findByRole('tooltip', {
               name: 'Really long tooltip showing how popup stacks overlap 1',
             }).should('not.exist');

--- a/cypress/integration/Tooltip.spec.ts
+++ b/cypress/integration/Tooltip.spec.ts
@@ -33,6 +33,8 @@ describe('Tooltip', () => {
 
       context('when the tooltip is hovered', () => {
         beforeEach(() => {
+          cy.clock();
+          cy.tick(300); // advance the timer by the amount of default delay time
           cy.get('button').trigger('mouseout');
           cy.findByRole('tooltip').trigger('mouseover');
         });

--- a/modules/react/tooltip/lib/Tooltip.tsx
+++ b/modules/react/tooltip/lib/Tooltip.tsx
@@ -74,7 +74,7 @@ export const Tooltip = ({
   placement = 'top',
   title,
   children,
-  showDelay = 500,
+  showDelay = 300,
   hideDelay = 100,
   ...elemProps
 }: TooltipProps) => {

--- a/modules/react/tooltip/lib/Tooltip.tsx
+++ b/modules/react/tooltip/lib/Tooltip.tsx
@@ -44,6 +44,14 @@ export interface TooltipProps extends Omit<React.HTMLAttributes<HTMLDivElement>,
    * @default 'label'
    */
   type?: 'label' | 'describe' | 'muted';
+  /**
+   * Amount of time (in ms) to delay before showing the tooltip
+   */
+  showDelay?: number;
+  /**
+   * Amount of time (in ms) to delay before hiding the tooltip
+   */
+  hideDelay?: number;
 }
 
 function mergeCallbacks<T extends {[key: string]: any}>(
@@ -66,10 +74,17 @@ export const Tooltip = ({
   placement = 'top',
   title,
   children,
+  showDelay = 500,
+  hideDelay = 100,
   ...elemProps
 }: TooltipProps) => {
   const titleText = innerText(title);
-  const {targetProps, popperProps, tooltipProps} = useTooltip({type, titleText});
+  const {targetProps, popperProps, tooltipProps} = useTooltip({
+    type,
+    titleText,
+    showDelay,
+    hideDelay,
+  });
 
   return (
     <React.Fragment>

--- a/modules/react/tooltip/lib/useTooltip.tsx
+++ b/modules/react/tooltip/lib/useTooltip.tsx
@@ -91,17 +91,17 @@ export function useTooltip<T extends Element = Element>({
   const popupModel = usePopupModel();
   const [anchorElement, setAnchorElement] = React.useState<T | null>(null);
   const [id] = React.useState(() => uuid());
-  const intentTimer = useIntentTimer(popupModel.events.hide, hideDelay);
+  const intentTimerHide = useIntentTimer(popupModel.events.hide, hideDelay);
   const intentTimerShow = useIntentTimer(popupModel.events.show, showDelay);
 
   const onHide = () => {
-    intentTimer.start();
+    intentTimerHide.start();
     intentTimerShow.clear();
   };
 
   const onOpen = () => {
     intentTimerShow.start();
-    intentTimer.clear();
+    intentTimerHide.clear();
   };
 
   const onOpenFromTarget = (event: React.SyntheticEvent) => {

--- a/modules/react/tooltip/lib/useTooltip.tsx
+++ b/modules/react/tooltip/lib/useTooltip.tsx
@@ -54,7 +54,7 @@ const isInteractiveElement = (element: Element) => {
 export function useTooltip<T extends Element = Element>({
   type = 'label',
   titleText = '',
-  showDelay = 500,
+  showDelay = 300,
   hideDelay = 100,
 }: {
   /**

--- a/modules/react/tooltip/spec/Tooltip.spec.tsx
+++ b/modules/react/tooltip/spec/Tooltip.spec.tsx
@@ -27,7 +27,7 @@ describe('Tooltip', () => {
 
       fireEvent.mouseEnter(screen.getByText('Test Text')); // triggers the tooltip
 
-      jest.advanceTimersByTime(500); // advance the timer by the amount of delay time
+      jest.advanceTimersByTime(300); // advance the timer by the amount of delay time
       expect(screen.getByText('Test Text')).toHaveAttribute('aria-describedby');
 
       const id = screen.getByText('Test Text').getAttribute('aria-describedby');
@@ -73,10 +73,35 @@ describe('Tooltip', () => {
 
       fireEvent.mouseEnter(screen.getByText('Test Text')); // triggers the tooltip
 
+      jest.advanceTimersByTime(300); // advance the timer by the amount less than delay time
       expect(screen.queryByText('Delayed Tooltip Text')).toBeNull(); // tooltip is not shown before the delay
 
-      jest.advanceTimersByTime(1000); // advance the timer by the amount of delay time
+      jest.advanceTimersByTime(700); // advance the timer by the amount of total delay time
       expect(screen.getByText('Delayed Tooltip Text')).toBeInTheDocument();
+    });
+    jest.clearAllTimers();
+  });
+
+  describe('when "hideDelay" is passed in', () => {
+    jest.useFakeTimers();
+    it('should render the tooltip after the delay', () => {
+      render(
+        <Tooltip type="describe" title="Delayed Tooltip Text" hideDelay={300}>
+          <span>Test Text</span>
+        </Tooltip>
+      );
+
+      fireEvent.mouseEnter(screen.getByText('Test Text')); // triggers the tooltip
+
+      jest.advanceTimersByTime(300); // advance the timer by the delay time
+      expect(screen.getByText('Delayed Tooltip Text')).toBeInTheDocument();
+
+      fireEvent.mouseLeave(screen.getByText('Test Text')); // triggers hiding the tooltip
+      jest.advanceTimersByTime(100); // advance the timer by the amount less than hide delay time
+      expect(screen.getByText('Delayed Tooltip Text')).toBeInTheDocument(); // tooltip is still shown
+
+      jest.advanceTimersByTime(200); // advance the timer by the total amount of the hide delay time
+      expect(screen.queryByText('Delayed Tooltip Text')).toBeNull(); // tooltip is hidden after the delay
     });
     jest.clearAllTimers();
   });

--- a/modules/react/tooltip/spec/Tooltip.spec.tsx
+++ b/modules/react/tooltip/spec/Tooltip.spec.tsx
@@ -17,6 +17,7 @@ describe('Tooltip', () => {
   });
 
   describe('when "type" is "describe"', () => {
+    jest.useFakeTimers();
     it('should render aria-describedby', () => {
       render(
         <Tooltip type="describe" title="This is an extra description">
@@ -26,11 +27,13 @@ describe('Tooltip', () => {
 
       fireEvent.mouseEnter(screen.getByText('Test Text')); // triggers the tooltip
 
+      jest.advanceTimersByTime(500); // advance the timer by the amount of delay time
       expect(screen.getByText('Test Text')).toHaveAttribute('aria-describedby');
 
       const id = screen.getByText('Test Text').getAttribute('aria-describedby');
       expect(screen.getByRole('tooltip')).toHaveAttribute('id', id);
     });
+    jest.clearAllTimers();
   });
 
   describe('when "type" is "muted"', () => {
@@ -57,6 +60,25 @@ describe('Tooltip', () => {
 
       expect(screen.getByText('Test Text')).toHaveAttribute('aria-label', 'Test Label');
     });
+  });
+
+  describe('when "showDelay" is passed in', () => {
+    jest.useFakeTimers();
+    it('should render the tooltip after the delay', () => {
+      render(
+        <Tooltip type="describe" title="Delayed Tooltip Text" showDelay={1000}>
+          <span>Test Text</span>
+        </Tooltip>
+      );
+
+      fireEvent.mouseEnter(screen.getByText('Test Text')); // triggers the tooltip
+
+      expect(screen.queryByText('Delayed Tooltip Text')).toBeNull(); // tooltip is not shown before the delay
+
+      jest.advanceTimersByTime(1000); // advance the timer by the amount of delay time
+      expect(screen.getByText('Delayed Tooltip Text')).toBeInTheDocument();
+    });
+    jest.clearAllTimers();
   });
 
   ['onMouseEnter', 'onMouseLeave', 'onFocus', 'onBlur', 'onClick', 'onMouseOver'].forEach(key => {

--- a/modules/react/tooltip/spec/useTooltip.spec.tsx
+++ b/modules/react/tooltip/spec/useTooltip.spec.tsx
@@ -33,7 +33,7 @@ describe('useTooltip with type="describe"', () => {
     const tooltip = getByRole('tooltip');
 
     fireEvent.mouseOver(target); // assign the ID to the tooltip
-    jest.advanceTimersByTime(500); // advance the timer by the amount of delay time
+    jest.advanceTimersByTime(300); // advance the timer by the amount of delay time
 
     expect(tooltip).toHaveAttribute('id');
     const id = tooltip.getAttribute('id');

--- a/modules/react/tooltip/spec/useTooltip.spec.tsx
+++ b/modules/react/tooltip/spec/useTooltip.spec.tsx
@@ -25,6 +25,7 @@ describe('useTooltip with type="label"', () => {
 });
 
 describe('useTooltip with type="describe"', () => {
+  jest.useFakeTimers();
   it('should add aria attributes to correlate the target and the tooltip', () => {
     const {getByText, getByRole} = render(<TooltipWithHook type="describe" />);
 
@@ -32,9 +33,11 @@ describe('useTooltip with type="describe"', () => {
     const tooltip = getByRole('tooltip');
 
     fireEvent.mouseOver(target); // assign the ID to the tooltip
+    jest.advanceTimersByTime(500); // advance the timer by the amount of delay time
 
     expect(tooltip).toHaveAttribute('id');
     const id = tooltip.getAttribute('id');
     expect(target).toHaveAttribute('aria-describedby', id);
   });
+  jest.clearAllTimers();
 });

--- a/modules/react/tooltip/stories/Tooltip.stories.mdx
+++ b/modules/react/tooltip/stories/Tooltip.stories.mdx
@@ -5,6 +5,7 @@ import {Specifications} from '@workday/canvas-kit-docs';
 
 import {Default} from './examples/Default';
 import {CustomContent} from './examples/CustomContent';
+import {DelayedTooltip} from './examples/DelayedTooltip';
 import {DescribeType} from './examples/DescribeType';
 import {Muted} from './examples/Muted';
 import {Placements} from './examples/Placements';
@@ -89,6 +90,13 @@ content or a focusable element is needed by your UI, a tooltip is not a good cho
 a dialog instead.
 
 <ExampleCodeBlock code={CustomContent} />
+
+### Delayed Tooltip
+
+The default delay for showing and hiding a tooltip are 500ms and 100ms, respectively. You can
+control the length of the delay by providing custom `showDelay` and `hideDelay` in ms.
+
+<ExampleCodeBlock code={DelayedTooltip} />
 
 ### Placements
 

--- a/modules/react/tooltip/stories/Tooltip.stories.mdx
+++ b/modules/react/tooltip/stories/Tooltip.stories.mdx
@@ -93,7 +93,7 @@ a dialog instead.
 
 ### Delayed Tooltip
 
-The default delay for showing and hiding a tooltip are 500ms and 100ms, respectively. You can
+The default delay for showing and hiding a tooltip are 300ms and 100ms, respectively. You can
 control the length of the delay by providing custom `showDelay` and `hideDelay` in ms.
 
 <ExampleCodeBlock code={DelayedTooltip} />

--- a/modules/react/tooltip/stories/examples/DelayedTooltip.tsx
+++ b/modules/react/tooltip/stories/examples/DelayedTooltip.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import {SecondaryButton} from '@workday/canvas-kit-react/button';
+import {Tooltip} from '@workday/canvas-kit-react/tooltip';
+
+export const DelayedTooltip = () => {
+  return (
+    <React.Fragment>
+      <Tooltip type="describe" title="Tooltip Text" showDelay={2000} hideDelay={1000}>
+        <SecondaryButton>
+          Tooltip appears after 2 seconds and disappears after 1 second
+        </SecondaryButton>
+      </Tooltip>
+    </React.Fragment>
+  );
+};


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

This PR introduces the default delay time of 300ms for showing a tooltip, and adds the ability to control the delay time for showing and hiding the tooltip.

![category](https://img.shields.io/badge/release_category-Components-blue)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

Currently, Canvas-Kit tooltip doesn't support delayed showing and hiding. As a result, the tooltip appears as soon as the anchor item is hovered. I don't think that's the typical behavior of a tooltip, it's redundant most of the time, and makes the UI look busy. I chose 500ms as the default delay per my brief research (listed below in References) on tooltip behavior

### Release Note
This change could cause visual regression tests to fail if a screen shot is taken expecting a tooltip to show immediately. Your visual regression will either have to add an explicit wait of 300ms, or change the delay to 1ms only under test.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests are changed or added
- [x] code has been documented

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->

https://www.nngroup.com/articles/timing-exposing-content/
https://www.linkedin.com/pulse/tooltips-samson-vijay-kumar-tennela/
https://ux.stackexchange.com/questions/358/how-long-should-the-delay-be-before-a-tooltip-pops-up

