### PR TITLE
fix: Fail gracefully if localStorage is blocked in useModalityType

### DIFF
--- a/modules/react/common/lib/utils/useModalityType.ts
+++ b/modules/react/common/lib/utils/useModalityType.ts
@@ -2,6 +2,22 @@ import React from 'react';
 
 type Modality = 'mouse' | 'touch' | 'pen';
 
+function safeLocalStorageGet(key: string): string | null {
+  try {
+    return localStorage.get(key);
+  } catch (_) {
+    return '';
+  }
+}
+
+function safeLocalStorageSet(key: string, value: string): void {
+  try {
+    localStorage.set(key, value);
+  } catch (_) {
+    // Do nothing
+  }
+}
+
 // Use this shared global value to reduce calls to localStorage which is a synchronous API to a
 // drive which could be slow (spinning disks could be hundreds of ms). We read only once this way.
 // The following initialization is very difficult to test via automation. Don't mess with it unless
@@ -12,7 +28,7 @@ type Modality = 'mouse' | 'touch' | 'pen';
 //   b. if < 768, default to 'touch'
 //   c. else default to 'mouse'
 let localStorageValue = ((typeof localStorage !== 'undefined'
-  ? localStorage.getItem('modality')
+  ? safeLocalStorageGet('modality')
   : '') ||
   (typeof document !== 'undefined'
     ? document.documentElement.clientWidth < 768
@@ -26,7 +42,7 @@ let localStorageValue = ((typeof localStorage !== 'undefined'
 // drives
 const updateLocalStorage = (value: Modality) => {
   if (localStorageValue !== value) {
-    localStorage.setItem('modality', value);
+    safeLocalStorageSet('modality', value);
   }
   localStorageValue = value;
 };

--- a/modules/react/common/lib/utils/useModalityType.ts
+++ b/modules/react/common/lib/utils/useModalityType.ts
@@ -6,7 +6,7 @@ function safeLocalStorageGet(key: string): string | null {
   try {
     return localStorage.get(key);
   } catch (_) {
-    return '';
+    return null;
   }
 }
 


### PR DESCRIPTION
## Summary

There could be many reasons localStorage is blocked (content security policy, iframe cross origin, etc). `useModalityType` uses localStorage to avoid possible flashing of UI for users. But a blank screen due to an access denied error is worse, so we'll wrap `localStorage` access in a `try/catch` block to gracefully fallback to guessing when localStorage is not available.

## Release Category
Components

---

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)
- [x] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [x] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?
