### PR TITLE
fix: Prevent icons from moving when clicked in ie11

### DIFF
--- a/modules/react/button/lib/parts/ButtonLabelIcon.tsx
+++ b/modules/react/button/lib/parts/ButtonLabelIcon.tsx
@@ -60,6 +60,7 @@ const ButtonLabelIconStyled = styled('span', {
 })<ButtonLabelIconProps>(
   {
     display: 'inline-block',
+    '& > *:first-of-type': {position: 'absolute'},
   },
   ({size}) => ({
     width: size ? iconSizes[size] : iconSizes.medium,

--- a/modules/react/icon/lib/Svg.tsx
+++ b/modules/react/icon/lib/Svg.tsx
@@ -41,6 +41,7 @@ export default class Svg extends React.Component<SvgProps> {
                 display: 'inline-block',
                 '& svg': {display: 'block'},
                 transform: shouldMirror ? 'scaleX(-1)' : undefined,
+                position: `relative`,
               }),
               elemProps.className
             )}


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: https://github.com/Workday/canvas-kit/issues/907

Applies some styles to icons such that they no longer move/shift when clicked in ie11.

I wouldn't say it's a high priority fix, but I wanted to see if it was possible and contribute to open source 😄 


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, and Documentation -->
![category](https://img.shields.io/badge/release_category-Components-blue)

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] code has been documented
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](https://workday.github.io/canvas-kit/?path=/story/welcome-dev-docs-api-pattern-guidelines--page)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
