### PR TITLE
chore: Pin colors to version 1.4.0

### DIFF
--- a/modules/codemod/package.json
+++ b/modules/codemod/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/Workday/canvas-kit#readme",
   "dependencies": {
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "jscodeshift": "^0.11.0",
     "yargs": "^16.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "babel-plugin-emotion": "^10.0.29",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
     "caniuse-lite": "^1.0.30001154",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "commitizen": "^4.0.4",
     "common-tags": "^1.8.0",
     "conventional-changelog-conventionalcommits": "^4.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6142,7 +6142,7 @@ colorette@^1.2.1, colorette@^1.2.2:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
-colors@^1.1.2, colors@^1.4.0:
+colors@1.4.0, colors@^1.1.2, colors@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==


### PR DESCRIPTION
## Summary

Pin `colors` to unaffected version.

![category](https://img.shields.io/badge/release_category-Infrastructure-blue)
---
The maintainer of faker.js and colors.js went rogue and introduced some breaking changes into the latest patch versions of those modules. 

The code affecting `colors` is this infinite loop that was introduced: https://github.com/Marak/colors.js/commit/5d2d242f656103ac38086d6b26433a09f1c38c75#diff-92bbac9a308cd5fcf9db165841f2d90ce981baddcb2b1e26cfff170929af3bd1R18

I'm not sure what the long term strategy will be for CKR (maybe moving to a different library for console colors like [chalk](https://www.npmjs.com/package/chalk)) but this just makes sure that the local dev environments and CI does not go bust in case it pulls in the latest `colors` version.
