### PR TITLE
fix: Fix useTooltip overriding targets aria-describedby value

### DIFF
--- a/modules/react/tooltip/lib/useTooltip.tsx
+++ b/modules/react/tooltip/lib/useTooltip.tsx
@@ -133,19 +133,33 @@ export function useTooltip<T extends Element = Element>({
 
   const visible = popupModel.state.visibility !== 'hidden';
 
+  const targetProps: {
+    'aria-describedby'?: string;
+    'aria-label'?: string;
+    onMouseEnter: typeof onOpenFromTarget;
+    onMouseLeave: typeof onHide;
+    onMouseDown: typeof onMouseDown;
+    onFocus: typeof onFocus;
+    onBlur: typeof onHide;
+  } = {
+    // This will replace the accessible name of the target element
+    'aria-label': type === 'label' ? titleText : undefined,
+    onMouseEnter: onOpenFromTarget,
+    onMouseLeave: onHide,
+    onMouseDown,
+    onFocus,
+    onBlur: onHide,
+  };
+
+  // Description added conditionally to avoid override of original description
+  if (type === 'describe' && visible) {
+    // extra description of the target element for assistive technology
+    targetProps['aria-describedby'] = id;
+  }
+
   return {
     /** Mix these properties into the target element. **Must be an Element** */
-    targetProps: {
-      // extra description of the target element for assistive technology
-      'aria-describedby': type === 'describe' && visible ? id : undefined,
-      // This will replace the accessible name of the target element
-      'aria-label': type === 'label' ? titleText : undefined,
-      onMouseEnter: onOpenFromTarget,
-      onMouseLeave: onHide,
-      onMouseDown,
-      onFocus,
-      onBlur: onHide,
-    },
+    targetProps,
     /** Mix these properties into the `Popper` component */
     popperProps: {
       open: visible,

--- a/modules/react/tooltip/spec/useTooltip.spec.tsx
+++ b/modules/react/tooltip/spec/useTooltip.spec.tsx
@@ -1,3 +1,4 @@
+
 import * as React from 'react';
 import {render, fireEvent} from '@testing-library/react';
 
@@ -8,7 +9,9 @@ const TooltipWithHook = ({type}: {type: 'label' | 'describe'}) => {
 
   return (
     <>
-      <button {...targetProps}>Hover</button>
+      <button aria-describedby="originalDescribedById" {...targetProps}>
+        Hover
+      </button>
       <TooltipContainer {...tooltipProps}>Tooltip Content</TooltipContainer>
     </>
   );
@@ -21,6 +24,14 @@ describe('useTooltip with type="label"', () => {
     const target = getByText('Hover');
 
     expect(target).toHaveAttribute('aria-label', 'Hover');
+  });
+
+  it('should keep original aria-describedby of target', () => {
+    const {getByText} = render(<TooltipWithHook type="label" />);
+
+    const target = getByText('Hover');
+
+    expect(target).toHaveAttribute('aria-describedby', 'originalDescribedById');
   });
 });
 


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes:  It is not possible to specify `aria-describedby` on a target element with any tooltip type, as `useTooltip `hook will override the value with `undefined`, even if tooltip is not providing its own value. Only `describe` type of tooltip should manipulate target `aria-describedby` value.

## Release Category
Components

### Release Note
`Tooltip` won't drop  `aria-describedby` prop of a target component unless a tooltip type is `describe`.

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [standard MDX template](https://github.com/Workday/canvas-kit/discussions/1131)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

`/modules/react/tooltip/lib/useTooltip.tsx` 


## Testing Manually

Add Tooltip to button component with `aria-describedby` value set. The original `aria-describedby` value should be set on element (previously it was dropped).