### PR TITLE
fix(layout): Pass key to Stack.Item when using shouldWrapChildren

### DIFF
--- a/modules/labs-react/layout/lib/Stack.tsx
+++ b/modules/labs-react/layout/lib/Stack.tsx
@@ -56,7 +56,9 @@ export const Stack = createComponent('div')({
         {...elemProps}
       >
         {shouldWrapChildren
-          ? validChildren.map(child => <StackItem>{child}</StackItem>)
+          ? validChildren.map((child, index) => (
+              <StackItem key={child.props.id || index}>{child}</StackItem>
+            ))
           : validChildren}
       </StyledStack>
     );

--- a/modules/labs-react/layout/stories/Stack.stories.mdx
+++ b/modules/labs-react/layout/stories/Stack.stories.mdx
@@ -156,6 +156,11 @@ further to the right. You could use two separate horizontal stacks here to achie
 but you could also use `shouldWrapChildren` and then put additional margin only where needed. Either
 approach would be fine; it's a matter of personal preference.
 
+> Note: `shouldWrapChildren` implicitly passes the child element's index as a unique `key` prop to
+> the `Stack.Item`, which works well for static lists. If you have dynamic lists with child elements
+> that change over time, you'll want to provide a unique `id` prop to each child element for the
+> `Stack.Item` to use as a key instead.
+
 <ExampleCodeBlock code={ShouldWrapChildren} />
 
 Use this approach when:


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #1516

![category](https://img.shields.io/badge/release_category-Components-blue)

---

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] code has been documented
- [ ] design approved final implementation
- [ ] a11y approved final implementation
- [ ] code adheres to the [API & Pattern guidelines](https://workday.github.io/canvas-kit/?path=/story/welcome-dev-docs-api-pattern-guidelines--page)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->
