### PR TITLE
docs: Add accessible example for LoadingDots

### DIFF
--- a/modules/react/loading-dots/stories/LoadingDots.stories.mdx
+++ b/modules/react/loading-dots/stories/LoadingDots.stories.mdx
@@ -2,6 +2,7 @@ import {LoadingDots} from '@workday/canvas-kit-react/loading-dots';
 
 import {Basic} from './examples/Basic';
 import {RTL} from './examples/RTL';
+import {Accessible} from './examples/Accessible';
 
 <Meta title="Components/Indicators/Loading Dots" component={LoadingDots} />
 
@@ -27,6 +28,10 @@ yarn add @workday/canvas-kit-react
 ### Right-to-Left (RTL)
 
 <ExampleCodeBlock code={RTL} />
+
+### Accessible Example
+
+<ExampleCodeBlock code={Accessible} />
 
 ## Props
 

--- a/modules/react/loading-dots/stories/examples/Accessible.tsx
+++ b/modules/react/loading-dots/stories/examples/Accessible.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import {LoadingDots} from '@workday/canvas-kit-react/loading-dots';
+
+export const Accessible = () => {
+  return <LoadingDots aria-live="polite" aria-label="Loading Users" />;
+};


### PR DESCRIPTION
## Summary

Fixes: #2241 

Current our loadingDots storybook example does not have an accessible example. Storybook examples should have this example to provide a way to make `LoadingDots` accessible.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Documentation

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [standard MDX template](https://github.com/Workday/canvas-kit/discussions/1131)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Documentation
- [ ] Testing
- [ ] Codemods