### PR TITLE
chore: Use index instead of identifier for cursor navigation

### DIFF
--- a/modules/docs/mdx/9.0-UPGRADE-GUIDE.mdx
+++ b/modules/docs/mdx/9.0-UPGRADE-GUIDE.mdx
@@ -26,6 +26,7 @@ any questions.
 - [Component Updates](#component-updates)
   - [Button](#button)
   - [Toast](#toast)
+  - [Collection](#collection)
 - [Utility Updates](#utility-updates)
   - [useTheme and getTheme](#usetheme-and-gettheme)
   - [useThemedRing](#usethemedring)
@@ -291,6 +292,8 @@ return {
 `as const` instructs Typescript the type is `readonly`. Typescript knows readonly values or objects
 cannot be changed and will therefore narrow the type for you.
 
+---
+
 ## Token Updates
 
 ### Depth
@@ -377,6 +380,15 @@ previously used `actionText` or `onActionClick`. The codemod will also update im
 
 > **Note:** You will manually need to set `mode` to `alert` if your `Toast` conveys urgent and
 > important information such as an error.
+
+---
+
+### Collection
+
+Navigation was updated to use numberical indexes instead of string ids. The `model.state.cursorId`
+is left unchanged. The change is to support virtual lists where navigation knows where it needs to
+go, but the id may not be loaded yet. The mechanism for navigating is private and should not
+breaking anything. If you created a custom navigation manager, the signature has been changed.
 
 ## Utility Updates
 

--- a/modules/docs/mdx/9.0-UPGRADE-GUIDE.mdx
+++ b/modules/docs/mdx/9.0-UPGRADE-GUIDE.mdx
@@ -385,10 +385,11 @@ previously used `actionText` or `onActionClick`. The codemod will also update im
 
 ### Collection
 
-Navigation was updated to use numberical indexes instead of string ids. The `model.state.cursorId`
-is left unchanged. The change is to support virtual lists where navigation knows where it needs to
-go, but the id may not be loaded yet. The mechanism for navigating is private and should not
-breaking anything. If you created a custom navigation manager, the signature has been changed.
+Navigation was updated to use numerical indexes instead of string identifiers. The
+`model.state.cursorId` is left unchanged. The change is to support virtual lists where navigation
+knows where it needs to go, but the identifier may not be loaded yet. The mechanism for navigating
+is private and should not breaking anything. If you created a custom navigation manager, the
+signature has been changed.
 
 ## Utility Updates
 

--- a/modules/react/collection/lib/useBaseListModel.tsx
+++ b/modules/react/collection/lib/useBaseListModel.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import {useVirtual} from './react-virtual';
 
-import {useUniqueId, assert, createModelHook, Generic} from '@workday/canvas-kit-react/common';
+import {useUniqueId, createModelHook, Generic} from '@workday/canvas-kit-react/common';
 
 export type Orientation = 'horizontal' | 'vertical';
 
 export const defaultGetId = (item: any): string => {
-  assert(item.id, 'A list item must have an `id` field or a `getId` function defined');
-  return item.id;
+  // assert(item.id, 'A list item must have an `id` field or a `getId` function defined');
+  return item.id || '';
 };
 
 export const defaultGetTextValue = (item: any): string => {
@@ -79,14 +79,18 @@ export const useBaseListModel = createModelHook({
     /** IDREF of the list. Children ids can be derived from this id */
     id: '',
     /**
-     * Optional function to return an id of an item. If not provided, the default function will return
-     * the `id` property from the object of each item. If you did not provide `items`, do not override
-     * this function. If you don't provided `items` and instead provide static items via JSX, the list
-     * will create an internal array of items where `id` is the only property and the default `getId`
-     * will return the desired result.
+     * Optional function to return an id of an item. If not provided, the default function will
+     * return the `id` property from the object of each item. If you did not provide `items`, do not
+     * override this function. If you don't provided `items` and instead provide static items via
+     * JSX, the list will create an internal array of items where `id` is the only property and the
+     * default `getId` will return the desired result.
      */
     getId: (item: Generic) => item.id as string,
-
+    /**
+     * Optional function to return the text representation of an item. If not provided, the default
+     * function will return the `text` property of the object of each item or an empty string if
+     * there is no `text` property. If you did not provide `items`, do not override this function.
+     */
     getTextValue: (item: Generic) => (item.text || '') as string,
     /**
      * Array of all ids which are currently disabled. This is used for navigation to skip over items

--- a/modules/react/collection/lib/useBaseListModel.tsx
+++ b/modules/react/collection/lib/useBaseListModel.tsx
@@ -6,7 +6,6 @@ import {useUniqueId, createModelHook, Generic} from '@workday/canvas-kit-react/c
 export type Orientation = 'horizontal' | 'vertical';
 
 export const defaultGetId = (item: any): string => {
-  // assert(item.id, 'A list item must have an `id` field or a `getId` function defined');
   return item.id || '';
 };
 

--- a/modules/react/collection/lib/useCursorListModel.tsx
+++ b/modules/react/collection/lib/useCursorListModel.tsx
@@ -322,6 +322,9 @@ export const useCursorListModel = createModelHook({
   const pageSizeRef = React.useRef(config.pageSize);
   const columnCount = config.columnCount || 0;
   const list = useBaseListModel(config);
+  const initialCurrentRef = React.useRef(
+    config.initialCursorId || (config.items?.length ? list.state.items![0].id : '')
+  );
   const navigation = config.navigation;
   const [cursorIndex, setCursorIndex] = React.useState(() => {
     return list.state.items.findIndex(item => item.id === cursorId) || 0;
@@ -355,6 +358,18 @@ export const useCursorListModel = createModelHook({
 
   const events = {
     ...list.events,
+    /**
+     * Register an item to the list. Takes in an identifier, a React.Ref and an optional index. This
+     * should be called on component mount
+     */
+    registerItem(data: Parameters<typeof list.events.registerItem>[0]) {
+      // point the cursor at the first item
+      if (!initialCurrentRef.current) {
+        initialCurrentRef.current = getId(data.item);
+        setCursorId(initialCurrentRef.current);
+      }
+      list.events.registerItem(data);
+    },
     /** Directly sets the cursor to the list item by its identifier. */
     goTo(data: {id: string}) {
       const index = state.items.findIndex(item => item.id === data.id);

--- a/modules/react/collection/lib/useCursorListModel.tsx
+++ b/modules/react/collection/lib/useCursorListModel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {assert, createModelHook, Generic} from '@workday/canvas-kit-react/common';
 
-import {useBaseListModel, Item} from './useBaseListModel';
+import {useBaseListModel, Item, defaultGetId as getId} from './useBaseListModel';
 
 type NavigationInput = Pick<ReturnType<typeof useCursorListModel>, 'state'>;
 

--- a/modules/react/collection/lib/useCursorListModel.tsx
+++ b/modules/react/collection/lib/useCursorListModel.tsx
@@ -326,14 +326,18 @@ export const useCursorListModel = createModelHook({
     config.initialCursorId || (config.items?.length ? list.state.items![0].id : '')
   );
   const navigation = config.navigation;
-  const [cursorIndex, setCursorIndex] = React.useState(() => {
-    return list.state.items.findIndex(item => item.id === cursorId) || 0;
-  });
+  const cursorIndexRef = React.useRef(-1);
   const setCursor = (index: number) => {
-    setCursorIndex(index);
     const id = state.items[index]?.id || '';
     setCursorId(id);
   };
+
+  // Keep the cursorIndex up to date with the cursor ID
+  if (cursorId && list.state.items[cursorIndexRef.current]?.id !== cursorId) {
+    cursorIndexRef.current = list.state.items.findIndex(item => item.id === cursorId);
+  } else if (!cursorId) {
+    cursorIndexRef.current = -1;
+  }
 
   const state = {
     ...list.state,
@@ -350,10 +354,6 @@ export const useCursorListModel = createModelHook({
      * based on the size of the list container and the number of items fitting within the container.
      */
     pageSizeRef,
-    /**
-     * A
-     */
-    cursorIndex,
   };
 
   const events = {
@@ -373,8 +373,7 @@ export const useCursorListModel = createModelHook({
     /** Directly sets the cursor to the list item by its identifier. */
     goTo(data: {id: string}) {
       const index = state.items.findIndex(item => item.id === data.id);
-      setCursorIndex(index);
-      setCursorId(data.id);
+      setCursor(index);
     },
     /**
      * Set the cursor to the "next" item in the list. This event delegates to the `getNext` method of
@@ -383,7 +382,7 @@ export const useCursorListModel = createModelHook({
      * item in a row.
      */
     goToNext() {
-      const index = navigation.getNext(state.cursorIndex, {state});
+      const index = navigation.getNext(cursorIndexRef.current, {state});
       setCursor(index);
     },
     /**
@@ -391,7 +390,7 @@ export const useCursorListModel = createModelHook({
      * it will wrap to the last item
      */
     goToPrevious() {
-      const index = navigation.getPrevious(state.cursorIndex, {state});
+      const index = navigation.getPrevious(cursorIndexRef.current, {state});
       setCursor(index);
     },
     /**
@@ -401,7 +400,7 @@ export const useCursorListModel = createModelHook({
      * this would be the previous row (current position - column count).
      */
     goToPreviousRow() {
-      const index = navigation.getPreviousRow(state.cursorIndex, {
+      const index = navigation.getPreviousRow(cursorIndexRef.current, {
         state,
       });
       setCursor(index);
@@ -413,33 +412,33 @@ export const useCursorListModel = createModelHook({
      * next row (current position + column count).
      */
     goToNextRow() {
-      const index = navigation.getNextRow(state.cursorIndex, {state});
+      const index = navigation.getNextRow(cursorIndexRef.current, {state});
       setCursor(index);
     },
     /** Set the cursor to the first item in the list */
     goToFirst() {
-      const index = navigation.getFirst(state.cursorIndex, {state});
+      const index = navigation.getFirst(cursorIndexRef.current, {state});
       setCursor(index);
     },
     /** Set the cursor to the last item in the list */
     goToLast() {
-      const index = navigation.getLast(state.cursorIndex, {state});
+      const index = navigation.getLast(cursorIndexRef.current, {state});
       setCursor(index);
     },
     goToFirstOfRow() {
-      const index = navigation.getFirstOfRow(state.cursorIndex, {state});
+      const index = navigation.getFirstOfRow(cursorIndexRef.current, {state});
       setCursor(index);
     },
     goToLastOfRow() {
-      const index = navigation.getLastOfRow(state.cursorIndex, {state});
+      const index = navigation.getLastOfRow(cursorIndexRef.current, {state});
       setCursor(index);
     },
     goToNextPage() {
-      const index = navigation.getNextPage(state.cursorIndex, {state});
+      const index = navigation.getNextPage(cursorIndexRef.current, {state});
       setCursor(index);
     },
     goToPreviousPage() {
-      const index = navigation.getPreviousPage(state.cursorIndex, {
+      const index = navigation.getPreviousPage(cursorIndexRef.current, {
         state,
       });
       setCursor(index);

--- a/modules/react/collection/lib/useCursorListModel.tsx
+++ b/modules/react/collection/lib/useCursorListModel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {assert, createModelHook, Generic} from '@workday/canvas-kit-react/common';
 
-import {useBaseListModel, Item, defaultGetId as getId} from './useBaseListModel';
+import {useBaseListModel, Item} from './useBaseListModel';
 
 type NavigationInput = Pick<ReturnType<typeof useCursorListModel>, 'state'>;
 
@@ -18,7 +18,7 @@ export interface NavigationManager {
    * and `Ctrl+End` for Grids. */
   getLast: NavigationRequestor;
   /** Get an item with the provided `id`. */
-  getItem: NavigationRequestor;
+  getItem: (id: string, model: NavigationInput) => Item<Generic>;
   /** Get the next item after the provided `id`. This will be called when the `Right` arrow key is
    * pressed for RTL languages and when the `Left` arrow is pressed for LTR languages. */
   getNext: NavigationRequestor;
@@ -69,90 +69,89 @@ export const createNavigationManager = (manager: NavigationManager) => manager;
 /**
  * Given an id and a model, return an item from the collection
  */
-export type NavigationRequestor = (id: string, model: NavigationInput) => Item<Generic>;
+export type NavigationRequestor = (index: number, model: NavigationInput) => number;
 
 /**
  * Get the first item in a list regardless of column count
  */
-export const getFirst: NavigationRequestor = (_, {state}) => state.items[0];
+export const getFirst: NavigationRequestor = (_, {state}) => 0;
 /**
  * Get the last item in a list regardless of column count
  */
-export const getLast: NavigationRequestor = (_, {state}) => state.items[state.items.length - 1];
+export const getLast: NavigationRequestor = (_, {state}) => state.items.length - 1;
 
 /**
  * Get the first item in a row. If column count is 0, it will return the results of `getFirst`
  */
-export const getFirstOfRow: NavigationRequestor = (id, {state}) => {
+export const getFirstOfRow: NavigationRequestor = (index, {state}) => {
   if (state.columnCount) {
-    const item = getItem(id, {state});
-    const currentIndex = item.index;
-    const offset = currentIndex % state.columnCount;
-    return state.items[currentIndex - offset];
+    const offset = index % state.columnCount;
+    return index - offset;
   }
-  return getFirst(id, {state});
+  return getFirst(index, {state});
 };
 
 /**
  * get the last item in a row - if column count is 0, it will return the results of `getLast`
  */
-export const getLastOfRow: NavigationRequestor = (id, {state}) => {
+export const getLastOfRow: NavigationRequestor = (index, {state}) => {
   if (state.columnCount) {
-    const item = getItem(id, {state});
-    const currentIndex = item.index;
-    const offset = (currentIndex % state.columnCount) - state.columnCount + 1;
-    let nextIndex = currentIndex - offset;
+    const offset = (index % state.columnCount) - state.columnCount + 1;
+    let nextIndex = index - offset;
     if (nextIndex >= state.items.length) {
       nextIndex = state.items.length - 1;
     }
-    return state.items[nextIndex];
+    return nextIndex;
   }
-  return getLast(id, {state});
+  return getLast(index, {state});
 };
 
 /**
  * get the item in the previous page. This can be author defined. By default it will return the
  * first item for a list, and the first item in the same column for a grid.
  */
-export const getPreviousPage: NavigationRequestor = (id, {state}) => {
+export const getPreviousPage: NavigationRequestor = (index, {state}) => {
   if (state.columnCount) {
-    const item = getItem(id, {state});
-    const currentIndex = item.index;
-    return state.items[currentIndex % state.columnCount];
+    return index % state.columnCount;
   }
-  return getFirst(id, {state});
+  return getFirst(index, {state});
 };
 
 /**
  * get the item in the next page. This can be author defined. By default, it will return the last
  * item for a list, and the last item in the same column for a grid.
  */
-export const getNextPage: NavigationRequestor = (id, {state}) => {
+export const getNextPage: NavigationRequestor = (index, {state}) => {
   if (state.columnCount) {
-    const item = getItem(id, {state});
-    const currentIndex = item.index;
     const lastRowIndex = state.items.length - state.columnCount;
-    return state.items[lastRowIndex + (currentIndex % state.columnCount)];
+    return lastRowIndex + (index % state.columnCount);
   }
-  return getLast(id, {state});
+  return getLast(index, {state});
 };
 
-const getItem: NavigationRequestor = (id, {state}) => {
-  const item = id ? state.items.find(item => getId(item) === id) : getFirst(id, {state}); // no id, return first item
+const getItem: (id: string, model: NavigationInput) => Item<Generic> = (id, {state}) => {
+  const item = id ? state.items.find(item => item.id === id) : state.items[0]; // no id, return first item
   assert(item, `Item not found: ${id}`);
   return item;
 };
 
 export const getWrappingOffsetItem = (offset: number) => (
-  id: string,
+  index: number,
   {state}: NavigationInput,
   tries = state.items.length
-): Item<Generic> => {
+): number => {
+  if (Number.isNaN(index)) {
+    // we have no valid index. If the offset is positive, we'll return the first item
+    if (offset === 1) {
+      return getFirst(index, {state});
+    }
+    if (offset === -1) {
+      return getLast(index, {state});
+    }
+  }
   const items = state.items;
-  const item = getItem(id, {state});
 
-  const currentIndex = item.index;
-  let nextIndex = currentIndex + offset;
+  let nextIndex = index + offset;
 
   // calculate idealLength as in if the grid was a perfect rectangle
   const rows = Math.ceil(items.length / state.columnCount);
@@ -185,34 +184,32 @@ export const getWrappingOffsetItem = (offset: number) => (
     }
   }
 
-  if (state.nonInteractiveIds.includes(getId(items[nextIndex])) && tries > 0) {
+  if (state.nonInteractiveIds.includes(items[nextIndex].id) && tries > 0) {
     // The next item is disabled, try again, but only if we haven't already tried everything.
     // Avoid an infinite loop with `tries`
-    return getWrappingOffsetItem(offset)(getId(items[nextIndex]), {state}, tries - 1);
+    return getWrappingOffsetItem(offset)(nextIndex, {state}, tries - 1);
   }
 
-  return items[nextIndex];
+  return nextIndex;
 };
 
 export const getOffsetItem = (offset: number) => (
-  id: string,
+  index: number,
   {state}: NavigationInput,
   tries = state.items.length
-): Item<Generic> => {
+): number => {
   const {items, columnCount} = state;
-  const item = getItem(id, {state});
 
-  const currentIndex = item.index;
-  let nextIndex = currentIndex + offset;
+  let nextIndex = index + offset;
 
   if (Math.abs(offset) < columnCount) {
     // if we're here, the columnCount is non-zero and the absolute value of offset is less than the
     // column count. We don't want to wrap, so we'll bound within the row
 
-    const currentIndexInRow = currentIndex % columnCount;
-    const nextIndexInRow = nextIndex - currentIndex + currentIndexInRow;
+    const currentIndexInRow = index % columnCount;
+    const nextIndexInRow = nextIndex - index + currentIndexInRow;
     if (nextIndexInRow >= columnCount || nextIndexInRow < 0) {
-      nextIndex = currentIndex;
+      nextIndex = index;
     }
   } else if (columnCount) {
     // if we're here, there's a column count, but the offset will move into another row. We need to
@@ -220,12 +217,12 @@ export const getOffsetItem = (offset: number) => (
     const nextRow = Math.floor(nextIndex / columnCount);
 
     if (nextRow < 0 || nextRow >= columnCount) {
-      nextIndex = currentIndex;
+      nextIndex = index;
     }
 
     // make sure we don't go out of bounds if the grid isn't a perfect rectangle
     if (nextIndex > items.length - 1) {
-      nextIndex = currentIndex;
+      nextIndex = index;
     }
   }
 
@@ -236,13 +233,13 @@ export const getOffsetItem = (offset: number) => (
     nextIndex = items.length - 1;
   }
 
-  if (state.nonInteractiveIds.includes(getId(items[nextIndex])) && tries > 0) {
+  if (state.nonInteractiveIds.includes(items[nextIndex].id) && tries > 0) {
     // The next item is disabled, try again, but only if we haven't already tried everything.
     // Avoid an infinite loop with `tries`
-    return getOffsetItem(offset)(getId(items[nextIndex]), {state}, tries - 1);
+    return getOffsetItem(offset)(nextIndex, {state}, tries - 1);
   }
 
-  return items[nextIndex];
+  return nextIndex;
 };
 
 /**
@@ -255,9 +252,9 @@ export const wrappingNavigationManager = createNavigationManager({
   getLast,
   getItem,
   getNext: getWrappingOffsetItem(1),
-  getNextRow: (id, {state}) => getWrappingOffsetItem(state.columnCount)(id, {state}),
+  getNextRow: (index, {state}) => getWrappingOffsetItem(state.columnCount)(index, {state}),
   getPrevious: getWrappingOffsetItem(-1),
-  getPreviousRow: (id, {state}) => getWrappingOffsetItem(-state.columnCount)(id, {state}),
+  getPreviousRow: (index, {state}) => getWrappingOffsetItem(-state.columnCount)(index, {state}),
   getPreviousPage,
   getNextPage,
   getFirstOfRow,
@@ -273,9 +270,9 @@ export const navigationManager = createNavigationManager({
   getLast,
   getItem,
   getNext: getOffsetItem(1),
-  getNextRow: (id, {state}) => getOffsetItem(state.columnCount)(id, {state}),
+  getNextRow: (index, {state}) => getOffsetItem(state.columnCount)(index, {state}),
   getPrevious: getOffsetItem(-1),
-  getPreviousRow: (id, {state}) => getOffsetItem(-state.columnCount)(id, {state}),
+  getPreviousRow: (index, {state}) => getOffsetItem(-state.columnCount)(index, {state}),
   getPreviousPage,
   getNextPage,
   getFirstOfRow,
@@ -312,16 +309,28 @@ export const useCursorListModel = createModelHook({
      * well as left/right keys to give a more consistent experience to all users.
      */
     navigation: wrappingNavigationManager,
+    /**
+     * Controls how much a pageUp/pageDown navigation request will jump. If not provided, the size
+     * of the list and number of items rendered will determine this value.
+     */
+    pageSize: 0,
   },
   requiredConfig: useBaseListModel.requiredConfig,
+  contextOverride: useBaseListModel.Context,
 })(config => {
   const [cursorId, setCursorId] = React.useState(config.initialCursorId);
+  const pageSizeRef = React.useRef(config.pageSize);
   const columnCount = config.columnCount || 0;
   const list = useBaseListModel(config);
-  const initialCurrentRef = React.useRef(
-    config.initialCursorId || (config.items?.length ? getId(list.state.items![0]) : '')
-  );
   const navigation = config.navigation;
+  const [cursorIndex, setCursorIndex] = React.useState(() => {
+    return list.state.items.findIndex(item => item.id === cursorId) || 0;
+  });
+  const setCursor = (index: number) => {
+    setCursorIndex(index);
+    const id = state.items[index]?.id || '';
+    setCursorId(id);
+  };
 
   const state = {
     ...list.state,
@@ -333,24 +342,23 @@ export const useCursorListModel = createModelHook({
      * @private Use useGridModel instead to make a grid instead of a list
      */
     columnCount,
+    /**
+     * A React.Ref of the current page size. Either provided as config, or determined at runtime
+     * based on the size of the list container and the number of items fitting within the container.
+     */
+    pageSizeRef,
+    /**
+     * A
+     */
+    cursorIndex,
   };
 
   const events = {
     ...list.events,
-    /**
-     * Register an item to the list. Takes in an identifier, a React.Ref and an optional index. This
-     * should be called on component mount
-     */
-    registerItem(data: Parameters<typeof list.events.registerItem>[0]) {
-      // point the cursor at the first item
-      if (!initialCurrentRef.current) {
-        initialCurrentRef.current = getId(data.item);
-        setCursorId(initialCurrentRef.current);
-      }
-      list.events.registerItem(data);
-    },
     /** Directly sets the cursor to the list item by its identifier. */
     goTo(data: {id: string}) {
+      const index = state.items.findIndex(item => item.id === data.id);
+      setCursorIndex(index);
       setCursorId(data.id);
     },
     /**
@@ -360,14 +368,16 @@ export const useCursorListModel = createModelHook({
      * item in a row.
      */
     goToNext() {
-      setCursorId(getId(navigation.getNext(state.cursorId, {state})));
+      const index = navigation.getNext(state.cursorIndex, {state});
+      setCursor(index);
     },
     /**
      * Set the cursor to the "previous" item in the list. If the beginning of the list is detected,
      * it will wrap to the last item
      */
     goToPrevious() {
-      setCursorId(getId(navigation.getPrevious(state.cursorId, {state})));
+      const index = navigation.getPrevious(state.cursorIndex, {state});
+      setCursor(index);
     },
     /**
      * Previous item perpendicular to the orientation of a list, or the previous row in a grid. For
@@ -376,13 +386,10 @@ export const useCursorListModel = createModelHook({
      * this would be the previous row (current position - column count).
      */
     goToPreviousRow() {
-      setCursorId(
-        getId(
-          navigation.getPreviousRow(state.cursorId, {
-            state,
-          })
-        )
-      );
+      const index = navigation.getPreviousRow(state.cursorIndex, {
+        state,
+      });
+      setCursor(index);
     },
     /**
      * Next item perpendicular to the orientation of a list, or the next row in a grid. For example,
@@ -391,33 +398,36 @@ export const useCursorListModel = createModelHook({
      * next row (current position + column count).
      */
     goToNextRow() {
-      setCursorId(getId(navigation.getNextRow(state.cursorId, {state})));
+      const index = navigation.getNextRow(state.cursorIndex, {state});
+      setCursor(index);
     },
     /** Set the cursor to the first item in the list */
     goToFirst() {
-      setCursorId(getId(navigation.getFirst(state.cursorId, {state})));
+      const index = navigation.getFirst(state.cursorIndex, {state});
+      setCursor(index);
     },
     /** Set the cursor to the last item in the list */
     goToLast() {
-      setCursorId(getId(navigation.getLast(state.cursorId, {state})));
+      const index = navigation.getLast(state.cursorIndex, {state});
+      setCursor(index);
     },
     goToFirstOfRow() {
-      setCursorId(getId(navigation.getFirstOfRow(state.cursorId, {state})));
+      const index = navigation.getFirstOfRow(state.cursorIndex, {state});
+      setCursor(index);
     },
     goToLastOfRow() {
-      setCursorId(getId(navigation.getLastOfRow(state.cursorId, {state})));
+      const index = navigation.getLastOfRow(state.cursorIndex, {state});
+      setCursor(index);
     },
     goToNextPage() {
-      setCursorId(getId(navigation.getNextPage(state.cursorId, {state})));
+      const index = navigation.getNextPage(state.cursorIndex, {state});
+      setCursor(index);
     },
     goToPreviousPage() {
-      setCursorId(
-        getId(
-          navigation.getPreviousPage(state.cursorId, {
-            state,
-          })
-        )
-      );
+      const index = navigation.getPreviousPage(state.cursorIndex, {
+        state,
+      });
+      setCursor(index);
     },
   };
 

--- a/modules/react/collection/spec/useCursorModel.spec.tsx
+++ b/modules/react/collection/spec/useCursorModel.spec.tsx
@@ -34,21 +34,21 @@ const createItem = (id, index) => ({id, index, value: id});
 
 describe('getFirstOfRow', () => {
   describe('when state represents a list', () => {
-    const items = ['1', '2', '3'].map(createItem);
+    const items = ['0', '1', '2'].map(createItem);
     const state = createState({
       items,
     });
 
     it('should return the first item', () => {
-      expect(getFirstOfRow('2', {state})).toEqual(items[0]);
+      expect(getFirstOfRow(1, {state})).toEqual(0);
     });
   });
 
   describe('when state represents a grid', () => {
     const items = flatten([
-      ['1', '2', '3'],
-      ['4', '5', '6'],
-      ['7', '8', '9'],
+      ['0', '1', '2'],
+      ['3', '4', '5'],
+      ['6', '7', '8'],
     ]).map(createItem);
     const state = createState({
       items,
@@ -56,91 +56,91 @@ describe('getFirstOfRow', () => {
     });
 
     it('should return the first item of the first row', () => {
-      expect(getFirstOfRow('2', {state})).toEqual(items[0]);
+      expect(getFirstOfRow(1, {state})).toEqual(0);
     });
 
     it('should return the first item of the second row when cursor is at 4', () => {
-      expect(getFirstOfRow('4', {state})).toEqual(items[3]);
+      expect(getFirstOfRow(3, {state})).toEqual(3);
     });
 
     it('should return the first item of the second row when cursor is at 5', () => {
-      expect(getFirstOfRow('5', {state})).toEqual(items[3]);
+      expect(getFirstOfRow(4, {state})).toEqual(3);
     });
 
     it('should return the first item of the second row when cursor is at 6', () => {
-      expect(getFirstOfRow('6', {state})).toEqual(items[3]);
+      expect(getFirstOfRow(5, {state})).toEqual(3);
     });
   });
 });
 
 describe('getPreviousPage', () => {
   describe('when state represents a list', () => {
-    const items = ['1', '2', '3'].map(createItem);
+    const items = ['0', '1', '2'].map(createItem);
     const state = createState({items});
     it('should return the first item', () => {
-      expect(getPreviousPage('2', {state})).toEqual(items[0]);
+      expect(getPreviousPage(1, {state})).toEqual(0);
     });
   });
 
   describe('when state represents a grid', () => {
     // use flatten to make it easier to visualize a grid in code, but code requires a flat array
     const items = flatten([
-      ['1', '2', '3'],
-      ['4', '5', '6'],
-      ['7', '8', '9'],
+      ['0', '1', '2'],
+      ['3', '4', '5'],
+      ['6', '7', '8'],
     ]).map(createItem);
     const state = createState({
       items,
       columnCount: 3,
-      cursorId: '2',
+      cursorId: '1',
     });
 
     it('should return the first item of the second row when cursor is at 2', () => {
-      expect(getPreviousPage('2', {state})).toEqual(items[1]);
+      expect(getPreviousPage(1, {state})).toEqual(1);
     });
 
     it('should return the first item of the second row when cursor is at 5', () => {
-      expect(getPreviousPage('2', {state})).toEqual(items[1]);
+      expect(getPreviousPage(1, {state})).toEqual(1);
     });
 
     it('should return the first item of the second row when cursor is at 8', () => {
-      expect(getPreviousPage('8', {state})).toEqual(items[1]);
+      expect(getPreviousPage(7, {state})).toEqual(1);
     });
   });
 });
 
 describe('getNextPage', () => {
   describe('when state represents a list', () => {
-    const items = ['1', '2', '3'].map(createItem);
+    const items = ['0', '1', '2'].map(createItem);
     const state = createState({items});
     it('should return the first item', () => {
-      expect(getNextPage('2', {state})).toEqual(items[2]);
+      expect(getNextPage(1, {state})).toEqual(2);
     });
   });
 
   describe('when state represents a grid', () => {
     // use flatten to make it easier to visualize a grid in code, but code requires a flat array
     const items = flatten([
-      ['1', '2', '3'],
-      ['4', '5', '6'],
-      ['7', '8', '9'],
+      ['0', '1', '2'],
+      ['3', '4', '5'],
+      ['6', '7', '8'],
     ]).map(createItem);
     const state = createState({
       items,
       columnCount: 3,
-      cursorId: '2',
+      cursorId: '1',
     });
 
     it('should return the first item of the second row when cursor is at 2', () => {
-      expect(getNextPage('2', {state})).toEqual(items[7]);
+      expect(getNextPage(1, {state})).toEqual(7);
     });
 
     it('should return the first item of the second row when cursor is at 5', () => {
-      expect(getNextPage('5', {state})).toEqual(items[7]);
+      expect(getNextPage(4, {state})).toEqual(7);
     });
 
     it('should return the first item of the second row when cursor is at 8', () => {
-      expect(getNextPage('8', {state})).toEqual(items[7]);
+      expect(getNextPage(7, {state})).toEqual(7);
     });
   });
 });
@@ -149,49 +149,49 @@ describe('navigationManager', () => {
   describe('when state represents a perfect grid', () => {
     // use flatten to make it easier to visualize a grid in code, but code requires a flat array
     const items = flatten([
-      ['1', '2', '3'],
-      ['4', '5', '6'],
-      ['7', '8', '9'],
+      ['0', '1', '2'],
+      ['3', '4', '5'],
+      ['6', '7', '8'],
     ]).map(createItem);
     const state = createState({
       items,
       columnCount: 3,
-      cursorId: '2',
+      cursorId: '1',
     });
 
     describe('getNextRow', () => {
       it('should return the second item of the second row when cursor is at 2', () => {
-        expect(navigationManager.getNextRow('2', {state})).toEqual(items[4]);
+        expect(navigationManager.getNextRow(1, {state})).toEqual(4);
       });
 
       it('should return the second item of the last row when cursor is at 5', () => {
-        expect(navigationManager.getNextRow('5', {state})).toEqual(items[7]);
+        expect(navigationManager.getNextRow(4, {state})).toEqual(7);
       });
 
       it('should return the original item when cursor is at 8', () => {
-        expect(navigationManager.getNextRow('8', {state})).toEqual(items[7]);
+        expect(navigationManager.getNextRow(7, {state})).toEqual(7);
       });
     });
 
     describe('getPreviousRow', () => {
       it('should return the original item when cursor is at 2', () => {
-        expect(navigationManager.getPreviousRow('2', {state})).toEqual(items[1]);
+        expect(navigationManager.getPreviousRow(1, {state})).toEqual(1);
       });
 
       it('should return the original item when cursor is at 3', () => {
-        expect(navigationManager.getPreviousRow('3', {state})).toEqual(items[2]);
+        expect(navigationManager.getPreviousRow(2, {state})).toEqual(2);
       });
     });
 
     describe('getNext', () => {
       it('should return the original item when the cursor is on the last item', () => {
-        expect(navigationManager.getNext('9', {state})).toEqual(items[8]);
+        expect(navigationManager.getNext(8, {state})).toEqual(8);
       });
     });
 
     describe('getPrevious', () => {
       it('should return the original item when the cursor is on the first item', () => {
-        expect(navigationManager.getPrevious('1', {state})).toEqual(items[0]);
+        expect(navigationManager.getPrevious(0, {state})).toEqual(0);
       });
     });
   });
@@ -199,65 +199,65 @@ describe('navigationManager', () => {
   describe('when state represents a imperfect grid', () => {
     // use flatten to make it easier to visualize a grid in code, but code requires a flat array
     const items = flatten([
-      ['1', '2', '3'],
-      ['4', '5', '6'],
-      ['7', '8'],
+      ['0', '1', '2'],
+      ['3', '4', '5'],
+      ['6', '7'],
     ]).map(createItem);
     const state = createState({
       items,
       columnCount: 3,
-      cursorId: '2',
+      cursorId: '1',
     });
 
     describe('getNextRow', () => {
       it('should return the second item of the second row when cursor is at 2', () => {
-        expect(navigationManager.getNextRow('2', {state})).toEqual(items[4]);
+        expect(navigationManager.getNextRow(1, {state})).toEqual(4);
       });
 
       it('should return the second item of the last row when cursor is at 5', () => {
-        expect(navigationManager.getNextRow('5', {state})).toEqual(items[7]);
+        expect(navigationManager.getNextRow(4, {state})).toEqual(7);
       });
 
       it('should return the original item when cursor is at 8', () => {
-        expect(navigationManager.getNextRow('8', {state})).toEqual(items[7]);
+        expect(navigationManager.getNextRow(7, {state})).toEqual(7);
       });
 
       it('should return the original item when cursor is at 6', () => {
-        expect(navigationManager.getNextRow('6', {state})).toEqual(items[5]);
+        expect(navigationManager.getNextRow(5, {state})).toEqual(5);
       });
     });
 
     describe('getPreviousRow', () => {
       it('should return the original item when cursor is at 2', () => {
-        expect(navigationManager.getPreviousRow('2', {state})).toEqual(items[1]);
+        expect(navigationManager.getPreviousRow(1, {state})).toEqual(1);
       });
 
       it('should return the original item when cursor is at 3', () => {
-        expect(navigationManager.getPreviousRow('3', {state})).toEqual(items[2]);
+        expect(navigationManager.getPreviousRow(2, {state})).toEqual(2);
       });
     });
 
     describe('getNext', () => {
       it('should return the original item when the cursor is on the last item', () => {
-        expect(navigationManager.getNext('8', {state})).toEqual(items[7]);
+        expect(navigationManager.getNext(7, {state})).toEqual(7);
       });
     });
 
     describe('getPrevious', () => {
       it('should return the original item when the cursor is on the first item', () => {
-        expect(navigationManager.getPrevious('1', {state})).toEqual(items[0]);
+        expect(navigationManager.getPrevious(0, {state})).toEqual(0);
       });
     });
 
     describe('getFirstOfRow', () => {
       it('should return 7 item when the cursor is at 8', () => {
-        expect(navigationManager.getFirstOfRow('8', {state})).toEqual(items[6]);
+        expect(navigationManager.getFirstOfRow(7, {state})).toEqual(6);
       });
     });
 
     describe('getLastOfRow', () => {
       it('should return the last item when the cursor is at 7', () => {
-        expect(navigationManager.getLastOfRow('7', {state})).toEqual(items[7]);
+        expect(navigationManager.getLastOfRow(6, {state})).toEqual(7);
       });
     });
   });
@@ -267,49 +267,49 @@ describe('wrappingNavigationManager', () => {
   describe('when state represents a perfect grid', () => {
     // use flatten to make it easier to visualize a grid in code, but code requires a flat array
     const items = flatten([
-      ['1', '2', '3'],
-      ['4', '5', '6'],
-      ['7', '8', '9'],
+      ['0', '1', '2'],
+      ['3', '4', '5'],
+      ['6', '7', '8'],
     ]).map(createItem);
     const state = createState({
       items,
       columnCount: 3,
-      cursorId: '2',
+      cursorId: '1',
     });
 
     describe('getNextRow', () => {
       it('should return the second item of the second row when cursor is at 2', () => {
-        expect(wrappingNavigationManager.getNextRow('2', {state})).toEqual(items[4]);
+        expect(wrappingNavigationManager.getNextRow(1, {state})).toEqual(4);
       });
 
       it('should return the second item of the last row when cursor is at 5', () => {
-        expect(wrappingNavigationManager.getNextRow('5', {state})).toEqual(items[7]);
+        expect(wrappingNavigationManager.getNextRow(4, {state})).toEqual(7);
       });
 
       it('should return the second item of the first row when cursor is at 8', () => {
-        expect(wrappingNavigationManager.getNextRow('8', {state})).toEqual(items[1]);
+        expect(wrappingNavigationManager.getNextRow(7, {state})).toEqual(1);
       });
     });
 
     describe('getPreviousRow', () => {
       it('should return the second item of the last row when cursor is at 2', () => {
-        expect(wrappingNavigationManager.getPreviousRow('2', {state})).toEqual(items[7]);
+        expect(wrappingNavigationManager.getPreviousRow(1, {state})).toEqual(7);
       });
 
       it('should return the third item of the last row when cursor is at 3', () => {
-        expect(wrappingNavigationManager.getPreviousRow('3', {state})).toEqual(items[8]);
+        expect(wrappingNavigationManager.getPreviousRow(2, {state})).toEqual(8);
       });
     });
 
     describe('getNext', () => {
       it('should return the first item when the cursor is on the last item', () => {
-        expect(wrappingNavigationManager.getNext('9', {state})).toEqual(items[0]);
+        expect(wrappingNavigationManager.getNext(8, {state})).toEqual(0);
       });
     });
 
     describe('getPrevious', () => {
       it('should return the last item when the cursor is on the first item', () => {
-        expect(wrappingNavigationManager.getPrevious('1', {state})).toEqual(items[8]);
+        expect(wrappingNavigationManager.getPrevious(0, {state})).toEqual(8);
       });
     });
   });
@@ -317,65 +317,65 @@ describe('wrappingNavigationManager', () => {
   describe('when state represents a imperfect grid', () => {
     // use flatten to make it easier to visualize a grid in code, but code requires a flat array
     const items = flatten([
-      ['1', '2', '3'],
-      ['4', '5', '6'],
-      ['7', '8'],
+      ['0', '1', '2'],
+      ['3', '4', '5'],
+      ['6', '7'],
     ]).map(createItem);
     const state = createState({
       items,
       columnCount: 3,
-      cursorId: '2',
+      cursorId: '1',
     });
 
     describe('getNextRow', () => {
       it('should return the second item of the second row when cursor is at 2', () => {
-        expect(wrappingNavigationManager.getNextRow('2', {state})).toEqual(items[4]);
+        expect(wrappingNavigationManager.getNextRow(1, {state})).toEqual(4);
       });
 
       it('should return the second item of the last row when cursor is at 5', () => {
-        expect(wrappingNavigationManager.getNextRow('5', {state})).toEqual(items[7]);
+        expect(wrappingNavigationManager.getNextRow(4, {state})).toEqual(7);
       });
 
       it('should return the second item of the first row when cursor is at 8', () => {
-        expect(wrappingNavigationManager.getNextRow('8', {state})).toEqual(items[1]);
+        expect(wrappingNavigationManager.getNextRow(7, {state})).toEqual(1);
       });
 
       it('should return the third item of the first row when cursor is at 6', () => {
-        expect(wrappingNavigationManager.getNextRow('6', {state})).toEqual(items[2]);
+        expect(wrappingNavigationManager.getNextRow(5, {state})).toEqual(2);
       });
     });
 
     describe('getPreviousRow', () => {
       it('should return the second item of the last row when cursor is at 2', () => {
-        expect(wrappingNavigationManager.getPreviousRow('2', {state})).toEqual(items[7]);
+        expect(wrappingNavigationManager.getPreviousRow(1, {state})).toEqual(7);
       });
 
       it('should return the third item of the second row when cursor is at 3', () => {
-        expect(wrappingNavigationManager.getPreviousRow('3', {state})).toEqual(items[5]);
+        expect(wrappingNavigationManager.getPreviousRow(2, {state})).toEqual(5);
       });
     });
 
     describe('getNext', () => {
       it('should return the first item when the cursor is on the last item', () => {
-        expect(wrappingNavigationManager.getNext('8', {state})).toEqual(items[0]);
+        expect(wrappingNavigationManager.getNext(7, {state})).toEqual(0);
       });
     });
 
     describe('getPrevious', () => {
       it('should return the last item when the cursor is on the first item', () => {
-        expect(wrappingNavigationManager.getPrevious('1', {state})).toEqual(items[7]);
+        expect(wrappingNavigationManager.getPrevious(0, {state})).toEqual(7);
       });
     });
 
     describe('getFirstOfRow', () => {
       it('should return 7 item when the cursor is at 8', () => {
-        expect(wrappingNavigationManager.getFirstOfRow('8', {state})).toEqual(items[6]);
+        expect(wrappingNavigationManager.getFirstOfRow(7, {state})).toEqual(6);
       });
     });
 
     describe('getLastOfRow', () => {
       it('should return the last item when the cursor is at 7', () => {
-        expect(wrappingNavigationManager.getLastOfRow('7', {state})).toEqual(items[7]);
+        expect(wrappingNavigationManager.getLastOfRow(6, {state})).toEqual(7);
       });
     });
   });
@@ -383,19 +383,19 @@ describe('wrappingNavigationManager', () => {
 
 describe('getLastOfRow', () => {
   describe('when state represents a list', () => {
-    const items = ['1', '2', '3'].map(createItem);
+    const items = ['0', '1', '2'].map(createItem);
     const state = createState({items});
     it('should return the first item', () => {
-      expect(getLastOfRow('2', {state})).toEqual(items[2]);
+      expect(getLastOfRow(1, {state})).toEqual(2);
     });
   });
 
   describe('when state represents a grid', () => {
     // use flatten to make it easier to visualize a grid in code, but code requires a flat array
     const items = flatten([
-      ['1', '2', '3'],
-      ['4', '5', '6'],
-      ['7', '8', '9'],
+      ['0', '1', '2'],
+      ['3', '4', '5'],
+      ['6', '7', '8'],
     ]).map(createItem);
     const state = createState({
       items,
@@ -403,55 +403,55 @@ describe('getLastOfRow', () => {
     });
 
     it('should return the last item of the first row', () => {
-      expect(getLastOfRow('2', {state})).toEqual(items[2]);
+      expect(getLastOfRow(1, {state})).toEqual(2);
     });
 
     it('should return the last item of the second row when cursor is at 4', () => {
-      expect(getLastOfRow('4', {state})).toEqual(items[5]);
+      expect(getLastOfRow(3, {state})).toEqual(5);
     });
 
     it('should return the last item of the second row when cursor is at 5', () => {
-      expect(getLastOfRow('5', {state})).toEqual(items[5]);
+      expect(getLastOfRow(4, {state})).toEqual(5);
     });
 
     it('should return the last item of the second row when cursor is at 6', () => {
-      expect(getLastOfRow('6', {state})).toEqual(items[5]);
+      expect(getLastOfRow(5, {state})).toEqual(5);
     });
   });
 });
 
 describe('getOffsetItem', () => {
   describe('when state represents a list', () => {
-    const items = ['1', '2', '3'].map(createItem);
+    const items = ['0', '1', '2'].map(createItem);
     const state = createState({items});
 
     describe('when the offset is the next item', () => {
       it('should return the next item', () => {
-        expect(getOffsetItem(1)('1', {state})).toEqual(items[1]);
+        expect(getOffsetItem(1)(0, {state})).toEqual(1);
       });
 
       it('should skip non-interactive items', () => {
-        const stateWithNonInteractive = {...state, nonInteractiveIds: ['2']};
-        expect(getOffsetItem(1)('1', {state: stateWithNonInteractive})).toEqual(items[2]);
+        const stateWithNonInteractive = {...state, nonInteractiveIds: ['1']};
+        expect(getOffsetItem(1)(0, {state: stateWithNonInteractive})).toEqual(2);
       });
 
       it('should return the last item if cursor is already the last item', () => {
-        expect(getOffsetItem(1)('3', {state})).toEqual(items[2]);
+        expect(getOffsetItem(1)(2, {state})).toEqual(2);
       });
     });
 
     describe('when the offset is the previous item', () => {
       it('should return the previous item', () => {
-        expect(getOffsetItem(-1)('2', {state})).toEqual(items[0]);
+        expect(getOffsetItem(-1)(1, {state})).toEqual(0);
       });
 
       it('should skip non-interactive items', () => {
-        const stateWithNonInteractive = {...state, nonInteractiveIds: ['2']};
-        expect(getOffsetItem(-1)('3', {state: stateWithNonInteractive})).toEqual(items[0]);
+        const stateWithNonInteractive = {...state, nonInteractiveIds: ['1']};
+        expect(getOffsetItem(-1)(2, {state: stateWithNonInteractive})).toEqual(0);
       });
 
       it('should return the first item if cursor is already the first item and previous item is requested', () => {
-        expect(getOffsetItem(-1)('1', {state})).toEqual(items[0]);
+        expect(getOffsetItem(-1)(0, {state})).toEqual(0);
       });
     });
   });
@@ -459,9 +459,9 @@ describe('getOffsetItem', () => {
   describe('when state represents a grid', () => {
     // use flatten to make it easier to visualize a grid in code, but code requires a flat array
     const items = flatten([
-      ['1', '2', '3'],
-      ['4', '5', '6'],
-      ['7', '8', '9'],
+      ['0', '1', '2'],
+      ['3', '4', '5'],
+      ['6', '7', '8'],
     ]).map(createItem);
     const state = createState({
       items,
@@ -470,61 +470,61 @@ describe('getOffsetItem', () => {
 
     describe('when the offset is the next item', () => {
       it('should return the next item in the row when initial item is within the same row', () => {
-        expect(getOffsetItem(1)('1', {state})).toEqual(items[1]);
+        expect(getOffsetItem(1)(0, {state})).toEqual(1);
       });
 
       it('should skip non-interactive items', () => {
-        const stateWithNonInteractive = {...state, nonInteractiveIds: ['2']};
-        expect(getOffsetItem(1)('1', {state: stateWithNonInteractive})).toEqual(items[2]);
+        const stateWithNonInteractive = {...state, nonInteractiveIds: ['1']};
+        expect(getOffsetItem(1)(0, {state: stateWithNonInteractive})).toEqual(2);
       });
 
       it('should return the last item in a row when the initial item is already on the last item of the row', () => {
-        expect(getOffsetItem(1)('3', {state})).toEqual(items[2]);
+        expect(getOffsetItem(1)(2, {state})).toEqual(2);
       });
     });
 
     describe('when the offset is the previous item', () => {
       it('should return the previous item in the row when initial item is within the same row', () => {
-        expect(getOffsetItem(-1)('2', {state})).toEqual(items[0]);
+        expect(getOffsetItem(-1)(1, {state})).toEqual(0);
       });
 
       it('should skip non-interactive items', () => {
-        const stateWithNonInteractive = {...state, nonInteractiveIds: ['2']};
-        expect(getOffsetItem(-1)('3', {state: stateWithNonInteractive})).toEqual(items[0]);
+        const stateWithNonInteractive = {...state, nonInteractiveIds: ['1']};
+        expect(getOffsetItem(-1)(2, {state: stateWithNonInteractive})).toEqual(0);
       });
 
       it('should return the first item in a row when the initial item is already on the first item of the row', () => {
-        expect(getOffsetItem(-1)('4', {state})).toEqual(items[3]);
+        expect(getOffsetItem(-1)(3, {state})).toEqual(3);
       });
     });
 
     describe('when the offset is the next row', () => {
       it('should return the item in the next row', () => {
-        expect(getOffsetItem(3)('2', {state})).toEqual(items[4]);
+        expect(getOffsetItem(3)(1, {state})).toEqual(4);
       });
 
       it('should skip non-interactive items', () => {
-        const stateWithNonInteractive = {...state, nonInteractiveIds: ['5']};
-        expect(getOffsetItem(3)('2', {state: stateWithNonInteractive})).toEqual(items[7]);
+        const stateWithNonInteractive = {...state, nonInteractiveIds: ['4']};
+        expect(getOffsetItem(3)(1, {state: stateWithNonInteractive})).toEqual(7);
       });
 
       it('should return the current item in a row when the initial item is already on the last row', () => {
-        expect(getOffsetItem(3)('8', {state})).toEqual(items[7]);
+        expect(getOffsetItem(3)(7, {state})).toEqual(7);
       });
     });
 
     describe('when the offset is the previous row', () => {
       it('should return the item in the previous row', () => {
-        expect(getOffsetItem(-3)('8', {state})).toEqual(items[4]);
+        expect(getOffsetItem(-3)(7, {state})).toEqual(4);
       });
 
       it('should skip non-interactive items', () => {
-        const stateWithNonInteractive = {...state, nonInteractiveIds: ['5']};
-        expect(getOffsetItem(-3)('8', {state: stateWithNonInteractive})).toEqual(items[1]);
+        const stateWithNonInteractive = {...state, nonInteractiveIds: ['4']};
+        expect(getOffsetItem(-3)(7, {state: stateWithNonInteractive})).toEqual(1);
       });
 
       it('should return the current item in a row if the initial item is already on the first row', () => {
-        expect(getOffsetItem(-3)('2', {state})).toEqual(items[1]);
+        expect(getOffsetItem(-3)(1, {state})).toEqual(1);
       });
     });
   });

--- a/modules/react/tabs/stories/examples/DynamicTabs.tsx
+++ b/modules/react/tabs/stories/examples/DynamicTabs.tsx
@@ -69,7 +69,6 @@ export const DynamicTabs = () => {
           addTab
         );
       });
-      model.events.goTo({id: 'add'});
     }
   };
 


### PR DESCRIPTION
## Summary

Virtual lists using dynamic data need to intercept navigation changes to trigger data loading. If data isn't loaded yet, an `id` isn't known yet. The navigation managers were updated to use indexes instead of ids to handle unloaded data. This should not effect most people as the navigation manager is provided by default. This is mostly internal.

## Release Category
Components

### BREAKING CHANGES
The signature of the `NavigationManaget` and `NavigationRequestor` was changed to use numeric indexes instead of string identifiers. This will only break for those who created a custom navigation manager.

---

## Checklist

- [x] Label `ready for review` has been added to PR

## For the Reviewer

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)
- [x] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

The tests are the best place to start

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [x] Code
- [x] Documentation
- [x] Testing

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

All code is covered by tests
