### PR TITLE
feat: Add support for opening stories in Tesseract

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -62,4 +62,8 @@ export const parameters = {
       defaultValue: defaultCanvasTheme,
     },
   },
+  // Make stories available to our internal code sandbox tool
+  tesseract: {
+    enable: true 
+  }
 };


### PR DESCRIPTION
## Summary

As discussed on slack, this inconsequential change will enable the "Open in Tesseract" button for CK stories in supported internal Storybook environments. Thanks! 🍻 

![](https://s.yimg.com/ny/api/res/1.2/vCHcnm7zz2uZMzER88NUIA--/YXBwaWQ9aGlnaGxhbmRlcjt3PTk2MDtoPTQ0NDtjZj13ZWJw/https://nerdist.com/wp-content/uploads/2019/03/tumblr_o9pm5bI1Kc1sbtt2jo3_540.gif)