### PR TITLE
docs: Update SidePanel right origin story [skip release]

### DIFF
--- a/modules/preview-react/side-panel/stories/examples/RightOrigin.tsx
+++ b/modules/preview-react/side-panel/stories/examples/RightOrigin.tsx
@@ -18,8 +18,7 @@ const StyledHeader = styled('h3')({
 });
 
 const StyledSidePanel = styled(SidePanel)({
-  position: 'absolute',
-  right: 0,
+  marginLeft: 'auto',
 });
 
 const RightPanel = () => {
@@ -46,7 +45,6 @@ export const RightOrigin = () => {
   return (
     <CanvasProvider theme={{canvas: {direction}}}>
       <Flex height={320}>
-        <RightPanel />
         <Flex
           as="main"
           alignItems="center"
@@ -60,6 +58,8 @@ export const RightOrigin = () => {
             Set to {direction === 'ltr' ? 'Right-to-Left' : 'Left-to-Right'}
           </SecondaryButton>
         </Flex>
+
+        <RightPanel />
       </Flex>
     </CanvasProvider>
   );


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #1643 <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

I tested this in IE11 too; here's the link to the deployed story: https://5d854c26ba934e0020f5e98a-mqybeegohw.chromatic.com/?path=/story/preview-side-panel-react--right-origin

Here's a CodeSandbox to play with too: https://codesandbox.io/s/sidepanel-right-origin-f7peik?file=/src/RightOrigin.tsx

Before:

<img width="515" alt="Screen Shot 2022-06-18 at 4 57 47 PM" src="https://user-images.githubusercontent.com/1075861/174459644-0350f7aa-a25d-42f0-a776-0dc07da00e3d.png">



After:
<img width="447" alt="Screen Shot 2022-06-18 at 5 06 33 PM" src="https://user-images.githubusercontent.com/1075861/174459704-f9a90909-8b60-43b9-be01-9e86eb0efe70.png">

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, and Documentation -->
![category](https://img.shields.io/badge/release_category-Documentation-blue)


---

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] code has been documented
- [x] code adheres to the [API & Pattern guidelines](https://workday.github.io/canvas-kit/?path=/story/welcome-dev-docs-api-pattern-guidelines--page)

## Additional References

Used [margin-left: auto](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-right#values) instead of absolute positioning.
