### PR TITLE
fix(common): Add support for class components to createComponent

### DIFF
--- a/modules/react/common/lib/utils/components.ts
+++ b/modules/react/common/lib/utils/components.ts
@@ -10,6 +10,9 @@ export type StyledType = {
   as?: React.ElementType;
 };
 
+// For React class components
+type Constructor<T> = new (...args: any[]) => T;
+
 /**
  * Extract a Ref from T if it exists
  * This will return the following:
@@ -20,6 +23,8 @@ export type StyledType = {
  */
 type ExtractRef<T> = T extends undefined // test if T was even passed in
   ? never // T not passed in, we'll set the ref to `never`
+  : T extends Constructor<infer C>
+  ? React.LegacyRef<C>
   : React.Ref<
       T extends keyof ElementTagNameMap // test if T is an element string like 'button' or 'div'
         ? ElementTagNameMap[T] // if yes, the ref should be the element interface. `'button' => HTMLButtonElement`

--- a/modules/react/common/spec/components.spec.tsx
+++ b/modules/react/common/spec/components.spec.tsx
@@ -392,4 +392,16 @@ describe('composeHooks', () => {
     const props = composeHooks(hook1, hook2)(myModel, {}, ref);
     expect(props).toHaveProperty('ref', ref);
   });
+
+  it('should type the ref of a class component as `LegacyRef`', () => {
+    class Component1 extends React.Component {}
+    const Component2 = createComponent(Component1)({
+      Component(props, ref, Element) {
+
+        // The `ref` of a class component is LegacyRef
+        expectTypeOf(ref).toEqualTypeOf<React.LegacyRef<Component1>>();
+        return <div />;
+      },
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Class components can only use `React.LegacyRef` (instead of `React.Ref`). Trying to use `createComponent` with class components resulted in type issues because `React.LegacyRef` was not supported. This change checks to see if it's a class component before deciding which ref type to apply.

This also enables `createComponent` to be used with `react-native`:

```tsx
import { View } from 'react-native'
import { createComponent } from '@workday/canvas-kit-react/common'

const MyView = createComponent(View)({
  Component(props, ref, Element) {
    return <View ref={ref} {...props} />;
  },
});
```

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, and Documentation -->
![category](https://img.shields.io/badge/release_category-Infrastructure-blue)

---

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests are changed or added
- [x] code adheres to the [API & Pattern guidelines](https://workday.github.io/canvas-kit/?path=/story/welcome-dev-docs-api-pattern-guidelines--page)
