### PR TITLE
fix: Update remaining Emotion 11 imports

### DIFF
--- a/jest/verifyComponent.tsx
+++ b/jest/verifyComponent.tsx
@@ -1,6 +1,6 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
-import {jsx} from '@emotion/core';
+import {jsx} from '@emotion/react';
 import React from 'react';
 import {render, fireEvent} from '@testing-library/react';
 

--- a/modules/react-fonts/README.md
+++ b/modules/react-fonts/README.md
@@ -24,7 +24,7 @@ yarn add emotion
 Then in your index or main file of your project...
 
 ```tsx
-import {Global, css} from '@emotion/core';
+import {Global, css} from '@emotion/react';
 import fonts from '@workday/canvas-kit-react-fonts';
 
 // Inject all of Canvas' @font-face declarations to <head> via emotion
@@ -38,7 +38,7 @@ same module.
 Examples:
 
 ```tsx
-import {css} from '@emotion/core';
+import {css} from '@emotion/react';
 import {type} from '@workday/canvas-kit-react/tokens';
 
 ...


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

This cleanups our `verifyComponent`'s import for Emotion (it might be using Emotion 10 incorrectly) as well as the example imports for using `@workday/canvas-kit-react-fonts`.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, and Documentation -->
![category](https://img.shields.io/badge/release_category-Documentation-blue)

### Release Note
Updated documentation for `@workday/canvas-kit-react-fonts` to correctly import utilities from Emotion 11 rather than Emotion 10.

---

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] code adheres to the [API & Pattern guidelines](https://workday.github.io/canvas-kit/?path=/story/welcome-dev-docs-api-pattern-guidelines--page)
