### PR TITLE
fix: Extract the correct ref with a styled component

### DIFF
--- a/modules/react/common/lib/utils/components.ts
+++ b/modules/react/common/lib/utils/components.ts
@@ -32,6 +32,10 @@ type ExtractRef<T> = T extends undefined // test if T was even passed in
         ? U extends keyof ElementTagNameMap // test inferred U to see if it extends an element string
           ? ElementTagNameMap[U] // if yes, use the inferred U and convert to an element interface. `'button' => HTMLButtonElement`
           : U // if no, fall back to inferred U. Hopefully it is already an element interface
+        : T extends React.FC<{ref?: infer R}> // test if T extends a React functional component with a ref (Emotion's styled components do this)
+        ? R extends React.RefObject<infer E> // if yes, extract the element interface. This step unwraps the ref. Otherwise we'll get React.Ref<React.Ref<Element>>
+          ? E // if yes, use the inferred E
+          : never // never here prevents double refs. Basically the return would be React.Ref<E | {this value}>. I'm not entirely sure why...
         : T // if no, fall back to T. Hopefully it is already an element interface
     >;
 

--- a/modules/react/common/spec/components.test-d.tsx
+++ b/modules/react/common/spec/components.test-d.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import styled from '@emotion/styled';
 import {expectTypeOf} from 'expect-type';
 
 import {
@@ -61,6 +62,17 @@ describe('createComponent', () => {
 
     // No expectation, but the next line will fail if the ref signature isn't valid and it should be
     return <Component ref={ref} />;
+  });
+
+  it('should extract the correct ref of a styled component', () => {
+    const StyledComponent = styled('button')({});
+    const Component = createComponent(StyledComponent)({
+      Component(props, ref, Element) {
+        expectTypeOf(ref).toEqualTypeOf<React.Ref<HTMLButtonElement>>();
+
+        return null;
+      },
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

This change allows a styled component to be used as the default component in `createComponent`, `createContainer`, and `createSubcomponent`. Before the `ref` was not be extracted correctly. This mean the `ref` was incompatible with any other components.

## Release Category
Components

### Release Note

The following is now allowed:

```tsx
const StyledComponent = styled('button')({})

const MyComponnent = createComponent(StyledComponent)({
  Component(elemProps, ref, Element) {
    return <Box as={Element} ref={ref} {...elemProps} />
  }
})
```

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [standard MDX template](https://github.com/Workday/canvas-kit/discussions/1131)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable

## Where Should the Reviewer Start?

- `modules/react/common/lib/utils/components.ts`
- `modules/react/common/spec/components.test-d.tsx`

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Testing


