### PR TITLE
chore: Rename Combobox.spec to ComboboxLabs.spec

### DIFF
--- a/cypress/integration/ComboboxLabs.spec.ts
+++ b/cypress/integration/ComboboxLabs.spec.ts
@@ -6,7 +6,7 @@ const haveAttrMatchingIdOf = (name: string, selector: string) => ($el: JQuery) =
   expect($el).to.have.attr(name, $matchingEl.attr('id')!);
 };
 
-describe('Combobox', () => {
+describe('Combobox Labs', () => {
   before(() => {
     h.stories.visit();
   });


### PR DESCRIPTION
## Summary

Rename `Combobox.spec.ts` to `ComboboxLabs.spec.ts`. We're adding a Combobox to main - the rename makes room.

## Release Category
Components

---
