### PR TITLE
docs: Add examples for Select and TextInput with Formik

### DIFF
--- a/modules/preview-react/_examples/stories/SelectWithFormik.stories.mdx
+++ b/modules/preview-react/_examples/stories/SelectWithFormik.stories.mdx
@@ -1,0 +1,10 @@
+import {Meta, Story} from '@storybook/addon-docs';
+import {SelectWithFormik} from './examples/SelectWithFormik';
+
+<Meta title="Examples/Select With Formik/React" />
+
+# Canvas Kit Examples
+
+## Select With Formik
+
+<ExampleCodeBlock code={SelectWithFormik} />

--- a/modules/preview-react/_examples/stories/TextInputWithFormik.stories.mdx
+++ b/modules/preview-react/_examples/stories/TextInputWithFormik.stories.mdx
@@ -1,0 +1,10 @@
+import {Meta, Story} from '@storybook/addon-docs';
+import {TextInputWithFormik} from './examples/TextInputWithFormik';
+
+<Meta title="Examples/Text Input With Formik/React" />
+
+# Canvas Kit Examples
+
+## Select With Formik
+
+<ExampleCodeBlock code={TextInputWithFormik} />

--- a/modules/preview-react/_examples/stories/TextInputWithFormik.stories.mdx
+++ b/modules/preview-react/_examples/stories/TextInputWithFormik.stories.mdx
@@ -5,6 +5,6 @@ import {TextInputWithFormik} from './examples/TextInputWithFormik';
 
 # Canvas Kit Examples
 
-## Select With Formik
+## Text Input With Formik
 
 <ExampleCodeBlock code={TextInputWithFormik} />

--- a/modules/preview-react/_examples/stories/examples/SelectWithFormik.tsx
+++ b/modules/preview-react/_examples/stories/examples/SelectWithFormik.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import {useFormik} from 'formik';
+import {Select} from '@workday/canvas-kit-preview-react/select';
+import {
+  FormField,
+  useFormFieldInput,
+  useFormFieldModel,
+} from '@workday/canvas-kit-preview-react/form-field';
+
+export const SelectWithFormik = () => {
+  const formik = useFormik({
+    initialValues: {
+      selectedBook: '',
+    },
+    onSubmit: data => {
+      console.log(data);
+    },
+  });
+
+  const model = useFormFieldModel();
+  const formFieldInputProps = useFormFieldInput(model);
+
+  return (
+    <form onSubmit={formik.handleSubmit}>
+      <FormField orientation="vertical" alignItems="stretch">
+        <FormField.Label>Choose a book</FormField.Label>
+        <Select
+          name="selectedBook"
+          options={bookList}
+          onChange={event => formik.setFieldValue('selectedBook', event.currentTarget.value)}
+          value={formik.values.selectedBook}
+          grow
+          {...formFieldInputProps}
+        />
+      </FormField>
+    </form>
+  );
+};
+
+const bookList = [
+  {label: 'Dessert Person by Claire Saffitz', value: 'dessert person'},
+  {label: 'Elements of Pizza by Ken Forkish', value: 'the elements of pizza'},
+  {label: 'Flour Water Salt Yeast by Ken Forkish', value: 'flour water salt yeast'},
+  {label: 'Mastering Pasta by Marc Verti', value: 'mastering pasta'},
+  {label: 'Patisserie by Christophe Felder', value: 'patisserie'},
+  {label: 'Tartine by Elisabeth Prueitt & Chad Robertson', value: 'tartine'},
+];

--- a/modules/preview-react/_examples/stories/examples/TextInputWithFormik.tsx
+++ b/modules/preview-react/_examples/stories/examples/TextInputWithFormik.tsx
@@ -9,7 +9,7 @@ import {IconButton, PrimaryButton} from '@workday/canvas-kit-react/button';
 import {visibleIcon, invisibleIcon} from '@workday/canvas-system-icons-web';
 import {useUniqueId} from '@workday/canvas-kit-react/common';
 
-export const LoginForm = () => {
+export const TextInputWithFormik = () => {
   const passwordMinimum = 8;
   const passwordHint = `Password should be of minimum ${passwordMinimum} characters length`;
   const emailRequired = 'Email is required';

--- a/modules/preview-react/form-field/stories/FormField.stories.mdx
+++ b/modules/preview-react/form-field/stories/FormField.stories.mdx
@@ -4,6 +4,7 @@ import {Specifications} from '@workday/canvas-kit-docs';
 import {FormField} from '@workday/canvas-kit-preview-react/form-field';
 
 import {Custom} from './examples/Custom';
+import {WithSelect} from './examples/Select';
 
 <Meta title="Preview/Inputs/Form Field/React" component={FormField} />
 
@@ -22,8 +23,19 @@ yarn add @workday/canvas-kit-preview-react
 
 ### Customizing With Behavior Hooks Example
 
-If you need full customization you can use the form field behavior hooks to build your own solution.
-It is also easy it work with custom components or third party libraries and get the CKR
+If you need full customization you can use the `FormField` behavior hooks to build your own
+solution. It is also easy it work with custom components or third party libraries and get the CKR
 accessibility guarantees by using the `as` prop.
 
 <ExampleCodeBlock code={Custom} />
+
+### Use with Select
+
+For some custom inputs, such as Canvas Kit's `Select`, you won't be able to reliably cast the
+`FormField.Input` with the `as` prop. Instead you'll want to use `FormField`'s hooks for the
+implementation. In the example below, we're using the `useFormFieldModel` hook to hoist the model
+and providing it to the `useFormFieldInput` behavior hook. Then we pass the model to the `FormField`
+component and the input props to `Select`. This connects `Select` to the `FormField` components and
+provides it with all the accessible attributes it needs.
+
+<ExampleCodeBlock code={WithSelect} />

--- a/modules/preview-react/form-field/stories/examples/Select.tsx
+++ b/modules/preview-react/form-field/stories/examples/Select.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import {
+  FormField,
+  useFormFieldInput,
+  useFormFieldModel,
+} from '@workday/canvas-kit-preview-react/form-field';
+import {Select} from '@workday/canvas-kit-preview-react/select';
+
+export const WithSelect = () => {
+  const [selected, setSelected] = React.useState(wineList[0].value);
+  // Hoist the FormField model so we can pass it to `useFormFieldInput`
+  const model = useFormFieldModel({isRequired: true});
+  // Get all the FormField-related input props to pass to `Select`
+  const formFieldInputProps = useFormFieldInput(model);
+
+  return (
+    <FormField orientation="vertical" model={model}>
+      <FormField.Label>Choose a wine</FormField.Label>
+      <Select
+        options={wineList}
+        value={selected}
+        onChange={event => setSelected(event.currentTarget.value)}
+        {...formFieldInputProps}
+      />
+      <FormField.Hint>When in doubt, go with the Chianti.</FormField.Hint>
+    </FormField>
+  );
+};
+
+export const wineList = [
+  {label: 'Beaujolais', value: 'beaujolais'},
+  {label: 'Bordeaux', value: 'bordeaux'},
+  {label: 'Cabernet Sauvignon', value: 'cabernet sauvignon'},
+  {label: 'Champagne', value: 'champagne'},
+  {label: 'Chardonnay', value: 'chardonnay'},
+  {label: 'Chianti', value: 'chianti'},
+  {label: 'Malbec', value: 'malbec'},
+  {label: 'Merlot', value: 'merlot'},
+  {label: 'Pinot Grigio', value: 'pinot grigio'},
+  {label: 'Pinot Gris', value: 'pinot gris'},
+  {label: 'Pinot Noir', value: 'pinot noir'},
+  {label: 'Primitivo', value: 'primitivo'},
+  {label: 'Prosecco', value: 'prosecco'},
+  {label: 'Riesling', value: 'riesling'},
+  {label: 'Rioja', value: 'rioja'},
+  {label: 'Rosé', value: 'rosé'},
+  {label: 'Sauvignon Blanc', value: 'sauvignon blanc'},
+  {label: 'Syrah', value: 'syrah'},
+  {label: 'Zinfandel', value: 'zinfandel'},
+];

--- a/modules/preview-react/text-input/stories/TextInput.stories.mdx
+++ b/modules/preview-react/text-input/stories/TextInput.stories.mdx
@@ -17,7 +17,6 @@ import {ThemedAlert} from './examples/ThemedAlert';
 import {ThemedError} from './examples/ThemedError';
 import {Error} from './examples/Error';
 import {Alert} from './examples/Alert';
-import {LoginForm} from './examples/LoginForm';
 
 <Meta title="Preview/Inputs/Text Input/React" component={TextInput} />
 
@@ -129,12 +128,6 @@ If the your theme's `main` color doesn't meet accessibility contrast, the `darke
 used in an outer ring.
 
 <ExampleCodeBlock code={ThemedAlert} />
-
-#### Full example
-
-Login Form using Formik
-
-<ExampleCodeBlock code={LoginForm} />
 
 ## Props
 


### PR DESCRIPTION
## Summary

Fixes: #1434
![category](https://img.shields.io/badge/release_category-Documentation-blue)

---

This PR:

* Adds a new Preview Select with Formik example 
* Moves the TextInput with Formik example to the "Examples" section
* Adds a new Preview Select + Preview FormField example

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] code has been documented
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](https://workday.github.io/canvas-kit/?path=/story/welcome-dev-docs-api-pattern-guidelines--page)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
