### PR TITLE
ci: Update secret to new token for project board actions [skip release]

### DIFF
--- a/.github/workflows/project-automations.yml
+++ b/.github/workflows/project-automations.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Move issue to ${{ env.new }}
         uses: leonsteinhaeuser/project-beta-automations@v1.3.0
         with:
-          gh_token: ${{ secrets.GH_RW_TOKEN }}
+          gh_token: ${{ secrets.CANVAS_BOARD_TOKEN }}
           organization: Workday
           project_id: 4
           resource_node_id: ${{ github.event.issue.node_id }}
@@ -42,7 +42,7 @@ jobs:
       - name: Moved issue to ${{ env.done }}
         uses: leonsteinhaeuser/project-beta-automations@v1.3.0
         with:
-          gh_token: ${{ secrets.GH_RW_TOKEN }}
+          gh_token: ${{ secrets.CANVAS_BOARD_TOKEN }}
           organization: Workday
           project_id: 4
           resource_node_id: ${{ github.event.issue.node_id }}
@@ -56,7 +56,7 @@ jobs:
         if: github.event.label.name == 'good first issue' || github.event.label.name == 'help wanted'
         uses: leonsteinhaeuser/project-beta-automations@v1.3.0
         with:
-          gh_token: ${{ secrets.GH_RW_TOKEN }}
+          gh_token: ${{ secrets.CANVAS_BOARD_TOKEN }}
           organization: Workday
           project_id: 4
           resource_node_id: ${{ github.event.issue.node_id }}
@@ -65,7 +65,7 @@ jobs:
         if: github.event.label.name == 'ready for review'
         uses: leonsteinhaeuser/project-beta-automations@v1.3.0
         with:
-          gh_token: ${{ secrets.GH_RW_TOKEN }}
+          gh_token: ${{ secrets.CANVAS_BOARD_TOKEN }}
           organization: Workday
           project_id: 4
           resource_node_id: $${{ github.event.issue.node_id }}
@@ -79,7 +79,7 @@ jobs:
         if: startsWith(github.head_ref, 'merge/prerelease/minor-into-prerelease/major')
         uses: leonsteinhaeuser/project-beta-automations@v1.3.0
         with:
-          gh_token: ${{ secrets.GH_RW_TOKEN }}
+          gh_token: ${{ secrets.CANVAS_BOARD_TOKEN }}
           organization: Workday
           project_id: 4
           resource_node_id: ${{ github.event.pull_request.node_id }}


### PR DESCRIPTION
## Summary

- using new gh token that was created for project board automations

![category](https://img.shields.io/badge/release_category-Infastructure-blue)
