### PR TITLE
ci: Close related issues with pull requests [skip release]

### DIFF
--- a/.github/workflows/close-related-issues.yml
+++ b/.github/workflows/close-related-issues.yml
@@ -1,0 +1,11 @@
+name: Close Linked Issues
+
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Workday/canvas-kit-actions/close-related-issues@v1


### PR DESCRIPTION
## Summary

Close related issues when the pull request is closed regardless of the target branch of the pull request. Github already closes issues with pull requests targeting the default branch, but Canvas Kit supports multiple support branches. An issue is considered closed when it is merged into `support`, for example. This change decreases the overhead of maintaining Canvas Kit Github.

## Release Category
Infrastruture

---

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resovles linked correctly)
- [x] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [x] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

