### PR TITLE
fix: Changing ARIA role to switch

### DIFF
--- a/cypress/integration/Switch.spec.ts
+++ b/cypress/integration/Switch.spec.ts
@@ -1,7 +1,7 @@
 import * as h from '../helpers';
 
 const getSwitch = () => {
-  return cy.findByRole('checkbox');
+  return cy.findByRole('switch');
 };
 
 describe('Switch', () => {

--- a/modules/react/switch/lib/Switch.tsx
+++ b/modules/react/switch/lib/Switch.tsx
@@ -177,8 +177,7 @@ export const Switch = createComponent('input')({
           id={inputId}
           ref={ref}
           onChange={onChange}
-          role="checkbox"
-          tabIndex={0}
+          role="switch"
           type="checkbox"
           value={value}
           {...elemProps}

--- a/modules/react/switch/spec/Switch.spec.tsx
+++ b/modules/react/switch/spec/Switch.spec.tsx
@@ -5,15 +5,7 @@ import {Switch} from '../lib/Switch';
 describe('Switch', () => {
   const cb = jest.fn();
 
-  /**
-   * Today, this is hardcoded but this could possibly be
-   * configurable in the future (e.g. role='switch').
-   * In fact, 'checkbox' probably isn't the correct role
-   * according to MDN and ARIA
-   * https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Switch_role
-   * https://www.w3.org/TR/wai-aria-1.1/#switch
-   */
-  const role = 'checkbox';
+  const role = 'switch';
 
   afterEach(() => {
     cb.mockClear();


### PR DESCRIPTION
## Summary

Contributing updates to the accessibility guidelines on the Canvas Kit design site, I noticed the Switch component rendered with an ARIA checkbox role. This didn't seem appropriate for the Switch component.  Additionally, removing tabindex attribute. Didn't seem necessary when the input element is already in focus order anyway.

## Release Category
Components

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [standard MDX template](https://github.com/Workday/canvas-kit/discussions/1131)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->
`/modules/react/switch/lib`

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Documentation
- [ ] Testing
- [ ] Codemods

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

<!-- Explain how your reviewer could verify this change  -->
1. Make sure the Switch component still appears in keyboard focus order, 
2. Make sure the Switch component still responds to the Space bar and changing state, 
3. Validate screen readers are describing the component's role as "switch"
4. Validate screen readers are describing the state of "on" or "off"

## Screenshots or GIFs (if applicable)

<!-- Does your change affect the UI? If so, please include a screenshot or short gif. -->
ARIA roles do not have any impact on the visual UI. 

## Thank You Gif (optional)

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer! -->
<!-- ![a smiling Shiba Inu typing on a laptop](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif) -->
