### PR TITLE
fix(collection): Default `T` to `any` to allow overriding children types

### DIFF
--- a/modules/react/collection/lib/useListModel.tsx
+++ b/modules/react/collection/lib/useListModel.tsx
@@ -5,7 +5,7 @@ import {useSelectionListModel} from './useSelectionListModel';
 // `SelectionListModel` and renames to `List*`. Without interfaces like this, the result would be
 // `SelectionList*` which is confusing to users, but the separation is easier to maintain
 
-export type ListProps<T = unknown> = {
+export type ListProps<T = any> = {
   children: React.ReactNode | ((item: T) => React.ReactNode);
 };
 


### PR DESCRIPTION
## Summary

Default `T` in the `ListProps` type signature to `any` to allow overriding of the `item` in the dynamic signature.

For example:

```tsx
<Menu items={items}>
  <Menu.List>
    {(item: Item) => <Menu.Item data-id={item.id}>{item.text}</Menu.Item>
  </Menu.List>
</Menu>
```

In this example, TypeScript will error on `item: Item` because `item` is defaulted to `unknown` which TypeScript complains is incompatible. We use `any` because there is no way to infer `item` in the render prop from the `items` from the `Menu` component. TypeScript doesn't do inference across JSX components.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

---

## Checklist

- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

