### PR TITLE
feat: Deprecated Status Indicator in Main

### DIFF
--- a/.storybook/routes.js
+++ b/.storybook/routes.js
@@ -17,7 +17,7 @@ const routes = {
   '/components/indicators/banner/': 'components-indicators-banner--basic',
   '/components/indicators/loading-dots/': 'components-indicators-loading-dots--basic',
   '/components/indicators/skeleton/': 'components-indicators-skeleton--basic',
-  '/components/indicators/status-indicator/': 'components-indicators-status-indicator--basic',
+  '/components/indicators/status-indicator/': 'preview-status-indicator--basic',
   '/components/inputs/checkbox/': 'components-inputs-checkbox--basic',
   '/components/inputs/color-input/': 'components-inputs-color-picker-color-input--basic',
   '/components/inputs/form-field/': 'components-inputs-form-field--basic',

--- a/modules/react/status-indicator/lib/StatusIndicator.tsx
+++ b/modules/react/status-indicator/lib/StatusIndicator.tsx
@@ -5,6 +5,11 @@ import {GenericStyle, PickRequired} from '@workday/canvas-kit-react/common';
 import {borderRadius, colors, type, space, CSSProperties} from '@workday/canvas-kit-react/tokens';
 import styled from '@emotion/styled';
 
+/**
+ * ### ⚠️ Status Indicator has been deprecated and will be removed in v11 ⚠️
+ * - Please consider using [`Status Indicator`](https://workday.github.io/canvas-kit/?path=/docs/preview-status-indicator--basic) in preview
+ * @deprecated
+ */
 export enum StatusIndicatorType {
   Gray = 'gray',
   Orange = 'orange',
@@ -14,11 +19,21 @@ export enum StatusIndicatorType {
   Transparent = 'transparent',
 }
 
+/**
+ * ### ⚠️ Status Indicator has been deprecated and will be removed in v11 ⚠️
+ * - Please consider using [`Status Indicator`](https://workday.github.io/canvas-kit/?path=/docs/preview-status-indicator--basic) in preview
+ * @deprecated
+ */
 export enum StatusIndicatorEmphasis {
   High = 'high',
   Low = 'low',
 }
 
+/**
+ * ### ⚠️ Status Indicator has been deprecated and will be removed in v11 ⚠️
+ * - Please consider using [`Status Indicator`](https://workday.github.io/canvas-kit/?path=/docs/preview-status-indicator--basic) in preview
+ * @deprecated
+ */
 export interface StatusIndicatorGenericStyle extends GenericStyle {
   styles: CSSProperties;
   variants: {
@@ -28,6 +43,11 @@ export interface StatusIndicatorGenericStyle extends GenericStyle {
   };
 }
 
+/**
+ * ### ⚠️ Status Indicator has been deprecated and will be removed in v11 ⚠️
+ * - Please consider using [`Status Indicator`](https://workday.github.io/canvas-kit/?path=/docs/preview-status-indicator--basic) in preview
+ * @deprecated
+ */
 export const statusIndicatorStyles: StatusIndicatorGenericStyle = {
   classname: 'status-indicator',
   styles: {
@@ -105,6 +125,11 @@ export const statusIndicatorStyles: StatusIndicatorGenericStyle = {
   },
 };
 
+/**
+ * ### ⚠️ Status Indicator has been deprecated and will be removed in v11 ⚠️
+ * - Please consider using [`Status Indicator`](https://workday.github.io/canvas-kit/?path=/docs/preview-status-indicator--basic) in preview
+ * @deprecated
+ */
 export interface StatusIndicatorProps extends React.HTMLAttributes<HTMLSpanElement> {
   /**
    * The type of the StatusIndicator. Accepts `Gray`, `Orange`, `Blue`, `Green`, `Red`, or `Transparent`.
@@ -146,6 +171,11 @@ const StatusLabel = styled('span')({
   textOverflow: 'ellipsis',
 });
 
+/**
+ * ### ⚠️ Status Indicator has been deprecated and will be removed in v11 ⚠️
+ * - Please consider using [`Status Indicator`](https://workday.github.io/canvas-kit/?path=/docs/preview-status-indicator--basic) in preview
+ * @deprecated
+ */
 export class StatusIndicator extends React.Component<StatusIndicatorProps> {
   public static Type = StatusIndicatorType;
   public static Emphasis = StatusIndicatorEmphasis;


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Deprecate `StatusIndicator` in main. 

Fixes: #2081  <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

`StatusIndicator` in preview is a better alternative since it's newer and a compound component. 

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

---

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
`/modules/react/status-indicator/lib/StatusIndicator.tsx`
`/.storybook/routes.js/`
