### PR TITLE
docs: Add headers examples to Storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -25,7 +25,8 @@ function storySort(a, b) {
     prefix('labs-', '4'),
     prefix('basic', 'aa'),
     prefix('default', 'ab'),
-    prefix('visual-testing', 'zz')
+    prefix('visual-testing', 'zz'),
+    prefix('examples', 'zzz')
   );
 
   const left = prefixFn(a[0]);

--- a/modules/docs/mdx/6.0-MIGRATION-GUIDE.mdx
+++ b/modules/docs/mdx/6.0-MIGRATION-GUIDE.mdx
@@ -220,6 +220,9 @@ const CustomGlobalHeader = props => {
 };
 ```
 
+You may continue to use this component exactly as you did in v5, but note that we plan to hard-deprecate it in Canvas Kit v7.
+If you would like to migrate away from this deprecated component now, you can reference [this example](https://workday.github.io/canvas-kit/?path=/story/examples-global-header-react--basic) instead.
+
 ### Page Header
 
 We are [soft-deprecating](#soft-deprecation) `PageHeader`. It has been renamed to
@@ -270,6 +273,9 @@ export const CustomPageHeader = (props: CustomPageHeaderProps) => {
   return <DeprecatedPageHeader {...props} />;
 };
 ```
+
+You may continue to use this component exactly as you did in v5, but note that we plan to hard-deprecate it in Canvas Kit v7.
+If you would like to migrate away from this deprecated component now, you can reference [this example](https://workday.github.io/canvas-kit/?path=/story/examples-page-header-react--basic) instead.
 
 ## Component Migrations
 

--- a/modules/react/_examples/stories/GlobalHeader.stories.mdx
+++ b/modules/react/_examples/stories/GlobalHeader.stories.mdx
@@ -6,5 +6,5 @@ import {Basic} from './examples/GlobalHeader';
 # Canvas Kit Examples
 
 ## GlobalHeader
-
+Developers building internal Workday applications will likely not need to create this component. However, if you're building components to be used outside of Workday, this is a helpful reference for building a global navigation header that looks like our internal `GlobalHeader`.
 <ExampleCodeBlock code={Basic} />

--- a/modules/react/_examples/stories/GlobalHeader.stories.mdx
+++ b/modules/react/_examples/stories/GlobalHeader.stories.mdx
@@ -1,0 +1,10 @@
+import {Meta, Story} from '@storybook/addon-docs/blocks';
+import {Basic} from './examples/GlobalHeader';
+
+<Meta title="Examples/GlobalHeader/React" />
+
+# Canvas Kit Examples
+
+## GlobalHeader
+
+<ExampleCodeBlock code={Basic} />

--- a/modules/react/_examples/stories/GlobalHeader.stories.mdx
+++ b/modules/react/_examples/stories/GlobalHeader.stories.mdx
@@ -7,4 +7,5 @@ import {Basic} from './examples/GlobalHeader';
 
 ## GlobalHeader
 Developers building internal Workday applications will likely not need to create this component. However, if you're building components to be used outside of Workday, this is a helpful reference for building a global navigation header that looks like our internal `GlobalHeader`.
+
 <ExampleCodeBlock code={Basic} />

--- a/modules/react/_examples/stories/PageHeader.stories.mdx
+++ b/modules/react/_examples/stories/PageHeader.stories.mdx
@@ -1,0 +1,10 @@
+import {Meta, Story} from '@storybook/addon-docs/blocks';
+import {Basic} from "./examples/PageHeader";
+
+<Meta title="Examples/PageHeader/React" />
+
+# Canvas Kit Examples
+
+## PageHeader
+
+<ExampleCodeBlock code={Basic} />

--- a/modules/react/_examples/stories/examples/GlobalHeader.tsx
+++ b/modules/react/_examples/stories/examples/GlobalHeader.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import {styled, createComponent, dubLogoBlue} from '@workday/canvas-kit-react/common';
+import {colors, depth, space, type} from '@workday/canvas-kit-react/tokens';
+
+import {
+  notificationsIcon,
+  inboxIcon,
+  justifyIcon,
+  assistantIcon,
+} from '@workday/canvas-system-icons-web';
+
+import {IconButton, Hyperlink} from '@workday/canvas-kit-react/button';
+import {Avatar} from '@workday/canvas-kit-react/avatar';
+import {SearchForm, HStack, HStackProps, StackSpacing} from '@workday/canvas-kit-labs-react';
+
+interface HeaderItemProps extends Omit<HStackProps, 'spacing'> {
+  spacing?: StackSpacing;
+}
+
+export const Basic = () => (
+  <GlobalHeader>
+    <GlobalHeader.Item>
+      <IconButton aria-label="menu" icon={justifyIcon} />
+      <Hyperlink>
+        <WorkdayLogo dangerouslySetInnerHTML={{__html: dubLogoBlue}} />
+      </Hyperlink>
+    </GlobalHeader.Item>
+    <GlobalHeader.Item margin="auto" width="100%" maxWidth={`calc(${space.xxxl} * 6)`}>
+      <SearchForm onSubmit={() => 1} />
+    </GlobalHeader.Item>
+    <GlobalHeader.Item>
+      <IconButton aria-label="messages" icon={assistantIcon} />
+      <IconButton aria-label="notifications" icon={notificationsIcon} />
+      <IconButton aria-label="inbox" icon={inboxIcon} />
+      <Avatar size={Avatar.Size.m} variant={Avatar.Variant.Light} />
+    </GlobalHeader.Item>
+  </GlobalHeader>
+);
+
+const GlobalHeaderItem = createComponent('div')({
+  displayName: 'GlobalHeader.Item',
+  Component: ({spacing = 's', ...props}: HeaderItemProps, ref) => (
+    <HStack spacing={spacing} alignItems="center" marginX={space.xs} ref={ref} {...props} />
+  ),
+});
+
+const GlobalHeader = createComponent('header')({
+  displayName: 'GlobalHeader',
+  Component: (props, ref, Element) => <HeaderWrapper ref={ref} as={Element} {...props} />,
+  subComponents: {Item: GlobalHeaderItem},
+});
+
+const HeaderWrapper = styled('header')({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  boxSizing: 'border-box',
+  ...type.levels.subtext.large,
+  WebkitFontSmoothing: 'antialiased',
+  MozOsxFontSmoothing: 'grayscale',
+  backgroundColor: colors.frenchVanilla100,
+  ...depth[1],
+  padding: space.xxs,
+});
+
+const WorkdayLogo = styled('span')({lineHeight: 0});

--- a/modules/react/_examples/stories/examples/PageHeader.tsx
+++ b/modules/react/_examples/stories/examples/PageHeader.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import {styled, createComponent} from '@workday/canvas-kit-react/common';
+
+import {colors, gradients, space, type} from '@workday/canvas-kit-react/tokens';
+
+import {HStack, HStackProps, StackSpacing} from '@workday/canvas-kit-labs-react';
+import {IconButton} from '@workday/canvas-kit-react/button';
+import {justifyIcon, notificationsIcon} from '@workday/canvas-system-icons-web';
+
+interface HeaderItemProps extends Omit<HStackProps, 'spacing'> {
+  spacing?: StackSpacing;
+}
+
+export const Basic = () => (
+  <PageHeader>
+    <PageHeader.Title>Page Header</PageHeader.Title>
+    <PageHeader.Item>
+      <IconButton aria-label="notifications" icon={notificationsIcon} variant="inverse" />
+      <IconButton aria-label="menu" icon={justifyIcon} variant="inverse" />
+    </PageHeader.Item>
+  </PageHeader>
+);
+
+const PageHeaderItem = createComponent('div')({
+  displayName: 'PageHeader.Item',
+  Component: ({spacing = 'xxs', ...props}: HeaderItemProps, ref, Element) => (
+    <HStack spacing={spacing} ref={ref} as={Element} {...props} />
+  ),
+});
+
+const PageHeaderTitle = createComponent('h2')({
+  displayName: 'PageHeader.Title',
+  Component: ({children, ...props}, ref, Element) => (
+    <Title ref={ref} as={Element} {...props}>
+      {children}
+    </Title>
+  ),
+});
+
+const PageHeader = createComponent('header')({
+  displayName: 'PageHeader',
+  Component: (props, ref, Element) => <Header ref={ref} as={Element} {...props} />,
+  subComponents: {Item: PageHeaderItem, Title: PageHeaderTitle},
+});
+
+const Header = styled('header')({
+  padding: `${space.xs} ${space.xl}`,
+  backgroundImage: gradients.blueberry,
+  color: colors.frenchVanilla100,
+  WebkitFontSmoothing: 'antialiased',
+  MozOsxFontSmoothing: 'grayscale',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+});
+
+const Title = styled('h2')({
+  ...type.levels.heading.medium,
+  color: colors.frenchVanilla100,
+  padding: `${space.xs} 0`,
+  margin: 0,
+  whiteSpace: 'nowrap',
+});


### PR DESCRIPTION
## Summary

Resolves: #1362, #1363  <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

Now that we've deprecated  `PageHeader` and `GlobalHeader` components in v6, we'd like to provide an example for users to use so that they can migrate from the deprecated component.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, and Documentation -->
![category](https://img.shields.io/badge/release_category-Documentation-blue)

