### PR TITLE
fix: Fix codemod command

### DIFF
--- a/modules/codemod/index.js
+++ b/modules/codemod/index.js
@@ -42,18 +42,19 @@ const transform = commands[0];
 console.log(transform, path);
 
 console.log(`\nApplying ${transform} transform to '${path}'\n`.brightBlue);
-
-spawn(
-  `jscodeshift -t ${__dirname}/dist/es6/${transform} ${path} --parser=tsx --extensions=js,jsx,ts,tsx`,
-  (error, stdout, stderr) => {
-    if (error) {
-      console.error(`${error}\n`);
-      return;
-    }
-    console.log(`${stdout}\n`);
-
-    if (stderr) {
-      console.error(`${stderr}\n`);
-    }
-  }
+const args = `-t ${__dirname}/dist/es6/${transform} ${path} --parser tsx --extensions js,jsx,ts,tsx`.split(
+  ' '
 );
+
+const proc = spawn(`jscodeshift`, args);
+
+let errCode = 0;
+proc.stdout.on('data', data => console.log(data.toString()));
+proc.stderr.on('data', data => {
+  errCode = 1;
+  console.error(data.toString());
+});
+
+proc.on('close', code => {
+  process.exit(code || errCode);
+});


### PR DESCRIPTION
## Summary

Fix the incorrect usage of `spawn` from #1340. This update uses `spawn`'s streaming API instead of `exec`s API.

![category](https://img.shields.io/badge/release_category-Infrastructure-blue)
