### PR TITLE
fix(action-bar): Update CSS selector to fix spacing bug

### DIFF
--- a/modules/react/action-bar/lib/ActionBar.tsx
+++ b/modules/react/action-bar/lib/ActionBar.tsx
@@ -42,7 +42,7 @@ const ChildrenContainer = styled('div')(
   {
     display: 'inline-block',
     padding: `0 ${space.m}`,
-    '*:not(:first-of-type)': {
+    '> *:not(style) ~ *:not(style)': {
       marginLeft: space.s,
     },
   },
@@ -54,7 +54,7 @@ const ChildrenContainer = styled('div')(
       flexDirection: 'row-reverse',
       '> *': {
         flex: 1,
-        '&:not(:first-of-type)': {
+        '&:not(style) ~ *:not(style)': {
           marginRight: space.s,
           marginLeft: 0,
         },


### PR DESCRIPTION
## Summary

Fixes: #1509

![category](https://img.shields.io/badge/release_category-Components-blue)

### Release Note

This change updates the CSS selector for the `ChildrenContainer`. We're using [the same selector as what's used in Stack](https://github.com/Workday/canvas-kit/blob/master/modules/labs-react/layout/lib/utils/stack.ts#L10). It is also now SSR-safe by avoiding applying styles to `style` tags. If you were compensating for this bug by adding space for non-button elements in the ActionBar, you'll need to remove that adjustment.

---

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] code has been documented
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](https://workday.github.io/canvas-kit/?path=/story/welcome-dev-docs-api-pattern-guidelines--page)

## Additional References

Fixed:

![](http://recordit.co/M5n16tjjrb.gif)