### PR TITLE
docs: Fix RadioGroup Basic example

### DIFF
--- a/modules/react/radio/stories/examples/Basic.tsx
+++ b/modules/react/radio/stories/examples/Basic.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import styled from '@emotion/styled';
 import {FormField} from '@workday/canvas-kit-react/form-field';
 import {Radio, RadioGroup} from '@workday/canvas-kit-react/radio';
-import styled from '@emotion/styled';
+import {space} from '@workday/canvas-kit-react/tokens';
 
 export const Basic = () => {
   const [value, setValue] = React.useState<string | number>('deep-dish');
@@ -11,7 +12,7 @@ export const Basic = () => {
   };
 
   const StyledFormField = styled(FormField)({
-    width: '161px',
+    width: space.xl,
   });
 
   return (
@@ -21,10 +22,7 @@ export const Basic = () => {
         <Radio label="Thin" value="thin" />
         <Radio label="Gluten free" value="gluten-free" />
         <Radio label="Cauliflower" value="cauliflower" />
-        <Radio
-          label="My favorite pizza crust flavor is butter because it's the best thing to put on bread"
-          value="cauliflower"
-        />
+        <Radio label="Butter - the best thing to put on bread" value="butter" />
       </RadioGroup>
     </StyledFormField>
   );


### PR DESCRIPTION
## Summary

Fixes: #1725

![category](https://img.shields.io/badge/release_category-Documentation-purple)

---

## For the Reviewer

### Overview

This PR:

- Updates the duplicated `value` for the fifth radio input
- Adjusts the `width` style to use a space token
- Edits the label copy to fit the language of the other inputs

### Where Should the Reviewer Start?

`modules/react/radio/stories/examples/Basic.tsx`

### Testing Manually

- View the Radio Basic story example

### Screenshots

**Before**

![](http://g.recordit.co/Nv7t7nWG6Q.gif)

**After**

![](http://g.recordit.co/db5LGdW2aI.gif)

## Thank You Gif

Thanks for reviewing!

![](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif)
