### PR TITLE
fix(search-form): Remove default autocomplete

### DIFF
--- a/modules/labs-react/search-form/lib/SearchForm.tsx
+++ b/modules/labs-react/search-form/lib/SearchForm.tsx
@@ -472,6 +472,7 @@ export class SearchForm extends React.Component<SearchFormProps, SearchFormState
                 inputColors={this.getThemeColors()}
                 height={height}
                 name="search"
+                autocomplete="off"
               />
             </SearchCombobox>
           </SearchField>

--- a/modules/labs-react/search-form/lib/SearchForm.tsx
+++ b/modules/labs-react/search-form/lib/SearchForm.tsx
@@ -472,7 +472,7 @@ export class SearchForm extends React.Component<SearchFormProps, SearchFormState
                 inputColors={this.getThemeColors()}
                 height={height}
                 name="search"
-                autocomplete="off"
+                autoComplete="off"
               />
             </SearchCombobox>
           </SearchField>


### PR DESCRIPTION
## Summary

Removed browsers' default autocomplete as it is overlapping with the search form's autocomplete results. 

![category](https://img.shields.io/badge/release_category-Components-blue)

## Additional References

![Screen Shot 2022-01-05 at 10 35 50 AM](https://user-images.githubusercontent.com/64246446/148270595-ffba15af-f9c1-4e20-94ce-17b5a48a8569.png)

