### PR TITLE
fix(form-field): Forward required prop to input

### DIFF
--- a/cypress/integration/FormField.spec.ts
+++ b/cypress/integration/FormField.spec.ts
@@ -54,8 +54,8 @@ describe('Form Field', () => {
       cy.checkA11y();
     });
 
-    it('the asterisk should a title attribute set to "required"', () => {
-      cy.get('abbr').should('have.attr', 'title', 'required');
+    it('the input should have a "required" attribute', () => {
+      cy.findByRole('textbox', {name: 'Email'}).should('have.attr', 'required');
     });
   });
 });

--- a/modules/react/form-field/lib/FormField.tsx
+++ b/modules/react/form-field/lib/FormField.tsx
@@ -166,6 +166,10 @@ class FormField extends React.Component<FormFieldProps> {
         }
       }
 
+      if (this.props.required) {
+        props.required = true;
+      }
+
       props.id = this.inputId;
 
       return React.cloneElement(child, props);

--- a/modules/react/form-field/lib/Label.tsx
+++ b/modules/react/form-field/lib/Label.tsx
@@ -15,7 +15,7 @@ export interface LabelProps extends FormFieldLabelPositionBehavior {
    */
   isLegend?: boolean;
   /**
-   * The id of a labelable form-related element. Synonymous with `for`.
+   * The id of the form-related element. Synonymous with `for`.
    */
   htmlFor?: string;
   /**
@@ -24,8 +24,9 @@ export interface LabelProps extends FormFieldLabelPositionBehavior {
    */
   required?: boolean;
   /**
-   * The title of the required label.
-   * @default required
+   * The required label is not visible to screen readers and should have no label. This prop will be
+   * ignored.
+   * @deprecated
    */
   requiredLabel?: string;
   /**
@@ -62,7 +63,7 @@ const labelStyles = [
   },
 ];
 
-const RequiredAstrisk = styled('abbr')({
+const RequiredAsterisk = styled('abbr')({
   color: colors.cinnamon500,
   fontSize: '16px',
   fontWeight: 400,
@@ -95,16 +96,16 @@ class Label extends React.Component<LabelProps> {
     const {
       labelPosition = Label.Position.Top,
       isLegend = false,
-      requiredLabel = 'required',
+      required,
       ...elemProps
     } = this.props;
-    const children = !this.props.required
+    const children = !required
       ? this.props.children
       : [
           this.props.children,
-          <RequiredAstrisk key={'0'} title={requiredLabel}>
+          <RequiredAsterisk key={'0'} aria-hidden>
             *
-          </RequiredAstrisk>,
+          </RequiredAsterisk>,
         ];
     return (
       <>

--- a/modules/react/form-field/spec/FormField.spec.tsx
+++ b/modules/react/form-field/spec/FormField.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {render} from '@testing-library/react';
+import {screen, render} from '@testing-library/react';
 import FormField from '../lib/FormField';
 import {ErrorType} from '@workday/canvas-kit-react/common';
 
@@ -36,15 +36,26 @@ describe('FormField', () => {
   });
 
   describe('when rendered as required', () => {
-    it('should add a required element to the label to indicate that it is required', () => {
+    it('should add a required attribute to the input', () => {
       const label = 'Label';
-      const {getByText} = render(
+      render(
         <FormField label={label} required={true}>
           <input type="text" />
         </FormField>
       );
 
-      expect(getByText('*')).toHaveAttribute('title', 'required');
+      expect(screen.getByRole('textbox', {name: 'Label'})).toHaveAttribute('required');
+    });
+
+    it('should render an asterisk', () => {
+      const label = 'Label';
+      render(
+        <FormField label={label} required={true}>
+          <input type="text" />
+        </FormField>
+      );
+
+      expect(screen.getByText('*')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #2051

## Release Category
Components

---

## Checklist

- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Testing Manually

Go to the Required stories of "Form Field", "TextInput" and "TextArea". Verify the `label` does not have a `required` attribute, verify the `input` does have a required attribute, and the `abbr` has an `aria-hidden="true"` attribute. 

## Screenshots or GIFs (if applicable)

<img width="258" alt="image" src="https://user-images.githubusercontent.com/338257/233746679-8f195495-b25a-4178-ae52-315a45be5c3d.png">

