### PR TITLE
fix(combobox): Do not clear the input when no item is selected

### DIFF
--- a/cypress/integration/Autocomplete.spec.ts
+++ b/cypress/integration/Autocomplete.spec.ts
@@ -332,6 +332,22 @@ describe('Autocomplete', () => {
           });
         });
       });
+      
+      context('when the user types in a value not found', () => {
+        beforeEach(() => {
+          cy.findByRole('combobox').type('Peach');
+        });
+
+        context('when the user hits the enter key', () => {
+          beforeEach(() => {
+            cy.findByRole('combobox').type('{enter}');
+          });
+        });
+
+        it('should not clear the input', () => {
+          cy.findByRole('combobox').should('have.value', 'Peach');
+        });
+      });
     });
   });
 });

--- a/modules/react/combobox/lib/ComboboxInput.tsx
+++ b/modules/react/combobox/lib/ComboboxInput.tsx
@@ -56,11 +56,8 @@ export const useComboboxInput = composeHooks(
           dispatchInputEvent(event.currentTarget as HTMLElement, '');
         }
         if (event.key === 'Enter' && !event.metaKey && model.state.visibility === 'visible') {
-          if (
-            document
-              .querySelector(`[data-id="${model.state.cursorId}"]`)
-              ?.getAttribute('aria-disabled') !== 'true'
-          ) {
+          const element = document.querySelector(`[data-id="${model.state.cursorId}"]`);
+          if (element && element?.getAttribute('aria-disabled') !== 'true') {
             model.events.select({id: model.state.cursorId});
             if (model.state.mode === 'single') {
               model.events.hide(event);


### PR DESCRIPTION
## Summary

Removes the accidental logic that closes the menu and clears the input when no item is selected.

Fixes: #2288

## Release Category
Components

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [standard MDX template](https://github.com/Workday/canvas-kit/discussions/1131)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Testing

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

Go to the Autocomplete example and type "Peach" and hit the enter key. It should not clear the input

