### PR TITLE
feat: Add 'as' method with a stable reference to all component utilities

### DIFF
--- a/modules/react/common/lib/utils/components.ts
+++ b/modules/react/common/lib/utils/components.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import {assert} from './assert';
+import {memoize} from './memoize';
 import {mergeProps} from './mergeProps';
 import {Model} from './models';
 
@@ -317,6 +318,16 @@ export const createContainer = <
     });
     ReturnedComponent.displayName = displayName;
 
+    // The `any`s are here because `ElementComponent` takes care of the `as` type and the
+    // `ReturnComponent` type is overridden
+    (ReturnedComponent as any).as = memoize(
+      (as: any) =>
+        createContainer(as)({displayName, subComponents, modelHook, elemPropsHook})(
+          Component as any
+        ),
+      as => as
+    );
+
     // Cast as `any`. We have already specified the return type. Be careful making changes to this
     // file due to this `any` `ReturnedComponent` is a `React.ForwardRefExoticComponent`, but we want
     // it to be either an `Component` or `ElementComponent`
@@ -425,6 +436,16 @@ export const createSubcomponent = <
       ReturnedComponent.displayName = displayName;
     }
 
+    // The `any`s are here because `ElementComponent` takes care of the `as` type and the
+    // `ReturnComponent` type is overridden
+    (ReturnedComponent as any).as = memoize(
+      (as: any) =>
+        createSubcomponent(as)({displayName, subComponents, modelHook, elemPropsHook})(
+          Component as any
+        ),
+      as => as
+    );
+
     // Cast as `any`. We have already specified the return type. Be careful making changes to this
     // file due to this `any` `ReturnedComponent` is a `React.ForwardRefExoticComponent`, but we want
     // it to be either an `Component` or `ElementComponent`
@@ -510,8 +531,10 @@ export const createComponent = <
 
   // The `any`s are here because `ElementComponent` takes care of the `as` type and the
   // `ReturnComponent` type is overridden
-  (ReturnedComponent as any).as = (as: any) =>
-    createComponent(as)({displayName, Component, subComponents});
+  (ReturnedComponent as any).as = memoize(
+    (as: any) => createComponent(as)({displayName, Component, subComponents}),
+    as => as
+  );
 
   // Cast as `any`. We have already specified the return type. Be careful making changes to this
   // file due to this `any` `ReturnedComponent` is a `React.ForwardRefExoticComponent`, but we want

--- a/modules/react/common/spec/components.spec.tsx
+++ b/modules/react/common/spec/components.spec.tsx
@@ -12,6 +12,9 @@ import {
   createHook,
   Model,
   BehaviorHook,
+  createContainer,
+  createSubcomponent,
+  createModelHook,
 } from '@workday/canvas-kit-react/common';
 
 describe('createComponent', () => {
@@ -97,12 +100,86 @@ describe('createComponent', () => {
   it('should render whatever element is passed through the "as" prop', () => {
     const Component = createComponent('div')({
       displayName: 'Test',
-      Component: (props, ref, Element) => <Element data-testid="test" />,
+      Component: (props, ref, Element) => <Element data-testid="test" {...props} />,
     });
 
     render(<Component as="button" />);
 
     expect(screen.getByTestId('test')).toHaveProperty('tagName', 'BUTTON');
+  });
+
+  it('should provide an `as` method that changes the default element', () => {
+    const Component = createComponent('div')({
+      displayName: 'Test',
+      Component: (props, ref, Element) => <Element data-testid="test" {...props} />,
+    });
+
+    const ButtonComponent = Component.as('button');
+
+    render(<ButtonComponent />);
+
+    expect(screen.getByTestId('test')).toHaveProperty('tagName', 'BUTTON');
+  });
+
+  it('should provide a stable reference `as` method to aid in component render functions without needing to use other hooks', () => {
+    const Component = createComponent('div')({
+      displayName: 'Test',
+      Component: (props, ref, Element) => <Element data-testid="test" {...props} />,
+    });
+
+    expect(Component.as('button')).toBe(Component.as('button'));
+  });
+});
+
+describe('createContainer', () => {
+  const modelHook = createModelHook({})(() => ({state: {}, events: {}}));
+
+  it('should provide an `as` method that changes the default element', () => {
+    const Component = createContainer('div')({
+      displayName: 'Test',
+      modelHook,
+    })((props, Element) => <Element data-testid="test" {...props} />);
+
+    const ButtonComponent = Component.as('button');
+
+    render(<ButtonComponent />);
+
+    expect(screen.getByTestId('test')).toHaveProperty('tagName', 'BUTTON');
+  });
+
+  it('should provide a stable reference `as` method to aid in component render functions without needing to use other hooks', () => {
+    const Component = createContainer('div')({
+      displayName: 'Test',
+      modelHook,
+    })((props, Element) => <Element data-testid="test" {...props} />);
+
+    expect(Component.as('button')).toBe(Component.as('button'));
+  });
+});
+
+describe('createSubcomponent', () => {
+  const modelHook = createModelHook({})(() => ({state: {}, events: {}}));
+
+  it('should provide an `as` method that changes the default element', () => {
+    const Component = createSubcomponent('div')({
+      displayName: 'Test',
+      modelHook,
+    })((props, Element) => <Element data-testid="test" {...props} />);
+
+    const ButtonComponent = Component.as('button');
+
+    render(<ButtonComponent />);
+
+    expect(screen.getByTestId('test')).toHaveProperty('tagName', 'BUTTON');
+  });
+
+  it('should provide a stable reference `as` method to aid in component render functions without needing to use other hooks', () => {
+    const Component = createSubcomponent('div')({
+      displayName: 'Test',
+      modelHook,
+    })((props, Element) => <Element data-testid="test" {...props} />);
+
+    expect(Component.as('button')).toBe(Component.as('button'));
   });
 });
 


### PR DESCRIPTION
## Summary

The `.as()` method on components can be very useful to extend, but change the default element of a component.

```tsx
// with `styled` - It is a `Box` component, but will render a `<button>` by default instead of a `<div>`
const Button = styled(Box.as('button'))(styles)

// inside a render function since `.as()` is a stable reference
const Button = () => {
  const BoxButton = Box.as('button')
  
  return <BoxButton />
}

// for tricky composition with multiple as...
return <InputGroup.Input as={FormField.Input.as(Combobox.Input)} />
```

This change does 2 things:
1. Add `.as()` to `createContainer` and `createSubcomponent` components
2. Makes the `.as()` of all 3 component utility functions return a stable reference using `memoize`

## Release Category
Components

---

## Checklist

- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Testing

