### PR TITLE
fix: Allow repositioning of PopperJS instances

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -2,5 +2,8 @@
   "projectId": "odida5",
   "baseUrl": "http://localhost:9001",
   "supportFile": "cypress/support/index.ts",
-  "watchForFileChanges": false
+  "watchForFileChanges": false,
+  "retries": {
+    "runMode": 2
+  }
 }

--- a/modules/react/popup/spec/Popper.spec.tsx
+++ b/modules/react/popup/spec/Popper.spec.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {render, getByTestId, act} from '@testing-library/react';
+import * as PopperJS from '@popperjs/core';
 
 import {Popper} from '../';
 
@@ -121,5 +122,16 @@ describe('Popper', () => {
     await act(() => new Promise(requestAnimationFrame));
 
     expect(onFirstUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('should forward the popperInstanceRef prop to the PopperJS instance', () => {
+    const ref = React.createRef<PopperJS.Instance>();
+    render(
+      <Popper anchorElement={document.body} popperInstanceRef={ref}>
+        Contents
+      </Popper>
+    );
+
+    expect(ref.current).toHaveProperty('update');
   });
 });

--- a/modules/react/popup/stories/stories_Popper.tsx
+++ b/modules/react/popup/stories/stories_Popper.tsx
@@ -7,6 +7,7 @@ import {Popper} from '@workday/canvas-kit-react/popup';
 import {Card} from '@workday/canvas-kit-react/card';
 
 import README from '../README.md';
+import {HStack} from '@workday/canvas-kit-labs-react';
 
 export default {
   title: 'Components/Popups/Popper/React',
@@ -20,21 +21,42 @@ export const PopperStory = () => {
   const [open, setOpen] = React.useState(false);
   const buttonRef = React.useRef<HTMLButtonElement>(null);
   const popupRef = React.useRef<HTMLDivElement>(null);
+  const popperInstanceRef = React.useRef(null);
 
   const onClickButton = () => setOpen(!open);
   const onClose = () => setOpen(false);
+  const [big, setBig] = React.useState(false);
 
   return (
     <div style={{display: 'flex', justifyContent: 'center'}}>
       <PrimaryButton ref={buttonRef} onClick={onClickButton}>
         Toggle Popup
       </PrimaryButton>
-      <Popper placement="bottom" open={open} anchorElement={buttonRef.current!} ref={popupRef}>
+      <Popper
+        placement="bottom"
+        open={open}
+        anchorElement={buttonRef.current!}
+        ref={popupRef}
+        popperInstanceRef={popperInstanceRef}
+      >
         <Card>
           <Card.Heading>Popper Example</Card.Heading>
           <Card.Body>
             <p>A card positioned by Popper!</p>
-            <SecondaryButton onClick={onClose}>Close</SecondaryButton>
+            <div style={big ? {width: 500} : {}}></div>
+            <HStack spacing="s">
+              <SecondaryButton
+                onClick={() => {
+                  setBig(!big);
+                  requestAnimationFrame(() => {
+                    popperInstanceRef.current.update();
+                  });
+                }}
+              >
+                Toggle size
+              </SecondaryButton>
+              <SecondaryButton onClick={onClose}>Close</SecondaryButton>
+            </HStack>
           </Card.Body>
         </Card>
       </Popper>


### PR DESCRIPTION
## Summary

Allow access to the `PopperJS` instance to allow resize positioning of a Popup.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, and Documentation -->
![category](https://img.shields.io/badge/release_category-Components-blue)

## Additional References

Before this change, the following video would show the popup size changing, but not recentering.

![PopperResize](https://user-images.githubusercontent.com/338257/149996349-e0e6179c-1c56-4e8a-a9cc-c153d60e6a71.gif)

