### PR TITLE
fix: Fix a model's TConfig type and add tests

### DIFF
--- a/modules/react/common/lib/utils/models.ts
+++ b/modules/react/common/lib/utils/models.ts
@@ -225,7 +225,7 @@ export type ModelExtras<TDefaultConfig, TRequiredConfig, TState, TEvents, TModel
   /**
    * This is only a type and not a value. If you want to
    */
-  TConfig: TDefaultConfig & TRequiredConfig;
+  TConfig: Partial<TDefaultConfig> & TRequiredConfig & ToEventConfig<TState, TEvents>;
   /**
    * The context of the model. This can be used directly, but is mostly used internally by
    * `createContainer` or `createSubcomponent` to handle model context automatically.
@@ -268,7 +268,7 @@ export type ModelExtras<TDefaultConfig, TRequiredConfig, TState, TEvents, TModel
    * ```
    */
   mergeConfig: (
-    source: TDefaultConfig & TRequiredConfig,
+    source: Partial<TDefaultConfig> & TRequiredConfig,
     target: Partial<
       TDefaultConfig & TRequiredConfig & ToEventConfig<TState, TEvents>
     >

--- a/modules/react/tabs/lib/useTabsModel.tsx
+++ b/modules/react/tabs/lib/useTabsModel.tsx
@@ -29,7 +29,7 @@ export const useTabsModel = createModelHook({
      * @default 'horizontal'
      */
     orientation: 'horizontal' as typeof useOverflowListModel.defaultConfig.orientation,
-    menuConfig: {} as Partial<typeof useMenuModel.defaultConfig>,
+    menuConfig: {} as typeof useMenuModel.TConfig,
   },
   requiredConfig: useOverflowListModel.requiredConfig,
 })(config => {
@@ -96,7 +96,7 @@ export const useTabsModel = createModelHook({
   };
 
   const menu = useMenuModel(
-    useMenuModel.mergeConfig(config.menuConfig as Required<typeof config.menuConfig>, {
+    useMenuModel.mergeConfig(config.menuConfig, {
       id: `menu-${model.state.id}`,
       items: overflowItems,
       nonInteractiveIds: state.nonInteractiveIds.filter(key => !state.hiddenIds.includes(key)),


### PR DESCRIPTION
## Summary

Fix the `TConfig` type exported by the `createModelHook` utility function to work better with model composition. The definition of `useTabsModel` was simplified due to this change.

## Release Category
Types

---

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)
- [x] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [x] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

`useTabsModel`