### PR TITLE
docs: Clean up component docs

### DIFF
--- a/modules/react/button/lib/SecondaryButton.tsx
+++ b/modules/react/button/lib/SecondaryButton.tsx
@@ -32,9 +32,9 @@ export interface SecondaryButtonProps extends Themeable, GrowthBehavior {
    */
   icon?: CanvasSystemIcon;
   /**
-   * Button icon positions can either be `left` or `right`.
-   * If no value is provided, it defaults to `left`.
-   * @default 'left'
+   * Button icon positions can either be `start` or `end`.
+   * If no value is provided, it defaults to `start`.
+   * @default 'start'
    */
   iconPosition?: IconPositions;
   /**

--- a/modules/react/button/lib/TertiaryButton.tsx
+++ b/modules/react/button/lib/TertiaryButton.tsx
@@ -27,9 +27,9 @@ export interface TertiaryButtonProps extends Themeable {
    */
   size?: ButtonSizes;
   /**
-   * Button icon positions can either be `left` or `right`.
-   * If no value is provided, it defaults to `left`.
-   * @default 'left'
+   * Button icon positions can either be `start` or `end`.
+   * If no value is provided, it defaults to `start`.
+   * @default 'start'
    */
   iconPosition?: IconPositions;
   /**

--- a/modules/react/button/stories/button/Button.stories.mdx
+++ b/modules/react/button/stories/button/Button.stories.mdx
@@ -42,7 +42,7 @@ action. Multiple primary buttons make it confusing for the user to understand wh
 should take. Not all screens require a Primary Button.
 
 Primary Buttons have four sizes: `extraSmall`, `small`, `medium`, and `large`. Icons are supported
-for every size and can be positioned to the `left` or `right` with the `iconPosition` prop.
+for every size and can be positioned at the `start` or `end` with the `iconPosition` prop.
 
 <ExampleCodeBlock code={Primary} />
 
@@ -65,7 +65,7 @@ Buttons can be used on most pages without restrictions and work well for multipl
 weight. They can be used in conjunction with a Primary Button or independently.
 
 Secondary Buttons have four sizes: `extraSmall`, `small`, `medium`, and `large`. Icons are supported
-for every size and can be positioned to the `left` or `right` with the `iconPosition` prop.
+for every size and can be positioned at the `start` or `end` with the `iconPosition` prop.
 
 <ExampleCodeBlock code={Secondary} />
 
@@ -88,7 +88,7 @@ not visible until it is interacted with. Use Tertiary Buttons for supplemental a
 More”, “Read More” or “Select a File”. Tertiary Buttons are frequently used on Cards.
 
 Tertiary Buttons have three sizes: `extraSmall`, `small`, and `medium`. Icons are supported for
-every size and can be positioned to the `left` or `right` with the `iconPosition` prop.
+every size and can be positioned at the `start` or `end` with the `iconPosition` prop.
 
 <ExampleCodeBlock code={Tertiary} />
 

--- a/modules/react/layout/stories/Flex.stories.mdx
+++ b/modules/react/layout/stories/Flex.stories.mdx
@@ -9,27 +9,38 @@ import {FlexStyle} from './examples/PropTables.splitprops.tsx';
 
 <Meta title="Components/Containers/Layout/Flex" component={Flex} />
 
-# Flex
+# Canvas Kit Flex
 
 `Flex` is a low-level layout component that provides a common, ergonomic API for building
 one-dimensional layouts with
 [CSS Flexbox](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox).
 
-## Table of Contents
+## Installation
 
-- [Flex](#flex)
-  - [Table of Contents](#table-of-contents)
-  - [Usage](#usage)
-  - [What's the difference between `Flex` and `Box`?](#whats-the-difference-between-flex-and-box)
-  - [Flex Props](#flex-props)
-  - [Examples](#examples)
-  - [Exhaustive Prop List](#exhaustive-prop-list)
+```sh
+yarn add @workday/canvas-kit-react
+```
 
 ## Usage
 
+### Basic Example
+
 <ExampleCodeBlock code={Usage} />
 
-## What's the difference between `Flex` and `Box`?
+### Rows and Columns
+
+You can nest `Flex` components to build layouts with rows and columns.
+
+<ExampleCodeBlock code={FlexLayout} />
+
+### Small Containers
+
+You can also use `Flex` to create layouts within smaller containers, such as this card example
+below:
+
+<ExampleCodeBlock code={FlexCard} />
+
+### Flex vs. Box
 
 `Flex` is built with `Box` and has access to all `BoxProps`. The main differences between `Box` and
 `Flex` are:
@@ -52,17 +63,6 @@ through style props as well. There are seven flex container props:
 
 <ArgsTable of={FlexStyle} />
 
-## Examples
-
-You can nest `Flex` components to build layouts with rows and columns.
-
-<ExampleCodeBlock code={FlexLayout} />
-
-You can also use `Flex` to create layouts within smaller containers, such as this card example
-below:
-
-<ExampleCodeBlock code={FlexCard} />
-
-## Exhaustive Prop List
+### Flex Props (Exhaustive List)
 
 <ArgsTable of={Flex} />

--- a/modules/react/layout/stories/Stack.stories.mdx
+++ b/modules/react/layout/stories/Stack.stories.mdx
@@ -12,7 +12,7 @@ import {VStackCards} from './examples/Stack/VStackCards';
 
 <Meta title="Components/Containers/Layout/Stack" component={Stack} />
 
-# Stack, HStack, and VStack
+# Canvas Kit Stack
 
 `Stack`, `HStack`, and `VStack` are higher-level layout components that provide an ergonomic API for
 building one-dimensional layouts with consistent spacing between elements. They're built on top of
@@ -20,48 +20,13 @@ building one-dimensional layouts with consistent spacing between elements. They'
 horizontal or vertical orientation. `HStack` and `VStack` will only align items in a horizontal or
 vertical orientation, respectively.
 
-## Table of Contents
+## Installation
 
-- [Stack, HStack, and VStack](#stack-hstack-and-vstack)
-  - [Table of Contents](#table-of-contents)
-  - [Stack](#stack)
-    - [Usage](#usage)
-    - [What Stack Is & Isn't](#what-stack-is--isnt)
-    - [Setting Direction](#setting-direction)
-    - [Setting Space](#setting-space)
-    - [Managing Child Elements](#managing-child-elements)
-      - [Basic Usage](#basic-usage)
-      - [Using `shouldWrapChildren`](#using-shouldwrapchildren)
-      - [Using `Stack.Item`](#using-stackitem)
-    - [Valid Children](#valid-children)
-    - [Examples](#examples)
-  - [HStack](#hstack)
-    - [Usage](#usage-1)
-    - [Example](#example)
-  - [VStack](#vstack)
-    - [Usage](#usage-2)
-    - [Example](#example-1)
-  - [Exhaustive Prop List](#exhaustive-prop-list)
-
-## Stack
-
-`Stack` is a composable component that's helpful for creating layouts with equal spacing between
-elements. It can create horizontal or vertical stacks of elements.
-
-### Usage
-
-```tsx
-import {Stack, StackStyleProps} from '@workday/canvas-kit-react/layout';
+```sh
+yarn add @workday/canvas-kit-react
 ```
 
-### What Stack Is & Isn't
-
-The most important distinction to make with `Stack` is that it is _not a grid._ Grid components are
-able to align items along two dimensions (rows and columns), and `Stack` is only built to support
-one dimension (rows _or_ columns). That said, you can nest horizontal and vertical `Stack`
-components to create grid-like layouts.
-
-### Thinking in Stacks
+## Usage
 
 `Stack` is a higher-level layout component, meaning:
 
@@ -70,14 +35,39 @@ components to create grid-like layouts.
 
 `Stack` has three core opinions that guide its API:
 
-- space should be equal between child elements
-- space should only exist between child elements
-- children should be semantic elements
+- Space should be equal between child elements
+- Space should only exist between child elements
+- Children should be semantic elements
 
 Much of layout design is founded on these opinions. Whether its creating lists of navigation links,
 groups of cards, or collections of buttons, once you think in stacks, you'll see them everywhere.
 
-### Setting Direction
+### Basic Example
+
+`Stack` is a composable component that's helpful for creating layouts with equal spacing between
+elements. It can create horizontal or vertical stacks of elements.
+
+> The most important distinction to make with `Stack` is that it is _not a grid._ Grid components
+> are able to align items along two dimensions (rows and columns), and `Stack` is only built to
+> support one dimension (rows _or_ columns). That said, you can nest horizontal and vertical `Stack`
+> components to create grid-like layouts.
+
+`Stack` uses CSS pseudo-classes to apply margin to child elements. This makes it really simple to
+get consistent spacing between child elements without much manual effort. Below is a basic example.
+Note that `Stack` does not add any space above or below the child elements. This helps your element
+fit nicely within their containers.
+
+<ExampleCodeBlock code={BasicStack} />
+
+Use this approach when:
+
+- You want consistent space between child elements
+- You don't need to apply custom margin to child elements
+  - Specifically `marginLeft`/`marginInlineStart` for horizontal stacks and `marginTop` for vertical
+    stacks
+- You don't want to add extra markup to wrap child elements
+
+#### Setting Direction
 
 The direction of the child elements is set with the `flexDirection` prop. This prop supports four
 directions: `column`, `column-reverse`, `row`, and `row-reverse`. By default, it will set the
@@ -89,7 +79,7 @@ direction to `row` as is consistent with the CSS Flexbox spec.
 > Note: `spacing` also supports bidirectionality automatically. This means you don't need to think
 > about it for localization as long as you properly pass the `direction` to the `theme` object un
 
-### Setting Space
+#### Setting Space
 
 The space between child elements is set with the `spacing` prop, which supports all space token and
 string values. `Stack` intentionally only sets space between elements and never outside. For
@@ -97,13 +87,13 @@ example: a vertical stack of three elements would only have margin added to the 
 and third child elements. Keeping space between elements makes building layouts more block-like and
 predictable.
 
-### Managing Child Elements
+#### Managing Child Elements
 
 There are three ways to manage space between child elements with `Stack`.
 
-- implicit spacing applied directly to child elements (default behavior)
-- implicit wrapping child elements with `shouldWrapChildren`
-- explicit wrapping child elements with `Stack.Item`s.
+- Implicit spacing applied directly to child elements (default behavior)
+- Implicit wrapping child elements with `shouldWrapChildren`
+- Explicit wrapping child elements with `Stack.Item`s.
 
 Each approach has its own benefits and limitations, which are discussed in further detail below. We
 chose to implicitly apply spacing to child elements as the default behavior because it requires the
@@ -112,33 +102,69 @@ hatches for when the default behavior becomes forced. Should you find none of th
 for your use case, we recommend using `Flex` instead of `Stack`, which will provide you with more
 flexibility.
 
-#### Basic Usage
+#### Valid Children
 
-`Stack` uses CSS pseudo-classes to apply margin to child elements. This makes it really simple to
-get consistent spacing between child elements without much manual effort. Below is a basic example.
-Note that `Stack` does not add any space above or below the child elements. This helps your element
-fit nicely within their containers.
+Because `Stack` applies styles to children, it requires its immediate children to be valid child
+elements. For example, text outside of an HTML tag would not render if it was an immediate `Stack`
+child. Here's an example snippet:
 
-<ExampleCodeBlock code={BasicStack} />
+```tsx
+const ValidChildrenExample = () => {
+  return (
+    <Stack flexDirection="row" spacing="s">
+      This text will not render. Don't do this.
+      <p>This text will render.</p>
+      <span>This text will also render.</span>
+    </Stack>
+  );
+};
+```
 
-Use this approach when:
+### Grid-like Layouts
 
-- you want consistent space between child elements
-- you don't need to apply custom margin to child elements
-  - specifically `marginLeft`/`marginInlineStart` for horizontal stacks and `marginTop` for vertical
-    stacks
-- you don't want to add extra markup to wrap child elements
+You can nest vertical and horizontal `Stack`s to create grid-like layouts. Here are three horizontal
+`Stack`s nested within a vertical `Stack`. The fourth row is a single `Flex` component.
 
-A side-effect of `Stack`'s pseduo-classes is an increased style specificity. This specificity can
+<ExampleCodeBlock code={NestedStacks} />
+
+### Small Containers
+
+You can also use `Stack` to manage smaller layouts, such as within Cards.
+
+<ExampleCodeBlock code={StackCard} />
+
+### HStack
+
+`HStack` works identically to `Stack` but is limited to only `row` and `row-reverse` directions. It
+defaults to `row` if no `flexDirection` is provided.
+
+> Note: `HStack` supports bidirectionality automatically. This means that you won't need to switch
+> the direction or spacing for localization. The direction switching is handled by the CSS Flexbox
+> spec, and the spacing will flip direction based on the `direction` provided in the `theme` object.
+
+In this example, `HStack` is placing three cards in a row with small spacing between them.
+
+<ExampleCodeBlock code={HStackCards} />
+
+### VStack
+
+`VStack` works identically to `Stack` but is limited to only `column` and `column-reverse`
+directions. It defaults to `column` if no `flexDirection` is provided.
+
+In this example, `VStack` is placing three cards in a column with small spacing between them.
+
+<ExampleCodeBlock code={VStackCards} />
+
+### shouldWrapChildren and Stack.Item
+
+A side-effect of `Stack`'s pseudo-classes is an increased style specificity. This specificity can
 override the child element's margin styles. If that creates a problem, there are two recommended
 options available:
 
 - Use the `shouldWrapChildren` prop (implicit option)
 - Use `Stack.Item` (explicit option)
 
-Both are discussed below.
-
-#### Using `shouldWrapChildren`
+#### shouldWrapChildren
 
 The `shouldWrapChildren` prop will implicitly wrap each child in a `Stack.Item` component (which is
 a `Box`) and apply the margin to it instead of the child element provided. This allows you to
@@ -158,12 +184,12 @@ preference.
 
 Use this approach when:
 
-- you want consistent space between child elements
-- you need to apply custom margin to particular children
-- wrapping each child element won't create issues with other semantic elements
-- you don't want to explicitly add extra markup to wrap child elements
+- You want consistent space between child elements
+- You need to apply custom margin to particular children
+- Wrapping each child element won't create issues with other semantic elements
+- You don't want to explicitly add extra markup to wrap child elements
 
-#### Using `Stack.Item`
+#### Stack.Item
 
 Sometimes inserting implicit wrapper elements can be problematic when you need access to those
 elements. In those situations, `shouldWrapChildren` is not the best choice, and you should opt for
@@ -178,77 +204,10 @@ styles to each. This would not be possible with `shouldWrapChildren`.
 
 Use this approach when:
 
-- you want consistent space between child elements
-- you need to have direct access to `Stack.Item` wrappers
-- wrapping each child element won't create issues with other semantic elements
+- You want consistent space between child elements
+- You need to have direct access to `Stack.Item` wrappers
+- Wrapping each child element won't create issues with other semantic elements
 
-### Valid Children
-
-Because `Stack` applies styles to children, it requires its immediate children to be valid child
-elements. For example, text outside of an HTML tag would not render if it was an immediate `Stack`
-child. Here's an example snippet:
-
-```tsx
-const ValidChildrenExample = () => {
-  return (
-    <Stack flexDirection="row" spacing="s">
-      This text will not render. Don't do this.
-      <p>This text will render.</p>
-      <span>This text will also render.</span>
-    </Stack>
-  );
-};
-```
-
-### Examples
-
-You can nest vertical and horizontal `Stack`s to create grid-like layouts. Here are three horizontal
-`Stack`s nested within a vertical `Stack`. The fourth row is a single `Flex` component.
-
-<ExampleCodeBlock code={NestedStacks} />
-
-You can also use `Stack` to manage smaller layouts, such as within Cards.
-
-<ExampleCodeBlock code={StackCard} />
-
-## HStack
-
-`HStack` works identically to `Stack` but is limited to only `row` and `row-reverse` directions. It
-defaults to `row` if no `flexDirection` is provided.
-
-> Note: `HStack` supports bidirectionality automatically. This means that you won't need to switch
-> the direction or spacing for localization. The direction switching is handled by the CSS Flexbox
-> spec, and the spacing will flip direction based on the `direction` provided in the `theme` object.
-
-### Usage
-
-```tsx
-import {HStack, HStackStyleProps} from '@workday/canvas-kit-react/layout';
-```
-
-### Example
-
-In this example, `HStack` is placing three cards in a row with small spacing between them.
-
-<ExampleCodeBlock code={HStackCards} />
-
-## VStack
-
-`VStack` works identically to `Stack` but is limited to only `column` and `column-reverse`
-directions. It defaults to `column` if no `flexDirection` is provided.
-
-### Usage
-
-```tsx
-import {VStack, VStackStyleProps} from '@workday/canvas-kit-react/layout';
-```
-
-### Example
-
-In this example, `VStack` is placing three cards in a column with small spacing between them.
-
-<ExampleCodeBlock code={VStackCards} />
-
-## Exhaustive Prop List
+## Stack Props
 
 <ArgsTable of={Stack} />


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->
Cleans up the Flex and Stack MDXes to follow our [documentation template](https://github.com/Workday/canvas-kit/discussions/1131) more closely. Both documents should now flow more smoothly, particularly when displayed within the context of the Canvas Site.

I had to diverge a bit from the template given that the Flex and Stack MDXes are both imported into the same Layout page on the Canvas Site. For instance, the Flex and Stack MDXes cannot share the same level 2 heading names (e.g., "Props") since this results in those headings being assigned the same `id` slug which creates problems with our AnchorNav jump links.

Aside from removing the non-standard Table of Contents sections, I mostly moved content around and renamed headings -- very little was added or removed to the MDX docs.

Additionally, I made a few corrections to the Button docs regarding `iconPosition` changing from `left` and `right` to `start` and `end` in v7.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, and Documentation -->
![category](https://img.shields.io/badge/release_category-Documentation-blue)