### PR TITLE
feat: Set initial v10 codemod

### DIFF
--- a/modules/codemod/index.js
+++ b/modules/codemod/index.js
@@ -61,6 +61,13 @@ const {_: commands, path, ignoreConfig, ignorePattern, verbose} = require('yargs
       describe: chalk.gray('The path to execute the transform in (recursively).'),
     });
   })
+  .command('v10 [path]', chalk.gray('Canvas Kit v9 > v10 upgrade transform'), yargs => {
+    yargs.positional('path', {
+      type: 'string',
+      default: '.',
+      describe: chalk.gray('The path to execute the transform in (recursively).'),
+    });
+  })
   .demandCommand(1, chalk.red.bold('You must provide a transform to apply.'))
   .strictCommands()
   .fail((msg, err, yargs) => {

--- a/modules/codemod/lib/v10/example.ts
+++ b/modules/codemod/lib/v10/example.ts
@@ -1,0 +1,10 @@
+import {API, FileInfo, Options} from 'jscodeshift';
+
+export default function transformer(file: FileInfo, api: API, options: Options) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  // codemode goes here ...
+
+  return root.toSource();
+}

--- a/modules/codemod/lib/v10/index.ts
+++ b/modules/codemod/lib/v10/index.ts
@@ -1,0 +1,14 @@
+import {Transform} from 'jscodeshift';
+import example from './example';
+
+const transform: Transform = (file, api, options) => {
+  // These will run in order. If your transform depends on others, place yours after dependent transforms
+  const fixes = [
+    // add codemods here
+    example,
+  ];
+
+  return fixes.reduce((source, fix) => fix({...file, source}, api, options) as string, file.source);
+};
+
+export default transform;

--- a/modules/codemod/lib/v10/spec/example.spec.ts
+++ b/modules/codemod/lib/v10/spec/example.spec.ts
@@ -1,0 +1,18 @@
+import {expectTransformFactory} from './expectTransformFactory';
+import transform from '../example';
+import {stripIndent} from 'common-tags';
+
+const expectTransform = expectTransformFactory(transform);
+
+describe('Example', () => {
+  it('should ignore non-canvas-kit imports', () => {
+    const input = stripIndent`
+      import Example from '@workday/some-other-library'
+    `;
+    const expected = stripIndent`
+      import Example from '@workday/some-other-library'
+    `;
+
+    expectTransform(input, expected);
+  });
+});

--- a/modules/codemod/lib/v10/spec/expectTransformFactory.ts
+++ b/modules/codemod/lib/v10/spec/expectTransformFactory.ts
@@ -1,0 +1,9 @@
+import {runInlineTest} from 'jscodeshift/dist/testUtils';
+
+export const expectTransformFactory = (fn: Function) => (
+  input: string,
+  expected: string,
+  options?: Record<string, any>
+) => {
+  return runInlineTest(fn, options, {source: input}, expected, {parser: 'tsx'});
+};


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Resolves: #2238  <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

I've added initial settings for v10 codemod, example codemod has been created to prevent typescript failure in index.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Codemods

## Thank you GIF

![thank you](https://media.giphy.com/media/YAUT0HhJuuRlvZctjy/giphy.gif)