### PR TITLE
docs: Add Pagination responsive range example

### DIFF
--- a/modules/react/pagination/stories/examples/ResponsiveRange.tsx
+++ b/modules/react/pagination/stories/examples/ResponsiveRange.tsx
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import {
+  Pagination,
+  getLastPage,
+  getVisibleResultsMax,
+  getVisibleResultsMin,
+  usePaginationModel,
+} from '@workday/canvas-kit-react/pagination';
+import {Flex} from '@workday/canvas-kit-react/layout';
+import {Text} from '@workday/canvas-kit-react/text';
+import {useResizeObserver, useTheme} from '@workday/canvas-kit-react/common';
+
+export const ResponsiveRange = () => {
+  const resultCount = 10;
+  const totalCount = 100;
+  const lastPage = getLastPage(resultCount, totalCount);
+  // Normally, rangeSize can be a static value, but we're making it stateful,
+  // so we can update it using useResizeObserver
+  const [rangeSize, setRangeSize] = React.useState(5);
+  const model = usePaginationModel({
+    lastPage,
+    rangeSize,
+  });
+  // We're only using this state to display the container width;
+  const [containerWidth, setContainerWidth] = React.useState(0);
+  // We're using breakpoints from the theme as reference points to adjust the range
+  const theme = useTheme();
+  const {values: breakpointValues} = theme.canvas.breakpoints;
+
+  // We'll use this ref to measure the size of the container
+  const containerRef = React.useRef(null);
+  useResizeObserver({
+    ref: containerRef,
+    onResize: ({width}) => {
+      // Note: onResizeObserver only accounts for the size of the container.
+      // It does not factor in margin, padding, or border widths.
+      // So, if you want to be exact, you'll need to adjust your math a bit to account for those.
+      // But if you're okay with being close enough on the measurements, this is fine.
+      if (width) {
+        // updating the container width for the display text
+        setContainerWidth(width);
+        // helper functions for better readability
+        const isBetweenZeroAndSmall = width >= breakpointValues.zero && width < breakpointValues.s;
+        const isBetweenSmallAndMedium = width >= breakpointValues.s && width < breakpointValues.m;
+        const isBetweenMediumAndLarge = width >= breakpointValues.m && width < breakpointValues.l;
+        const isBetweenLargeAndXLarge = width >= breakpointValues.l && width < breakpointValues.xl;
+        // We're checking the rangeSize at each level to prevent extra re-renders.
+        if (rangeSize !== 1 && isBetweenZeroAndSmall) {
+          setRangeSize(1);
+        }
+        if (rangeSize !== 3 && isBetweenSmallAndMedium) {
+          setRangeSize(3);
+        }
+        if (rangeSize !== 5 && isBetweenMediumAndLarge) {
+          setRangeSize(5);
+        }
+        if (rangeSize !== 7 && isBetweenLargeAndXLarge) {
+          setRangeSize(7);
+        }
+      }
+    },
+  });
+
+  return (
+    <Flex
+      border="solid 1px"
+      ref={containerRef}
+      justifyContent="space-between"
+      padding="s"
+      alignItems="center"
+    >
+      <Text typeLevel="body.small" fontWeight="bold">
+        Width: {containerWidth}px
+      </Text>
+      <Pagination model={model} aria-label="Pagination">
+        <Pagination.Controls>
+          <Pagination.StepToPreviousButton aria-label="Previous" />
+          <Pagination.PageList>
+            {({state}) =>
+              state.range.map(pageNumber => (
+                <Pagination.PageListItem key={pageNumber}>
+                  <Pagination.PageButton
+                    aria-label={`Page ${pageNumber}`}
+                    pageNumber={pageNumber}
+                  />
+                </Pagination.PageListItem>
+              ))
+            }
+          </Pagination.PageList>
+          <Pagination.StepToNextButton aria-label="Next" />
+        </Pagination.Controls>
+        <Pagination.AdditionalDetails shouldHideDetails>
+          {({state}) =>
+            `${getVisibleResultsMin(state.currentPage, resultCount)}-${getVisibleResultsMax(
+              state.currentPage,
+              resultCount,
+              totalCount
+            )} of ${totalCount} results`
+          }
+        </Pagination.AdditionalDetails>
+      </Pagination>
+    </Flex>
+  );
+};

--- a/modules/react/pagination/stories/examples/ResponsiveRange.tsx
+++ b/modules/react/pagination/stories/examples/ResponsiveRange.tsx
@@ -34,8 +34,8 @@ export const ResponsiveRange = () => {
     onResize: ({width}) => {
       // Note: onResizeObserver only accounts for the size of the container.
       // It does not factor in margin, padding, or border widths.
-      // So, if you want to be exact, you'll need to adjust your math a bit to account for those.
-      // But if you're okay with being close enough on the measurements, this is fine.
+      // If you want to be exact, adjust your math to account for those.
+      // If you're okay with being close enough on the measurements, this is fine.
       if (width) {
         // updating the container width for the display text
         setContainerWidth(width);

--- a/modules/react/pagination/stories/pagination.stories.mdx
+++ b/modules/react/pagination/stories/pagination.stories.mdx
@@ -7,6 +7,7 @@ import {CustomRange} from './examples/CustomRange';
 import {JumpControls} from './examples/JumpControls';
 import {GoToForm} from './examples/GoToForm';
 import {HoistedModel} from './examples/HoistedModel';
+import {ResponsiveRange} from './examples/ResponsiveRange';
 import {RTL} from './examples/RTL';
 import {
   PaginationHoistedComponent,
@@ -92,6 +93,13 @@ the range.
 This example uses a custom range that allows you to control the width of the component.
 
 <ExampleCodeBlock code={CustomRange} />
+
+### Responsive Range
+
+In some situations, you might want to adjust Pagination's range based on the width of the container.
+You can use `useResizeObserver` to accomplish this as in the example below.
+
+<ExampleCodeBlock code={ResponsiveRange} />
 
 ## Components
 


### PR DESCRIPTION
## Summary

Fixes: #1965


## Release Category
Documentation

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [standard MDX template](https://github.com/Workday/canvas-kit/discussions/1131)

## For the Reviewer

This is a documentation-only change. We're adding an example for how to build a responsive range for Pagination with `useResizeObserver`.

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

`modules/react/pagination/stories/examples/ResponsiveRange.tsx`

## Areas for Feedback? (optional)

- [ ] Code
- [x] Documentation
- [ ] Testing
- [ ] Codemods

## Testing Manually

- Visit the [Storybook example](https://5d854c26ba934e0020f5e98a-cdabjimqxg.chromatic.com/?path=/docs/components-navigation-pagination-react--responsive-range)

## Screenshots or GIFs (if applicable)

![Pagination's range buttons adjusts responsively](http://g.recordit.co/eMdJws1Lvf.gif)

## Thank You Gif (optional)

A cat responding to the size of the container.

![a cat sitting in a bowl](https://media.giphy.com/media/v6aOjy0Qo1fIA/giphy.gif)
