### PR TITLE
fix(search-form): Enable overriding the generated labelId

### DIFF
--- a/modules/labs-react/search-form/lib/SearchForm.tsx
+++ b/modules/labs-react/search-form/lib/SearchForm.tsx
@@ -86,6 +86,11 @@ export interface SearchFormProps extends GrowthBehavior, React.FormHTMLAttribute
    * @default false
    */
   allowEmptyStringSearch?: boolean;
+  /**
+   * Sets the `id` for the label
+   * @default unique identifier
+   */
+  labelId?: string;
 }
 
 export interface SearchFormState {
@@ -279,7 +284,7 @@ export class SearchForm extends React.Component<SearchFormProps, SearchFormState
 
   private inputRef = React.createRef<HTMLInputElement>();
   private openRef = React.createRef<HTMLButtonElement>();
-  private labelId = generateUniqueId();
+  private defaultLabelId = generateUniqueId();
 
   state: Readonly<SearchFormState> = {
     showForm: false,
@@ -384,6 +389,7 @@ export class SearchForm extends React.Component<SearchFormProps, SearchFormState
       submitAriaLabel = 'Search',
       openButtonAriaLabel = 'Open Search',
       closeButtonAriaLabel = 'Cancel',
+      labelId = this.defaultLabelId,
       showClearButton = true,
       height = 40,
       grow,
@@ -404,7 +410,7 @@ export class SearchForm extends React.Component<SearchFormProps, SearchFormState
         action="."
         rightAlign={rightAlign}
         grow={grow}
-        aria-labelledby={this.labelId}
+        aria-labelledby={labelId}
         isCollapsed={isCollapsed}
         onSubmit={this.handleSubmit}
         showForm={this.state.showForm}
@@ -431,8 +437,8 @@ export class SearchForm extends React.Component<SearchFormProps, SearchFormState
           />
           <SearchField
             grow={grow}
-            id={this.labelId}
-            inputId={`input-${this.labelId}`}
+            id={labelId}
+            inputId={`input-${labelId}`}
             label={inputLabel}
             labelPosition={FormFieldLabelPosition.Hidden}
             useFieldset={false}
@@ -449,7 +455,7 @@ export class SearchForm extends React.Component<SearchFormProps, SearchFormState
               onBlur={this.handleBlur}
               showClearButton={!isCollapsed && showClearButton}
               clearButtonAriaLabel={clearButtonAriaLabel}
-              labelId={this.labelId}
+              labelId={labelId}
             >
               <SearchInput
                 ref={this.inputRef}

--- a/modules/labs-react/search-form/spec/SearchForm.spec.tsx
+++ b/modules/labs-react/search-form/spec/SearchForm.spec.tsx
@@ -115,7 +115,7 @@ describe('SearchForm', () => {
     expect(openButton).toHaveFocus();
   });
 
-  test('Search Bar can accept custom themes', () => {
+  test('SearchForm can accept custom themes', () => {
     const inputLabelText = `label`;
     render(
       <SearchForm
@@ -148,7 +148,7 @@ describe('SearchForm', () => {
     expect(styleFocused.boxShadow).toBe('0 0 0 1px white');
   });
 
-  test('Search Bar can accept default themes', () => {
+  test('SearchForm can accept default themes', () => {
     const inputLabelText = `label`;
     const theme = SearchTheme.Dark;
     render(<SearchForm onSubmit={jest.fn()} inputLabel={inputLabelText} searchTheme={theme} />);
@@ -161,11 +161,20 @@ describe('SearchForm', () => {
     expect(style.boxShadow).toBe(searchThemes[theme].boxShadow);
   });
 
-  test('Search Bar should spread extra props', async () => {
+  test('SearchForm should spread extra props', () => {
     const cb = jest.fn();
     const data = 'test';
     render(<SearchForm onSubmit={cb} data-propspread={data} />);
 
     expect(screen.getByRole('search')).toHaveAttribute('data-propspread', data);
+  });
+
+  test('SearchForm supports overriding the generated labelId', () => {
+    const cb = jest.fn();
+    const labelId = 'search-form-fixed-label-id';
+
+    const {container} = render(<SearchForm onSubmit={cb} labelId={labelId} />);
+
+    expect(container.querySelector(`#${labelId}`)).toHaveTextContent('Search');
   });
 });


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

This adds the `labelId` prop to `SearchForm` so users can override the generated value if needed.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components


---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [standard MDX template](https://github.com/Workday/canvas-kit/discussions/1131)

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Fix (patch) vs feature (minor) - I set this as a fix to address a problem with the current API
- [ ] Documentation - I don't think this needs more documentation than the prop addition (type and JSDoc)
- [ ] Testing - I added a test case to make sure it can be looked up by the specified Id

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

<!-- Explain how your reviewer could verify this change  -->

## Screenshots or GIFs (if applicable)

Here is what the generated id looks like (`"sevu0"`), default behavior maintained:

<img width="831" alt="Screen Shot 2022-11-09 at 1 33 24 PM" src="https://user-images.githubusercontent.com/1075861/200936156-10daddad-10e4-43d5-882a-e256263a6d7c.png">

## Thank You Gif (optional)

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer! -->
![Pusheen thank you](https://media.giphy.com/media/osjgQPWRx3cac/giphy.gif)
