### PR TITLE
docs: Fix multiSelectionManager import in Collections example

### DIFF
--- a/modules/react/collection/stories/examples/MultiSelection.tsx
+++ b/modules/react/collection/stories/examples/MultiSelection.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {
+  multiSelectionManager,
   useListItemRegister,
   useListItemRovingFocus,
   useListItemSelect,
@@ -9,7 +10,6 @@ import {
   ListBox,
 } from '@workday/canvas-kit-react/collection';
 import {composeHooks, createSubcomponent} from '@workday/canvas-kit-react/common';
-import {multiSelectionManager} from '../../lib/useSelectionListModel';
 
 const useMultiSelectItem = composeHooks(
   useListItemSelect,


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Updates the `multiSelectionManager` import in the Collection MultiSelection example to import from `@workday/canvas-kit-react/collection` rather than `../../lib/useSelectionListModel`. This keeps the example self-contained. This will allow the example to be copy-and-pasteable and prevent issues with consumers of the `canvas-kit-docs` package such as the Canvas Site.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Documentation

---

## Where Should the Reviewer Start?

Ensure the Collection Multi Selection example renders identically as before. To navigate to it within Storybook: `WELCOME > Dev Docs > Collections > Multi Selection`
