### PR TITLE
ci: Adding action to auto assign PR reviewer on label [skip release]

### DIFF
--- a/.github/assign_label_reviewers.yml
+++ b/.github/assign_label_reviewers.yml
@@ -1,0 +1,2 @@
+assign:
+  ready_for_review: ['jamesfan', 'NicholasBoll', 'willklein', 'alanbsmith', 'mannycarrera4', 'josh-bagwell', 'RayRedGoose']

--- a/.github/workflows/pull-request-label-reviewer.yml
+++ b/.github/workflows/pull-request-label-reviewer.yml
@@ -1,0 +1,25 @@
+name: Pull Request Label Reviewers
+on:
+  pull_request:
+    types:
+      - unlabeled
+      - labeled
+
+jobs:
+  assign_and_unassign:
+    name: assign and unassign reviewers
+    runs-on: ubuntu-latest
+    steps:
+      - name: main
+        id: assign_reviewers
+        uses: totallymoney/assign-reviewers-by-labels-action@v1
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: assigned reviewers
+        if: steps.assign_reviewers.outputs.assigned_status == 'success'
+        run: |
+          echo "reviewers assigned: ${{ steps.reviewer.outputs.assigned_reviewers }}"
+      - name: unassigned reviewers
+        if: steps.assign_reviewers.outputs.unassigned_status == 'success'
+        run: |
+          echo "reviewers unassigned: ${{ steps.reviewer.outputs.unassigned_reviewers }}"

--- a/.github/workflows/pull-request-label-reviewer.yml
+++ b/.github/workflows/pull-request-label-reviewer.yml
@@ -1,6 +1,6 @@
 name: Pull Request Label Reviewers
 on:
-  pull_request:
+  pull_request_target:
     types:
       - unlabeled
       - labeled


### PR DESCRIPTION
## Summary

Adding new action that will auto assign a reviewer to the PR when the label `ready for review` has been added.

## Release Category
Infrastructure 

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [standard MDX template](https://github.com/Workday/canvas-kit/discussions/1131)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

Please see the [action documentation](https://github.com/totallymoney/assign-reviewers-by-labels-action) to verify the set up

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

.github/assign_label_reviewers.yml - this is the config
.github/workflows/pull-request-label-reviewer.yml - this is the action

## Thank You Gif (optional)

![aassignment](https://media.giphy.com/media/3o6MbnqpZBwWdWg3gk/giphy.gif)
