### PR TITLE
fix: Fixed an issue with codemod not recognizing VStack or HStack

### DIFF
--- a/modules/codemod/lib/softDeprecate/Stack/softDeprecateStack.ts
+++ b/modules/codemod/lib/softDeprecate/Stack/softDeprecateStack.ts
@@ -15,14 +15,9 @@ export default function transformer(file: FileInfo, api: API, options: Options) 
   root.find(j.ImportDeclaration, (nodePath: ImportDeclaration) => {
     const value = nodePath.source.value;
     // If there's an import from the stack package, set the import boolean check to true
-    if (value === stackPackage) {
-      hasStackImports = true;
-      return false;
-    }
-
     // If there's an import from the main package, check to see if Stack or Stackprops are among the named imports
     // e.g. import {Stack} from '@workday/canvas-kit-react/layout';
-    if (value === mainPackage) {
+    if (value === mainPackage || value === stackPackage) {
       (nodePath.specifiers || []).forEach(specifier => {
         if (
           (specifier.type === 'ImportSpecifier' &&

--- a/modules/codemod/lib/softDeprecate/Stack/softDeprecateStack.ts
+++ b/modules/codemod/lib/softDeprecate/Stack/softDeprecateStack.ts
@@ -154,6 +154,7 @@ export default function transformer(file: FileInfo, api: API, options: Options) 
   // Transform `<Stack spacing="l">` to `<Flex gap="l">`
   // Transform `<VStack spacing="l">` to `<Flex gap="l">`
   // Transform `<HStack spacing="l">` to `<Flex gap="l">`
+  // Transform `<Stack shouldWrapChildren>` to `<Flex >`
   root.find(j.JSXOpeningElement).forEach(nodePath => {
     if (nodePath.node.type === 'JSXOpeningElement') {
       if (nodePath.node.name.type === 'JSXIdentifier') {
@@ -163,21 +164,6 @@ export default function transformer(file: FileInfo, api: API, options: Options) 
               if (path.name.name === 'spacing') {
                 path.name.name = 'gap';
               }
-            }
-          });
-        }
-      }
-    }
-  });
-
-  // Transform Stack JSXElements
-  // Transform `<Stack shouldWrapChildren>` to `<Flex >`
-  root.find(j.JSXOpeningElement).forEach(nodePath => {
-    if (nodePath.node.type === 'JSXOpeningElement') {
-      if (nodePath.node.name.type === 'JSXIdentifier') {
-        if (stackImportNames.includes(nodePath.node.name.name)) {
-          nodePath.node.attributes?.forEach(path => {
-            if (path.type === 'JSXAttribute') {
               if (path.name.name === 'shouldWrapChildren') {
                 path.name.name = '';
               }

--- a/modules/codemod/lib/softDeprecate/Stack/softDeprecateStack.ts
+++ b/modules/codemod/lib/softDeprecate/Stack/softDeprecateStack.ts
@@ -157,20 +157,41 @@ export default function transformer(file: FileInfo, api: API, options: Options) 
 
   // Transform Stack JSXElements
   // Transform `<Stack spacing="l">` to `<Flex gap="l">`
-  root
-    .findJSXElements('Stack')
-    .find(j.JSXIdentifier, {name: 'spacing'})
-    .forEach(nodePath => {
-      nodePath.node.name = 'gap';
-    });
+  // Transform `<VStack spacing="l">` to `<Flex gap="l">`
+  // Transform `<HStack spacing="l">` to `<Flex gap="l">`
+  root.find(j.JSXOpeningElement).forEach(nodePath => {
+    if (nodePath.node.type === 'JSXOpeningElement') {
+      if (nodePath.node.name.type === 'JSXIdentifier') {
+        if (stackImportNames.includes(nodePath.node.name.name)) {
+          nodePath.node.attributes?.forEach(path => {
+            if (path.type === 'JSXAttribute') {
+              if (path.name.name === 'spacing') {
+                path.name.name = 'gap';
+              }
+            }
+          });
+        }
+      }
+    }
+  });
 
   // Transform Stack JSXElements
   // Transform `<Stack shouldWrapChildren>` to `<Flex >`
-  root
-    .findJSXElements('Stack')
-    .find(j.JSXIdentifier)
-    .filter(path => path.node.name === 'shouldWrapChildren')
-    .remove();
+  root.find(j.JSXOpeningElement).forEach(nodePath => {
+    if (nodePath.node.type === 'JSXOpeningElement') {
+      if (nodePath.node.name.type === 'JSXIdentifier') {
+        if (stackImportNames.includes(nodePath.node.name.name)) {
+          nodePath.node.attributes?.forEach(path => {
+            if (path.type === 'JSXAttribute') {
+              if (path.name.name === 'shouldWrapChildren') {
+                path.name.name = '';
+              }
+            }
+          });
+        }
+      }
+    }
+  });
 
   // Transform styled compoents
   // e.g. `const StyledStack = styled(Stack)({});`

--- a/modules/codemod/lib/softDeprecate/Stack/spec/softDeprecateStack.spec.ts
+++ b/modules/codemod/lib/softDeprecate/Stack/spec/softDeprecateStack.spec.ts
@@ -347,6 +347,54 @@ describe('Canvas Kit Deprecate Stack Codemod', () => {
       expectTransform(input, expected);
     });
 
+    it('should properly transform shouldWrapChildren identifiers', () => {
+      const input = `
+      import {HStack} from '@workday/canvas-kit-react/layout';
+
+      export const BasicStack = () => (
+        <HStack border="solid 2px" shouldWrapChildren>
+          Hello World
+        </HStack>
+      );
+      `;
+
+      const expected = `
+      import {Flex} from '@workday/canvas-kit-react/layout';
+
+      export const BasicStack = () => (
+        <Flex border="solid 2px" >
+          Hello World
+        </Flex>
+      );
+      `;
+
+      expectTransform(input, expected);
+    });
+
+    it('should properly transform shouldWrapChildren identifiers', () => {
+      const input = `
+      import {VStack} from '@workday/canvas-kit-react/layout';
+
+      export const BasicStack = () => (
+        <VStack border="solid 2px" shouldWrapChildren>
+          Hello World
+        </VStack>
+      );
+      `;
+
+      const expected = `
+      import {Flex} from '@workday/canvas-kit-react/layout';
+
+      export const BasicStack = () => (
+        <Flex border="solid 2px"  flexDirection="column">
+          Hello World
+        </Flex>
+      );
+      `;
+
+      expectTransform(input, expected);
+    });
+
     it('should properly transform spacing identifiers to gap', () => {
       const input = `
       import {Stack} from '@workday/canvas-kit-react/layout';
@@ -355,6 +403,54 @@ describe('Canvas Kit Deprecate Stack Codemod', () => {
         <Stack border="solid 2px" spacing="l">
           Hello World
         </Stack>
+      );
+      `;
+
+      const expected = `
+      import {Flex} from '@workday/canvas-kit-react/layout';
+
+      export const BasicStack = () => (
+        <Flex border="solid 2px" gap="l">
+          Hello World
+        </Flex>
+      );
+      `;
+
+      expectTransform(input, expected);
+    });
+
+    it('should properly transform spacing identifiers to gap', () => {
+      const input = `
+      import {VStack} from '@workday/canvas-kit-react/layout';
+
+      export const BasicStack = () => (
+        <VStack border="solid 2px" spacing="l">
+          Hello World
+        </VStack>
+      );
+      `;
+
+      const expected = `
+      import {Flex} from '@workday/canvas-kit-react/layout';
+
+      export const BasicStack = () => (
+        <Flex border="solid 2px" gap="l" flexDirection="column">
+          Hello World
+        </Flex>
+      );
+      `;
+
+      expectTransform(input, expected);
+    });
+
+    it('should properly transform spacing identifiers to gap', () => {
+      const input = `
+      import {HStack} from '@workday/canvas-kit-react/layout';
+
+      export const BasicStack = () => (
+        <HStack border="solid 2px" spacing="l">
+          Hello World
+        </HStack>
       );
       `;
 


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

This is a fix for the softDeprecate codemod for `Stack`, `HStack` and `VStack`. It was not recognizing the `spacing` prop on `HStack` and `VStack`. 

Fixes: #2035  <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

To fix the `softDepreacte/Stack` codemod to recognize the `spacing` prop on `HStack` and `VStack`. 

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Codemods

## For the Reviewer

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
`/modules/codemod/lib/softDeprecate/Stack/softDeprecateStack.ts`