### PR TITLE
fix: Storybook sidebar highlight styling

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -45,7 +45,9 @@
     color: #d7eafc;
   }
 
-  .sidebar-subheading button {
+  .sidebar-subheading button,
+  .sidebar-subheading span,
+  .sidebar-item span {
       color: #5e6a75;
   }
 

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -29,7 +29,7 @@
   #storybook-explorer-menu svg {
     color: #0875e1;
   }
-  #storybook-explorer-menu button[aria-expanded="true"],
+
   #storybook-explorer-menu button:focus,
   #storybook-explorer-menu a[data-selected]:hover {
     background-color: #a6d2ff;
@@ -45,7 +45,8 @@
     color: #d7eafc;
   }
 
-  .os-content button:hover {
+  .os-content button:hover,
+  .os-content button:focus {
     background-color: #a6d2ff;
     color: #0875e1;
   }

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -45,6 +45,10 @@
     color: #d7eafc;
   }
 
+  .sidebar-subheading button {
+      color: #5e6a75;
+  }
+
   .os-content button:hover,
   .os-content button:focus {
     background-color: #a6d2ff;


### PR DESCRIPTION
## Summary
**Current**
When folder was expanded it was highlighted despite it not being the current folder
<img width="349" alt="Screen Shot 2023-01-09 at 2 21 54 PM" src="https://user-images.githubusercontent.com/23533895/211410798-115755a4-9e47-4110-98e3-ca891afc7d32.png">

**Fix**
The current highlight will only be within the current story folder
<img width="290" alt="Screen Shot 2023-01-09 at 2 24 07 PM" src="https://user-images.githubusercontent.com/23533895/211411115-5b192cb5-d342-4a22-9b45-e9ae1ed8d0e3.png">

Subheading contrast fix
<img width="280" alt="Screen Shot 2023-01-09 at 2 48 04 PM" src="https://user-images.githubusercontent.com/23533895/211415251-eb7580c1-b59a-4682-80a5-1215e46bda27.png">

## Release Category
Infrastructure

## Thank You Gif (optional)

![I wanted to fix it](https://media.giphy.com/media/Ih6f3JK5YkZCY9azoQ/giphy-downsized-large.gif)
