### PR TITLE
fix(text): Update text component imports

### DIFF
--- a/modules/react/breadcrumbs/lib/BreadcrumbsCurrentItem.tsx
+++ b/modules/react/breadcrumbs/lib/BreadcrumbsCurrentItem.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import {
-  styled,
   createElemPropsHook,
   useLocalRef,
   composeHooks,
   createSubcomponent,
-  StyledType,
-  ellipsisStyles,
   useForkRef,
 } from '@workday/canvas-kit-react/common';
 import {OverflowTooltip, OverflowTooltipProps} from '@workday/canvas-kit-react/tooltip';
@@ -20,18 +17,6 @@ import {Text, TextProps} from '@workday/canvas-kit-react/text';
 export interface BreadcrumbsCurrentItemProps extends TextProps {
   tooltipProps?: OverflowTooltipProps;
 }
-
-const ListItem = styled(Text)<BreadcrumbsCurrentItemProps & StyledType>(
-  {
-    alignItems: 'center',
-    flexDirection: 'column',
-  },
-  ({maxWidth}: BreadcrumbsCurrentItemProps) => ({
-    maxWidth,
-    display: 'inline-block',
-    ...ellipsisStyles,
-  })
-);
 
 export const useBreadcrumbsItem = composeHooks(
   createElemPropsHook(useBreadcrumbsModel)((_model: any, ref: any, elemProps) => {
@@ -61,15 +46,19 @@ export const BreadcrumbsCurrentItem = createSubcomponent('li')({
   ({children, tooltipProps = {}, maxWidth = '350px', ...elemProps}, Element) => {
     return (
       <OverflowTooltip {...tooltipProps}>
-        <ListItem
+        <Text
           as={Element}
           typeLevel="subtext.large"
-          maxWidth={maxWidth}
           fontWeight="medium"
+          display="inline-block"
+          maxWidth={maxWidth}
+          whiteSpace="nowrap"
+          textOverflow="ellipsis"
+          overflow="hidden"
           {...elemProps}
         >
           {children}
-        </ListItem>
+        </Text>
       </OverflowTooltip>
     );
   }

--- a/modules/react/breadcrumbs/lib/BreadcrumbsCurrentItem.tsx
+++ b/modules/react/breadcrumbs/lib/BreadcrumbsCurrentItem.tsx
@@ -21,7 +21,7 @@ export interface BreadcrumbsCurrentItemProps extends TextProps {
   tooltipProps?: OverflowTooltipProps;
 }
 
-const ListItem = styled(Text.as('li'))<BreadcrumbsCurrentItemProps & StyledType>(
+const ListItem = styled(Text)<BreadcrumbsCurrentItemProps & StyledType>(
   {
     alignItems: 'center',
     flexDirection: 'column',

--- a/modules/react/text/lib/LabelText.tsx
+++ b/modules/react/text/lib/LabelText.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {Property} from 'csstype';
-import {createComponent, styled, StyledType} from '@workday/canvas-kit-react/common';
+import {createComponent} from '@workday/canvas-kit-react/common';
 import {Text, TextProps} from './Text';
 import {inputColors} from '@workday/canvas-kit-react/tokens';
 
@@ -8,12 +8,6 @@ export interface TypeLabelProps extends TextProps {
   cursor?: Property.Cursor;
   disabled?: boolean;
 }
-
-const StyledLabel = styled(Text)<StyledType & TypeLabelProps>(({cursor, disabled, variant}) => ({
-  color: disabled && variant !== 'inverse' ? inputColors.disabled.text : undefined,
-  cursor: cursor && !disabled ? cursor : 'default',
-  opacity: disabled && variant === 'inverse' ? '.4' : '1',
-}));
 
 /**
  * ## LabelText
@@ -39,7 +33,17 @@ const StyledLabel = styled(Text)<StyledType & TypeLabelProps>(({cursor, disabled
  */
 export const LabelText = createComponent('label')({
   displayName: 'Label',
-  Component: (elemProps: TypeLabelProps, ref, Element) => {
-    return <StyledLabel ref={ref} as={Element} typeLevel="subtext.large" {...elemProps} />;
+  Component: ({cursor, disabled, variant, ...elemProps}: TypeLabelProps, ref, Element) => {
+    return (
+      <Text
+        ref={ref}
+        as={Element}
+        typeLevel="subtext.large"
+        color={disabled && variant !== 'inverse' ? inputColors.disabled.text : undefined}
+        cursor={cursor && !disabled ? cursor : 'default'}
+        opacity={disabled && variant === 'inverse' ? '.4' : '1'}
+        {...elemProps}
+      />
+    );
   },
 });

--- a/modules/react/text/lib/LabelText.tsx
+++ b/modules/react/text/lib/LabelText.tsx
@@ -42,6 +42,7 @@ export const LabelText = createComponent('label')({
         color={disabled && variant !== 'inverse' ? inputColors.disabled.text : undefined}
         cursor={cursor && !disabled ? cursor : 'default'}
         opacity={disabled && variant === 'inverse' ? '.4' : '1'}
+        variant={variant}
         {...elemProps}
       />
     );

--- a/modules/react/text/lib/LabelText.tsx
+++ b/modules/react/text/lib/LabelText.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {Property} from 'csstype';
 import {createComponent, styled, StyledType} from '@workday/canvas-kit-react/common';
-import {Text, TextProps} from '@workday/canvas-kit-react/text';
+import {Text, TextProps} from './Text';
 import {inputColors} from '@workday/canvas-kit-react/tokens';
 
 export interface TypeLabelProps extends TextProps {
@@ -9,13 +9,11 @@ export interface TypeLabelProps extends TextProps {
   disabled?: boolean;
 }
 
-const StyledLabel = styled(Text.as('label'))<StyledType & TypeLabelProps>(
-  ({cursor, disabled, variant}) => ({
-    color: disabled && variant !== 'inverse' ? inputColors.disabled.text : undefined,
-    cursor: cursor && !disabled ? cursor : 'default',
-    opacity: disabled && variant === 'inverse' ? '.4' : '1',
-  })
-);
+const StyledLabel = styled(Text)<StyledType & TypeLabelProps>(({cursor, disabled, variant}) => ({
+  color: disabled && variant !== 'inverse' ? inputColors.disabled.text : undefined,
+  cursor: cursor && !disabled ? cursor : 'default',
+  opacity: disabled && variant === 'inverse' ? '.4' : '1',
+}));
 
 /**
  * ## LabelText

--- a/modules/react/text/lib/TypeLevelComponents.tsx
+++ b/modules/react/text/lib/TypeLevelComponents.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {createComponent} from '@workday/canvas-kit-react/common';
-import {Text, TextProps} from '@workday/canvas-kit-react/text';
+import {Text, TextProps} from './Text';
 
 /**
  * Prop interface for type level specific components:
@@ -83,9 +83,7 @@ export const BodyText = createComponent('p')({
   displayName: 'BodyText',
   Component: ({size, ...elemProps}: TypeLevelProps, ref, Element) => {
     const typeLevel = `body.${size}` as TextProps['typeLevel'];
-    return (
-      <Text ref={ref} as={Element} typeLevel={typeLevel} {...elemProps} />
-    );
+    return <Text ref={ref} as={Element} typeLevel={typeLevel} {...elemProps} />;
   },
 });
 


### PR DESCRIPTION
## Summary

Fixes: #1905  <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

Changed text package import to relative and removed `Text.as` from `LabelText` and `Breadcrumbs.Item` to fix CSB render.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components