### PR TITLE
fix(collection): Fix SSR focus and multiple tab stops

### DIFF
--- a/modules/react/collection/lib/useCursorListModel.tsx
+++ b/modules/react/collection/lib/useCursorListModel.tsx
@@ -315,12 +315,12 @@ export const useCursorListModel = createModelHook({
   },
   requiredConfig: useBaseListModel.requiredConfig,
 })(config => {
-  const [cursorId, setCursorId] = React.useState(config.initialCursorId);
-  const columnCount = config.columnCount || 0;
   const list = useBaseListModel(config);
-  const initialCurrentRef = React.useRef(
+  const [cursorId, setCursorId] = React.useState(
     config.initialCursorId || (config.items?.length ? getId(list.state.items![0]) : '')
   );
+  const columnCount = config.columnCount || 0;
+  const initialCurrentRef = React.useRef(cursorId);
   const navigation = config.navigation;
 
   const state = {


### PR DESCRIPTION
## Summary

Use HTML to extract id when changing focus to avoid issues when the server and client do not agree on id generation. Also, force-choose a default cursor ID when no `initialCursorId` is passed in the model config.

Fixes: #2152, #2218

## Release Category
Components

---

## Checklist

- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [x] Code
- [x] Testing

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

Go through the steps outlined in #2152
The SSR cannot be tested manually without a static-site generator.