### PR TITLE
fix: Popper placements export in fallbackPlacements

### DIFF
--- a/modules/react/popup/lib/fallbackPlacements.ts
+++ b/modules/react/popup/lib/fallbackPlacements.ts
@@ -1,6 +1,5 @@
 import {
   Placement as PopperJSPlacement,
-  placements,
   State,
   detectOverflow,
   SideObject,
@@ -9,6 +8,26 @@ import {
 } from '@popperjs/core';
 
 export type Placement = PopperJSPlacement; // Use template literals to make documentation list them out
+
+// We must use our own copy because the commonjs version of Popper doesn't export enums
+// https://github.com/floating-ui/floating-ui/issues/1325
+const placements: Placement[] = [
+  'top',
+  'top-start',
+  'top-end',
+  'bottom',
+  'bottom-start',
+  'bottom-end',
+  'right',
+  'right-start',
+  'right-end',
+  'left',
+  'left-start',
+  'left-end',
+  'auto',
+  'auto-start',
+  'auto-end'
+];
 
 const getOppositePlacement = (popperPlacement: Placement): Placement => {
   const [first, second] = popperPlacement.split('-');


### PR DESCRIPTION
## Summary

We are manually copying `placements` because `@popperjs/core` does not export enums in the commonjs package. This caused Jest tests to fail since Jest uses commonjs module format by default.

https://github.com/floating-ui/floating-ui/issues/1325

## Release Category
Components

---

## Checklist

- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)
