### PR TITLE
fix(codemod): Limit specifier renaming to Canvas Kit imports

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -13,7 +13,7 @@ module.exports = {
 };
 
 // Extra scopes supported outside the `modules` folder
-const scopes = ['labs', 'preview', 'fonts', 'popup-stack'];
+const scopes = ['labs', 'preview', 'fonts', 'popup-stack', 'codemod'];
 
 /**
  * @param {{ cwd: string}} context

--- a/modules/codemod/lib/v6/moveAndRenameSearchBar.ts
+++ b/modules/codemod/lib/v6/moveAndRenameSearchBar.ts
@@ -96,6 +96,7 @@ const transform: Transform = (file, api) => {
     if (searchBarSpecifiers.length) {
       searchBarSpecifiers.forEach(specifier => {
         const specifierName = specifier.imported.name;
+
         if (specifierName in renameMap) {
           // if it hasn't been aliased, track it for updating JSX
           if (!specifier.local || specifier.local.name === specifier.imported.name) {

--- a/modules/codemod/lib/v6/moveAndRenameSearchBar.ts
+++ b/modules/codemod/lib/v6/moveAndRenameSearchBar.ts
@@ -42,7 +42,7 @@ const transform: Transform = (file, api) => {
     nodePath.insertBefore(j.importDeclaration(specifiers, j.stringLiteral(sourcePath)));
   }
 
-  const discoveredImportAliases: Record<string, boolean> = {};
+  const discoveredImportSpecifiers: Record<string, boolean> = {};
 
   // Rename search-bar named imports from @workday/canvas-kit-labs-react
   // e.g. import { SearchBar, SearchBarProps } from '@workday/canvas-kit-labs-react';
@@ -56,7 +56,10 @@ const transform: Transform = (file, api) => {
     searchBarImports.forEach(specifier => {
       const specifierName = specifier.imported.name;
       if (specifierName in renameMap) {
-        discoveredImportAliases[specifier.imported.name] = true;
+        // if it hasn't been aliased, track it for updating JSX
+        if (!specifier.local || specifier.local.name === specifier.imported.name) {
+          discoveredImportSpecifiers[specifier.imported.name] = true;
+        }
 
         specifier.imported.name = renameMap[specifierName];
       }
@@ -94,7 +97,10 @@ const transform: Transform = (file, api) => {
       searchBarSpecifiers.forEach(specifier => {
         const specifierName = specifier.imported.name;
         if (specifierName in renameMap) {
-          discoveredImportAliases[specifier.imported.name] = true;
+          // if it hasn't been aliased, track it for updating JSX
+          if (!specifier.local || specifier.local.name === specifier.imported.name) {
+            discoveredImportSpecifiers[specifier.imported.name] = true;
+          }
 
           specifier.imported.name = renameMap[specifierName];
         }
@@ -119,7 +125,7 @@ const transform: Transform = (file, api) => {
     root,
     '@workday/canvas-kit-labs-react/search-form',
     renameMap,
-    discoveredImportAliases
+    discoveredImportSpecifiers
   ).toSource();
 };
 

--- a/modules/codemod/lib/v6/spec/deprecateHeader.spec.ts
+++ b/modules/codemod/lib/v6/spec/deprecateHeader.spec.ts
@@ -55,7 +55,7 @@ describe('Canvas Kit Deprecate Header Codemod', () => {
       expectTransform(input, expected);
     });
 
-    it('should rename aliased specifiers from the component package', () => {
+    it('should only rename the import specifier and not similarly named components', () => {
       const input = `
         import { Header as CanvasHeader } from '@workday/canvas-kit-labs-react/header';
 
@@ -80,7 +80,7 @@ describe('Canvas Kit Deprecate Header Codemod', () => {
       expectTransform(input, expected);
     });
 
-    it('should rename aliased specifiers from the main package', () => {
+    it('should only rename the import specifier from the main package and not similarly named components', () => {
       const input = `
         import { Header as CanvasHeader } from '@workday/canvas-kit-labs-react';
 

--- a/modules/codemod/lib/v6/spec/deprecateHeader.spec.ts
+++ b/modules/codemod/lib/v6/spec/deprecateHeader.spec.ts
@@ -15,7 +15,7 @@ describe('Canvas Kit Deprecate Header Codemod', () => {
 
     it('should ignore non-canvas-kit header identifiers', () => {
       const input = `
-        import Header, {GlobalHeader} from "@workday/some-other-library";
+        import Header, {GlobalHeader} from '@workday/some-other-library';
 
         const SomeComponent = (props) => {
           return (
@@ -23,17 +23,17 @@ describe('Canvas Kit Deprecate Header Codemod', () => {
               <Header {...props}/>
               <GlobalHeader {...props}/>
             </>
-          )
-        }
+          );
+        };
       `;
       const expected = `${input}`;
 
       expectTransform(input, expected);
     });
 
-    it('should ignore Skeleton header components', () => {
+    it('should ignore header sub-components', () => {
       const input = `
-        import {Skeleton} from '@workday/canvas-kit-react/skeleton';
+        import { Skeleton } from '@workday/canvas-kit-react/skeleton';
 
         const SomeComponent = () => {
           return (
@@ -44,6 +44,63 @@ describe('Canvas Kit Deprecate Header Codemod', () => {
         };
       `;
       const expected = `${input}`;
+
+      expectTransform(input, expected);
+    });
+
+    it('should rename aliased imports', () => {
+      const input = `import { Header as CanvasHeader } from '@workday/canvas-kit-labs-react/header';`;
+      const expected = `import { DeprecatedHeader as CanvasHeader } from '@workday/canvas-kit-labs-react/header';`;
+
+      expectTransform(input, expected);
+    });
+
+    it('should rename aliased specifiers from the component package', () => {
+      const input = `
+        import { Header as CanvasHeader } from '@workday/canvas-kit-labs-react/header';
+
+        const SomeComponent = () => {
+          return <>
+            <Header />
+            <CanvasHeader />
+          </>;
+        };
+      `;
+      const expected = `
+        import { DeprecatedHeader as CanvasHeader } from '@workday/canvas-kit-labs-react/header';
+
+        const SomeComponent = () => {
+          return <>
+            <Header />
+            <CanvasHeader />
+          </>;
+        };
+      `;
+
+      expectTransform(input, expected);
+    });
+
+    it('should rename aliased specifiers from the main package', () => {
+      const input = `
+        import { Header as CanvasHeader } from '@workday/canvas-kit-labs-react';
+
+        const SomeComponent = () => {
+          return <>
+            <Header />
+            <CanvasHeader />
+          </>;
+        };
+      `;
+      const expected = `
+        import { DeprecatedHeader as CanvasHeader } from '@workday/canvas-kit-labs-react';
+
+        const SomeComponent = () => {
+          return <>
+            <Header />
+            <CanvasHeader />
+          </>;
+        };
+      `;
 
       expectTransform(input, expected);
     });

--- a/modules/codemod/lib/v6/spec/deprecateHeader.spec.ts
+++ b/modules/codemod/lib/v6/spec/deprecateHeader.spec.ts
@@ -8,7 +8,42 @@ describe('Canvas Kit Deprecate Header Codemod', () => {
   context('when transforming header imports', () => {
     it('should ignore non-canvas-kit imports', () => {
       const input = `import Header, {GlobalHeader} from "@workday/some-other-library";`;
-      const expected = `import Header, {GlobalHeader} from "@workday/some-other-library";`;
+      const expected = `${input}`;
+
+      expectTransform(input, expected);
+    });
+
+    it('should ignore non-canvas-kit header identifiers', () => {
+      const input = `
+        import Header, {GlobalHeader} from "@workday/some-other-library";
+
+        const SomeComponent = (props) => {
+          return (
+            <>
+              <Header {...props}/>
+              <GlobalHeader {...props}/>
+            </>
+          )
+        }
+      `;
+      const expected = `${input}`;
+
+      expectTransform(input, expected);
+    });
+
+    it('should ignore Skeleton header components', () => {
+      const input = `
+        import {Skeleton} from '@workday/canvas-kit-react/skeleton';
+
+        const SomeComponent = () => {
+          return (
+            <Skeleton>
+              <Skeleton.Header {...props} />
+            </Skeleton>
+          );
+        };
+      `;
+      const expected = `${input}`;
 
       expectTransform(input, expected);
     });

--- a/modules/codemod/lib/v6/spec/moveAndRenameSearchBar.spec.ts
+++ b/modules/codemod/lib/v6/spec/moveAndRenameSearchBar.spec.ts
@@ -78,10 +78,65 @@ describe('Canvas Kit Move and Rename Search Bar Codemod', () => {
 
       expectTransform(input, expected);
     });
+
+    it('should ignore non-canvas-kit components from main package', () => {
+      const input = `
+        import { SearchBar as CanvasSearchBar } from "@workday/canvas-kit-labs-react";
+        import { SearchBar } from "@other/search-bar";
+
+        const CustomSearch = () => {
+          return <>
+            <CanvasSearchBar />
+            <SearchBar />
+          </>;
+        }
+      `;
+      const expected = `
+        import { SearchForm as CanvasSearchBar } from "@workday/canvas-kit-labs-react";
+        import { SearchBar } from "@other/search-bar";
+
+        const CustomSearch = () => {
+          return <>
+            <CanvasSearchBar />
+            <SearchBar />
+          </>;
+        }
+      `;
+
+      expectTransform(input, expected);
+    });
+
+    it('should ignore non-canvas-kit components from sub-path', () => {
+      const input = `
+        import { SearchBar as CanvasSearchBar } from "@workday/canvas-kit-labs-react/header";
+        import { SearchBar } from "@other/search-bar";
+
+        const CustomSearch = () => {
+          return <>
+            <CanvasSearchBar />
+            <SearchBar />
+          </>;
+        }
+      `;
+      const expected = `
+        import { SearchForm as CanvasSearchBar } from "@workday/canvas-kit-labs-react/search-form";
+        import { SearchBar } from "@other/search-bar";
+
+        const CustomSearch = () => {
+          return <>
+            <CanvasSearchBar />
+            <SearchBar />
+          </>;
+        }
+      `;
+
+      expectTransform(input, expected);
+    });
+
     it('should transform type reference identifiers', () => {
       const input = `
         import { SearchBarProps } from "@workday/canvas-kit-labs-react/header";
-    
+
         type CustomSearchProps = SearchBarProps;
         interface AnotherSearchProps extends SearchBarProps {
           specialProp?: boolean;
@@ -89,7 +144,7 @@ describe('Canvas Kit Move and Rename Search Bar Codemod', () => {
       `;
       const expected = `
         import { SearchFormProps } from "@workday/canvas-kit-labs-react/search-form";
-    
+
         type CustomSearchProps = SearchFormProps;
         interface AnotherSearchProps extends SearchFormProps {
           specialProp?: boolean;

--- a/modules/codemod/lib/v6/utils/index.ts
+++ b/modules/codemod/lib/v6/utils/index.ts
@@ -183,6 +183,7 @@ export function renameImports(
     nodePath.value.specifiers?.forEach(specifier => {
       if (specifier.type === 'ImportSpecifier') {
         if (Object.keys(specifierMap).includes(specifier.imported.name)) {
+          // if it hasn't been aliased, track it for updating JSX
           if (!specifier.local || specifier.local.name === specifier.imported.name) {
             discoveredImportSpecifiers[specifier.imported.name] = true;
           }
@@ -209,6 +210,7 @@ export function renameImports(
       // Transform named exports
       if (specifier.type === 'ImportSpecifier') {
         if (Object.keys(specifierMap).includes(specifier.imported.name)) {
+          // if it hasn't been aliased, track it for updating JSX
           if (!specifier.local || specifier.local.name === specifier.imported.name) {
             discoveredImportSpecifiers[specifier.imported.name] = true;
           }
@@ -248,8 +250,9 @@ export function renameImports(
   // e.g. `<CookieBanner>` becomes `<DeprecatedCookieBanner>`
   root.find(j.JSXIdentifier).forEach(nodePath => {
     if (
-      Object.keys(specifierMap).includes(nodePath.value.name) &&
-      discoveredImportSpecifiers[nodePath.value.name]
+      // Check to see if it was imported from Canvas Kit
+      discoveredImportSpecifiers[nodePath.value.name] &&
+      Object.keys(specifierMap).includes(nodePath.value.name)
     ) {
       nodePath.node.name = specifierMap[nodePath.value.name];
     }
@@ -260,8 +263,9 @@ export function renameImports(
   root.find(j.MemberExpression, {object: {type: 'Identifier'}}).forEach(nodePath => {
     if (
       nodePath.value.object.type === 'Identifier' &&
-      Object.keys(specifierMap).includes(nodePath.value.object.name) &&
-      discoveredImportSpecifiers[nodePath.value.object.name]
+      // Check to see if it was imported from Canvas Kit
+      discoveredImportSpecifiers[nodePath.value.object.name] &&
+      Object.keys(specifierMap).includes(nodePath.value.object.name)
     ) {
       nodePath.value.object.name = specifierMap[nodePath.value.object.name];
     }


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #1496 <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

The current code mods will rename components that aren't imported from Canvas Kit. They also rename sub-components like `Skeleton.Header`. This change addresses both of these issues.

This change implements the following:
- [x] adds test cases to guard against undesired component renaming
- [x] identifies Canvas Kit component imports to track which components should be renamed
- [x] only renames identified components that have been imported from Canvas Kit
- [x] only renames identified components where they are not aliased to a different name
- [x] amends the `renameImports` utility to allow for specialized code mods to pass in its identified component imports
- [x] removes the `renameImportSpecifiers` utility since it was only used by one file

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, and Documentation -->
![category](https://img.shields.io/badge/release_category-Codemods-blue)

### Release Note
Fixed code mods that improperly rename non-Canvas Kit components as well as Canvas Kit sub-components. This typically includes non-Canvas Kit `Header` components and Canvas Kit's `Skeleton.Header` being improperly renamed in the JSX, but solves for all future cases of Canvas Kit component names.

---

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests are changed or added
- [x] code has been documented
- [x] code adheres to the [API & Pattern guidelines](https://workday.github.io/canvas-kit/?path=/story/welcome-dev-docs-api-pattern-guidelines--page)

## Additional References

<!-- Upload screenshots of the final component or any other artifacts that would help a reviewer understand the choices you made in the PR. -->

Past behavior:
```jsx
        import { Header as CanvasHeader } from '@workday/canvas-kit-labs-react/header';
        import { Header } from './localProjectHeader';
        import { Skeleton } from '@workday/canvas-kit-labs-react/skeleton';

        const SomeComponent = () => {
          return <>
            <Header />
            <CanvasHeader />
            
            <Skeleton>
              <Skeleton.Header />
            </Skeleton>
          </>;
        };
```
would get code shifted to be:

```jsx
        import { DeprecatedHeader as CanvasHeader } from '@workday/canvas-kit-labs-react/header';
        import { Header } from './localProjectHeader';
        import { Skeleton } from '@workday/canvas-kit-labs-react/skeleton';

        const SomeComponent = () => {
          return <>
            <DeprecatedHeader />
            <CanvasHeader />
            
            <Skeleton>
              <Skeleton.DeprecatedHeader />
            </Skeleton>
          </>;
        };
```
...where `Header` and `Skeleton.Header` are incorrectly renamed. This problem potentially extends to any of our component renames, but `Header` is the most prevalent one that teams are using from local or external sources. This PR fixes all potential cases by building a Record of import identifiers where the import name is used (not aliased to a local name) and only in these cases updating the `Identifier` or `MemberExpression` in the rest of the file's AST.