### PR TITLE
fix(collection): Correctly use custom getId

### DIFF
--- a/modules/react/collection/lib/useCursorListModel.tsx
+++ b/modules/react/collection/lib/useCursorListModel.tsx
@@ -312,7 +312,7 @@ export const useCursorListModel = createModelHook({
   const columnCount = config.columnCount || 0;
   const list = useBaseListModel(config);
   const initialCurrentRef = React.useRef(
-    config.initialCursorId || (config.items?.length ? getId(config.items![0]) : '')
+    config.initialCursorId || (config.items?.length ? getId(list.state.items![0]) : '')
   );
   const navigation = config.navigation;
 

--- a/modules/react/collection/lib/useListItemRovingFocus.tsx
+++ b/modules/react/collection/lib/useListItemRovingFocus.tsx
@@ -62,11 +62,10 @@ const hasOwnKey = <T extends object>(obj: T, key: any): key is keyof T => obj.ha
  * @see https://www.w3.org/TR/wai-aria-practices/#kbd_roving_tabindex
  */
 export const useListItemRovingFocus = createElemPropsHook(useCursorListModel)(
-  ({state, events, getId, navigation}, ref, elemProps: {'data-id'?: string} = {}) => {
+  ({state, events, navigation}, ref, elemProps: {'data-id'?: string} = {}) => {
     // Tracks when this element has focus. If this item is removed while still focused, we have to
     // inform the model to move the cursor to the next item.
     const focusRef = React.useRef(false);
-    const getIdRef = React.useRef(getId);
 
     // Create a ref out of state. We don't want to watch state on unmount, so we use a ref to get the
     // current value at the time of unmounting. Otherwise, `state.items` would be a cached value of an
@@ -85,9 +84,7 @@ export const useListItemRovingFocus = createElemPropsHook(useCursorListModel)(
         }
         requestAnimationFrame(() => {
           document
-            .querySelector<HTMLElement>(
-              `[data-focus-id="${`${state.id}-${getIdRef.current(item)}`}"]`
-            )
+            .querySelector<HTMLElement>(`[data-focus-id="${`${state.id}-${item.id}`}"]`)
             ?.focus();
         });
 

--- a/modules/react/tabs/stories/examples/DynamicTabs.tsx
+++ b/modules/react/tabs/stories/examples/DynamicTabs.tsx
@@ -32,9 +32,9 @@ export const DynamicTabs = () => {
    * @param id The id of the item that will be removed
    */
   const removeItem = <T extends unknown>(id: string, model: ReturnType<typeof useTabsModel>) => {
-    const index = model.state.items.findIndex(item => model.getId(item) === model.state.cursorId);
+    const index = model.state.items.findIndex(item => item.id === model.state.cursorId);
     const nextIndex = index === model.state.items.length - 1 ? index - 1 : index + 1;
-    const nextId = model.getId(model.state.items[nextIndex]);
+    const nextId = model.state.items[nextIndex].id;
     if (model.state.selectedIds[0] === id) {
       // We're removing the currently selected item. Select next item
       model.events.select({id: nextId});


### PR DESCRIPTION
## Summary

Fix the custom list model to correctly use custom `getId` config. The BaseListModel creates `items` that are wrapped with extra metadata. `useListItemRovingFocus` will now use the wrapped item metadata correctly and `useCursorListModel` will set the correct cursorId

Fixes #2095 

## Release Category
Components

### Release Note
An example was incorrectly using the wrong id. Note that `state.items` in a dynamic collection wraps your provided items so there is a `.id` property on `state.items`. `model.getId` is no longer needed and will be removed in the future to avoid confusion.

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [standard MDX template](https://github.com/Workday/canvas-kit/discussions/1131)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)

## Areas for Feedback? (optional)
