### PR TITLE
ci: Fix canary releases

### DIFF
--- a/utils/publish-canary.mjs
+++ b/utils/publish-canary.mjs
@@ -109,7 +109,6 @@ exec('git diff --name-only HEAD HEAD^')
     const lernaFlags = [
       `--yes`,
       `--force-publish="*"`,
-      `--canary`,
       `--preid ${preid}`,
       `--dist-tag ${distTag}`,
       bump,


### PR DESCRIPTION
## Summary

Lerna doesn't seem to support the `canary` option anymore when creating prereleases. The command doesn't work correctly for us anyways, so I'm removing it. From what I can gather (docs don't mention it and info is sparse), it is supposed to create a pre-id using previous tags and the number of commits between the last tag and the current `HEAD`. But this caused problems for us for a long time because we release with every commit on `master` which caused the commit count to repeat and caused the order of versions to be listed out of order. We started using CI build numbers to fix the problem [#1281](https://github.com/Workday/canvas-kit/pull/1281/commits/95b31c1ae82e9a0996996e03a41c86f68419c96e).

## Release Category
Infrastructure

---

I've verified the regex matches and extracts version information properly and it creates the correct output. Running from `prerelease/minor`:

**Before:**

```
yarn lerna publish '--force-publish=*' --canary --preid 427-next --dist-tag next preminor
yarn run v1.22.18
$ /Users/nicholas.boll/projects/canvas-kit/node_modules/.bin/lerna publish '--force-publish=*' --canary --preid 427-next --dist-tag next preminor
lerna notice cli v3.22.1
lerna info canary enabled
lerna WARN Yarn's registry proxy is broken, replacing with public npm registry
lerna WARN If you don't have an npm token, you should exit and run `npm login`
lerna WARN force-publish all packages
lerna info Assuming all packages changed

Found 31 packages to publish:
 - @workday/canvas-kit-codemod => 7.2.0-427-next.2+2c79134a
 - @workday/canvas-kit-css-fonts => 7.2.0-427-next.2+2c79134a
 - @workday/canvas-kit-css-action-bar => 7.2.0-427-next.2+2c79134a
....
```

**After:**

```
yarn lerna publish '--force-publish=*' --preid 427-next --dist-tag next preminor 
yarn run v1.22.18
$ /Users/nicholas.boll/projects/canvas-kit/node_modules/.bin/lerna publish '--force-publish=*' --preid 427-next --dist-tag next preminor
lerna notice cli v3.22.1
lerna WARN Yarn's registry proxy is broken, replacing with public npm registry
lerna WARN If you don't have an npm token, you should exit and run `npm login`
lerna info current version 9.0.2
lerna notice FYI git repository validation has been skipped, please ensure your version bumps are correct
lerna WARN force-publish all packages
lerna info Assuming all packages changed
lerna WARN version Skipping working tree validation, proceed at your own risk

Changes:
 - @workday/canvas-kit-codemod: 9.0.2 => 9.1.0-427-next.0
 - @workday/canvas-kit-css-fonts: 9.0.2 => 9.1.0-427-next.0
 - @workday/canvas-kit-css-action-bar: 9.0.2 => 9.1.0-427-next.0
```