### PR TITLE
fix: Add react-dom peer-dep to main package

### DIFF
--- a/modules/react/package.json
+++ b/modules/react/package.json
@@ -41,7 +41,8 @@
     "workday"
   ],
   "peerDependencies": {
-    "react": "^16.8 || ^17.0"
+    "react": "^16.8 || ^17.0",
+    "react-dom": "^16.8 || ^17.0"
   },
   "dependencies": {
     "@emotion/is-prop-valid": "^1.1.1",


### PR DESCRIPTION
## Summary

Fixes: #2161

## Release Category

Dependencies

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [standard MDX template](https://github.com/Workday/canvas-kit/discussions/1131)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

`@workday/canvas-kit-react/popup` depends on `react-dom`, but it wasn't listed as a peer dependency. This PR fixes that.


- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Areas for Feedback? (optional)

- [ ] Code
- [ ] Documentation
- [ ] Testing
- [ ] Codemods

## Thank You Gif (optional)

![a smiling Shiba Inu typing on a laptop](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif)
