### PR TITLE
fix: Correctly call keyboard click events when Preview Menu has headers

### DIFF
--- a/modules/preview-react/menu/lib/Menu.tsx
+++ b/modules/preview-react/menu/lib/Menu.tsx
@@ -181,11 +181,12 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
     const children = React.Children.toArray(this.props.children);
     let nextSelectedIndex = 0;
     let isShortcut = false;
-    const itemCount = children.filter(child => {
+    const interactiveItems = children.filter(child => {
       return !(child as React.ReactElement<MenuItemProps>)?.props?.isHeader;
-    }).length;
+    });
+    const interactiveItemCount = interactiveItems.length;
     const firstItem = 0;
-    const lastItem = itemCount - 1;
+    const lastItem = interactiveItemCount - 1;
 
     if (event.key.length === 1 && event.key.match(/\S/)) {
       let start = this.state.selectedItemIndex + 1;
@@ -211,7 +212,7 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
           isShortcut = true;
           const nextIndex = this.state.selectedItemIndex + direction;
           nextSelectedIndex =
-            nextIndex < 0 ? lastItem : nextIndex >= itemCount ? firstItem : nextIndex;
+            nextIndex < 0 ? lastItem : nextIndex >= interactiveItemCount ? firstItem : nextIndex;
           break;
 
         case 'Home':
@@ -239,7 +240,9 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
         case ' ':
         case 'Enter':
           nextSelectedIndex = this.state.selectedItemIndex;
-          const child = children[this.state.selectedItemIndex] as React.ReactElement<MenuItemProps>;
+          const child = interactiveItems[this.state.selectedItemIndex] as React.ReactElement<
+            MenuItemProps
+          >;
           this.handleClick(event, child.props);
           isShortcut = true;
           break;

--- a/modules/preview-react/menu/lib/Menu.tsx
+++ b/modules/preview-react/menu/lib/Menu.tsx
@@ -185,8 +185,8 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
       return !(child as React.ReactElement<MenuItemProps>)?.props?.isHeader;
     });
     const interactiveItemCount = interactiveItems.length;
-    const firstItem = 0;
-    const lastItem = interactiveItemCount - 1;
+    const firstIndex = 0;
+    const lastIndex = interactiveItemCount - 1;
 
     if (event.key.length === 1 && event.key.match(/\S/)) {
       let start = this.state.selectedItemIndex + 1;
@@ -212,12 +212,12 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
           isShortcut = true;
           const nextIndex = this.state.selectedItemIndex + direction;
           nextSelectedIndex =
-            nextIndex < 0 ? lastItem : nextIndex >= interactiveItemCount ? firstItem : nextIndex;
+            nextIndex < 0 ? lastIndex : nextIndex >= interactiveItemCount ? firstIndex : nextIndex;
           break;
 
         case 'Home':
         case 'End':
-          const skipTo = event.key === 'Home' ? firstItem : lastItem;
+          const skipTo = event.key === 'Home' ? firstIndex : lastIndex;
           isShortcut = true;
           nextSelectedIndex = skipTo;
           break;

--- a/modules/preview-react/menu/spec/Menu.spec.tsx
+++ b/modules/preview-react/menu/spec/Menu.spec.tsx
@@ -325,25 +325,25 @@ describe('Menu Keyboard Shortcuts', () => {
   it('should call the "onClose" event when the space key is pressed', () => {
     render(
       <Menu onClose={cb}>
-        <MenuItem>Alpha</MenuItem>
+        <MenuItem onClick={cb}>Alpha</MenuItem>
       </Menu>
     );
 
     fireEvent.keyDown(screen.getByRole('menu'), {key: ' '});
 
-    expect(cb).toHaveBeenCalled();
+    expect(cb).toHaveBeenCalledTimes(2);
   });
 
   it('should call the "onClose" event when the enter key is pressed', () => {
     render(
       <Menu onClose={cb}>
-        <MenuItem>Alpha</MenuItem>
+        <MenuItem onClick={cb}>Alpha</MenuItem>
       </Menu>
     );
 
     fireEvent.keyDown(screen.getByRole('menu'), {key: 'Enter'});
 
-    expect(cb).toHaveBeenCalled();
+    expect(cb).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/modules/preview-react/menu/spec/Menu.spec.tsx
+++ b/modules/preview-react/menu/spec/Menu.spec.tsx
@@ -211,7 +211,7 @@ describe('Menu Keyboard Shortcuts', () => {
 
   it('should loop around selected items using the down arrow', () => {
     render(
-      <Menu isOpen={false}>
+      <Menu>
         <MenuItem isHeader>Beginning</MenuItem>
         <MenuItem>Alpha</MenuItem>
         <MenuItem>Bravo</MenuItem>
@@ -332,6 +332,34 @@ describe('Menu Keyboard Shortcuts', () => {
     fireEvent.keyDown(screen.getByRole('menu'), {key: ' '});
 
     expect(cb).toHaveBeenCalledTimes(2);
+  });
+
+  it('should call the correct click event when headers are present', () => {
+    const one = jest.fn();
+    const two = jest.fn();
+    const three = jest.fn();
+    render(
+      <Menu onClose={cb}>
+        <MenuItem isHeader>Beginning</MenuItem>
+        <MenuItem onClick={one}>Alpha</MenuItem>
+        <MenuItem isHeader>Middle</MenuItem>
+        <MenuItem isHeader>Center</MenuItem>
+        <MenuItem onClick={two}>Bravo</MenuItem>
+        <MenuItem onClick={three}>Charlie</MenuItem>
+        <MenuItem isHeader>End</MenuItem>
+      </Menu>
+    );
+
+    fireEvent.keyDown(screen.getByRole('menu'), {key: ' '});
+    fireEvent.keyDown(screen.getByRole('menu'), {key: 'ArrowDown'});
+    fireEvent.keyDown(screen.getByRole('menu'), {key: ' '});
+    fireEvent.keyDown(screen.getByRole('menu'), {key: 'ArrowDown'});
+    fireEvent.keyDown(screen.getByRole('menu'), {key: ' '});
+    fireEvent.keyDown(screen.getByRole('menu'), {key: 'ArrowDown'});
+    fireEvent.keyDown(screen.getByRole('menu'), {key: ' '});
+    expect(one).toHaveBeenCalledTimes(2);
+    expect(two).toHaveBeenCalled();
+    expect(three).toHaveBeenCalled();
   });
 
   it('should call the "onClose" event when the enter key is pressed', () => {

--- a/modules/preview-react/menu/spec/Menu.spec.tsx
+++ b/modules/preview-react/menu/spec/Menu.spec.tsx
@@ -258,7 +258,6 @@ describe('Menu Keyboard Shortcuts', () => {
     );
 
     const firstId = screen.getByRole('menuitem', {name: 'Alpha'}).getAttribute('id');
-    const secondId = screen.getByRole('menuitem', {name: 'Bravo'}).getAttribute('id');
 
     fireEvent.keyDown(screen.getByRole('menu'), {key: 'Home'});
     expect(screen.getByRole('menu')).toHaveAttribute('aria-activedescendant', firstId);
@@ -274,7 +273,6 @@ describe('Menu Keyboard Shortcuts', () => {
       </Menu>
     );
 
-    const firstId = screen.getByRole('menuitem', {name: 'Alpha'}).getAttribute('id');
     const secondId = screen.getByRole('menuitem', {name: 'Bravo'}).getAttribute('id');
 
     fireEvent.keyDown(screen.getByRole('menu'), {key: 'End'});
@@ -296,42 +294,6 @@ describe('Menu Keyboard Shortcuts', () => {
     fireEvent.keyDown(screen.getByRole('menu'), {key: 'ArrowRight'});
 
     expect(screen.getByRole('menu')).toHaveAttribute('aria-activedescendant', secondId);
-  });
-
-  it('should call the "onClose" event when the tab key is pressed', () => {
-    render(
-      <Menu onClose={cb}>
-        <MenuItem>Alpha</MenuItem>
-      </Menu>
-    );
-
-    fireEvent.keyDown(screen.getByRole('menu'), {key: 'Tab'});
-
-    expect(cb).toHaveBeenCalled();
-  });
-
-  it('should call the "onClose" event when the escape key is pressed', () => {
-    render(
-      <Menu onClose={cb}>
-        <MenuItem>Alpha</MenuItem>
-      </Menu>
-    );
-
-    fireEvent.keyDown(screen.getByRole('menu'), {key: 'Escape'});
-
-    expect(cb).toHaveBeenCalled();
-  });
-
-  it('should call the "onClose" event when the space key is pressed', () => {
-    render(
-      <Menu onClose={cb}>
-        <MenuItem onClick={cb}>Alpha</MenuItem>
-      </Menu>
-    );
-
-    fireEvent.keyDown(screen.getByRole('menu'), {key: ' '});
-
-    expect(cb).toHaveBeenCalledTimes(2);
   });
 
   it('should call the correct click event when headers are present', () => {
@@ -362,16 +324,52 @@ describe('Menu Keyboard Shortcuts', () => {
     expect(three).toHaveBeenCalled();
   });
 
+  it('should call the "onClose" event when the tab key is pressed', () => {
+    render(
+      <Menu onClose={cb}>
+        <MenuItem>Alpha</MenuItem>
+      </Menu>
+    );
+
+    fireEvent.keyDown(screen.getByRole('menu'), {key: 'Tab'});
+
+    expect(cb).toHaveBeenCalled();
+  });
+
+  it('should call the "onClose" event when the escape key is pressed', () => {
+    render(
+      <Menu onClose={cb}>
+        <MenuItem>Alpha</MenuItem>
+      </Menu>
+    );
+
+    fireEvent.keyDown(screen.getByRole('menu'), {key: 'Escape'});
+
+    expect(cb).toHaveBeenCalled();
+  });
+
+  it('should call the "onClose" event when the space key is pressed', () => {
+    render(
+      <Menu onClose={cb}>
+        <MenuItem>Alpha</MenuItem>
+      </Menu>
+    );
+
+    fireEvent.keyDown(screen.getByRole('menu'), {key: ' '});
+
+    expect(cb).toHaveBeenCalled();
+  });
+
   it('should call the "onClose" event when the enter key is pressed', () => {
     render(
       <Menu onClose={cb}>
-        <MenuItem onClick={cb}>Alpha</MenuItem>
+        <MenuItem>Alpha</MenuItem>
       </Menu>
     );
 
     fireEvent.keyDown(screen.getByRole('menu'), {key: 'Enter'});
 
-    expect(cb).toHaveBeenCalledTimes(2);
+    expect(cb).toHaveBeenCalled();
   });
 });
 

--- a/modules/preview-react/menu/spec/Menu.spec.tsx
+++ b/modules/preview-react/menu/spec/Menu.spec.tsx
@@ -339,7 +339,7 @@ describe('Menu Keyboard Shortcuts', () => {
     const two = jest.fn();
     const three = jest.fn();
     render(
-      <Menu onClose={cb}>
+      <Menu>
         <MenuItem isHeader>Beginning</MenuItem>
         <MenuItem onClick={one}>Alpha</MenuItem>
         <MenuItem isHeader>Middle</MenuItem>


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #1878 <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->
Recently added headers but did not correctly update the index for keyboard style "clicks"

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

---

## Checklist

- [X] Added Regression Test

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable


## Testing Manually

I added console.logs the MenuItems in storybook and was able to reproduce bug.


## Thank You Gif (optional)
<img src="https://media.giphy.com/media/WrgQBXlUPBw3Ar73xG/giphy.gif" alt="Smithers slowly revealing his clerical collar says Out of Service" />

