### PR TITLE
fix(action-bar): Make hidden buttons non-interactive

### DIFF
--- a/modules/react/action-bar/lib/useActionBarModel.tsx
+++ b/modules/react/action-bar/lib/useActionBarModel.tsx
@@ -46,8 +46,9 @@ export const useActionBarModel = createModelHook({
   // Always show the first button and make sure it is interactive
   if (totalSize - hiddenIds.length === 0) {
     hiddenIds = items.slice(1, totalSize).map(getId);
-    nonInteractiveIds = [];
   }
+
+  nonInteractiveIds = hiddenIds;
 
   const state = {
     ...model.state,


### PR DESCRIPTION
## Summary

PR fixes issue with focus order for ActionBar. It was still select hidden buttons before focusing overflow menu button.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, and Documentation -->
![category](https://img.shields.io/badge/release_category-Components-blue)