### PR TITLE
docs: Fix Preview Table docs

### DIFF
--- a/modules/preview-react/table/stories/Table.stories.mdx
+++ b/modules/preview-react/table/stories/Table.stories.mdx
@@ -25,34 +25,31 @@ yarn add @workday/canvas-kit-preview-react
 
 ### Basic Example
 
-Users may not want to use a `caption` so they can import
-[Heading](/docs/components-text-heading--basic) or [Text](/docs/components-text-text--basic)
-instead. This will give the user more flexibility around the customization of the title/heading of
-their table.
+Users may not want to use a `caption` so they can import [Heading](/components/text/heading/) or
+[Text](/components/text/text/) instead. This will give the user more flexibility around the
+customization of the title/heading of their table.
 
 <ExampleCodeBlock code={BasicWithHeading} />
 
 ### Example with Container
 
-Users may want to have some padding around the `table` and have inset dividers for their rows. This
+Users may want to add padding around the `table` and have inset dividers for their rows. This
 showcases how a user can achieve this with creating a styled component to wrap the `table`.
 
 <ExampleCodeBlock code={TableWithContainer} />
 
 ### Example with Caption
 
-We built a simple table that includes a `caption` without a Heading. A `caption` is not required but
-it is good for
+Users are free to use a `caption` instead of a heading. A `caption` is not required but it is good
+for
 [accessibility](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table#accessibility_concerns)
 purposes.
 
 <ExampleCodeBlock code={Basic} />
 
-### Fixed Column with TableContainer
+### Fixed Column
 
-Users may want to have some padding surrounding their table and have a fixed column. They can use
-the `TableContainer` to wrap the `Table` component and some styles to make it so that the left
-column is fixed.
+Users may add styles to the `Table.Header` to render a fixed column.
 
 <ExampleCodeBlock code={FixedColumn} />
 

--- a/modules/preview-react/table/stories/Table.stories.mdx
+++ b/modules/preview-react/table/stories/Table.stories.mdx
@@ -49,7 +49,9 @@ purposes.
 
 ### Fixed Column
 
-Users may add styles to the `Table.Header` to render a fixed column.
+Users may add styles to the `Table.Header` to render a fixed column. The example below assigns a
+`width` to the `Table` to guarantee the fixed column is triggered, but you are free to omit the
+`width` if you would only like the fixed column to be triggered if necessary.
 
 <ExampleCodeBlock code={FixedColumn} />
 

--- a/modules/preview-react/table/stories/examples/BasicWithHeading.tsx
+++ b/modules/preview-react/table/stories/examples/BasicWithHeading.tsx
@@ -6,7 +6,9 @@ import {Heading} from '@workday/canvas-kit-react/text';
 export const BasicWithHeading = () => {
   return (
     <>
-      <Heading size="small">Pizza Toppings</Heading>
+      <Heading size="small" marginBottom="s">
+        Pizza Toppings
+      </Heading>
       <Table>
         <Table.Head>
           <Table.Row>

--- a/modules/preview-react/table/stories/examples/FixedColumn.tsx
+++ b/modules/preview-react/table/stories/examples/FixedColumn.tsx
@@ -75,7 +75,9 @@ export const FixedColumn = () => {
   ];
   return (
     <>
-      <Heading size="small">Performance Car Specs</Heading>
+      <Heading size="small" marginBottom="s">
+        Performance Car Specs
+      </Heading>
       <Table>
         <Table.Head>
           <Table.Row>

--- a/modules/preview-react/table/stories/examples/FixedColumn.tsx
+++ b/modules/preview-react/table/stories/examples/FixedColumn.tsx
@@ -78,7 +78,7 @@ export const FixedColumn = () => {
       <Heading size="small" marginBottom="s">
         Performance Car Specs
       </Heading>
-      <Table>
+      <Table width={690}>
         <Table.Head>
           <Table.Row>
             <Table.Header

--- a/modules/preview-react/table/stories/examples/TableWithContainer.tsx
+++ b/modules/preview-react/table/stories/examples/TableWithContainer.tsx
@@ -18,7 +18,9 @@ const Container = styled(Box)({
 export const TableWithContainer = () => {
   return (
     <>
-      <Heading size="small">Pizza Toppings</Heading>
+      <Heading size="small" marginBottom="s">
+        Pizza Toppings
+      </Heading>
       <Container>
         <Table border="none">
           <Table.Head>


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #2158 <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->
Fixes a few issues with the Preview Table docs when consuming the docs on the Canvas Site.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Documentation
---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [standard MDX template](https://github.com/Workday/canvas-kit/discussions/1131)
- [x] Label `ready for review` has been added to PR