### PR TITLE
fix(tabs): Fix focusability of the More button

### DIFF
--- a/cypress/integration/Tabs.spec.ts
+++ b/cypress/integration/Tabs.spec.ts
@@ -540,7 +540,7 @@ describe('Tabs', () => {
             cy.focused().tab();
           });
 
-          it('should focus on the tab panel', () => {
+          it('should focus on the "More" button', () => {
             cy.findByRole('button', {name: 'More'}).should('have.focus');
           });
         });

--- a/cypress/integration/Tabs.spec.ts
+++ b/cypress/integration/Tabs.spec.ts
@@ -497,6 +497,24 @@ describe('Tabs', () => {
       cy.findByRole('button', {name: 'More'}).should('not.exist');
     });
 
+    context('when the "First Tab" is focused', () => {
+      beforeEach(() => {
+        cy.findByRole('tab', {name: 'First Tab'})
+          .click()
+          .focus();
+      });
+
+      context('when the Tab key is pressed', () => {
+        beforeEach(() => {
+          cy.focused().tab();
+        });
+
+        it('should focus on the tab panel', () => {
+          cy.findByRole('tabpanel', {name: 'First Tab'}).should('have.focus');
+        });
+      });
+    });
+
     context('when tab list container is only 500px wide', () => {
       beforeEach(() => {
         cy.findByRole('button', {name: '500px'}).click();
@@ -508,6 +526,24 @@ describe('Tabs', () => {
 
       it('should show the "More" button', () => {
         cy.findByRole('button', {name: 'More'}).should('exist');
+      });
+
+      context('when the "First Tab" is focused', () => {
+        beforeEach(() => {
+          cy.findByRole('tab', {name: 'First Tab'})
+            .click()
+            .focus();
+        });
+
+        context('when the Tab key is pressed', () => {
+          beforeEach(() => {
+            cy.focused().tab();
+          });
+
+          it('should focus on the tab panel', () => {
+            cy.findByRole('button', {name: 'More'}).should('have.focus');
+          });
+        });
       });
 
       context('when the "More" button is clicked', () => {

--- a/modules/react/tabs/lib/overflow/useOverflowTarget.tsx
+++ b/modules/react/tabs/lib/overflow/useOverflowTarget.tsx
@@ -35,7 +35,7 @@ export const useOverflowTarget = createHook(
     return {
       ref: elementRef,
       'aria-hidden': isHidden,
-      tabIndex: -1,
+      tabIndex: isHidden ? -1 : 0,
       style: isHidden ? hiddenStyle : {},
     };
   }


### PR DESCRIPTION
## Summary

The "More" button in tabs should be focusable so that keyboard users and screen reader users can access it.

![category](https://img.shields.io/badge/release_category-Components-blue)
