### PR TITLE
fix(preview): Preview FormField.Hint error text not the correct color

### DIFF
--- a/modules/preview-react/form-field/lib/FormFieldHint.tsx
+++ b/modules/preview-react/form-field/lib/FormFieldHint.tsx
@@ -39,9 +39,8 @@ export const FormFieldHint = createComponent('p')({
         as={Element}
         css={{
           ...type.levels.subtext.medium,
+          color: localModel.state.hasError ? theme.canvas.palette.error.main : undefined,
         }}
-        color={localModel.state.hasError ? theme.canvas.palette.error.main : undefined}
-        marginY={space.xxs}
         {...props}
       >
         {children}

--- a/modules/preview-react/form-field/lib/FormFieldHint.tsx
+++ b/modules/preview-react/form-field/lib/FormFieldHint.tsx
@@ -8,7 +8,7 @@ import {
   useModelContext,
   useTheme,
 } from '@workday/canvas-kit-react/common';
-import {space, type} from '@workday/canvas-kit-react/tokens';
+import {type} from '@workday/canvas-kit-react/tokens';
 import {Box} from '@workday/canvas-kit-labs-react/common';
 
 import {FormFieldModelContext} from './FormField';


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #1444 

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, and Documentation -->
![Components](https://img.shields.io/badge/release_category-Components-blue)

---

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] design approved final implementation
- [x] code adheres to the [API & Pattern guidelines](https://workday.github.io/canvas-kit/?path=/story/welcome-dev-docs-api-pattern-guidelines--page)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
<img width="318" alt="Screen Shot 2022-01-26 at 5 56 12 PM" src="https://user-images.githubusercontent.com/1562615/151277882-f54f4603-fc30-4634-8b0e-4d0c2a673938.png">

