### PR TITLE
fix: Remove style attribute on Expandable Title

### DIFF
--- a/modules/labs-react/expandable/lib/ExpandableTitle.tsx
+++ b/modules/labs-react/expandable/lib/ExpandableTitle.tsx
@@ -18,13 +18,11 @@ export const ExpandableTitle = createComponent('div')({
       <Box
         as={Element}
         ref={ref}
-        padding={`2px ${space.zero} 2px`}
+        {...type.levels.body.medium}
+        fontWeight={type.properties.fontWeights.bold}
         color={colors.blackPepper400}
-        style={{
-          ...type.levels.body.medium,
-          fontWeight: type.properties.fontWeights.bold,
-          textAlign: 'left',
-        }}
+        padding={`2px ${space.zero} 2px`}
+        textAlign="left"
         {...elemProps}
       >
         {children}


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

<kbd>🐛 Bug Squish</kbd><kbd>🚤 Quick Fix</kbd>
  
## Summary

Fixes: #2073 <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

[ExpandableTitle has some styles in a style attr](https://github.com/Workday/canvas-kit/blob/755aa6f628c9f6a09a9a094e39296dba2e47e0cc/modules/labs-react/expandable/lib/ExpandableTitle.tsx#L24-L26). It is preventing css attribute overrides.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

### Release Note
Not explicitly a breaking change for `Expandable.Title`, but does alter the specificity for fontFamily, fontSize, lineHeight, fontWeight, color, and textAlign.

---

## Checklist

- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable


## Thank You Gif (optional)

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer! -->
![Spider-Man tagging a wall](https://media.giphy.com/media/69jG0VxZ2JgGVuUHAl/giphy.gif)
