### PR TITLE
test(select): Reduce sensitivity of scrolling test

### DIFF
--- a/cypress/integration/SelectPreview.spec.ts
+++ b/cypress/integration/SelectPreview.spec.ts
@@ -902,7 +902,7 @@ describe('Select', () => {
         context('the page', () => {
           it('should not scroll', () => {
             cy.window().then($window => {
-              cy.get('@originalWindowScrollY').should('equal', $window.scrollY);
+              cy.get('@originalWindowScrollY').should('equal', Math.floor($window.scrollY));
             });
           });
         });
@@ -919,7 +919,7 @@ describe('Select', () => {
           context('the page', () => {
             it('should not scroll', () => {
               cy.window().then($window => {
-                cy.get('@originalWindowScrollY').should('equal', $window.scrollY);
+                cy.get('@originalWindowScrollY').should('equal', Math.floor($window.scrollY));
               });
             });
           });


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

<!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->
Reduces the sensitivity of a couple Cypress tests for the Preview Select which were looking at `window.scrollY`. These tests were failing locally (`expecting 2120 to equal 2120.5`) but not on the CI, which may be why we didn't notice this until now. We suspect Chrome was updated recently to support a fractional `scrollY`.

In any event, a half-pixel of scrolling doesn't even seem to produce visible scrolling. I've relaxed the tests to chop off the fractional pixel when making the comparison.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, and Documentation -->
![category](https://img.shields.io/badge/release_category-Components-blue)