### PR TITLE
chore: Have verify action to wait on visual tests [skip release]

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -134,7 +134,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           appCode: dlpro96xybh
           storybookBuildDir: docs
-          exitOnceUploaded: true
+          exitOnceUploaded: false
           exitZeroOnChanges: true
 
   integration-test:
@@ -183,7 +183,7 @@ jobs:
 
   verify:
     runs-on: ubuntu-latest
-    needs: ['check', 'integration-test']
+    needs: ['check', 'integration-test', 'visual-test']
     steps:
       - name: Done
         run: echo "Done"


### PR DESCRIPTION
## Summary

For a more accurate verify process, I've added `visual-testing` to the verify step as a dependency.

![category](https://img.shields.io/badge/release_category-Infrastructure-blue)