### PR TITLE
fix(popup): Restore overflow y and x with `useDisableBodyScroll`

### DIFF
--- a/modules/react/popup/lib/hooks/useDisableBodyScroll.ts
+++ b/modules/react/popup/lib/hooks/useDisableBodyScroll.ts
@@ -16,11 +16,17 @@ export const useDisableBodyScroll = (model: PopupModel, elemProps = {}) => {
     if (!visible) {
       return;
     }
+
+    const overflowY = document.body.style.overflowY;
+    const overflowX = document.body.style.overflowX;
     const overflow = document.body.style.overflow;
+
     document.body.style.overflow = 'hidden';
 
     return () => {
       document.body.style.overflow = overflow;
+      document.body.style.overflowY = overflowY;
+      document.body.style.overflowX = overflowX;
     };
   }, [visible]);
 


### PR DESCRIPTION
## Summary

`useDisableBodyScroll` now restores `overflow`, `overflowX`, and `overflowY`

Fixes #1469