### PR TITLE
fix(menu): aria-disabled should not hide the menu

### DIFF
--- a/modules/react/collection/lib/useListItemSelect.tsx
+++ b/modules/react/collection/lib/useListItemSelect.tsx
@@ -9,12 +9,11 @@ export const useListItemSelect = createElemPropsHook(useListModel)(
     const name = elemProps['data-id'] || '';
     const onClick = (event: React.MouseEvent<HTMLElement>) => {
       if (
-        state.nonInteractiveIds.includes(name) ||
-        event.currentTarget.hasAttribute('aria-disabled')
+        !state.nonInteractiveIds.includes(name) &&
+        event.currentTarget.getAttribute('aria-disabled') !== 'true'
       ) {
-        return;
+        events.select({id: name});
       }
-      events.select({id: name});
     };
 
     return {onClick};

--- a/modules/react/menu/lib/MenuItem.tsx
+++ b/modules/react/menu/lib/MenuItem.tsx
@@ -97,7 +97,7 @@ const StyledItem = styled(Box.as('button'))<StyledType>(
         },
       },
       backgroundColor: 'inherit',
-      '&:disabled, &[aria-disabled]': {
+      '&:disabled, &[aria-disabled=true]': {
         color: colors.licorice100,
         cursor: 'default',
         '.wd-icon-fill, .wd-icon-accent, .wd-icon-accent2': {
@@ -158,7 +158,10 @@ export const useMenuItem = composeHooks(
         onClick:
           model.state.mode === 'single'
             ? (event: React.SyntheticEvent) => {
-                model.events.hide(event);
+                // only hide if the item isn't disabled
+                if (event.currentTarget.getAttribute('aria-disabled') !== 'true') {
+                  model.events.hide(event);
+                }
               }
             : undefined,
       };


### PR DESCRIPTION
## Summary

Don't close the menu when an `aria-disabled=true` element is selected. Also don't style `aria-disabled=false` as disabled.

Fixes #2121, #2116

## Release Category
Components

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [standard MDX template](https://github.com/Workday/canvas-kit/discussions/1131)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Documentation
- [ ] Testing
- [ ] Codemods

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

<!-- Explain how your reviewer could verify this change  -->

