### PR TITLE
fix: Add missing `Popper` props to `Popup.Popper`

### DIFF
--- a/modules/react/popup/lib/PopupPopper.tsx
+++ b/modules/react/popup/lib/PopupPopper.tsx
@@ -3,9 +3,7 @@ import * as React from 'react';
 import {createSubcomponent} from '@workday/canvas-kit-react/common';
 
 import {usePopupModel, usePopupPopper} from './hooks';
-import {Placement, PopperOptions, Popper} from './Popper';
-
-import {PopperProps} from './Popper';
+import {Placement, PopperOptions, Popper, PopperProps} from './Popper';
 
 export interface PopupPopperProps extends PopperProps {
   /**

--- a/modules/react/popup/lib/PopupPopper.tsx
+++ b/modules/react/popup/lib/PopupPopper.tsx
@@ -5,7 +5,9 @@ import {createSubcomponent} from '@workday/canvas-kit-react/common';
 import {usePopupModel, usePopupPopper} from './hooks';
 import {Placement, PopperOptions, Popper} from './Popper';
 
-export interface PopupPopperProps {
+import {PopperProps} from './Poppper';
+
+export interface PopupPopperProps extends PopperProps {
   /**
    * The placement of the `Popper` contents relative to the `anchorElement`. Accepts `auto`, `top`,
    * `right`, `bottom`, or `left`. Each placement can also be modified using any of the following
@@ -17,7 +19,6 @@ export interface PopupPopperProps {
    * The additional options passed to the Popper's `popper.js` instance.
    */
   popperOptions?: Partial<PopperOptions>;
-  children?: React.ReactNode;
 }
 
 export const PopupPopper = createSubcomponent('div')({

--- a/modules/react/popup/lib/PopupPopper.tsx
+++ b/modules/react/popup/lib/PopupPopper.tsx
@@ -5,7 +5,7 @@ import {createSubcomponent} from '@workday/canvas-kit-react/common';
 import {usePopupModel, usePopupPopper} from './hooks';
 import {Placement, PopperOptions, Popper} from './Popper';
 
-import {PopperProps} from './Poppper';
+import {PopperProps} from './Popper';
 
 export interface PopupPopperProps extends PopperProps {
   /**


### PR DESCRIPTION
## Summary

Fixes: #1681

![category](https://img.shields.io/badge/release_category-Components-blue)

---

