### PR TITLE
fix: Allow overriding of return focus when closing a popup

### DIFF
--- a/cypress/integration/Popup.spec.ts
+++ b/cypress/integration/Popup.spec.ts
@@ -492,6 +492,17 @@ describe('Popup', () => {
           });
         });
       });
+
+      context('when the user closes the popup using the link', () => {
+        beforeEach(() => {
+          cy.findByTestId('focus-text-input-link').click();
+        });
+
+        it('should focus the "Name" input', () => {
+          cy.findByRole('button', {name: 'Open Popup'}).should('not.have.focus');
+          cy.findByLabelText('Name').should('have.focus');
+        });
+      });
     });
   });
 

--- a/modules/popup-stack/lib/PopupStack.ts
+++ b/modules/popup-stack/lib/PopupStack.ts
@@ -344,10 +344,7 @@ export const PopupStack = {
    * opt-in to toggling. Otherwise there is no way to opt-out of toggle behavior (because the target
    * is not inside `element`).
    */
-  contains(element: HTMLElement | null, eventTarget: Element | null): boolean {
-    if (!element || !eventTarget) {
-      return false;
-    }
+  contains(element: HTMLElement, eventTarget: HTMLElement): boolean {
     const stack = getTopStack();
     if (stack._adapter?.contains) {
       return stack._adapter.contains(element, eventTarget);

--- a/modules/popup-stack/lib/PopupStack.ts
+++ b/modules/popup-stack/lib/PopupStack.ts
@@ -344,7 +344,10 @@ export const PopupStack = {
    * opt-in to toggling. Otherwise there is no way to opt-out of toggle behavior (because the target
    * is not inside `element`).
    */
-  contains(element: HTMLElement, eventTarget: HTMLElement): boolean {
+  contains(element: HTMLElement | null, eventTarget: Element | null): boolean {
+    if (!element || !eventTarget) {
+      return false;
+    }
     const stack = getTopStack();
     if (stack._adapter?.contains) {
       return stack._adapter.contains(element, eventTarget);

--- a/modules/react/popup/lib/hooks/useReturnFocus.tsx
+++ b/modules/react/popup/lib/hooks/useReturnFocus.tsx
@@ -116,11 +116,13 @@ export const useReturnFocus = createElemPropsHook(usePopupModel)(model => {
         return;
       }
 
-      if (
-        (document.activeElement !== document.body &&
-          !PopupStack.contains(model.state.stackRef.current, document.activeElement)) ||
-        requiresFocusChangeRef.current
-      ) {
+      const activeElementOutsidePopupStack =
+        document.activeElement !== document.body &&
+        model.state.stackRef.current &&
+        document.activeElement instanceof HTMLElement &&
+        !PopupStack.contains(model.state.stackRef.current, document.activeElement);
+
+      if (activeElementOutsidePopupStack || requiresFocusChangeRef.current) {
         // We need to change focus _before_ the browser process the default action of picking a new
         // focus target. Doing this immediately prevents the `focus` event from firing on `element`,
         // but that's okay because the browser will change focus anyways.

--- a/modules/react/popup/lib/hooks/useReturnFocus.tsx
+++ b/modules/react/popup/lib/hooks/useReturnFocus.tsx
@@ -116,7 +116,11 @@ export const useReturnFocus = createElemPropsHook(usePopupModel)(model => {
         return;
       }
 
-      if (requiresFocusChangeRef.current) {
+      if (
+        (document.activeElement !== document.body &&
+          !PopupStack.contains(model.state.stackRef.current, document.activeElement)) ||
+        requiresFocusChangeRef.current
+      ) {
         // We need to change focus _before_ the browser process the default action of picking a new
         // focus target. Doing this immediately prevents the `focus` event from firing on `element`,
         // but that's okay because the browser will change focus anyways.
@@ -131,7 +135,14 @@ export const useReturnFocus = createElemPropsHook(usePopupModel)(model => {
 
       elementRef.current = null;
     };
-  }, [model.state.returnFocusRef, model.state.targetRef, visible, onMouseDown, onKeyDown]);
+  }, [
+    model.state.returnFocusRef,
+    model.state.targetRef,
+    visible,
+    onMouseDown,
+    onKeyDown,
+    model.state.stackRef,
+  ]);
 
   return {};
 });

--- a/modules/react/popup/stories/stories_testing.tsx
+++ b/modules/react/popup/stories/stories_testing.tsx
@@ -350,7 +350,7 @@ export const ReturnFocusTest = () => {
         <p style={{marginBottom: 400}}>Scroll down</p>
         <p>Scroll right and click on the button</p>
         <Popup model={model}>
-          <FormField label="Name" style={{marginLeft: 400}}>
+          <FormField inputId="return-focus-text-input" label="Name" style={{marginLeft: 400}}>
             <TextInput />
           </FormField>
           <Popup.Target style={{marginBottom: 400, marginLeft: 410}} data-testid="target">
@@ -365,6 +365,17 @@ export const ReturnFocusTest = () => {
                   <li>You click on the input</li>
                   <li>
                     You scroll the container so that less than half of the "Open Popup" is showing
+                  </li>
+                  <li>
+                    <TertiaryButton
+                      data-testid="focus-text-input-link"
+                      onClick={() => {
+                        model.events.hide();
+                        document.getElementById('return-focus-text-input').focus();
+                      }}
+                    >
+                      You click this link
+                    </TertiaryButton>
                   </li>
                 </ul>
               </Popup.Body>


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #1990 <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

Allows components to override which element focus is returned to when closing a popup. When not overridden, the default behaviour continues.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [standard MDX template](https://github.com/Workday/canvas-kit/discussions/1131)

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)
- [x] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [x] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

modules/react/popup/lib/hooks/useReturnFocus.tsx

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

<!-- Explain how your reviewer could verify this change  -->

The Testing/React/Popups/Popup/ReturnFocusTest story has been updated to include an example. Click on the link in the popup and see that focus is moved to the text input. When clicking anywhere else, existing focus move behaviour is preserved.
