### PR TITLE
docs: Remove stale references to Icon Buttons [skip release]

### DIFF
--- a/modules/react/button/stories/button/Button.stories.mdx
+++ b/modules/react/button/stories/button/Button.stories.mdx
@@ -83,10 +83,10 @@ Undocumented props are spread to the underlying `<button>` element.
 
 ### TertiaryButton
 
-Tertiary Buttons have the lowest emphasis (before Icon Buttons). Use for less important actions that
-the user may not often be looking to do. Tertiary Buttons have lower prominence as its container is
-not visible until it is interacted with. Use Tertiary Buttons for supplemental actions such as “View
-More”, “Read More” or “Select a File”. Tertiary Buttons are frequently used on Cards.
+Tertiary Buttons have the lowest emphasis. Use for less important actions that the user may not
+often be looking to do. Tertiary Buttons have lower prominence as its container is not visible until
+it is interacted with. Use Tertiary Buttons for supplemental actions such as “View More”, “Read
+More” or “Select a File”. Tertiary Buttons are frequently used on Cards.
 
 Tertiary Buttons have three sizes: `extraSmall`, `small`, `medium` and `large`. Icons are supported
 for every size and can be positioned at the `start` or `end` with the `iconPosition` prop.

--- a/modules/react/tooltip/stories/Tooltip.stories.mdx
+++ b/modules/react/tooltip/stories/Tooltip.stories.mdx
@@ -59,11 +59,10 @@ tooltip being visible
 
 ### Basic Example
 
-Here is a basic example of an `TertiaryButton` that renders an icon using a tooltip to label the
-icon. This is labeling the button for both sighted users and for screen readers. A tooltip will
-provide an `aria-label` to child elements for the accessibility tree and a visual tooltip during
-mouse hover and focus events. Mouse over or focus on the x icon below. Click "Show code" to see the
-source code.
+Here is a basic example of a `TertiaryButton` that renders an icon using a tooltip to label the
+icon. This labels the button for both sighted users and screen readers. A tooltip provides an
+`aria-label` to child elements for the accessibility tree and a visual tooltip during mouse hover
+and focus events.
 
 <ExampleCodeBlock code={Default} />
 

--- a/modules/react/tooltip/stories/Tooltip.stories.mdx
+++ b/modules/react/tooltip/stories/Tooltip.stories.mdx
@@ -19,7 +19,8 @@ import {UseTooltip} from './examples/UseTooltip';
 
 A Tooltip component that renders information/text when the user hovers over an element. A tooltip is
 used to label or describe an element. By default, a tooltip will label an element. This is useful
-for icon button. A tooltip can also be used to describe additional information about an element
+for buttons with icons. A tooltip can also be used to describe additional information about an
+element
 
 [> Workday Design Reference](https://design.workday.com/components/popups/tooltips)
 
@@ -33,7 +34,7 @@ yarn add @workday/canvas-kit-react
 
 This component follows the
 [W3 Tooltip specification](https://www.w3.org/TR/wai-aria-practices/#tooltip). Tooltips are used to
-label icon buttons and provide additional context to elements.
+label buttons with icons and provide additional context to elements.
 
 ### When to use tooltips
 
@@ -58,10 +59,11 @@ tooltip being visible
 
 ### Basic Example
 
-Here is a basic example of an `TertiaryButton` that renders an icon using a tooltip to label the icon. This is labeling the
-button for both sighted users and for screen readers. A tooltip will provide an `aria-label` to
-child elements for the accessibility tree and a visual tooltip during mouse hover and focus events.
-Mouse over or focus on the x icon below. Click "Show code" to see the source code.
+Here is a basic example of an `TertiaryButton` that renders an icon using a tooltip to label the
+icon. This is labeling the button for both sighted users and for screen readers. A tooltip will
+provide an `aria-label` to child elements for the accessibility tree and a visual tooltip during
+mouse hover and focus events. Mouse over or focus on the x icon below. Click "Show code" to see the
+source code.
 
 <ExampleCodeBlock code={Default} />
 


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->
Removes stale references to Icon Buttons (removed in v7) from the Button and Tooltip MDXes.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Documentation

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [standard MDX template](https://github.com/Workday/canvas-kit/discussions/1131)

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resovles linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->
Examine to Button and Tooltip MDXes in Storybook to verify all traces of Icon Button are removed.
