### PR TITLE
fix: Update usePopupTarget to apply Refs to elements not class instance

### DIFF
--- a/modules/react/popup/lib/hooks/usePopupTarget.ts
+++ b/modules/react/popup/lib/hooks/usePopupTarget.ts
@@ -13,7 +13,7 @@ export const usePopupTarget = createHook(({events, state}: PopupModel, ref) => {
       // `state.targetRef` manually. This ensures that custom target components don't need to handle
       // ref forwarding since ref forwarding is only really needed to programmatically open popups
       // around a target _before_ a user clicks. In that rare case, ref forwarding is required.
-      if (!state.targetRef.current) {
+      if (!(state.targetRef.current instanceof Element)) {
         (state.targetRef as React.MutableRefObject<any>).current = event.currentTarget;
       }
 


### PR DESCRIPTION

<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #1234 <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

Add a ref to banner component doesn't cause the ref to work. Code uses instanceof to apply ref to element rather than class instance.
This is a suggestion from @NicholasBoll

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, and Documentation -->
![category](https://img.shields.io/badge/release_category-Components-blue)

---

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] code has been documented
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](https://workday.github.io/canvas-kit/?path=/story/welcome-dev-docs-api-pattern-guidelines--page)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
