### PR TITLE
fix(action-bar): Remove subcomponents from ActionBar.Item

### DIFF
--- a/modules/react/action-bar/lib/ActionBarItem.tsx
+++ b/modules/react/action-bar/lib/ActionBarItem.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import {composeHooks, EllipsisText, createSubcomponent} from '@workday/canvas-kit-react/common';
-import {SystemIcon} from '@workday/canvas-kit-react/icon';
+import {composeHooks, createSubcomponent} from '@workday/canvas-kit-react/common';
 import {SecondaryButton} from '@workday/canvas-kit-react/button';
 import {
   useListItemRegister,
@@ -37,10 +36,6 @@ export const ActionBarItem = createSubcomponent(SecondaryButton)({
   displayName: 'ActionBar.Item',
   modelHook: useActionBarModel,
   elemPropsHook: useActionBarItem,
-  subComponents: {
-    Icon: SystemIcon,
-    Text: EllipsisText,
-  },
 })<ActionBarItemProps>((elemProps, Element) => {
   return <Element {...elemProps} />;
 });


### PR DESCRIPTION
## Summary

This PR removes subcomponents from `ActionBar.Item`. Because `ActionBar.Item` is build under Button component, these subcomponents are not necessary. 

![category](https://img.shields.io/badge/release_category-Components-blue)