### PR TITLE
fix: PopupCard maxHeight calc function

### DIFF
--- a/modules/react/popup/lib/PopupCard.tsx
+++ b/modules/react/popup/lib/PopupCard.tsx
@@ -71,9 +71,18 @@ export const PopupCard = createSubcomponent('div')({
     return getTransformFromPlacement(model.state.placement || 'bottom');
   }, [model.state.placement]);
 
+  const getMargin = (margin?: string | number) => {
+    if (margin) {
+      const result = space[margin as CanvasSpaceKeys];
+      // Get the top margin from "25px 50px" or "10px 15px 20px" format.
+      const marginTop = typeof margin === 'string' ? margin.split(' ')[0] : margin;
+      return result ? result : marginTop;
+    }
+    return space.xl;
+  };
+
   // As is a Flex that will render an element of `Element`
   const As = useConstant(() => Flex.as(Element));
-
   return (
     <StyledPopupCard
       as={As}
@@ -84,9 +93,7 @@ export const PopupCard = createSubcomponent('div')({
       flexDirection="column"
       minHeight={0}
       padding="m"
-      maxHeight={`calc(100vh - ${
-        elemProps.margin ? space[elemProps.margin as CanvasSpaceKeys] || elemProps.margin : space.xl
-      } * 2)`}
+      maxHeight={`calc(100vh - ${getMargin(elemProps.margin)} * 2)`}
       overflowY="auto"
       {...type.levels.subtext.large}
       {...elemProps}

--- a/modules/react/popup/lib/PopupCard.tsx
+++ b/modules/react/popup/lib/PopupCard.tsx
@@ -70,7 +70,7 @@ function getSpace(value?: string | number) {
   }
 }
 
-function getMaxHeight(margin: PopupCardProps['margin']) {
+function getMaxHeight(margin?: string | number) {
   // set the default margin offset to space.xl
   let marginOffset: string | number = space.xl;
 

--- a/modules/react/popup/lib/PopupCard.tsx
+++ b/modules/react/popup/lib/PopupCard.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {keyframes} from '@emotion/react';
 
 import {Card} from '@workday/canvas-kit-react/card';
-import {space, type, CanvasSpaceKeys} from '@workday/canvas-kit-react/tokens';
+import {space, type} from '@workday/canvas-kit-react/tokens';
 import {
   styled,
   TransformOrigin,
@@ -62,6 +62,35 @@ const StyledPopupCard = styled(Card)<
   };
 });
 
+function getSpace(value?: string | number) {
+  if (value && value in space) {
+    return space[value as keyof typeof space];
+  } else {
+    return value;
+  }
+}
+
+function getMaxHeight(margin: PopupCardProps['margin']) {
+  // set the default margin offset to space.xl
+  let marginOffset: string | number = space.xl;
+
+  if (margin) {
+    // parse the margin prop
+    if (typeof margin === 'string') {
+      const marginValues = margin.split(' ');
+      const marginTop = getSpace(marginValues[0]);
+      // If provided, use the specific margin-bottom in the shorthand, otherwise use the margin-top value
+      const marginBottom = getSpace(marginValues[2]) || marginTop;
+
+      marginOffset = `(${marginTop} + ${marginBottom})`;
+    } else {
+      // if margin is a number, double it to get the offset
+      marginOffset = `${margin * 2}px`;
+    }
+  }
+  return `calc(100vh - ${marginOffset})`;
+}
+
 export const PopupCard = createSubcomponent('div')({
   displayName: 'Popup.Card',
   modelHook: usePopupModel,
@@ -70,16 +99,6 @@ export const PopupCard = createSubcomponent('div')({
   const transformOrigin = React.useMemo(() => {
     return getTransformFromPlacement(model.state.placement || 'bottom');
   }, [model.state.placement]);
-
-  const getMargin = (margin?: string | number) => {
-    if (margin) {
-      const result = space[margin as CanvasSpaceKeys];
-      // Get the top margin from "25px 50px" or "10px 15px 20px" format.
-      const marginTop = typeof margin === 'string' ? margin.split(' ')[0] : margin;
-      return result ? result : marginTop;
-    }
-    return space.xl;
-  };
 
   // As is a Flex that will render an element of `Element`
   const As = useConstant(() => Flex.as(Element));
@@ -93,7 +112,7 @@ export const PopupCard = createSubcomponent('div')({
       flexDirection="column"
       minHeight={0}
       padding="m"
-      maxHeight={`calc(100vh - ${getMargin(elemProps.margin)} * 2)`}
+      maxHeight={getMaxHeight(elemProps.margin)}
       overflowY="auto"
       {...type.levels.subtext.large}
       {...elemProps}


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #1919 <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

Fixed the bug in PopUpCard where multiple margin value broke `maxHeight` calculation.


<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [standard MDX template](https://github.com/Workday/canvas-kit/discussions/1131)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Documentation
- [ ] Testing
- [ ] Codemods
