### PR TITLE
fix(menu): Remove excess divs around Menu component

### DIFF
--- a/modules/preview-react/menu/lib/Menu.tsx
+++ b/modules/preview-react/menu/lib/Menu.tsx
@@ -288,6 +288,7 @@ export const Menu = createComponent('ul')({
       <Card
         as={List}
         padding={`${space.xxs} 0`}
+        margin={space.zero}
         width={cardWidth}
         display="inline-block"
         background={commonColors.background}

--- a/modules/preview-react/menu/lib/Menu.tsx
+++ b/modules/preview-react/menu/lib/Menu.tsx
@@ -1,12 +1,20 @@
 import * as React from 'react';
-import styled from '@emotion/styled';
 
 import {MenuItemProps} from './MenuItem';
 import {Card} from '@workday/canvas-kit-react/card';
-import {commonColors, space, borderRadius} from '@workday/canvas-kit-react/tokens';
-import {hideMouseFocus, GrowthBehavior, generateUniqueId} from '@workday/canvas-kit-react/common';
+import {borderRadius, commonColors, space, type} from '@workday/canvas-kit-react/tokens';
+import {
+  createComponent,
+  ElementComponent,
+  ExtractProps,
+  hideMouseFocus,
+  GrowthBehavior,
+  styled,
+  useUniqueId,
+  StyledType,
+} from '@workday/canvas-kit-react/common';
 
-export interface MenuProps extends GrowthBehavior, React.HTMLAttributes<HTMLUListElement> {
+export interface MenuProps extends GrowthBehavior, ExtractProps<typeof Card, never> {
   /**
    * The MenuItem children of the Menu (must be at least one). Also accepts other components which share the same interface as `MenuItem`.
    */
@@ -46,288 +54,270 @@ export interface MenuState {
   selectedItemIndex: number;
 }
 
-const List = styled('ul')({
-  background: commonColors.background,
-  borderRadius: borderRadius.m,
-  padding: 0,
-  margin: `${space.xxs} 0`,
+const List = (styled('ul')<MenuProps & StyledType>({
+  ...type.levels.subtext.large,
   '&:focus': {
     outline: 'none',
   },
   ...hideMouseFocus,
-});
+}) as unknown) as ElementComponent<'ul', MenuProps>;
 
-export default class Menu extends React.Component<MenuProps, MenuState> {
-  private id = generateUniqueId();
-  private animateId!: number;
+export const Menu = createComponent('ul')({
+  displayName: 'Menu',
+  Component: ({
+    children,
+    isOpen = true,
+    onSelect,
+    onClose,
+    grow,
+    initialSelectedItem,
+    id: _id,
+    width,
+    ...elemProps
+  }: MenuProps) => {
+    const id = _id ?? useUniqueId();
+    const animateId = React.useRef<number>();
+    const menuRef = React.useRef<HTMLUListElement>(null);
+    const firstCharacters = React.useRef<string[]>([]);
 
-  private menuRef: React.RefObject<HTMLUListElement>;
-  private firstCharacters!: string[];
+    const getInitialSelectedItem = React.useCallback((): number => {
+      let selected = initialSelectedItem || 0;
+      selected = selected < 0 ? React.Children.count(children) + selected : selected;
+      if (selected < 0) {
+        selected = 0;
+      } else if (selected > React.Children.count(children) - 1) {
+        selected = React.Children.count(children) - 1;
+      }
 
-  constructor(props: MenuProps) {
-    super(props);
-    this.menuRef = React.createRef();
+      return selected;
+    }, [children, initialSelectedItem]);
 
-    const selected = this.getInitialSelectedItem();
+    const setInitialSelectedItem = React.useCallback(() => {
+      const selected = getInitialSelectedItem();
+      setSelectedItemIndex(selected);
+    }, [getInitialSelectedItem]);
 
     // We track the active menu item by index so we can avoid setting a bunch of refs
     // for doing things like selecting an item by first character (or really calling .focus() at all)
     // It allows us to use the activedescendant design pattern
     // https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-actions-active-descendant.html
-    this.state = {
-      selectedItemIndex: selected,
-    };
-  }
+    const [selectedItemIndex, setSelectedItemIndex] = React.useState(getInitialSelectedItem());
 
-  componentDidUpdate(prevProps: MenuProps) {
-    if (this.props.children !== prevProps.children) {
-      this.setFirstCharacters();
-      this.setInitialSelectedItem();
-    }
-    if (this.props.isOpen && !prevProps.isOpen) {
-      this.setInitialSelectedItem();
-    }
-    this.animateId = requestAnimationFrame(() => {
-      if (this.props.isOpen && this.menuRef.current) {
-        this.menuRef.current.focus();
-      }
-    });
-  }
+    React.useEffect(() => {
+      const getFirstCharacter = (child: React.ReactNode): string => {
+        let character = '';
+        if (!child || typeof child === 'boolean' || child === {}) {
+          character = '';
+        } else if (typeof child === 'string' || typeof child === 'number') {
+          character = child
+            .toString()
+            .trim()
+            .substring(0, 1)
+            .toLowerCase();
+        } else if (Array.isArray(child) && child[0]) {
+          // TODO test React.ReactNodeArray
+          character = getFirstCharacter(child[0]);
+        } else if ('props' in child) {
+          const {children} = child.props;
 
-  componentDidMount() {
-    this.setFirstCharacters();
-    this.setInitialSelectedItem();
-  }
+          if (Array.isArray(children)) {
+            character = getFirstCharacter(children[0]);
+          } else {
+            character = getFirstCharacter(children);
+          }
+        }
+        return character;
+      };
 
-  componentWillUnmount() {
-    cancelAnimationFrame(this.animateId);
-  }
+      const firstCharacterMap = React.Children.map(children, child => {
+        return getFirstCharacter(child);
+      });
 
-  public render() {
-    // TODO: Standardize on prop spread location (see #150)
-    const {
-      id = this.id,
-      isOpen = true,
-      children,
-      'aria-labelledby': ariaLabelledby,
-      grow,
-      width,
-      onSelect,
-      onClose,
-      initialSelectedItem,
-      ...elemProps
-    } = this.props;
-    const {selectedItemIndex} = this.state;
+      firstCharacters.current = firstCharacterMap ?? [];
+
+      setInitialSelectedItem();
+    }, [children, setInitialSelectedItem]);
+
+    React.useEffect(() => {
+      setInitialSelectedItem();
+    }, [isOpen, setInitialSelectedItem]);
+
+    React.useEffect(() => {
+      animateId.current = requestAnimationFrame(() => {
+        if (isOpen && menuRef.current) {
+          menuRef.current.focus();
+        }
+      });
+      return () => {
+        if (animateId.current) {
+          cancelAnimationFrame(animateId.current);
+        }
+      };
+    }, [isOpen]);
+
     const cardWidth = grow ? '100%' : width;
 
-    return (
-      <Card style={{display: 'inline-block'}} padding={space.zero} width={cardWidth}>
-        <Card.Body>
-          <List
-            role="menu"
-            tabIndex={0}
-            id={id}
-            aria-labelledby={ariaLabelledby}
-            aria-activedescendant={`${id}-${selectedItemIndex}`}
-            onKeyDown={this.handleKeyboardShortcuts}
-            ref={this.menuRef}
-            {...elemProps}
-          >
-            {React.Children.map(children, (menuItem, index) => {
-              if (!React.isValidElement(menuItem)) {
-                return;
-              }
-              const itemId = `${id}-${index}`;
-              return (
-                <React.Fragment key={itemId}>
-                  {React.cloneElement(menuItem, {
-                    onClick: (event: React.MouseEvent) => this.handleClick(event, menuItem.props),
-                    id: itemId,
-                    isFocused: selectedItemIndex === index,
-                  })}
-                </React.Fragment>
-              );
-            })}
-          </List>
-        </Card.Body>
-      </Card>
-    );
-  }
-
-  public getNormalizedItemIndex = (index: number | undefined): number => {
-    const itemCount = React.Children.count(this.props.children);
-    const firstItem = 0;
-    const lastItem = itemCount - 1;
-    if (!index) {
-      return firstItem;
-    }
-    return index < 0 ? firstItem : index >= itemCount ? lastItem : index;
-  };
-
-  public setNormalizedItemIndex = (index: number | undefined): void => {
-    this.setState({selectedItemIndex: this.getNormalizedItemIndex(index)});
-  };
-
-  private handleKeyboardShortcuts = (event: React.KeyboardEvent): void => {
-    if (event.ctrlKey || event.altKey || event.metaKey) {
-      return;
-    }
-    const children = React.Children.toArray(this.props.children);
-    let nextSelectedIndex = 0;
-    let isShortcut = false;
-    const itemCount = children.length;
-    const firstItem = 0;
-    const lastItem = itemCount - 1;
-
-    if (event.key.length === 1 && event.key.match(/\S/)) {
-      let start = this.state.selectedItemIndex + 1;
-      let searchIndex;
-      if (start === children.length) {
-        start = 0;
+    const getNormalizedItemIndex = (index: number | undefined): number => {
+      const itemCount = React.Children.count(children);
+      const firstItem = 0;
+      const lastItem = itemCount - 1;
+      if (!index) {
+        return firstItem;
       }
-      searchIndex = this.getIndexFirstChars(start, event.key.toLowerCase());
-      if (searchIndex === -1) {
-        searchIndex = this.getIndexFirstChars(0, event.key.toLowerCase(), start);
-      }
-      if (searchIndex > -1) {
-        isShortcut = true;
-        nextSelectedIndex = searchIndex;
-      }
-    } else {
-      switch (event.key) {
-        case 'ArrowUp':
-        case 'ArrowDown':
-        case 'Down': // IE/Edge specific value
-        case 'Up': // IE/Edge specific value
-          const direction = event.key === 'ArrowUp' ? -1 : 1;
-          isShortcut = true;
-          const nextIndex = this.state.selectedItemIndex + direction;
-          nextSelectedIndex =
-            nextIndex < 0 ? lastItem : nextIndex >= itemCount ? firstItem : nextIndex;
-          break;
-
-        case 'Home':
-        case 'End':
-          const skipTo = event.key === 'Home' ? firstItem : lastItem;
-          isShortcut = true;
-          nextSelectedIndex = skipTo;
-          break;
-
-        case 'Tab':
-          if (this.props.onClose) {
-            this.props.onClose();
-          }
-          break;
-
-        case 'Escape':
-        case 'Esc': // IE/Edge specific value
-          isShortcut = true;
-          if (this.props.onClose) {
-            this.props.onClose();
-          }
-          break;
-
-        case 'Spacebar':
-        case ' ':
-        case 'Enter':
-          nextSelectedIndex = this.state.selectedItemIndex;
-          const child = children[this.state.selectedItemIndex] as React.ReactElement<MenuItemProps>;
-          this.handleClick(event, child.props);
-          isShortcut = true;
-          break;
-
-        default:
-      }
-    }
-    if (isShortcut) {
-      this.setNormalizedItemIndex(nextSelectedIndex);
-      event.stopPropagation();
-      event.preventDefault();
-    }
-  };
-
-  private handleClick = (
-    event: React.MouseEvent | React.KeyboardEvent,
-    menuItemProps: MenuItemProps
-  ): void => {
-    /* istanbul ignore next line for coverage */
-    if (menuItemProps.isDisabled) {
-      // You should only hit this point if you are using a custom MenuItem implementation.
-      return;
-    }
-    if (menuItemProps.onClick) {
-      menuItemProps.onClick(event as React.MouseEvent);
-    }
-    if (this.props.onSelect) {
-      this.props.onSelect();
-    }
-    if (this.props.onClose) {
-      if (menuItemProps.shouldClose) {
-        this.props.onClose();
-      }
-    }
-  };
-
-  private getIndexFirstChars = (
-    startIndex: number,
-    character: string,
-    lastIndex: number = this.firstCharacters.length
-  ) => {
-    for (let i = startIndex; i < lastIndex; i++) {
-      if (character === this.firstCharacters[i]) {
-        return i;
-      }
-    }
-    return -1;
-  };
-
-  private setFirstCharacters = (): void => {
-    const getFirstCharacter = (child: React.ReactNode): string => {
-      let character = '';
-      if (!child || typeof child === 'boolean' || child === {}) {
-        character = '';
-      } else if (typeof child === 'string' || typeof child === 'number') {
-        character = child
-          .toString()
-          .trim()
-          .substring(0, 1)
-          .toLowerCase();
-      } else if (Array.isArray(child) && child[0]) {
-        // TODO test React.ReactNodeArray
-        character = getFirstCharacter(child[0]);
-      } else if ('props' in child) {
-        const {children} = child.props;
-
-        if (Array.isArray(children)) {
-          character = getFirstCharacter(children[0]);
-        } else {
-          character = getFirstCharacter(children);
-        }
-      }
-      return character;
+      return index < 0 ? firstItem : index >= itemCount ? lastItem : index;
     };
 
-    const firstCharacters = React.Children.map(this.props.children, child => {
-      return getFirstCharacter(child);
-    });
+    const setNormalizedItemIndex = (index: number | undefined): void => {
+      setSelectedItemIndex(getNormalizedItemIndex(index));
+    };
 
-    this.firstCharacters = firstCharacters as string[];
-  };
+    const handleKeyboardShortcuts = (event: React.KeyboardEvent): void => {
+      if (event.ctrlKey || event.altKey || event.metaKey) {
+        return;
+      }
+      const menuItems = React.Children.toArray(children);
+      let nextSelectedIndex = 0;
+      let isShortcut = false;
+      const itemCount = menuItems.length;
+      const firstItem = 0;
+      const lastItem = itemCount - 1;
 
-  private getInitialSelectedItem = (): number => {
-    let selected = this.props.initialSelectedItem || 0;
-    selected = selected < 0 ? React.Children.count(this.props.children) + selected : selected;
-    if (selected < 0) {
-      selected = 0;
-    } else if (selected > React.Children.count(this.props.children) - 1) {
-      selected = React.Children.count(this.props.children) - 1;
-    }
+      if (event.key.length === 1 && event.key.match(/\S/)) {
+        let start = selectedItemIndex + 1;
+        let searchIndex;
+        if (start === menuItems.length) {
+          start = 0;
+        }
+        searchIndex = getIndexFirstChars(start, event.key.toLowerCase());
+        if (searchIndex === -1) {
+          searchIndex = getIndexFirstChars(0, event.key.toLowerCase(), start);
+        }
+        if (searchIndex > -1) {
+          isShortcut = true;
+          nextSelectedIndex = searchIndex;
+        }
+      } else {
+        switch (event.key) {
+          case 'ArrowUp':
+          case 'ArrowDown':
+          case 'Down': // IE/Edge specific value
+          case 'Up': // IE/Edge specific value
+            const direction = event.key === 'ArrowUp' ? -1 : 1;
+            isShortcut = true;
+            const nextIndex = selectedItemIndex + direction;
+            nextSelectedIndex =
+              nextIndex < 0 ? lastItem : nextIndex >= itemCount ? firstItem : nextIndex;
+            break;
 
-    return selected;
-  };
+          case 'Home':
+          case 'End':
+            const skipTo = event.key === 'Home' ? firstItem : lastItem;
+            isShortcut = true;
+            nextSelectedIndex = skipTo;
+            break;
 
-  private setInitialSelectedItem = () => {
-    const selected = this.getInitialSelectedItem();
-    this.setState({selectedItemIndex: selected});
-  };
-}
+          case 'Tab':
+            if (onClose) {
+              onClose();
+            }
+            break;
+
+          case 'Escape':
+          case 'Esc': // IE/Edge specific value
+            isShortcut = true;
+            if (onClose) {
+              onClose();
+            }
+            break;
+
+          case 'Spacebar':
+          case ' ':
+          case 'Enter':
+            nextSelectedIndex = selectedItemIndex;
+            const child = menuItems[selectedItemIndex] as React.ReactElement<MenuItemProps>;
+            handleClick(event, child.props);
+            isShortcut = true;
+            break;
+
+          default:
+        }
+      }
+      if (isShortcut) {
+        setNormalizedItemIndex(nextSelectedIndex);
+        event.stopPropagation();
+        event.preventDefault();
+      }
+    };
+
+    const handleClick = (
+      event: React.MouseEvent | React.KeyboardEvent,
+      menuItemProps: MenuItemProps
+    ): void => {
+      /* istanbul ignore next line for coverage */
+      if (menuItemProps.isDisabled) {
+        // You should only hit this point if you are using a custom MenuItem implementation.
+        return;
+      }
+      if (menuItemProps.onClick) {
+        menuItemProps.onClick(event as React.MouseEvent);
+      }
+      if (onSelect) {
+        onSelect();
+      }
+      if (onClose) {
+        if (menuItemProps.shouldClose !== false) {
+          onClose();
+        }
+      }
+    };
+
+    const getIndexFirstChars = (
+      startIndex: number,
+      character: string,
+      lastIndex: number = firstCharacters.current?.length ?? 0
+    ) => {
+      for (let i = startIndex; i < lastIndex; i++) {
+        if (character === firstCharacters.current?.[i]) {
+          return i;
+        }
+      }
+      return -1;
+    };
+
+    return (
+      <Card
+        as={List}
+        padding={`${space.xxs} 0`}
+        width={cardWidth}
+        display="inline-block"
+        background={commonColors.background}
+        borderRadius={borderRadius.m}
+        role="menu"
+        tabIndex={0}
+        id={id}
+        aria-activedescendant={`${id}-${selectedItemIndex}`}
+        onKeyDown={handleKeyboardShortcuts}
+        ref={menuRef}
+        {...elemProps}
+      >
+        {React.Children.map(children, (menuItem, index) => {
+          if (!React.isValidElement(menuItem)) {
+            return;
+          }
+          const itemId = `${id}-${index}`;
+          return (
+            <React.Fragment key={itemId}>
+              {React.cloneElement(menuItem, {
+                onClick: (event: React.MouseEvent) => handleClick(event, menuItem.props),
+                id: itemId,
+                isFocused: selectedItemIndex === index,
+              })}
+            </React.Fragment>
+          );
+        })}
+      </Card>
+    );
+  },
+});
+
+export default Menu;

--- a/modules/preview-react/menu/lib/MenuItem.tsx
+++ b/modules/preview-react/menu/lib/MenuItem.tsx
@@ -237,78 +237,61 @@ const scrollIntoViewIfNeeded = (elem: HTMLElement, centerIfNeeded = true): void 
   }
 };
 
-class MenuItem extends React.Component<MenuItemProps> {
-  ref = React.createRef<HTMLLIElement>();
+const MenuItem: React.FC<MenuItemProps> = ({
+  onClick,
+  children,
+  id,
+  icon,
+  secondaryIcon,
+  hasDivider,
+  isDisabled,
+  isFocused,
+  shouldClose = true,
+  role = 'menuitem',
+  ...elemProps
+}) => {
+  const ref = React.useRef<HTMLLIElement>(null);
 
-  componentDidUpdate = (prevProps: MenuItemProps) => {
-    if (!prevProps.isFocused && this.props.isFocused) {
-      if (this.ref.current) {
-        scrollIntoViewIfNeeded(this.ref.current);
-      }
+  React.useEffect(() => {
+    if (ref.current) {
+      scrollIntoViewIfNeeded(ref.current);
     }
-  };
+  }, [isFocused]);
 
-  render(): React.ReactNode {
-    const {
-      onClick,
-      children,
-      id,
-      icon,
-      secondaryIcon,
-      hasDivider,
-      isDisabled,
-      isFocused,
-      role,
-      ...elemProps
-    } = this.props;
+  iconProps = setIconProps(icon, isDisabled, isFocused);
+  secondaryIconProps = setIconProps(secondaryIcon, isDisabled, isFocused);
 
-    iconProps = setIconProps(icon, isDisabled, isFocused);
-    secondaryIconProps = setIconProps(secondaryIcon, isDisabled, isFocused);
-
-    return (
-      <>
-        {hasDivider && <Divider />}
-        <Item
-          ref={this.ref}
-          tabIndex={-1}
-          id={id}
-          role={role}
-          onClick={this.handleClick}
-          aria-disabled={isDisabled ? true : undefined}
-          isDisabled={!!isDisabled}
-          isFocused={!!isFocused}
-          {...elemProps}
-        >
-          {icon && iconProps && <StyledSystemIcon {...iconProps} />}
-          <LabelContainer>{children}</LabelContainer>
-          {secondaryIcon && secondaryIconProps && (
-            <SecondaryStyledSystemIcon {...secondaryIconProps} />
-          )}
-        </Item>
-      </>
-    );
-  }
-
-  private handleClick = (event: React.MouseEvent): void => {
-    if (this.props.isDisabled) {
+  const handleClick = (event: React.MouseEvent): void => {
+    if (isDisabled) {
       return;
     }
-    if (this.props.onClick) {
-      this.props.onClick(event);
+    if (onClick) {
+      onClick(event);
     }
   };
-}
 
-/**
- * If we destructure props, shouldClose will be undefined because the value is only applied for the render method only.
- * We have to use defaultProps so that the value of shouldClose is applied for every method and therefore references in the Menu component.
- * For reference: https://github.com/Workday/canvas-kit/blob/f6d4d29e9bb2eb2af0b204e6f4ce2e5ed5a98e57/modules/_labs/menu/react/lib/Menu.tsx#L259,
- */
-// TODO: Remove this ts-ignore when we convert to a functional component
-// @ts-ignore
-MenuItem.defaultProps = {
-  shouldClose: true,
-  role: 'menuitem',
+  return (
+    <>
+      {hasDivider && <Divider />}
+      <Item
+        ref={ref}
+        tabIndex={-1}
+        id={id}
+        role={role}
+        onClick={handleClick}
+        aria-disabled={isDisabled ? true : undefined}
+        isDisabled={!!isDisabled}
+        isFocused={!!isFocused}
+        {...elemProps}
+      >
+        {icon && iconProps && <StyledSystemIcon {...iconProps} />}
+        <LabelContainer>{children}</LabelContainer>
+        {secondaryIcon && secondaryIconProps && (
+          <SecondaryStyledSystemIcon {...secondaryIconProps} />
+        )}
+      </Item>
+    </>
+  );
 };
 
 export default MenuItem;

--- a/modules/preview-react/menu/stories/examples/Basic.tsx
+++ b/modules/preview-react/menu/stories/examples/Basic.tsx
@@ -8,10 +8,12 @@ import {
   useReturnFocus,
   useCloseOnEscape,
 } from '@workday/canvas-kit-react/popup';
+import {useUniqueId} from '@workday/canvas-kit-react';
 
 const menuId = 'basic-menu';
 
 export const Basic = () => {
+  const id = useUniqueId();
   const model = usePopupModel();
 
   useAlwaysCloseOnOutsideClick(model);
@@ -48,6 +50,7 @@ export const Basic = () => {
         aria-expanded={isOpen}
         aria-haspopup={true}
         aria-controls={isOpen ? menuId : undefined}
+        id={id}
       >
         Open Menu
       </Popup.Target>
@@ -57,7 +60,7 @@ export const Basic = () => {
           onClose must be set in order to the Menu to close properly after
           selecting a MenuItem
         */}
-        <Menu id={menuId} isOpen={isOpen} onClose={model.events.hide}>
+        <Menu id={menuId} isOpen={isOpen} onClose={model.events.hide} aria-labelledby={id}>
           <MenuItem>First Item</MenuItem>
           <MenuItem>Second Item (with a really really really long label)</MenuItem>
           <MenuItem isDisabled>Third Item (disabled)</MenuItem>


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #1467  <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

Excess divs make the Menu hard to customize without fragile css trickery. The divs are not needed for styling and can be removed. This PR also changes the component from a class to a functional component.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, and Documentation -->
![Components](https://img.shields.io/badge/release_category-Components-blue)

### Release Note
Extends MenuProps to except and override Card attributes.

---

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests are changed or added
- [x] code has been documented
- [x] design approved final implementation
- [x] a11y approved final implementation
- [x] code adheres to the [API & Pattern guidelines](https://workday.github.io/canvas-kit/?path=/story/welcome-dev-docs-api-pattern-guidelines--page)

