### PR TITLE
chore: Add actions for major release

### DIFF
--- a/.github/workflows/dist-tag.yaml
+++ b/.github/workflows/dist-tag.yaml
@@ -1,0 +1,30 @@
+name: 'Dist Tag Update'
+
+on:
+  workflow_dispatch:
+    inputs:
+      dist-tag:
+        required: true
+        description: Dist tag name
+      version:
+        required: true
+        description: Package version number
+
+jobs:
+  release-major:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: Workday/canvas-kit-actions/install@v1
+        with:
+          node_version: 16.x
+
+      - name: Check packages
+        run: node utils/dist-tag.mjs
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_CI_PUBLISH_TOKEN }}
+          DIST_TAG: ${{ inputs.dist-tag }}
+          VERSION: ${{ inputs.version }}

--- a/.github/workflows/dist-tag.yaml
+++ b/.github/workflows/dist-tag.yaml
@@ -1,4 +1,6 @@
 name: 'Dist Tag Update'
+## Action to update an existing npm dist-tag by the entered package version
+## or to create a new dist-tag if you enter not-existing name
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-major.yml
+++ b/.github/workflows/release-major.yml
@@ -1,0 +1,72 @@
+name: Major Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release-major:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          fetch-depth: 0 # Needed to do a proper push
+
+      # Update support to point to the current major version master is currently pointing to.
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GH_RW_TOKEN }}
+          branch: support
+          tags: true
+
+      # Get and save current major version tag
+      # before the next major version is released
+      # to use it for dist-tag update
+      - name: Get previous tag
+        id: previous-tag
+        run: echo "::set-output name=tag::$(node -p 'require("./lerna.json").version')"
+
+      # Update master to point to the next major release prerelease/major is currently pointing to.
+      # Changes will be pushed with release commit
+      - name: Pull changes >> prerelease/major -> master
+        run: git pull origin prerelease/major
+
+      - uses: Workday/canvas-kit-actions/install@v1
+        with:
+          node_version: 16.x
+
+      # Run release job to launch the next major version
+      - uses: Workday/canvas-kit-actions/release@v1
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          gh_rw_token: ${{ secrets.GH_RW_TOKEN }}
+          publish_token: ${{ secrets.NPM_CI_PUBLISH_TOKEN }}
+          chromatic_project_token: ${{ secrets.CHROMATIC_APP_CODE }}
+          version: 'major'
+          toRef: 'prerelease/major'
+
+      # Update prerelease/minor to point to the next major release.
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GH_RW_TOKEN }}
+          branch: prerelease/minor
+          tags: true
+
+      # Update prerelease/major with the changes from prerelease/minor which include the major release version bump.
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GH_RW_TOKEN }}
+          branch: prerelease/major
+          tags: true
+
+      # Update npm dist tag for support by adding a current major release version
+      - name: Update support dist tag
+        run: node utils/dist-tag.mjs
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_CI_PUBLISH_TOKEN }}
+          DIST_TAG: 'support'
+          VERSION: ${{ steps.previous-tag.outputs.tag }}

--- a/.github/workflows/release-major.yml
+++ b/.github/workflows/release-major.yml
@@ -28,7 +28,7 @@ jobs:
         id: previous-tag
         run: echo "::set-output name=tag::$(node -p 'require("./lerna.json").version')"
 
-      # Update master to point to the next major release prerelease/major is currently pointing to.
+      # Pull changes from prerelease/major into master.
       # Changes will be pushed with release commit
       - name: Pull changes >> prerelease/major -> master
         run: git pull origin prerelease/major

--- a/.github/workflows/release-major.yml
+++ b/.github/workflows/release-major.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           node_version: 16.x
 
-      # Run release job to launch the next major version
+      # Run the release job to publish the next major version to npm
       - uses: Workday/canvas-kit-actions/release@v1
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-major.yml
+++ b/.github/workflows/release-major.yml
@@ -29,7 +29,7 @@ jobs:
         run: echo "::set-output name=tag::$(node -p 'require("./lerna.json").version')"
 
       # Pull changes from prerelease/major into master.
-      # Changes will be pushed with release commit
+      # Changes will be pushed with a release commit
       - name: Pull changes >> prerelease/major -> master
         run: git pull origin prerelease/major
 

--- a/.github/workflows/release-major.yml
+++ b/.github/workflows/release-major.yml
@@ -13,7 +13,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0 # Needed to do a proper push
 
-      # Update support to point to the current major version on master before updating master with the next major version.
+      # Update support to point to the current major version
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:

--- a/.github/workflows/release-major.yml
+++ b/.github/workflows/release-major.yml
@@ -21,7 +21,7 @@ jobs:
           branch: support
           tags: true
 
-      # Get and save current major version tag
+      # Get and save the current major version tag
       # before the next major version is released
       # to use it for dist-tag update
       - name: Get previous tag

--- a/.github/workflows/release-major.yml
+++ b/.github/workflows/release-major.yml
@@ -13,7 +13,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0 # Needed to do a proper push
 
-      # Update support to point to the current major version master is currently pointing to.
+      # Update support to point to the current major version on master before updating master with the next major version.
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:

--- a/.github/workflows/release-major.yml
+++ b/.github/workflows/release-major.yml
@@ -19,7 +19,6 @@ jobs:
         with:
           github_token: ${{ secrets.GH_RW_TOKEN }}
           branch: support
-          tags: true
 
       # Get and save the current major version tag
       # before the next major version is released
@@ -53,7 +52,6 @@ jobs:
         with:
           github_token: ${{ secrets.GH_RW_TOKEN }}
           branch: prerelease/minor
-          tags: true
 
       # Update prerelease/major with the changes from prerelease/minor which include the major release version bump.
       - name: Push changes
@@ -61,7 +59,6 @@ jobs:
         with:
           github_token: ${{ secrets.GH_RW_TOKEN }}
           branch: prerelease/major
-          tags: true
 
       # Update npm dist tag for support by adding a current major release version
       - name: Update support dist tag

--- a/.github/workflows/release-major.yml
+++ b/.github/workflows/release-major.yml
@@ -23,7 +23,7 @@ jobs:
 
       # Get and save the current major version tag
       # before the next major version is released
-      # to use it for dist-tag update
+      # to use it for updating dist-tag on support branch.
       - name: Get previous tag
         id: previous-tag
         run: echo "::set-output name=tag::$(node -p 'require("./lerna.json").version')"

--- a/utils/dist-tag.mjs
+++ b/utils/dist-tag.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// @ts-check
+'use strict';
+
+import {promisify} from 'util';
+import * as childProcess from 'child_process';
+const exec = promisify(childProcess.exec);
+
+const {DIST_TAG = '', VERSION} = process.env;
+
+/**
+ * @description
+ * A util to add and update dist tags from packages
+ *
+ * @param {Object[]} packages - an array of package names
+ * @param {string} version - the package version to be tagged
+ * @param {string} distTag - the dist tag name to associate with the version
+ *
+ * @example
+ * ```ts
+ * const packages = ['@workday/canvas-kit-react'];
+ * updatePackageDistTags(packages, '10.4.2' 'canary', '000000');
+ * ```
+ *
+ */
+export function updatePackageDistTags(packages = [], version = '', distTag = '') {
+  packages.forEach(({name}) => {
+    console.log(`Updating ${distTag} tag on ${name} to ${version}`);
+    exec(`npm dist-tag add "${name}@${version}" ${distTag}`, (error, stdout) => {
+      if (error) {
+        console.warn(error.message);
+      }
+      console.log(stdout);
+    });
+  });
+}
+
+/**
+ * @description
+ * A util to remove unwanted dist tags from packages
+ *
+ * @param {Object[]} packages - an array of package names
+ * @param {string} distTag - the dist tag name to be removed
+ *
+ * @example
+ * ```ts
+ * const packages = ['@workday/canvas-kit-react'];
+ * removePackageDistTags(packages, 'canary', '000000');
+ * ```
+ *
+ */
+export function removePackageDistTags(packages, distTag) {
+  packages.forEach(({name}) => {
+    console.log(`Removing ${distTag} tag for ${name}`);
+    exec(`npm dist-tag remove "${name}" ${distTag}`, (error, stdout) => {
+      if (error) {
+        console.warn(error.message);
+      }
+      console.log(stdout);
+    });
+  });
+}
+
+exec('lerna ls --json')
+  .then(({stdout}) => {
+    const packages = JSON.parse(stdout);
+    if (!VERSION || !DIST_TAG) {
+      console.log('Please review your inputs. Version and dist tag are required');
+      process.exit(1);
+    }
+
+    updatePackageDistTags(packages, VERSION, DIST_TAG);
+  })
+  .catch(err => {
+    console.error(err);
+
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

Resolves: #2185 

This PR adds 2 actions:
- `Dist Tag Update` for the fast dist tag update (I left only functionality for updating tag. We can easily add functionality for removing if we need it.)
- `Major Release` to automize a release process for the next major version

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Infrastructure