### PR TITLE
fix: Set overflowX and overflowY to cater for IE11 scrolling bug

### DIFF
--- a/modules/react/popup/lib/hooks/useDisableBodyScroll.ts
+++ b/modules/react/popup/lib/hooks/useDisableBodyScroll.ts
@@ -22,6 +22,8 @@ export const useDisableBodyScroll = (model: PopupModel, elemProps = {}) => {
     const overflow = document.body.style.overflow;
 
     document.body.style.overflow = 'hidden';
+    document.body.style.overflowY = 'hidden';
+    document.body.style.overflowX = 'hidden';
 
     return () => {
       document.body.style.overflow = overflow;


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

<!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->
No issue raised for this, but this fixes an issue in IE 11 where the background behind a modal can sometimes remain scrollable. It seems that this is due to partial support for the overflow attribute in IE 11.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, and Documentation -->
![category](https://img.shields.io/badge/release_category-Components-blue)

---
