### PR TITLE
docs: Change link URL to non-interactive examples

### DIFF
--- a/cypress/integration/Tooltip.spec.ts
+++ b/cypress/integration/Tooltip.spec.ts
@@ -279,9 +279,9 @@ describe('Tooltip', () => {
     );
   });
 
-  context('given the [Testing/React/Popups/Tooltip, NonInteractive] example is rendered', () => {
+  context('given the [Testing/React/Popups/Tooltip, Non Interactive] example is rendered', () => {
     beforeEach(() => {
-      h.stories.load('Testing/React/Popups/Tooltip', 'NonInteractive');
+      h.stories.load('Testing/React/Popups/Tooltip', 'Non Interactive');
     });
 
     context('when the "Non-interactive Tooltip" text is hovered', () => {


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #1720 <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

The links for "NonInteractive" examples didn't work.  Before this change the link read:
https://workday.github.io/canvas-kit/?path=/story/testing-react-popups-tooltip--noninteractive 

but now with the fix, we have the correct link:

https://workday.github.io/canvas-kit/?path=/story/testing-react-popups-tooltip--non-interactive 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, and Documentation -->
![category](https://img.shields.io/badge/release_category-Documentation-blue)
