### PR TITLE
chore(collection): Move initial cursor to roving focus

### DIFF
--- a/modules/docs/mdx/9.0-UPGRADE-GUIDE.mdx
+++ b/modules/docs/mdx/9.0-UPGRADE-GUIDE.mdx
@@ -388,6 +388,23 @@ knows where it needs to go, but the identifier may not be loaded yet. The mechan
 is private and should not breaking anything. If you created a custom navigation manager, the
 signature has been changed.
 
+The `useListModel` modelHook no longers sets the initial `cursorId` to the first item if no
+`initialCursorId` config option is set. This functionality has been moved to the
+`useListItemRovingFocus` elemProps hook. If you use `useListItemRovingFocus`, the behavior is
+unchanged. If you need the first item to be set as the `cursorId` and you do not use
+`useListItemRovingFocus`, you will have to add this functionality back to your collection logic.
+
+The logic to set the `cursorId` to the first item should go into an item elemProps hook that
+contains the following:
+
+```ts
+React.useEffect(() => {
+  if (!model.state.cursorId && model.state.items.length) {
+    model.events.goTo({id: model.state.items[0].id});
+  }
+}, [model.state.cursorId, model.state.items, model.events]);
+```
+
 ## Utility Updates
 
 ### useTheme and getTheme

--- a/modules/react/collection/lib/useCursorListModel.tsx
+++ b/modules/react/collection/lib/useCursorListModel.tsx
@@ -322,9 +322,6 @@ export const useCursorListModel = createModelHook({
   const pageSizeRef = React.useRef(config.pageSize);
   const columnCount = config.columnCount || 0;
   const list = useBaseListModel(config);
-  const initialCurrentRef = React.useRef(
-    config.initialCursorId || (config.items?.length ? list.state.items![0].id : '')
-  );
   const navigation = config.navigation;
   const cursorIndexRef = React.useRef(-1);
   const setCursor = (index: number) => {
@@ -358,18 +355,6 @@ export const useCursorListModel = createModelHook({
 
   const events = {
     ...list.events,
-    /**
-     * Register an item to the list. Takes in an identifier, a React.Ref and an optional index. This
-     * should be called on component mount
-     */
-    registerItem(data: Parameters<typeof list.events.registerItem>[0]) {
-      // point the cursor at the first item
-      if (!initialCurrentRef.current) {
-        initialCurrentRef.current = list.getId(data.item);
-        setCursorId(initialCurrentRef.current);
-      }
-      list.events.registerItem(data);
-    },
     /** Directly sets the cursor to the list item by its identifier. */
     goTo(data: {id: string}) {
       const index = state.items.findIndex(item => item.id === data.id);

--- a/modules/react/collection/lib/useListItemRovingFocus.tsx
+++ b/modules/react/collection/lib/useListItemRovingFocus.tsx
@@ -47,6 +47,13 @@ export const useListItemRovingFocus = createElemPropsHook(useCursorListModel)(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [model.state.cursorId]);
 
+    // Roving focus must always have a focus stop to function correctly
+    React.useEffect(() => {
+      if (!model.state.cursorId && model.state.items.length) {
+        model.events.goTo({id: model.state.items[0].id});
+      }
+    }, [model.state.cursorId, model.state.items, model.events]);
+
     return {
       onKeyDown(event: React.KeyboardEvent) {
         const handled = keyboardEventToCursorEvents(event, model, isRTL);


### PR DESCRIPTION
## Summary

Fixes: #1234 <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

Not all collections need an initial cursor position to function. This functionality is more suitable for roving tabindex and doesn't work as well for `aria-activedescendant`. This change moves the functionality out of the cursor model and into `useListItemRovingFocus`

## Release Category
Components

### BREAKING CHANGES
If you use `useListModel` to create AND need the initially registered item to be the cursor position AND do not use `useListItemRovingFocus`, you'll have to add logic to set the cursor to that first item in the list. If you use both `useListModel` and `useListItemRovingFocus`, there is not change in behavior.

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [standard MDX template](https://github.com/Workday/canvas-kit/discussions/1131)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)
- [x] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Documentation
