### PR TITLE
fix: Fix build mdx script to better handle splitprops files

### DIFF
--- a/modules/docs/utils/build-mdx.js
+++ b/modules/docs/utils/build-mdx.js
@@ -27,8 +27,54 @@ const sanitizeMdxFile = (inFile, outFile) => {
       .replace(/import {.*} from '@storybook\/addon-docs';/g, '')
       .replace(/<Meta.* \/>\n/g, '')
       .replace(/^\s+|\s+$/g, '')
-      // Convert named example import to default
-      .replace(/import {\s?(\w+)\s?} from '\.\/examples/g, "import $1 from './examples");
+      // The replace below converts named imports from files in the examples
+      // folder to default imports (this is required by canvas-site in order
+      // for examples to work). The regex specifically targets import
+      // statements which exist on on a single line, which is fine because
+      // example imports almost always fall on a single line. For example:
+      //
+      // import {FlexCard} from './examples/Flex/FlexCard';
+      //
+      // The line above will be converted (as desired) to:
+      //
+      // import FlexCard from './examples/Flex/FlexCard';
+      // 
+      // This build process contains logic elsewhere to convert the named
+      // exports in those example files to default exports.
+      //
+      // That said, we do NOT want to convert imports for splitprops files.
+      // Splitprops files include dummy components which are used to display
+      // prop tables for things that aren't actually components such as a
+      // model's config, state, and event objects. Splitprops files must remain
+      // named imports since they often export multiple components.
+      //
+      // Most splitprops imports span multiple lines so our regex wouldn't
+      // catch them anyway:
+      //
+      // import {
+      //   TabsModelConfigComponent,
+      //   TabsStateComponent,
+      //   TabsEventsComponent,
+      // } from './TabsModel.splitprops.tsx';
+      //
+      // Note that the TabsModel splitprops file isn't in the examples folder,
+      // so it wouldn't have been caught by the regex even if it was on a
+      // single line. However, it's possible a splitprops file may be placed in
+      // an examples folder AND fall on a single line:
+      //
+      // import {FlexStyle} from './examples/PropTables.splitprops.tsx';
+      //
+      // We add the `(?!.*splitprops)` negative lookahead to the regex to
+      // ensure the named import is preserved in this case. The part before
+      // the negative lookahead (import ... examples) will only match if
+      // "splitprops" is NOT present later in the line.
+      //
+      // More info on negative lookahead:
+      // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Assertions#other_assertions
+      .replace(
+        /import {\s?(\w+)\s?} from '\.\/examples(?!.*splitprops)/g,
+        "import $1 from './examples"
+      );
 
     fs.writeFile(outFile, result, 'utf8', err => {
       if (err) return console.error(err);


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #1571 <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->
Fixes an issue in the build-mdx script where it was incorrectly rewriting a named import in `Flex.stories.mdx` to a default import.

`import {FlexStyle} from './examples/PropTables.splitprops.tsx'` was being rewritten to `import FlexStyle from './examples/PropTables.splitprops.tsx'` when instead it should NOT have been rewritten at all. Imports from splitprops files need to remain named imports.

This PR updates the regex we use to rewrite the imports to properly exclude all imports from `splitprops` files. The code change itself is very small (adds a `(?!.*splitprops)` [negative lookahead](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Assertions#other_assertions) to the regex); most of the PR is better documentation around how the regex for rewriting the imports works.

I performed a `yarn build` from `modules/docs` before and after the fix and diff-ed the resulting `dist` folders. The folders were identical except for desired change to the `FlexStyle` import.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, and Documentation -->
![category](https://img.shields.io/badge/release_category-Infrastructure-blue)