### PR TITLE
fix(codemod): Pass codemod options to jscodeshift script

### DIFF
--- a/modules/codemod/README.md
+++ b/modules/codemod/README.md
@@ -1,6 +1,7 @@
 # Canvas Kit Codemods
 
-This package is designed to help you migrate between major versions of Canvas Kit and adopt API changes. 
+This package is designed to help you migrate between major versions of Canvas Kit and adopt API
+changes.
 
 ## Usage
 
@@ -13,13 +14,18 @@ Commands (transforms):
   canvas-kit-codemod v5 [path]  Canvas Kit v4 > v5 migration transform
 
 Options:
-  -v, --version  Show version number                                   [boolean]
-  -h, --help     Show help                                             [boolean]
+  --ignore-config,  Ignore files if they match patterns sourced from a config file [string]
+  --ignore-pattern, Ignore files that match a provided glob expression             [string] [default: **/node_modules/**]
+  --verbose,        Show more information about the transform process              [number] [choices: 0, 1, 2] [default: 0]
+  -v, --version     Show version number                                            [boolean]
+  -h, --help        Show help                                                      [boolean]
 ```
 
-> Note: These codemods only work on .js, .jsx, .ts, and .tsx extensions. You may need to make some manual changes in other file types (.json, .mdx, .md, etc.).
+> Note: These codemods only work on .js, .jsx, .ts, and .tsx extensions. You may need to make some
+> manual changes in other file types (.json, .mdx, .md, etc.).
 
-> Note: You may need to run your linter after executing the codemod, as it's resulting formatting (spacing, quotes, etc.) may not match your project's styling.
+> Note: You may need to run your linter after executing the codemod, as it's resulting formatting
+> (spacing, quotes, etc.) may not match your project's styling.
 
 ## Installation
 
@@ -28,4 +34,34 @@ Alternatively, you can install the codemod package and run it without npx.
 ```sh
 > yarn add @workday/canvas-kit-codemod
 > canvas-kit-codemod <transform> [path]
+```
+
+## Options
+
+### Ignore Config
+
+If you'd like to provide a configuration for files to ignore instead of a glob, use
+`--ignore-config`.
+
+```sh
+> canvas-kit-codemod <transform> [path] --ignore-config=.gitignore
+```
+
+### Ignore Pattern
+
+If you'd like to provide a glob to ignore files, use `--ignore-pattern`. By default, this is set to
+ignore all `node_modules` directories.
+
+```sh
+> canvas-kit-codemod <transform> [path] --ignore-pattern=**/dist/**
+```
+
+### Verbose
+
+If you'd like to have more verbose logging to know which files are being parsed, use `--verbose`. By
+default this is set to `0`.
+
+```sh
+# See all files being parsed
+> canvas-kit-codemod <transform> [path] --verbose=2
 ```

--- a/modules/codemod/index.js
+++ b/modules/codemod/index.js
@@ -4,9 +4,27 @@
 const {spawn} = require('child_process');
 const chalk = require('chalk');
 
-const {_: commands, path} = require('yargs')
+const {_: commands, path, ignoreConfig, ignorePattern, verbose } = require('yargs')
   .scriptName('canvas-kit-codemod')
   .usage(chalk.bold.blueBright('$0 <transform> [path]'))
+  .options({
+    'ignore-config': {
+      type: 'string',
+      describe: 'Ignore files if they match patterns sourced from a configuration file (e.g. a .gitignore)',
+      default: '',
+    },
+    'ignore-pattern': {
+      type: 'string',
+      describe: 'Ignore files that match a provided glob expression (e.g. **/dist/**)',
+      default: '**/node_modules/**',
+    },
+    verbose: {
+      type: 'number',
+      describe: 'Show more information about the transform process',
+      default: 0,
+      choices: [0, 1, 2]
+    },
+  })
   .command('v5 [path]', chalk.gray('Canvas Kit v4 > v5 migration transform'), yargs => {
     yargs.positional('path', {
       type: 'string',
@@ -60,10 +78,12 @@ const {_: commands, path} = require('yargs')
   .help().argv;
 
 const transform = commands[0];
-console.log(transform, path);
+// Only add an ignore-config if one is provided
+const ignoreConfigArg = ignoreConfig ? `--ignore-config=${ignoreConfig}` : '';
+console.log(ignorePattern)
 
 console.log(chalk.blueBright(`\nApplying ${transform} transform to '${path}'\n`));
-const args = `-t ${__dirname}/dist/es6/${transform} ${path} --parser tsx --extensions js,jsx,ts,tsx`.split(
+const args = `-t ${__dirname}/dist/es6/${transform} ${path} --parser tsx --extensions js,jsx,ts,tsx ${ignoreConfigArg} --ignore-pattern=${ignorePattern} --verbose=${verbose}`.split(
   ' '
 );
 


### PR DESCRIPTION
## Summary

Fixes: #2136

The codemod was ignoring valid JSCodeshift options that are helpful to optimize the script. This patch allows `--ignore-pattern`, `--ignore-config`, and `--verbose` to be passed through. I also set the codemod to ignore `node_modules` directories by default and updated the docs.

## Release Category

Codemods

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [standard MDX template](https://github.com/Workday/canvas-kit/discussions/1131)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Documentation
- [ ] Testing
- [x] Codemods

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

There's not a great way to test this manually, but if the codemod tests pass, it works. I added the output of running this updated script in another consumer repo to show that it works as expected.

## Screenshots or GIFs (if applicable)

```sh
 🐠  yarn canvas-kit-codemod v5 src/ --ignore-config=".gitignore" --verbose=2                                                                                                         (base)
yarn run v1.22.19
$ /../../node_modules/.bin/canvas-kit-codemod v5 src/ --ignore-config=.gitignore --verbose=2

Applying v5 transform to 'src/'

Processing 660 files...

...

All done.

Results:
0 errors
660 unmodified
0 skipped
0 ok

Time elapsed: 15.310seconds
```

## Thank You Gif (optional)

![a smiling Shiba Inu typing on a laptop](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif)
