### PR TITLE
fix(tabs): Add back the extending bottom border

### DIFF
--- a/modules/react/tabs/lib/TabsList.tsx
+++ b/modules/react/tabs/lib/TabsList.tsx
@@ -47,7 +47,7 @@ export const TabsList = createComponent('div')({
         as={Element}
         position="relative"
         borderBottom={`1px solid ${commonColors.divider}`}
-        marginX="m"
+        paddingX="m"
         spacing="xxxs"
         {...props}
       >


### PR DESCRIPTION
## Summary

v6 removed an extra `div` in Tabs, but didn't change `margin` to `padding` in the single `div` element which caused a regression of the bottom border of the tablist.

![category](https://img.shields.io/badge/release_category-Components-blue)

---

<img width="749" alt="image" src="https://user-images.githubusercontent.com/338257/153964856-4b529048-8b14-469d-88c0-7dce1cfdbb55.png">
