### PR TITLE
fix(checkbox): Fix indeterminate state not getting correctly applied

### DIFF
--- a/cypress/integration/Checkbox.spec.ts
+++ b/cypress/integration/Checkbox.spec.ts
@@ -43,4 +43,24 @@ describe('Checkbox', () => {
       getCheckbox().should('be.disabled');
     });
   });
+
+  context(`given the 'Indeterminate' story is rendered`, () => {
+    beforeEach(() => {
+      h.stories.load('Components/Inputs/Checkbox', 'Indeterminate');
+    });
+
+    it('should not have any axe errors', () => {
+      cy.checkA11y();
+    });
+
+    it('should have the correct attributes', () => {
+      getCheckbox()
+        .eq(1)
+        .click();
+      getCheckbox()
+        .eq(0)
+        .should('have.prop', 'indeterminate', true)
+        .should('have.attr', 'aria-checked', 'mixed');
+    });
+  });
 });

--- a/modules/react/checkbox/lib/Checkbox.tsx
+++ b/modules/react/checkbox/lib/Checkbox.tsx
@@ -220,7 +220,7 @@ const CheckboxInput = styled('input')<CheckboxProps & StyledType>(
           variant === 'inverse' ? `1px solid ${colors.soap300}` : `1px solid ${errorColors.inner}`,
         boxShadow: `0 0 0 1px ${errorColors.inner}, 0 0 0 2px ${errorColors.outer}`,
       },
-      '&:not(:checked):not(:indeterminate):not(:disabled):not(:focus):hover, &:not(:checked):not(indeterminate):not(:disabled):active': {
+      '&:not(:checked):not(:indeterminate):not(:disabled):not(:focus):hover, &:not(:checked):not(:indeterminate):not(:disabled):active': {
         '~ div:first-of-type': {
           borderColor: variant === 'inverse' ? `1px solid ${colors.soap300}` : errorColors.inner,
         },

--- a/modules/react/checkbox/lib/Checkbox.tsx
+++ b/modules/react/checkbox/lib/Checkbox.tsx
@@ -11,7 +11,6 @@ import {
   useTheme,
   Themeable,
   useLocalRef,
-  useForkRef,
 } from '@workday/canvas-kit-react/common';
 import {borderRadius, colors, inputColors, spaceNumbers} from '@workday/canvas-kit-react/tokens';
 import {SystemIcon} from '@workday/canvas-kit-react/icon';

--- a/modules/react/checkbox/lib/Checkbox.tsx
+++ b/modules/react/checkbox/lib/Checkbox.tsx
@@ -324,7 +324,7 @@ export const Checkbox = createComponent('input')({
     Element
   ) => {
     const inputId = useUniqueId(id);
-    const {localRef} = useLocalRef(useForkRef(ref));
+    const {localRef, elementRef} = useLocalRef(ref);
     React.useEffect(() => {
       if (typeof indeterminate === 'boolean' && localRef.current) {
         localRef.current.indeterminate = indeterminate;
@@ -339,7 +339,7 @@ export const Checkbox = createComponent('input')({
             checked={checked}
             disabled={disabled}
             id={inputId}
-            ref={localRef}
+            ref={elementRef}
             type="checkbox"
             variant={variant}
             aria-checked={indeterminate ? 'mixed' : checked}

--- a/modules/react/checkbox/lib/Checkbox.tsx
+++ b/modules/react/checkbox/lib/Checkbox.tsx
@@ -10,6 +10,8 @@ import {
   styled,
   useTheme,
   Themeable,
+  useLocalRef,
+  useForkRef,
 } from '@workday/canvas-kit-react/common';
 import {borderRadius, colors, inputColors, spaceNumbers} from '@workday/canvas-kit-react/tokens';
 import {SystemIcon} from '@workday/canvas-kit-react/icon';
@@ -132,12 +134,12 @@ const CheckboxInput = styled('input')<CheckboxProps & StyledType>(
     },
 
     // States
-    '&:not(:checked):not(:disabled):not(:focus):hover, &:not(:checked):not(:disabled):active': {
+    '&:not(:checked):not(:indeterminate):not(:disabled):not(:focus):hover, &:not(:checked):not(:indeterminate):not(:disabled):active': {
       '~ div:first-of-type': {
         borderColor: variant === 'inverse' ? colors.soap300 : inputColors.hoverBorder,
       },
     },
-    '&:checked ~ div:first-of-type': {
+    '&:checked ~ div:first-of-type, &:indeterminate ~ div:first-of-type': {
       borderColor: variant === 'inverse' ? colors.soap300 : themePrimary.main,
       backgroundColor: variant === 'inverse' ? colors.frenchVanilla100 : themePrimary.main,
     },
@@ -146,7 +148,7 @@ const CheckboxInput = styled('input')<CheckboxProps & StyledType>(
       backgroundColor: variant === 'inverse' ? colors.soap300 : inputColors.disabled.background,
       opacity: variant === 'inverse' ? '.4' : '1',
     },
-    '&:disabled:checked ~ div:first-of-type': {
+    '&:disabled:checked ~ div:first-of-type, &:disabled:indeterminate ~ div:first-of-type': {
       borderColor: variant === 'inverse' ? colors.soap300 : themePrimary.light,
       backgroundColor: variant === 'inverse' ? colors.soap300 : themePrimary.light,
     },
@@ -167,7 +169,7 @@ const CheckboxInput = styled('input')<CheckboxProps & StyledType>(
         outerColor: variant === 'inverse' ? colors.frenchVanilla100 : undefined,
       }),
     },
-    '&:checked:focus ~ div:first-of-type': {
+    '&:checked:focus ~ div:first-of-type, &:indeterminate:focus ~ div:first-of-type': {
       ...focusRing({
         width: 2,
         separation: 2,
@@ -192,10 +194,10 @@ const CheckboxInput = styled('input')<CheckboxProps & StyledType>(
           marginLeft: '-6px',
         },
       },
-      '&:checked ~ div:first-of-type': {
+      '&:checked ~ div:first-of-type, &:indeterminate ~ div:first-of-type': {
         borderColor: variant === 'inverse' ? colors.soap300 : themePrimary.main,
       },
-      '&:disabled:checked ~ div:first-of-type': {
+      '&:disabled:checked ~ div:first-of-type, &:disabled:indeterminate ~ div:first-of-type': {
         borderColor: themePrimary.light,
         backgroundColor: variant === 'inverse' ? colors.soap300 : themePrimary.light,
       },
@@ -219,12 +221,12 @@ const CheckboxInput = styled('input')<CheckboxProps & StyledType>(
           variant === 'inverse' ? `1px solid ${colors.soap300}` : `1px solid ${errorColors.inner}`,
         boxShadow: `0 0 0 1px ${errorColors.inner}, 0 0 0 2px ${errorColors.outer}`,
       },
-      '&:not(:checked):not(:disabled):not(:focus):hover, &:not(:checked):not(:disabled):active': {
+      '&:not(:checked):not(:indeterminate):not(:disabled):not(:focus):hover, &:not(:checked):not(indeterminate):not(:disabled):active': {
         '~ div:first-of-type': {
           borderColor: variant === 'inverse' ? `1px solid ${colors.soap300}` : errorColors.inner,
         },
       },
-      '&:checked ~ div:first-of-type': {
+      '&:checked ~ div:first-of-type, &:indeterminate ~ div:first-of-type': {
         borderColor: variant === 'inverse' ? colors.soap300 : theme.canvas.palette.primary.main,
         boxShadow: `
               0 0 0 2px ${colors.frenchVanilla100},
@@ -236,7 +238,7 @@ const CheckboxInput = styled('input')<CheckboxProps & StyledType>(
       // Error rings take precedence over focus
       ...mouseFocusBehavior({
         ...errorStyles,
-        '&:not(:checked):focus ~ div:first-of-type': {
+        '&:not(:checked):not(:indeterminate):focus ~ div:first-of-type': {
           border: `1px solid ${errorColors.inner}`,
           boxShadow: `0 0 0 1px ${errorColors.inner}, 0 0 0 2px ${errorColors.outer}`,
         },
@@ -266,7 +268,7 @@ const CheckboxBackground = styled('div')<CheckboxProps>(
   })
 );
 
-const CheckboxCheck = styled('div')<Pick<CheckboxProps, 'checked'>>(
+const CheckboxCheck = styled('div')<Pick<CheckboxProps, 'checked' | 'indeterminate'>>(
   {
     display: 'flex',
     flexDirection: 'column',
@@ -284,9 +286,9 @@ const CheckboxCheck = styled('div')<Pick<CheckboxProps, 'checked'>>(
       transition: 'margin 200ms ease',
     },
   },
-  ({checked}) => ({
-    opacity: checked ? 1 : 0,
-    transform: checked ? 'scale(1)' : 'scale(0.5)',
+  ({checked, indeterminate}) => ({
+    opacity: checked || indeterminate ? 1 : 0,
+    transform: checked || indeterminate ? 'scale(1)' : 'scale(0.5)',
   })
 );
 
@@ -322,6 +324,13 @@ export const Checkbox = createComponent('input')({
     Element
   ) => {
     const inputId = useUniqueId(id);
+    const {localRef} = useLocalRef(useForkRef(ref));
+    React.useEffect(() => {
+      if (typeof indeterminate === 'boolean' && localRef.current) {
+        localRef.current.indeterminate = indeterminate;
+      }
+    }, [indeterminate, localRef]);
+
     return (
       <CheckboxContainer>
         <CheckboxInputWrapper disabled={disabled}>
@@ -330,7 +339,7 @@ export const Checkbox = createComponent('input')({
             checked={checked}
             disabled={disabled}
             id={inputId}
-            ref={ref}
+            ref={localRef}
             type="checkbox"
             variant={variant}
             aria-checked={indeterminate ? 'mixed' : checked}
@@ -338,10 +347,10 @@ export const Checkbox = createComponent('input')({
           />
           <CheckboxRipple variant={variant} />
           <CheckboxBackground variant={variant} checked={checked} disabled={disabled}>
-            <CheckboxCheck checked={checked}>
+            <CheckboxCheck checked={checked} indeterminate={indeterminate}>
               {indeterminate ? (
                 <IndeterminateBox variant={variant} />
-              ) : (
+              ) : checked ? (
                 <SystemIcon
                   icon={checkSmallIcon}
                   color={
@@ -350,7 +359,7 @@ export const Checkbox = createComponent('input')({
                       : theme.canvas.palette.primary.contrast
                   }
                 />
-              )}
+              ) : null}
             </CheckboxCheck>
           </CheckboxBackground>
         </CheckboxInputWrapper>

--- a/modules/react/checkbox/lib/Checkbox.tsx
+++ b/modules/react/checkbox/lib/Checkbox.tsx
@@ -368,6 +368,7 @@ export const Checkbox = createComponent('input')({
             disabled={disabled}
             variant={variant}
             paddingInlineStart={checkboxLabelDistance}
+            cursor="pointer"
           >
             {label}
           </LabelText>

--- a/modules/react/checkbox/stories/examples/Indeterminate.tsx
+++ b/modules/react/checkbox/stories/examples/Indeterminate.tsx
@@ -45,8 +45,8 @@ export const Indeterminate = () => {
 
     const anyToppingChecked = newToppings.filter(topping => topping.checked).length > 0;
     const anyToppingUnchecked = newToppings.filter(topping => !topping.checked).length > 0;
-    setPizzaChecked(anyToppingChecked);
     setPizzaIndeterminate(anyToppingChecked && anyToppingUnchecked);
+    setPizzaChecked(anyToppingChecked && !anyToppingUnchecked);
   };
 
   return (

--- a/modules/react/checkbox/stories/examples/Indeterminate.tsx
+++ b/modules/react/checkbox/stories/examples/Indeterminate.tsx
@@ -45,8 +45,9 @@ export const Indeterminate = () => {
 
     const anyToppingChecked = newToppings.filter(topping => topping.checked).length > 0;
     const anyToppingUnchecked = newToppings.filter(topping => !topping.checked).length > 0;
+    const allToppingChecked = !anyToppingUnchecked;
     setPizzaIndeterminate(anyToppingChecked && anyToppingUnchecked);
-    setPizzaChecked(anyToppingChecked && !anyToppingUnchecked);
+    setPizzaChecked(allToppingChecked);
   };
 
   return (


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #2280   <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

The underlying checkbox was not getting the indeterminate attribute applied and we were relying on it being both checked and indeterminate to update the visual display. This change sets the attribute and updates the CSS to also check the `:indeterminate` pseudo class. Indeterminate checkboxes are a bit odd as [the state can't be directly changed via HTML and needs to be set with a ref](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes)

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [standard MDX template](https://github.com/Workday/canvas-kit/discussions/1131)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)
- [x] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [x] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Documentation
- [x] Testing
- [ ] Codemods

## Thank You Gif (optional)

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer! -->
![a Simpsons character holding up a diploma "With minor indetermination"](https://media.giphy.com/media/3o6Mblw9QLk8arGbIc/giphy.gif)
