### PR TITLE
fix(popup-stack): Fix popup element removal when adapter is used

### DIFF
--- a/modules/popup-stack/lib/PopupStack.ts
+++ b/modules/popup-stack/lib/PopupStack.ts
@@ -246,7 +246,10 @@ export const PopupStack = {
    */
   remove(element: HTMLElement): void {
     // Find the stack the popup belongs to.
-    const stack = find(stacks, stack => !!find(stack.items, item => item.element === element));
+    const stack = find(
+      stacks,
+      stack => !!find(PopupStack.getElements(stack), el => el === element)
+    );
     if (stack) {
       if (stack._adapter?.remove) {
         stack._adapter.remove(element);


### PR DESCRIPTION
## Summary

Fixes an issue where an adapted PopupStack was never removed from the DOM

![category](https://img.shields.io/badge/release_category-Components-blue)
