### PR TITLE
fix: Return the correct props from composeHooks

### DIFF
--- a/modules/docs/mdx/9.0-UPGRADE-GUIDE.mdx
+++ b/modules/docs/mdx/9.0-UPGRADE-GUIDE.mdx
@@ -29,6 +29,7 @@ any questions.
 - [Utility Updates](#utility-updates)
   - [useTheme and getTheme](#usetheme-and-gettheme)
   - [useThemedRing](#usethemedring)
+  - [composeHooks](#composehooks)
 - [Glossary](#glossary)
   - [Main](#main)
   - [Preview](#preview)
@@ -257,6 +258,38 @@ recommend using
 instead.
 
 ---
+
+### composeHooks
+
+The `composeHooks` types are now accurate. Before the types were incorrectly merged to equal `{}`.
+This also affects components created using `createContainer` or `createSubcomponent`. The
+`elemProps` type interface will now reflect all the incoming props from the hook properly. If you
+get an error when passing `elemProps` from a hook using `composeHooks`, you may get a Typescript
+error. Sometimes returning a generic object widens types and style or JSX attributes are more
+strict. This can cause problems with JSX attributes like `position` which expects values like
+`'relative' | 'absolute'` and doesn't accept a string.
+
+For example:
+
+```ts
+return {
+  position: 'relative',
+}; // { 'position': string }
+```
+
+Typescript doesn't know that this object interface cannot be mutated, so it will widen the
+`position` type to a `string` which is now allowed when you pass the prop list to a JSX element.
+You'll have to add an `as const` to either the property or the whole object to force Typescript to
+narrow the type.
+
+```ts
+return {
+  position: 'relative' as const, // forces the type to be `'relative'` instead of `string`
+} as const; // OR add `as const` here to narrow the whole object.
+```
+
+`as const` instructs Typescript the type is `readonly`. Typescript knows readonly values or objects
+cannot be changed and will therefore narrow the type for you.
 
 ## Token Updates
 

--- a/modules/docs/mdx/9.0-UPGRADE-GUIDE.mdx
+++ b/modules/docs/mdx/9.0-UPGRADE-GUIDE.mdx
@@ -277,7 +277,7 @@ return {
 }; // { 'position': string }
 ```
 
-Typescript doesn't know that this object interface cannot be mutated, so it will widen the
+TypeScript doesn't know that this object interface cannot be mutated, so it will widen the
 `position` type to a `string` which is now allowed when you pass the prop list to a JSX element.
 You'll have to add an `as const` to either the property or the whole object to force Typescript to
 narrow the type.

--- a/modules/react/common/lib/utils/components.ts
+++ b/modules/react/common/lib/utils/components.ts
@@ -705,7 +705,7 @@ export function createSubModelElemPropsHook<M extends () => Model<any, any>>(mod
   };
 }
 
-/** Simplify and speedup inference by capturing types in the signature itself */
+/** Simplify and speed up inference by capturing types in the signature itself */
 interface BaseHook<M extends Model<any, any>, O extends {}> {
   /**
    * Capture the model type in TypeScript only. Do not use in runtime!

--- a/modules/react/common/lib/utils/components.ts
+++ b/modules/react/common/lib/utils/components.ts
@@ -714,7 +714,7 @@ interface BaseHook<M extends Model<any, any>, O extends {}> {
    */
   __model: M;
   /**
-   * Capture the hook's output type in Typescript only. Do not use in runtime! This is used to cache
+   * Capture the hook's output type in TypeScript only. Do not use in runtime! This is used to cache
    * and speed up the output types during inference
    *
    * @private

--- a/modules/react/common/lib/utils/components.ts
+++ b/modules/react/common/lib/utils/components.ts
@@ -708,21 +708,21 @@ export function createSubModelElemPropsHook<M extends () => Model<any, any>>(mod
 /** Simplify and speedup inference by capturing types in the signature itself */
 interface BaseHook<M extends Model<any, any>, O extends {}> {
   /**
-   * Capture the model type in Typescript only. Do not use in runtime!
+   * Capture the model type in TypeScript only. Do not use in runtime!
    *
    * @private
    */
   __model: M;
   /**
    * Capture the hook's output type in Typescript only. Do not use in runtime! This is used to cache
-   * and speedup the output types during inference
+   * and speed up the output types during inference
    *
    * @private
    */
   __output: O;
 }
 
-// Typescript function parameters are contravariant while return types are covariant. This is a
+// TypeScript function parameters are contravariant while return types are covariant. This is a
 // problem when someone hands us a model that correctly extends `Model<any, any>`, but adds extra
 // properties to the model. So `M extends Model<any, any>`. But the `BehaviorHook` is the return
 // type which will reverse the direction which is no longer true: `Model<any, any> extends M`. In

--- a/modules/react/common/lib/utils/components.ts
+++ b/modules/react/common/lib/utils/components.ts
@@ -583,9 +583,7 @@ export const createComponent = <
  * })
  * ```
  */
-export const createElemPropsHook = <
-  TModelHook extends (config: any) => {state: Record<string, any>; events: Record<string, any>}
->(
+export const createElemPropsHook = <TModelHook extends (config: any) => Model<any, any>>(
   modelHook: TModelHook
 ) => <PO extends {}, PI extends {}>(
   fn: (
@@ -596,17 +594,20 @@ export const createElemPropsHook = <
     elemProps?: PI
   ) => PO
 ): BehaviorHook<
-  TModelHook extends (config: any) => infer TModel
-    ? TModel
-    : {state: Record<string, any>; events: Record<string, any>},
+  TModelHook extends (config: any) => infer TModel ? TModel : Model<any, any>,
   PO
-> => (model, elemProps, ref) => {
-  const props = mergeProps(fn(model, ref, elemProps || ({} as any)), elemProps || ({} as any));
-  if (!props.hasOwnProperty('ref') && ref) {
-    // This is the weird "incoming ref isn't in props, but outgoing ref is in props" thing
-    props.ref = ref;
-  }
-  return props;
+> => {
+  return ((model, elemProps, ref) => {
+    const props = mergeProps(fn(model, ref, elemProps || ({} as any)), elemProps || ({} as any));
+    if (!props.hasOwnProperty('ref') && ref) {
+      // This is the weird "incoming ref isn't in props, but outgoing ref is in props" thing
+      props.ref = ref;
+    }
+    return props;
+  }) as BehaviorHook<
+    TModelHook extends (config: any) => infer TModel ? TModel : Model<any, any>,
+    PO
+  >;
 };
 
 /**
@@ -646,26 +647,26 @@ export const createElemPropsHook = <
 export const createHook = <M extends Model<any, any>, PO extends {}, PI extends {}>(
   fn: (model: M, ref?: React.Ref<any>, elemProps?: PI) => PO
 ): BehaviorHook<M, PO> => {
-  return (model, elemProps, ref) => {
+  return ((model, elemProps, ref) => {
     const props = mergeProps(fn(model, ref, elemProps || ({} as any)), elemProps || ({} as any));
     if (!props.hasOwnProperty('ref') && ref) {
       // This is the weird "incoming ref isn't in props, but outgoing ref is in props" thing
       props.ref = ref;
     }
     return props;
-  };
+  }) as BehaviorHook<M, PO>;
 };
 
 /**
- * @deprecated use `subModel` instead
+ * @deprecated use `createSubModelElemPropsHook` instead
  */
 export const subModelHook = <M extends Model<any, any>, SM extends Model<any, any>, O extends {}>(
   fn: (model: M) => SM,
   hook: BehaviorHook<SM, O>
 ): BehaviorHook<M, O> => {
-  return (model: M, props: any, ref: React.Ref<any>) => {
+  return ((model: M, props: any, ref: React.Ref<any>) => {
     return hook(fn(model), props, ref);
-  };
+  }) as BehaviorHook<M, O>;
 };
 
 /**
@@ -698,10 +699,27 @@ export function createSubModelElemPropsHook<M extends () => Model<any, any>>(mod
     fn: (model: ReturnType<M>) => SM,
     elemPropsHook: BehaviorHook<SM, O>
   ): BehaviorHook<ReturnType<M>, O> => {
-    return (model: ReturnType<M>, props: any, ref: React.Ref<any>) => {
+    return ((model: ReturnType<M>, props: any, ref: React.Ref<any>) => {
       return elemPropsHook(fn(model), props, ref);
-    };
+    }) as BehaviorHook<ReturnType<M>, O>;
   };
+}
+
+/** Simplify and speedup inference by capturing types in the signature itself */
+interface BaseHook<M extends Model<any, any>, O extends {}> {
+  /**
+   * Capture the model type in Typescript only. Do not use in runtime!
+   *
+   * @private
+   */
+  __model: M;
+  /**
+   * Capture the hook's output type in Typescript only. Do not use in runtime! This is used to cache
+   * and speedup the output types during inference
+   *
+   * @private
+   */
+  __output: O;
 }
 
 // Typescript function parameters are contravariant while return types are covariant. This is a
@@ -718,13 +736,11 @@ export function createSubModelElemPropsHook<M extends () => Model<any, any>>(mod
  * A BehaviorHook is a React hook that takes a model, elemProps, and a ref and returns props and
  * attributes to apply to an element or component.
  */
-export type BehaviorHook<M extends Model<any, any>, O extends {}> = {
-  bivarianceHack<P extends {}, R>(
-    model: M,
-    elemProps?: P,
-    ref?: React.Ref<R>
-  ): O & P & (R extends HTMLOrSVGElement ? {ref: React.Ref<R>} : {});
-}['bivarianceHack'];
+export interface BehaviorHook<M extends Model<any, any>, O extends {}> extends BaseHook<M, O> {
+  <P extends {}, R>(model: M, elemProps?: P, ref?: React.Ref<R>): O &
+    P &
+    (R extends HTMLOrSVGElement ? {ref: React.Ref<R>} : {});
+}
 
 function setRef<T>(ref: React.Ref<T> | undefined, value: T): void {
   if (ref) {
@@ -889,51 +905,80 @@ export function useModelContext<T>(
  * props {a: 'useHook1', b: 'useHook2', c: 'foo'}
  * ```
  */
-export function composeHooks<M extends Model<any, any>, O1 extends {}, O2 extends {}>(
-  hook1: BehaviorHook<M, O1>,
-  hook2: BehaviorHook<M, O2>
-): BehaviorHook<M, O1 & O2>;
-
-export function composeHooks<
-  M extends Model<any, any>,
-  O1 extends {},
-  O2 extends {},
-  O3 extends {}
->(
-  hook1: BehaviorHook<M, O1>,
-  hook2: BehaviorHook<M, O2>,
-  hook3: BehaviorHook<M, O3>
-): BehaviorHook<M, O1 & O2 & O3>;
-export function composeHooks<
-  M extends Model<any, any>,
-  O1 extends {},
-  O2 extends {},
-  O3 extends {},
-  O4 extends {}
->(
-  hook1: BehaviorHook<M, O1>,
-  hook2: BehaviorHook<M, O2>,
-  hook3: BehaviorHook<M, O3>,
-  hook4: BehaviorHook<M, O4>
-): BehaviorHook<M, O1 & O2 & O3 & O4>;
-export function composeHooks<
-  M extends Model<any, any>,
-  O1 extends {},
-  O2 extends {},
-  O3 extends {},
-  O4 extends {},
-  O5 extends {}
->(
-  hook1: BehaviorHook<M, O1>,
-  hook2: BehaviorHook<M, O2>,
-  hook3: BehaviorHook<M, O3>,
-  hook4: BehaviorHook<M, O4>,
-  hook5: BehaviorHook<M, O5>
-): BehaviorHook<M, O1 & O2 & O3 & O4 & O5>;
-export function composeHooks<M extends Model<any, any>, R, P extends {}, O extends {}>(
-  ...hooks: ((model: M, props: P, ref: React.Ref<R>) => O)[]
+export function composeHooks<H1, H2, H3, H4>(
+  hook1: H1,
+  hook2: H2
+): H1 extends BaseHook<infer M, infer O1>
+  ? H2 extends BaseHook<any, infer O2>
+    ? BehaviorHook<M, O1 & O2>
+    : never
+  : never;
+export function composeHooks<H1, H2, H3, H4>(
+  hook1: H1,
+  hook2: H2,
+  hook3: H3
+): H1 extends BaseHook<infer M, infer O1>
+  ? H2 extends BaseHook<any, infer O2>
+    ? H3 extends BaseHook<any, infer O3>
+      ? BehaviorHook<M, O1 & O2 & O3>
+      : never
+    : never
+  : never;
+export function composeHooks<H1, H2, H3, H4>(
+  hook1: H1,
+  hook2: H2,
+  hook3: H3,
+  hook4: H4
+): H1 extends BaseHook<infer M, infer O1>
+  ? H2 extends BaseHook<any, infer O2>
+    ? H3 extends BaseHook<any, infer O3>
+      ? H4 extends BaseHook<any, infer O4>
+        ? BehaviorHook<M, O1 & O2 & O3 & O4>
+        : never
+      : never
+    : never
+  : never;
+export function composeHooks<H1, H2, H3, H4, H5>(
+  hook1: H1,
+  hook2: H2,
+  hook3: H3,
+  hook4: H4,
+  hook5: H5
+): H1 extends BaseHook<infer M, infer O1>
+  ? H2 extends BaseHook<any, infer O2>
+    ? H3 extends BaseHook<any, infer O3>
+      ? H4 extends BaseHook<any, infer O4>
+        ? H5 extends BaseHook<any, infer O5>
+          ? BehaviorHook<M, O1 & O2 & O3 & O4 & O5>
+          : never
+        : never
+      : never
+    : never
+  : never;
+export function composeHooks<H1, H2, H3, H4, H5, H6>(
+  hook1: H1,
+  hook2: H2,
+  hook3: H3,
+  hook4: H4,
+  hook5: H5,
+  hook6: H6
+): H1 extends BaseHook<infer M, infer O1>
+  ? H2 extends BaseHook<any, infer O2>
+    ? H3 extends BaseHook<any, infer O3>
+      ? H4 extends BaseHook<any, infer O4>
+        ? H5 extends BaseHook<any, infer O5>
+          ? H6 extends BaseHook<any, infer O6>
+            ? BehaviorHook<M, O1 & O2 & O3 & O4 & O5 & O6>
+            : never
+          : never
+        : never
+      : never
+    : never
+  : never;
+export function composeHooks<M extends Model<any, any>, P extends {}, O extends {}>(
+  ...hooks: ((model: M, props: P, ref: React.Ref<unknown>) => O)[]
 ): BehaviorHook<M, O> {
-  return (model, props, ref) => {
+  return ((model, props, ref) => {
     const returnProps = [...hooks].reverse().reduce((props: any, hook) => {
       return hook(model, props, props.ref || ref);
     }, props);
@@ -944,5 +989,5 @@ export function composeHooks<M extends Model<any, any>, R, P extends {}, O exten
     }
 
     return returnProps;
-  };
+  }) as BehaviorHook<M, O>;
 }

--- a/modules/react/common/spec/components.spec.tsx
+++ b/modules/react/common/spec/components.spec.tsx
@@ -405,9 +405,17 @@ describe('composeHooks', () => {
   });
 
   it('should merge properties from both hooks', () => {
+    const hook1 = createHook(() => {
+      return {hook1: ''};
+    });
+    const hook2 = createHook(() => {
+      return {hook2: ''};
+    });
     const props = composeHooks(hook1, hook2)(myModel, {}, null);
     expect(props).toHaveProperty('hook1', 'hook1');
     expect(props).toHaveProperty('hook2', 'hook2');
+
+    expectTypeOf(props).toEqualTypeOf<{hook1: string; hook2: string}>();
   });
 
   it('should overwrite props of the first hook with props from the second hook', () => {

--- a/modules/react/common/spec/components.spec.tsx
+++ b/modules/react/common/spec/components.spec.tsx
@@ -405,17 +405,9 @@ describe('composeHooks', () => {
   });
 
   it('should merge properties from both hooks', () => {
-    const hook1 = createHook(() => {
-      return {hook1: 'hook1'};
-    });
-    const hook2 = createHook(() => {
-      return {hook2: 'hook2'};
-    });
     const props = composeHooks(hook1, hook2)(myModel, {}, null);
     expect(props).toHaveProperty('hook1', 'hook1');
     expect(props).toHaveProperty('hook2', 'hook2');
-
-    expectTypeOf(props).toEqualTypeOf<{hook1: string; hook2: string}>();
   });
 
   it('should overwrite props of the first hook with props from the second hook', () => {
@@ -516,6 +508,117 @@ describe('composeHooks', () => {
         expectTypeOf(ref).toEqualTypeOf<React.LegacyRef<Component1>>();
         return <div />;
       },
+    });
+  });
+
+  describe('composeHooks types', () => {
+    const hook1 = createHook(() => ({hook1: ''}));
+    const hook2 = createHook(() => ({hook2: ''}));
+    const hook3 = createHook(() => ({hook3: ''}));
+    const hook4 = createHook(() => ({hook4: ''}));
+    const hook5 = createHook(() => ({hook5: ''}));
+    const hook6 = createHook(() => ({hook6: ''}));
+
+    it('should return the correct prop interface for 2 hooks', () => {
+      const props = composeHooks(hook1, hook2)(myModel, {});
+
+      type Expected = {hook1: string; hook2: string};
+
+      expectTypeOf(props).toEqualTypeOf<Expected>();
+    });
+
+    it('should return the correct prop interface for 2 hooks with incoming props', () => {
+      const props = composeHooks(hook1, hook2)(myModel, {foo: ''});
+
+      type Expected = {hook1: string; hook2: string; foo: string};
+
+      expectTypeOf(props).toEqualTypeOf<Expected>();
+    });
+
+    it('should return the correct prop interface for 2 hooks', () => {
+      const props = composeHooks(hook1, hook2, hook3)(myModel, {});
+
+      type Expected = {hook1: string; hook2: string; hook3: string};
+
+      expectTypeOf(props).toEqualTypeOf<Expected>();
+    });
+
+    it('should return the correct prop interface for 2 hooks with incoming props', () => {
+      const props = composeHooks(hook1, hook2, hook3)(myModel, {foo: ''});
+
+      type Expected = {hook1: string; hook2: string; hook3: string; foo: string};
+
+      expectTypeOf(props).toEqualTypeOf<Expected>();
+    });
+
+    it('should return the correct prop interface for 2 hooks', () => {
+      const props = composeHooks(hook1, hook2, hook3, hook4)(myModel, {});
+
+      type Expected = {hook1: string; hook2: string; hook3: string; hook4: string};
+
+      expectTypeOf(props).toEqualTypeOf<Expected>();
+    });
+
+    it('should return the correct prop interface for 2 hooks with incoming props', () => {
+      const props = composeHooks(hook1, hook2, hook3, hook4)(myModel, {foo: ''});
+
+      type Expected = {hook1: string; hook2: string; hook3: string; hook4: string; foo: string};
+
+      expectTypeOf(props).toEqualTypeOf<Expected>();
+    });
+
+    it('should return the correct prop interface for 2 hooks', () => {
+      const props = composeHooks(hook1, hook2, hook3, hook4, hook5)(myModel, {});
+
+      type Expected = {hook1: string; hook2: string; hook3: string; hook4: string; hook5: string};
+
+      expectTypeOf(props).toEqualTypeOf<Expected>();
+    });
+
+    it('should return the correct prop interface for 2 hooks with incoming props', () => {
+      const props = composeHooks(hook1, hook2, hook3, hook4, hook5)(myModel, {foo: ''});
+
+      type Expected = {
+        hook1: string;
+        hook2: string;
+        hook3: string;
+        hook4: string;
+        hook5: string;
+        foo: string;
+      };
+
+      expectTypeOf(props).toEqualTypeOf<Expected>();
+    });
+
+    it('should return the correct prop interface for 2 hooks', () => {
+      const props = composeHooks(hook1, hook2, hook3, hook4, hook5, hook6)(myModel, {});
+
+      type Expected = {
+        hook1: string;
+        hook2: string;
+        hook3: string;
+        hook4: string;
+        hook5: string;
+        hook6: string;
+      };
+
+      expectTypeOf(props).toEqualTypeOf<Expected>();
+    });
+
+    it('should return the correct prop interface for 2 hooks with incoming props', () => {
+      const props = composeHooks(hook1, hook2, hook3, hook4, hook5, hook6)(myModel, {foo: ''});
+
+      type Expected = {
+        hook1: string;
+        hook2: string;
+        hook3: string;
+        hook4: string;
+        hook5: string;
+        hook6: string;
+        foo: string;
+      };
+
+      expectTypeOf(props).toEqualTypeOf<Expected>();
     });
   });
 });

--- a/modules/react/common/spec/components.spec.tsx
+++ b/modules/react/common/spec/components.spec.tsx
@@ -406,10 +406,10 @@ describe('composeHooks', () => {
 
   it('should merge properties from both hooks', () => {
     const hook1 = createHook(() => {
-      return {hook1: ''};
+      return {hook1: 'hook1'};
     });
     const hook2 = createHook(() => {
-      return {hook2: ''};
+      return {hook2: 'hook2'};
     });
     const props = composeHooks(hook1, hook2)(myModel, {}, null);
     expect(props).toHaveProperty('hook1', 'hook1');

--- a/modules/react/common/spec/components.spec.tsx
+++ b/modules/react/common/spec/components.spec.tsx
@@ -455,7 +455,7 @@ describe('composeHooks', () => {
       mergeProps({id: number, foo: number, [`hook${number}`]: model.state.foo}, props)
     );
 
-    const props = composeHooks.apply(null, hooks as any)(myModel, {foo: 'baz'}, null);
+    const props = (composeHooks as any).apply(null, hooks as any)(myModel, {foo: 'baz'}, null);
     expect(props).toHaveProperty('id', 9);
     expect(props).toHaveProperty('hook1', 'bar');
     expect(props).toHaveProperty('foo', 'baz');

--- a/modules/react/menu/lib/MenuContextTarget.tsx
+++ b/modules/react/menu/lib/MenuContextTarget.tsx
@@ -27,7 +27,7 @@ const useMenuTargetBase = createElemPropsHook(useMenuModel)(model => {
           model.events.show(event);
       }
     },
-  };
+  } as const;
 });
 
 export const useMenuTarget = composeHooks(useMenuTargetBase, usePopupTarget);

--- a/modules/react/menu/lib/MenuTarget.tsx
+++ b/modules/react/menu/lib/MenuTarget.tsx
@@ -27,7 +27,7 @@ export const useMenuTargetBase = createElemPropsHook(useMenuModel)(model => {
           model.events.show(event);
       }
     },
-  };
+  } as const;
 });
 
 export const useMenuTarget = composeHooks(useMenuTargetBase, usePopupTarget);


### PR DESCRIPTION
## Summary

`composeHooks` accidentally broke at some point during our compound component paradigm building. It no longer merges the output of all incoming hooks together properly. This fix changes the signature of `composeHooks` and `BehaviorHook` to allow for the correct extraction of output props.

## Release Category
Components

### BREAKING CHANGES
The type signature of `composeHooks` was changed to give more accurate return prop types. This may cause issues with Typescript if your code expected the incorrect return types.

---

## Checklist

- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)
- [x] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [x] Code
- [x] Documentation
- [x] Testing

