### PR TITLE
docs: Make release category easier to change in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,8 +6,9 @@ Fixes: #1234 <!-- For bug fixes, use "Fixes". For new features use "Resolves". T
 
 <!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->
 
-<!-- This is the category in the release notes. Common categories are Components, Infrastructure, and Documentation -->
-![category](https://img.shields.io/badge/release_category-Components-blue)
+<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
+## Release Category
+Components
 
 ### Release Note
 Optional release note message. Changelog and release summaries will contain a pull request title. This section will add additional notes under that title. This section is not a summary, but something extra to point out in release notes. An example might be calling out breaking changes in a labs component or minor visual changes that need visual regression updates. Remove this section if no additional release notes are required.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,12 @@ Optional breaking changes message. If your PR includes breaking changes. It is e
 
 ## For the Reviewer
 
-<!-- Provide a bit of context about what this PR does. -->
+<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->
+
+- [ ] PR title is short and descriptive
+- [ ] PR summary describes the change (Fixes/Resovles linked correctly)
+- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
+- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable
 
 ## Where Should the Reviewer Start?
 


### PR DESCRIPTION
## Summary

We've been using the release category badge for a while, and it is difficult to parse and change the category. It is also harder to read the category in the badge due to lower contrast. This change updates the pull request template to make "Release Category" be a regular section.

## Release Category
Documentation

---

## For the Reviewer

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resovles linked correctly)
- [x] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [x] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

Check out the markdown rendering here: https://github.com/Workday/canvas-kit/blob/8303782db7e16963a31ffc1c0d878ccec44fa2de/.github/PULL_REQUEST_TEMPLATE.md

## Testing Manually

No testing necessary
