### PR TITLE
ci: Replace install steps by composite actions

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -6,7 +6,6 @@ on:
       - prerelease/*
   workflow_dispatch: # Allow manual triggering of this job in case of failures
 
-
 jobs:
   canary:
     runs-on: ubuntu-latest
@@ -15,49 +14,14 @@ jobs:
       ## First, we'll checkout the repository. We don't persist credentials because we need a
       ## Personal Access Token to push on a branch that is protected. See
       ## https://github.com/cycjimmy/semantic-release-action#basic-usage
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           persist-credentials: false
           fetch-depth: 0 # Used for conventional commit ranges
 
-      - name: Get Cypress Version
-        id: cypress-version
-        run: echo "::set-output name=version::$(node utils/get-cypress-version.js)"
-
-      ## This step installs node and sets up several matchers (regex matching for Github
-      ## Annotations). See
-      ## https://github.com/actions/setup-node/blob/25316bbc1f10ac9d8798711f44914b1cf3c4e954/src/main.ts#L58-L65
-      - uses: actions/setup-node@v2.4.0
+      - uses: Workday/canvas-kit-actions/install@v1
         with:
-          node-version: 14.x
-          registry-url: https://registry.npmjs.org
-
-      ## The caching steps create a cache key based on the OS and hash of the yarn.lock file. A
-      ## cache hit will copy files from Github cache into the `node_modules` and `.cache/cypress`
-      ## folders. A cache hit will skip the cache steps
-      - name: Cache node modules
-        id: yarn-cache
-        uses: actions/cache@v1
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-hash-${{ hashFiles('yarn.lock') }}
-
-      - name: Cache Cypress
-        id: cypress-cache
-        uses: actions/cache/@v1
-        with:
-          path: .cache/cypress
-          key: ${{ runner.os }}-cypress-cache-version-${{ steps.cypress-version.outputs.version }}
-
-      ## If both `node_modules` and `.cache/cypress` were cache hits, we're going to skip the `yarn
-      ## install` step. This effectively saves up to 3m on a cache hit build.
-      - name: Install Packages
-        if:
-          steps.yarn-cache.outputs.cache-hit != 'true' || steps.cypress-cache.outputs.cache-hit !=
-          'true'
-        run: yarn install --production=false
-        env:
-          CYPRESS_CACHE_FOLDER: .cache/cypress
+          node_version: 16.x
 
       ## Build Storybook and extract component stories for Storybook aggregation. This will be used
       ## for Chromatic rebaselining and publishing to GH Pages. Should be before `yarn build` since
@@ -77,14 +41,15 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_CI_PUBLISH_TOKEN}}
           SLACK_WEBHOOK: ${{secrets.SLACK_WEBHOOK}}
-          BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BUILD_URL:
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       ## Create a Chromatic baseline auto-accepting changes. Chromatic changes are already accepted
       ## in PRs, so we don't need to manually approve them here again. This new baseline will be
       ## used for future PRs. New PRs may show extra Chromatic changes until the "Update Branch"
       ## button is used in PRs which will pull this new baseline.
       - name: Update Chromatic Baseline
-        uses: chromaui/action@v1
+        uses: chromaui/action@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: ${{ secrets.CHROMATIC_APP_CODE }}

--- a/.github/workflows/forward-merge.yml
+++ b/.github/workflows/forward-merge.yml
@@ -19,18 +19,20 @@ jobs:
     #   the release workflow will commit a release commit starting with `chore: Release ...` back to
     #   the branch and this job will run on that commit instead. Also, forward merges that skipped
     #   a release
-    if: "((github.ref_name == 'support' || github.ref_name == 'master') && startsWith(github.event.head_commit.message, 'chore: Release')) || startsWith(github.ref_name, 'prerelease/') || contains(github.event.head_commit.message, '[skip release]')"
+    if:
+      "((github.ref_name == 'support' || github.ref_name == 'master') &&
+      startsWith(github.event.head_commit.message, 'chore: Release')) || startsWith(github.ref_name,
+      'prerelease/') || contains(github.event.head_commit.message, '[skip release]')"
     runs-on: ubuntu-latest
     outputs: # Output branch names for the make-pull-request job
       branch: ${{steps.extract-branch.outputs.branch}}
       next-branch: ${{steps.extract-next-branch.outputs.branch}}
 
     steps:
-
       ## First, we'll checkout the repository. We don't persist credentials because we need a
       ## Personal Access Token to push on a branch that is protected. See
       ## https://github.com/cycjimmy/semantic-release-action#basic-usage
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           persist-credentials: false
           fetch-depth: 0 # Needed to do merges
@@ -49,44 +51,9 @@ jobs:
           echo "::set-output name=branch::$(node utils/get-forward-merge-branch.js)"
           echo ${{steps.extract-next-branch.outputs.branch}}
 
-      ## This step installs node and sets up several matchers (regex matching for Github
-      ## Annotations). See
-      ## https://github.com/actions/setup-node/blob/25316bbc1f10ac9d8798711f44914b1cf3c4e954/src/main.ts#L58-L65
-      - uses: actions/setup-node@v2.4.0
+      - uses: Workday/canvas-kit-actions/install@v1
         with:
-          node-version: 14.x
-          registry-url: https://registry.npmjs.org
-
-      - name: Get Cypress Version
-        id: cypress-version
-        run: echo "::set-output name=version::$(node utils/get-cypress-version.js)"
-
-      ## The caching steps create a cache key based on the OS and hash of the yarn.lock file. A
-      ## cache hit will copy files from Github cache into the `node_modules` and `.cache/cypress`
-      ## folders. A cache hit will skip the cache steps
-      - name: Cache node modules
-        id: yarn-cache
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-hash-${{ hashFiles('yarn.lock') }}
-
-      - name: Cache Cypress
-        id: cypress-cache
-        uses: actions/cache/@v2
-        with:
-          path: .cache/cypress
-          key: ${{ runner.os }}-cypress-cache-version-${{ steps.cypress-version.outputs.version }}
-
-      ## If both `node_modules` and `.cache/cypress` were cache hits, we're going to skip the `yarn
-      ## install` step. This effectively saves up to 3m on a cache hit build.
-      - name: Install Packages
-        if:
-          steps.yarn-cache.outputs.cache-hit != 'true' || steps.cypress-cache.outputs.cache-hit !=
-          'true'
-        run: yarn install --production=false
-        env:
-          CYPRESS_CACHE_FOLDER: .cache/cypress
+          node_version: 16.x
 
       ## A `yarn bump` will create a commit and a tag. We need to set up the git user to do this.
       ## We'll make that user be the github-actions user.
@@ -127,7 +94,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ github.sha }}
 
       - name: Visual Tests
-        uses: chromaui/action@v1
+        uses: chromaui/action@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           appCode: dlpro96xybh
@@ -213,4 +180,3 @@ jobs:
             You must then force-push the branch and the CI will rerun verification.
 
             Use the `automerge` label like normal and the CI will pick the correct merge strategy.
-

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,56 +9,22 @@ jobs:
       cypress-version: ${{ steps.cypress-version.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+
+      - uses: Workday/canvas-kit-actions/install@v1
         with:
-          node-version: 14.x
-
-      - name: Get Cypress Version
-        id: cypress-version
-        run: echo "::set-output name=version::$(node utils/get-cypress-version.js)"
-
-      - name: Cache Cypress
-        id: cypress-cache
-        uses: actions/cache/@v2
-        with:
-          path: .cache/cypress
-          key: ${{ runner.os }}-cypress-cache-version-${{ steps.cypress-version.outputs.version }}
-
-      - name: Cache node modules
-        id: yarn-cache
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-hash-${{ hashFiles('yarn.lock') }}
-
-      - name: Install Packages
-        if:
-          steps.yarn-cache.outputs.cache-hit != 'true' || steps.cypress-cache.outputs.cache-hit !=
-          'true'
-        run: yarn install --production=false
-        env:
-          CYPRESS_CACHE_FOLDER: .cache/cypress
+          node_version: 16.x
 
   check:
     runs-on: ubuntu-latest
     needs: 'install'
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
+      - uses: actions/checkout@v3
 
-      - uses: actions/cache/@v2
+      - uses: Workday/canvas-kit-actions/install@v1
         with:
-          path: .cache/cypress
-          key: ${{ runner.os }}-cypress-cache-version-${{ needs.install.outputs.cypress-version }}
-
-      - uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-hash-${{ hashFiles('yarn.lock') }}
+          node_version: 16.x
 
       # Keep steps separate for Github Actions annotation matching: https://github.com/actions/setup-node/blob/83c9f7a7df54d6b57455f7c57ac414f2ae5fb8de/src/setup-node.ts#L26-L33
       - name: Lint
@@ -78,27 +44,18 @@ jobs:
     needs: 'install'
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
+      - uses: actions/checkout@v3
 
-      - uses: actions/cache/@v2
+      - uses: Workday/canvas-kit-actions/install@v1
         with:
-          path: .cache/cypress
-          key: ${{ runner.os }}-cypress-cache-version-${{ needs.install.outputs.cypress-version }}
-
-      - uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-hash-${{ hashFiles('yarn.lock') }}
+          node_version: 16.x
 
       - name: Build Storybook
         run: yarn build-storybook --quiet
 
       - name: Cache Build
         id: build-cache
-        uses: actions/cache/@v2
+        uses: actions/cache@v3
         with:
           path: docs
           key: ${{ runner.os }}-build-${{ github.sha }}
@@ -108,30 +65,21 @@ jobs:
     needs: 'build'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Required to retrieve git history
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
 
-      - uses: actions/cache/@v2
+      - uses: Workday/canvas-kit-actions/install@v1
         with:
-          path: .cache/cypress
-          key: ${{ runner.os }}-cypress-cache-version-${{ needs.install.outputs.cypress-version }}
-
-      - uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-hash-${{ hashFiles('yarn.lock') }}
+          node_version: 16.x
 
       - name: Restore Build
-        uses: actions/cache/@v2
+        uses: actions/cache@v3
         with:
           path: docs
           key: ${{ runner.os }}-build-${{ github.sha }}
 
-      - uses: chromaui/action@v1
+      - uses: chromaui/action@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           appCode: dlpro96xybh
@@ -151,22 +99,13 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0 # Required to retrieve git history
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
 
-      - uses: actions/cache/@v2
+      - uses: Workday/canvas-kit-actions/install@v1
         with:
-          path: .cache/cypress
-          key: ${{ runner.os }}-cypress-cache-version-${{ needs.install.outputs.cypress-version }}
-
-      - uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-hash-${{ hashFiles('yarn.lock') }}
+          node_version: 16.x
 
       - name: Restore Build
-        uses: actions/cache/@v2
+        uses: actions/cache@v3
         with:
           path: docs
           key: ${{ runner.os }}-build-${{ github.sha }}


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #2107 <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

Canary build is failed because storybook requires node 16. Composite action `install` already updated to use node 16. 
After refactoring `release` and `minor-release` actions, we can replace hard-coded install steps (caching and packages install) by calling the composite action. It allows cleaning repeated steps to increase code readability and to make action maintenance easier in situations like this failure. 

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Infrastructure