### PR TITLE
docs: Update comments about Select options prop to match actual use

### DIFF
--- a/modules/preview-react/select/lib/Select.tsx
+++ b/modules/preview-react/select/lib/Select.tsx
@@ -13,9 +13,10 @@ import {getCorrectedIndexByValue} from './utils';
 
 export interface SelectProps extends CoreSelectBaseProps {
   /**
-   * The options of the Select. `options` may be an array of objects or an array of strings.
+   * The options of the Select. `options` may be an array of objects, an array of strings,
+   * or an array that contains both objects and strings.
    *
-   * If `options` is an array of objects, each object must adhere to the `Option` interface:
+   * If `options` includes objects, each included object must adhere to the `Option` interface:
    *
    * * `data: object` (optional)
    * * `disabled: boolean` (optional)
@@ -76,8 +77,8 @@ class SelectContainer extends React.Component<SelectContainerProps, SelectContai
   };
 
   // Store normalized options since the options prop can take on multiple
-  // forms: an array of strings or an array of objects (sometimes with
-  // arbitrary keys)
+  // forms. It can be an array of strings, an array of objects (sometimes with
+  // arbitrary keys), or an array that contains both strings and objects
   private setNormalizedOptions = (): void => {
     const {options} = this.props;
 


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #2262  <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

This updates certain comments about the `options` prop of `Select` to better match the actual typing of the prop. The prop can include a mix of strings and objects, rather than just one or the other, but the comments did not make that clear.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Documentation

## Checklist

- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)