### PR TITLE
fix: Add PopperProps to PopupPopper props

### DIFF
--- a/modules/react/popup/lib/PopupPopper.tsx
+++ b/modules/react/popup/lib/PopupPopper.tsx
@@ -3,9 +3,9 @@ import * as React from 'react';
 import {createComponent, useModelContext} from '@workday/canvas-kit-react/common';
 
 import {PopupModel, PopupModelContext, usePopupPopper} from './hooks';
-import {Placement, PopperOptions, Popper} from './Popper';
+import {Placement, PopperOptions, Popper, PopperProps} from './Popper';
 
-export interface PopupPopperProps {
+export interface PopupPopperProps extends PopperProps {
   /**
    * Optionally pass a model directly to this component. Default is to implicitly use the same
    * model as the container component which uses React context. Only use this for advanced use-cases
@@ -22,7 +22,6 @@ export interface PopupPopperProps {
    * The additional options passed to the Popper's `popper.js` instance.
    */
   popperOptions?: Partial<PopperOptions>;
-  children?: React.ReactNode;
 }
 
 export const PopupPopper = createComponent('div')({


### PR DESCRIPTION
## Summary

Fixes: #1771 

![category](https://img.shields.io/badge/release_category-Components-blue)

---

## For the Reviewer

We fixed these types in #1701, for V7, but we didn't fix the issue in V6. This PR adds PopperProps to PopupPopper.

## Where Should the Reviewer Start?

`modules/react/popup/lib/PopupPopper.tsx`

## Thank You Gif (optional)

![franks a lot gif](https://media.giphy.com/media/xFledVVcJzFrexsHge/giphy-downsized.gif)
