### PR TITLE
chore: Add option to skip docgen

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,6 +4,8 @@ const createCompiler = require('@storybook/addon-docs/mdx-compiler-plugin');
 const modulesPath = path.resolve(__dirname, '../modules');
 const getSpecifications = require('../modules/docs/utils/get-specifications');
 
+const processDocs = process.env.SKIP_DOCGEN !== 'true';
+
 module.exports = {
   stories: [
     '../modules/docs/mdx/**/*.mdx',
@@ -27,34 +29,84 @@ module.exports = {
   },
   webpackFinal: async config => {
     // Get the specifications object and replace with a real object in the spec.ts file
-    const specs = await getSpecifications();
+    if (processDocs) {
+      const specs = await getSpecifications();
 
+      config.module.rules.push({
+        test: /.ts$/,
+        include: [path.resolve(__dirname, '../modules/docs')],
+        use: [
+          {
+            loader: require.resolve('string-replace-loader'),
+            options: {
+              search: '[/* SPEC_FILES_REPLACE_BY_WEBPACK */]',
+              replace: JSON.stringify(specs, null, '  '),
+            },
+          },
+        ],
+      });
+
+      // Load the source code of story files to display in docs.
+      config.module.rules.push({
+        test: /stories.*\.tsx?$/,
+        include: [modulesPath],
+        loaders: [
+          {
+            loader: require.resolve('@storybook/source-loader'),
+            options: {parser: 'typescript'},
+          },
+        ],
+        enforce: 'pre',
+      });
+
+      config.module.rules.push({
+        test: /.+\.tsx?$/,
+        include: [modulesPath],
+        exclude: /examples|stories|spec|codemod|docs/,
+        loaders: [
+          {
+            loader: path.resolve(__dirname, 'symbol-doc-loader'),
+          },
+        ],
+        enforce: 'pre',
+      });
+    }
+
+    // Convert mdx links to point to github
     /**
      * This was added to tell webpack not to parse the typescript.js file in node_modules and suppress these warnings:
      * WARN Module not found: Error: Can't resolve 'perf_hooks' in 'node_modules/typescript/lib'
      * WARN resolve 'perf_hooks' in 'node_modules/typescript/lib
-     * 
+     *
      * These warnings relate to this open GitHub issue: https://github.com/microsoft/TypeScript/issues/39436
      * If you no longer see these warnings when this is config is removed, you can safely delete this config.
-    */ 
-    config.module = {
-      ...config.module,
-      // This solution was taken from this comment: https://github.com/microsoft/TypeScript/issues/39436#issuecomment-817029140
-      noParse: [require.resolve('typescript/lib/typescript.js')],
-    }
+    */
+    config.module.noParse: [require.resolve('typescript/lib/typescript.js')],
 
     config.module.rules.push({
-      test: /.ts$/,
-      include: [path.resolve(__dirname, '../modules/docs')],
+      test: /\.mdx?$/,
+      include: [path.resolve(__dirname, '..')],
+      exclude: [/node_modules/],
       use: [
         {
-          loader: require.resolve('string-replace-loader'),
-          options: {
-            search: '[/* SPEC_FILES_REPLACE_BY_WEBPACK */]',
-            replace: JSON.stringify(specs, null, '  '),
-          },
+          loader: path.resolve(__dirname, 'webpack-loader-redirect-mdx-to-github'),
+        },
+        {
+          loader: path.resolve(__dirname, 'mdx-code-block-rewrite'),
         },
       ],
+    });
+
+    // Load the whole example code of story files to display in docs.
+    config.module.rules.push({
+      test: /examples\/.*\.tsx?$/,
+      include: [modulesPath],
+      loaders: [
+        {
+          loader: path.resolve(__dirname, 'whole-source-loader'),
+        },
+      ],
+      enforce: 'pre',
     });
 
     /**
@@ -75,58 +127,6 @@ module.exports = {
     mdxRule.use.find(loader => loader.loader.includes('mdx1-csf')).options['compilers'] = [
       createCompiler({}),
     ];
-
-    // Convert mdx links to point to github
-    config.module.rules.push({
-      test: /\.mdx?$/,
-      include: [path.resolve(__dirname, '..')],
-      exclude: [/node_modules/],
-      use: [
-        {
-          loader: path.resolve(__dirname, 'webpack-loader-redirect-mdx-to-github'),
-        },
-        {
-          loader: path.resolve(__dirname, 'mdx-code-block-rewrite'),
-        },
-      ],
-    });
-
-    // Load the source code of story files to display in docs.
-    config.module.rules.push({
-      test: /stories.*\.tsx?$/,
-      include: [modulesPath],
-      loaders: [
-        {
-          loader: require.resolve('@storybook/source-loader'),
-          options: {parser: 'typescript'},
-        },
-      ],
-      enforce: 'pre',
-    });
-
-    // Load the whole example code of story files to display in docs.
-    config.module.rules.push({
-      test: /examples\/.*\.tsx?$/,
-      include: [modulesPath],
-      loaders: [
-        {
-          loader: path.resolve(__dirname, 'whole-source-loader'),
-        },
-      ],
-      enforce: 'pre',
-    });
-
-    config.module.rules.push({
-      test: /.+\.tsx?$/,
-      include: [modulesPath],
-      exclude: /examples|stories|spec|codemod|docs/,
-      loaders: [
-        {
-          loader: path.resolve(__dirname, 'symbol-doc-loader'),
-        },
-      ],
-      enforce: 'pre',
-    });
 
     // Load our scss files with postscss.
     // Note: This is the same as @storybook/preset-scss, but with postcss added.

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -80,8 +80,8 @@ module.exports = {
      *
      * These warnings relate to this open GitHub issue: https://github.com/microsoft/TypeScript/issues/39436
      * If you no longer see these warnings when this is config is removed, you can safely delete this config.
-    */
-    config.module.noParse: [require.resolve('typescript/lib/typescript.js')],
+     */
+    config.module.noParse = [require.resolve('typescript/lib/typescript.js')];
 
     config.module.rules.push({
       test: /\.mdx?$/,
@@ -143,14 +143,6 @@ module.exports = {
       ],
       include: modulesPath,
     });
-
-    // Remove progress updates to reduce log lines in Travis
-    // See: https://github.com/storybookjs/storybook/issues/2029
-    if (process.env.TRAVIS) {
-      config.plugins = config.plugins.filter(
-        plugin => plugin.constructor.name !== 'ProgressPlugin'
-      );
-    }
 
     return config;
   },


### PR DESCRIPTION
## Summary

Adds a `SKIP_DOCGEN=true` option to Storybook to get Storybook to load faster by skipping all docgen. This is nice when you want to work only on the component and get faster feedback. The Docgen adds about 2s on all hot module reloading.

The MDX doc will still work, but all `SymbolDoc` calls will not return any useful content.

## Release Category
Infrastructure

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [standard MDX template](https://github.com/Workday/canvas-kit/discussions/1131)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

Storybook's `main.js` file

## Areas for Feedback? (optional)

- [x] Code
- [x] Documentation

## Testing Manually

Run `SKIP_DOCGEN=true yarn start`
