### PR TITLE
docs: Fix link in TESTING.mdx

### DIFF
--- a/modules/docs/mdx/TESTING.mdx
+++ b/modules/docs/mdx/TESTING.mdx
@@ -166,7 +166,7 @@ different, but this will prevent snapshot tests that don't have any changes from
 
 ## Functional tests
 
-Canvas Kit uses [Cypress][https://cypress.io] for browser-based behavior testing (additional info:
+Canvas Kit uses [Cypress](https://cypress.io) for browser-based behavior testing (additional info:
 [Why Cypress?](https://github.com/Workday/canvas-kit/tree/master/cypress/WHY_CYPRESS.md)).
 Functional tests ensure the code meets functional specifications from a user's perspective. All
 functional tests are written against a Storybook Story. Specifications can come from many different


### PR DESCRIPTION
## Summary

Before this change, the Cypress link wasn't clickable. This change turns `[Cypress][https://cypress.io]` into [Cypress](https://cypress.io/)