### PR TITLE
feat(text-input): Add clear icon to InputGroup

### DIFF
--- a/jest/verifyComponent.tsx
+++ b/jest/verifyComponent.tsx
@@ -21,7 +21,7 @@ export function verifyComponent(
   Component: React.ComponentType<any>,
   {modelFn, props}: {modelFn?: Function; props: object}
 ) {
-  describe('verifyComponent', () => {
+  describe(`verifyComponent "${Component.displayName}"`, () => {
     const Test = React.forwardRef(({...elemProps}: {as?: React.ElementType}, ref) => {
       const model = modelFn?.() || null;
 

--- a/modules/react/common/lib/utils/components.ts
+++ b/modules/react/common/lib/utils/components.ts
@@ -294,6 +294,11 @@ export const createContainer = <
           ? (elemPropsHook as any)(localModel, elemProps, ref)
           : elemProps;
 
+        // make sure there's always a ref being passed, even if there are no elemProps hooks to run
+        if (ref && !finalElemProps.hasOwnProperty('ref')) {
+          finalElemProps.ref = ref;
+        }
+
         return React.createElement(
           Context.Provider,
           {value: localModel},

--- a/modules/react/text-input/index.ts
+++ b/modules/react/text-input/index.ts
@@ -1,3 +1,3 @@
 export * from './lib/InputIconContainer';
 export * from './lib/TextInput';
-export {InputGroup} from './lib/InputGroup';
+export {InputGroup, useInputGroupModel} from './lib/InputGroup';

--- a/modules/react/text-input/lib/InputGroup.tsx
+++ b/modules/react/text-input/lib/InputGroup.tsx
@@ -17,7 +17,7 @@ import {xSmallIcon} from '@workday/canvas-system-icons-web';
 
 import {TextInput} from './TextInput';
 
-const useInputGroupModel = createModelHook({})(() => {
+export const useInputGroupModel = createModelHook({})(() => {
   const inputRef = React.useRef<HTMLInputElement>(null);
 
   return {

--- a/modules/react/text-input/lib/InputGroup.tsx
+++ b/modules/react/text-input/lib/InputGroup.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 
 import {space} from '@workday/canvas-kit-react/tokens';
 import {
-  createComponent,
+  createContainer,
+  createElemPropsHook,
+  createModelHook,
+  createSubcomponent,
   dispatchInputEvent,
   ExtractProps,
-  mergeProps,
   useForkRef,
   useIsRTL,
 } from '@workday/canvas-kit-react/common';
@@ -15,110 +17,110 @@ import {xSmallIcon} from '@workday/canvas-system-icons-web';
 
 import {TextInput} from './TextInput';
 
-const InputGroupContext = React.createContext<React.RefObject<HTMLInputElement>>({
-  current: null,
+const useInputGroupModel = createModelHook({})(() => {
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  return {
+    state: {
+      inputRef,
+    },
+    events: {},
+  };
 });
 
-export const InputGroupInnerStart = createComponent('div')({
-  Component(elemProps: ExtractProps<typeof Flex>, ref, Element) {
-    return (
-      <Flex
-        ref={ref}
-        as={Element}
-        position="absolute"
-        alignItems="center"
-        justifyContent="center"
-        height="xl"
-        width="xl"
-        {...elemProps}
-      />
-    );
-  },
+export const InputGroupInnerStart = createSubcomponent('div')({
+  modelHook: useInputGroupModel,
+})<ExtractProps<typeof Flex, never>>((elemProps, Element) => {
+  return (
+    <Flex
+      as={Element}
+      position="absolute"
+      alignItems="center"
+      justifyContent="center"
+      height="xl"
+      width="xl"
+      {...elemProps}
+    />
+  );
 });
 
-export const InputGroupInnerEnd = createComponent('div')({
-  Component(elemProps: ExtractProps<typeof Flex>, ref, Element) {
-    return (
-      <Flex
-        ref={ref}
-        as={Element}
-        position="absolute"
-        alignItems="center"
-        justifyContent="center"
-        height="xl"
-        width="xl"
-        {...elemProps}
-      />
-    );
-  },
+export const InputGroupInnerEnd = createSubcomponent('div')({
+  modelHook: useInputGroupModel,
+})<ExtractProps<typeof Flex, never>>((elemProps, Element) => {
+  return (
+    <Flex
+      as={Element}
+      position="absolute"
+      alignItems="center"
+      justifyContent="center"
+      height="xl"
+      width="xl"
+      {...elemProps}
+    />
+  );
 });
 
-export const InputGroupInput = createComponent(TextInput)({
-  Component(elemProps: ExtractProps<typeof Flex>, ref, Element) {
-    const inputRef = React.useContext(InputGroupContext);
-    const elementRef = useForkRef(ref, inputRef);
-    return <Flex ref={elementRef} as={Element} width="100%" {...elemProps} />;
-  },
+const useInputGroupInput = createElemPropsHook(useInputGroupModel)((model, ref) => {
+  const elementRef = useForkRef(ref, model.state.inputRef);
+
+  return {
+    ref: elementRef,
+  };
 });
 
-export interface ClearInputButtonProps {}
+export const InputGroupInput = createSubcomponent(TextInput)({
+  modelHook: useInputGroupModel,
+  elemPropsHook: useInputGroupInput,
+})<ExtractProps<typeof Flex, never>>((elemProps, Element) => {
+  return <Flex as={Element} width="100%" {...elemProps} />;
+});
+
+export const useClearButton = createElemPropsHook(useInputGroupModel)(model => {
+  const [inputHasValue, setInputHasValue] = React.useState(false);
+
+  React.useLayoutEffect(() => {
+    const input = model.state.inputRef.current;
+
+    if (input) {
+      input.addEventListener('input', () => {
+        setInputHasValue(!!input.value);
+      });
+    }
+  }, [model.state.inputRef]);
+
+  return {
+    // This element does not need to be accessible via screen reader. The user can already clear
+    // an input
+    role: 'presentation',
+    // A clear input button doesn't need focus. There's already keyboard keys to clear an input
+    tabIndex: -1,
+    icon: xSmallIcon,
+    // "small" is needed to render correctly within a `TextInput`
+    size: 'small',
+    transition: 'opacity 300ms ease',
+    // prevent a focus change to the button. Focus should stay in the input.
+    onMouseDown(event: React.MouseEvent) {
+      event.preventDefault();
+    },
+    onClick() {
+      // This will clear the input's value
+      dispatchInputEvent(model.state.inputRef.current, '');
+    },
+    style: {
+      opacity: inputHasValue ? 1 : 0,
+      pointerEvents: inputHasValue ? 'auto' : 'none',
+    },
+  } as const;
+});
 
 /**
  * A clear input button. This can be a component later.
  */
-export const ClearInputButton = createComponent(TertiaryButton)({
-  Component(elemProps: ClearInputButtonProps, ref, Element) {
-    const inputRef = React.useContext(InputGroupContext);
-    const localRef = React.useRef<HTMLButtonElement>(null);
-    const elementRef = useForkRef(localRef, ref);
-    const [inputHasValue, setInputHasValue] = React.useState(false);
-
-    React.useLayoutEffect(() => {
-      const input = inputRef.current;
-      const button = localRef.current;
-
-      if (input && button) {
-        input.addEventListener('input', () => {
-          setInputHasValue(!!input.value);
-        });
-      }
-    }, [inputRef, localRef]);
-
-    const props = mergeProps(
-      {
-        onMouseDown(event: React.MouseEvent) {
-          event.preventDefault();
-        },
-        onClick() {
-          dispatchInputEvent(inputRef.current, '');
-        },
-      },
-      elemProps
-    );
-
-    return (
-      <Element
-        ref={elementRef}
-        // This element does not need to be accessible via screen reader. The user can already clear
-        // an input
-        role="presentation"
-        icon={xSmallIcon}
-        // "small" is needed to render correctly within a `TextInput`
-        size="small"
-        // A clear input button doesn't need focus. There's already keyboard keys to clear an input
-        tabIndex={-1}
-        transition="opacity 300ms ease"
-        // Use style attribute to avoid the cost of Emotion's styling solution that causes the
-        // browser to throw away style cache. The difference can be significant for large amount of
-        // elements (could be a 80ms difference)
-        style={{
-          opacity: inputHasValue ? 1 : 0,
-          pointerEvents: inputHasValue ? 'auto' : 'none',
-        }}
-        {...props}
-      />
-    );
-  },
+export const ClearButton = createSubcomponent(TertiaryButton)({
+  modelHook: useInputGroupModel,
+  elemPropsHook: useClearButton,
+})<ExtractProps<typeof TertiaryButton, never>>((elemProps, Element) => {
+  return <Element {...elemProps} />;
 });
 
 // make sure we always use pixels if the input is a number - this is required for `calc`
@@ -158,67 +160,9 @@ const wrapInCalc = (values: (string | number)[]): string | number | undefined =>
  * </InputGroup>
  * ```
  */
-export const InputGroup = createComponent('div')({
+export const InputGroup = createContainer('div')({
   displayName: 'InputGroup',
-  Component({children, ...elemProps}: ExtractProps<typeof Flex>, ref, Element) {
-    const isRTL = useIsRTL();
-    const offsetsStart: (string | number)[] = [];
-    const offsetsEnd: (string | number)[] = [];
-
-    // Collect the widths of the `InnerStart` and `InnerEnd` components into `offsetStart` and
-    // `offsetEnd` arrays
-    React.Children.forEach(children, child => {
-      if (React.isValidElement<any>(child) && child.type === InputGroupInnerStart) {
-        const width = child.props.width || space.xl;
-        offsetsStart.push(width);
-      }
-      if (React.isValidElement<any>(child) && child.type === InputGroupInnerEnd) {
-        const width = child.props.width || space.xl;
-        offsetsEnd.push(width);
-      }
-    });
-
-    // keep track of the index offsets to make sure we calculate the correct position offset
-    let indexStart = 0;
-    let indexEnd = 0;
-
-    // Loop over all the children and set the correct padding and positions
-    const mappedChildren = React.Children.map(children, child => {
-      if (React.isValidElement<any>(child)) {
-        if (child.type === InputGroupInput) {
-          return React.cloneElement(child, {
-            paddingInlineStart: wrapInCalc(offsetsStart),
-            paddingInlineEnd: wrapInCalc(offsetsEnd),
-          });
-        }
-        if (child.type === InputGroupInnerStart) {
-          const offset = wrapInCalc(offsetsStart.slice(0, indexStart)) || 0;
-          indexStart++;
-
-          return React.cloneElement(child, {
-            left: isRTL ? undefined : offset,
-            right: isRTL ? offset : undefined,
-          });
-        }
-        if (child.type === InputGroupInnerEnd) {
-          const offset = wrapInCalc(offsetsEnd.slice(indexEnd, -1)) || 0;
-          indexEnd++;
-
-          return React.cloneElement(child, {
-            left: isRTL ? offset : undefined,
-            right: isRTL ? undefined : offset,
-          });
-        }
-      }
-      return child;
-    });
-
-    return (
-      <Flex ref={ref} as={Element} position="relative" {...elemProps}>
-        {mappedChildren}
-      </Flex>
-    );
-  },
+  modelHook: useInputGroupModel,
   subComponents: {
     /**
      * A component to show inside and at the start of the input. The input's padding will be
@@ -243,6 +187,64 @@ export const InputGroup = createComponent('div')({
      * A component that can be added to an input group that will clear the input. It will only render
      * when the input has a value and will fade when a value is entered.
      */
-    ClearInputButton: ClearInputButton,
+    ClearButton: ClearButton,
   },
+})<ExtractProps<typeof Flex, never>>(({children, ...elemProps}, Element) => {
+  const isRTL = useIsRTL();
+  const offsetsStart: (string | number)[] = [];
+  const offsetsEnd: (string | number)[] = [];
+
+  // Collect the widths of the `InnerStart` and `InnerEnd` components into `offsetStart` and
+  // `offsetEnd` arrays
+  React.Children.forEach(children, child => {
+    if (React.isValidElement<any>(child) && child.type === InputGroupInnerStart) {
+      const width = child.props.width || space.xl;
+      offsetsStart.push(width);
+    }
+    if (React.isValidElement<any>(child) && child.type === InputGroupInnerEnd) {
+      const width = child.props.width || space.xl;
+      offsetsEnd.push(width);
+    }
+  });
+
+  // keep track of the index offsets to make sure we calculate the correct position offset
+  let indexStart = 0;
+  let indexEnd = 0;
+
+  // Loop over all the children and set the correct padding and positions
+  const mappedChildren = React.Children.map(children, child => {
+    if (React.isValidElement<any>(child)) {
+      if (child.type === InputGroupInput) {
+        return React.cloneElement(child, {
+          paddingInlineStart: wrapInCalc(offsetsStart),
+          paddingInlineEnd: wrapInCalc(offsetsEnd),
+        });
+      }
+      if (child.type === InputGroupInnerStart) {
+        const offset = wrapInCalc(offsetsStart.slice(0, indexStart)) || 0;
+        indexStart++;
+
+        return React.cloneElement(child, {
+          left: isRTL ? undefined : offset,
+          right: isRTL ? offset : undefined,
+        });
+      }
+      if (child.type === InputGroupInnerEnd) {
+        const offset = wrapInCalc(offsetsEnd.slice(indexEnd, -1)) || 0;
+        indexEnd++;
+
+        return React.cloneElement(child, {
+          left: isRTL ? offset : undefined,
+          right: isRTL ? undefined : offset,
+        });
+      }
+    }
+    return child;
+  });
+
+  return (
+    <Flex as={Element} position="relative" {...elemProps}>
+      {mappedChildren}
+    </Flex>
+  );
 });

--- a/modules/react/text-input/spec/InputGroup.spec.tsx
+++ b/modules/react/text-input/spec/InputGroup.spec.tsx
@@ -1,13 +1,16 @@
 import * as React from 'react';
 import {renderToString} from 'react-dom/server';
 
-import {searchIcon, xSmallIcon} from '@workday/canvas-system-icons-web';
-import {InputGroup} from '../lib/InputGroup';
-import {TertiaryButton} from '@workday/canvas-kit-react/button';
+import {searchIcon} from '@workday/canvas-system-icons-web';
+import {InputGroup, useInputGroupModel} from '../lib/InputGroup';
 import {SystemIcon} from '@workday/canvas-kit-react/icon';
 
 describe('InputGroup', () => {
-  verifyComponent(InputGroup, {});
+  verifyComponent(InputGroup, {modelFn: useInputGroupModel});
+  verifyComponent(InputGroup.InnerStart, {modelFn: useInputGroupModel});
+  verifyComponent(InputGroup.InnerEnd, {modelFn: useInputGroupModel});
+  verifyComponent(InputGroup.ClearButton, {modelFn: useInputGroupModel});
+  verifyComponent(InputGroup.Input, {modelFn: useInputGroupModel});
 
   it('should render on a server without crashing', () => {
     const ssrRender = () =>
@@ -18,7 +21,7 @@ describe('InputGroup', () => {
           </InputGroup.InnerStart>
           <InputGroup.Input />
           <InputGroup.InnerEnd>
-            <TertiaryButton role="presentation" icon={xSmallIcon} size="small" tabIndex={-1} />
+            <InputGroup.ClearButton />
           </InputGroup.InnerEnd>
         </InputGroup>
       );

--- a/modules/react/text-input/stories/examples/Icons.tsx
+++ b/modules/react/text-input/stories/examples/Icons.tsx
@@ -22,7 +22,7 @@ const InputGroupFormFieldForwarder = (props: {}) => {
       </InputGroup.InnerStart>
       <InputGroup.Input {...props} />
       <InputGroup.InnerEnd>
-        <InputGroup.ClearInputButton />
+        <InputGroup.ClearButton />
       </InputGroup.InnerEnd>
     </InputGroup>
   );

--- a/modules/react/text-input/stories/examples/Icons.tsx
+++ b/modules/react/text-input/stories/examples/Icons.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 
-import {xSmallIcon, mailIcon} from '@workday/canvas-system-icons-web';
+import {mailIcon} from '@workday/canvas-system-icons-web';
 import {FormField} from '@workday/canvas-kit-react/form-field';
-import {TertiaryButton} from '@workday/canvas-kit-react/button';
 import {InputGroup} from '@workday/canvas-kit-react/text-input';
 import {SystemIcon} from '@workday/canvas-kit-react/icon';
-import {createComponent, dispatchInputEvent} from '@workday/canvas-kit-react/common';
 
 export const Icons = () => {
   return (
@@ -17,66 +15,15 @@ export const Icons = () => {
 
 // create a prop forwarding component for FormField to forward to
 const InputGroupFormFieldForwarder = (props: {}) => {
-  const inputRef = React.useRef(null);
-  const [inputHasValue, setInputHasValue] = React.useState(false);
-
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setInputHasValue(!!event.currentTarget.value);
-  };
-
   return (
     <InputGroup width={280}>
       <InputGroup.InnerStart pointerEvents="none">
         <SystemIcon icon={mailIcon} size="small" />
       </InputGroup.InnerStart>
-      <InputGroup.Input ref={inputRef} onChange={handleChange} {...props} />
+      <InputGroup.Input {...props} />
       <InputGroup.InnerEnd>
-        <ClearInputButton inputRef={inputRef} inputHasValue={inputHasValue} />
+        <InputGroup.ClearInputButton />
       </InputGroup.InnerEnd>
     </InputGroup>
   );
 };
-
-/**
- * A clear input button. This can be a component later.
- */
-const ClearInputButton = createComponent(TertiaryButton)({
-  Component(
-    {
-      inputRef,
-      inputHasValue,
-      ...elemProps
-    }: {inputRef: React.RefObject<HTMLInputElement>; inputHasValue: boolean},
-    ref,
-    Element
-  ) {
-    return (
-      <Element
-        ref={ref}
-        // This element does not need to be accessible via screen reader. The user can already clear
-        // an input
-        role="presentation"
-        icon={xSmallIcon}
-        // "small" is needed to render correctly within a `TextInput`
-        size="small"
-        // A clear input button doesn't need focus. There's already keyboard keys to clear an input
-        tabIndex={-1}
-        transition="opacity 300ms ease"
-        // Use style attribute to avoid the cost of Emotion's styling solution that causes the
-        // browser to throw away style cache. The difference can be significant for large amount of
-        // elements (could be a 80ms difference)
-        style={{
-          opacity: inputHasValue ? 1 : 0,
-          pointerEvents: inputHasValue ? 'auto' : 'none',
-        }}
-        {...elemProps}
-        onMouseDown={event => {
-          event.preventDefault(); // prevent a focus change to the button. Focus should stay in the input
-        }}
-        onClick={_ => {
-          dispatchInputEvent(inputRef.current, '');
-        }}
-      />
-    );
-  },
-});


### PR DESCRIPTION
## Summary

It is error prone to add a clear input button to an `InputGroup`. This change makes `ClearInputButton` a subcomponent of `InputGroup` where `InputGroup` internally tracks the inputRef and can match our accessibility specifications.

## Release Category
Components

---

## Checklist

- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [x] Code
- [x] Documentation
- [x] Testing

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

Try typing in the input of this story: https://5d854c26ba934e0020f5e98a-twbtpktbtg.chromatic.com/?path=/story/components-inputs-text-input--icons
