### PR TITLE
fix: Update avatar on expandable component

### DIFF
--- a/modules/labs-react/expandable/lib/ExpandableAvatar.tsx
+++ b/modules/labs-react/expandable/lib/ExpandableAvatar.tsx
@@ -21,6 +21,6 @@ const StyledAvatar = styled(Avatar)<StyledType>({
 export const ExpandableAvatar = createComponent('button')({
   displayName: 'Expandable.Avatar',
   Component: ({altText, ...elemProps}: ExpandableAvatarProps, ref) => {
-    return <StyledAvatar altText={undefined} as={'div'} ref={ref} size={32} {...elemProps} />;
+    return <StyledAvatar altText={undefined} as="div" ref={ref} size={32} {...elemProps} />;
   },
 });

--- a/modules/labs-react/expandable/lib/ExpandableAvatar.tsx
+++ b/modules/labs-react/expandable/lib/ExpandableAvatar.tsx
@@ -1,7 +1,3 @@
-/** @jsxRuntime classic */
-/** @jsx jsx */
-import {jsx} from '@emotion/react';
-
 import React from 'react';
 
 import {createComponent, ExtractProps, styled, StyledType} from '@workday/canvas-kit-react/common';
@@ -19,9 +15,12 @@ const StyledAvatar = styled(Avatar)<StyledType>({
   flexShrink: 0,
 });
 
+// When the component is created, it needs to be a button element to match AvatarProps.
+// Once Avatar becomes a `createComponent` we can default the element type to a `div`
+// and the types should be properly extracted
 export const ExpandableAvatar = createComponent('button')({
   displayName: 'Expandable.Avatar',
-  Component: ({...elemProps}: ExpandableAvatarProps, ref, Element) => {
-    return <StyledAvatar altText={undefined} as={Element} ref={ref} size={32} {...elemProps} />;
+  Component: ({altText, ...elemProps}: ExpandableAvatarProps, ref) => {
+    return <StyledAvatar altText={undefined} as={'div'} ref={ref} size={32} {...elemProps} />;
   },
 });


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Per accessibility, we don't need an alt text on the Expandable Avatar because it is a decorative element. Also, we default the element to be a div because we can't have a button within a button.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, and Documentation -->
![category](https://img.shields.io/badge/release_category-Components-blue)