### PR TITLE
fix(preview): Blur firing incorrectly onClick

### DIFF
--- a/modules/preview-react/select/lib/Select.tsx
+++ b/modules/preview-react/select/lib/Select.tsx
@@ -544,6 +544,7 @@ class SelectContainer extends React.Component<SelectContainerProps, SelectContai
       buttonRef,
       options,
       onKeyDown,
+      onBlur,
 
       ...elemProps
     } = this.props;

--- a/modules/preview-react/select/lib/SelectBase.tsx
+++ b/modules/preview-react/select/lib/SelectBase.tsx
@@ -304,6 +304,7 @@ export const SelectBase = ({
   menuVisibility = 'closed',
   onChange,
   onKeyDown,
+  onBlur,
   onClose,
   onOptionSelection,
   options,
@@ -432,6 +433,14 @@ export const SelectBase = ({
         grow={grow}
         menuVisibility={menuVisibility}
         onKeyDown={onKeyDown}
+        onBlur={event => {
+          if (menuVisibility === 'closed') {
+            onBlur?.(event);
+          } else {
+            event.preventDefault();
+            event.stopPropagation();
+          }
+        }}
         // Prevent Firefox from triggering click handler on spacebar during
         // type-ahead when the menu is closed (and, thus, incorrectly displaying
         // the menu)


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #2303 <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

When you click to open the preview `<Select />` menu, onBlur event is immediately triggered. This is somewhat expected since the focus moves from the button to the menu, however is not desirable since many validation libraries use the blur event to check the field. This change blocks triggering the blur event unless the menu is closed.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [standard MDX template](https://github.com/Workday/canvas-kit/discussions/1131)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Documentation
- [x] Testing
- [ ] Codemods

I tried writing RTL tests for this, but couldn't get the events to trigger like they do for real users. Not sure if we would need to introduce the user-event lib for more accurate results.

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

I tested in storybook adding an onBlur to the FormField wrapper

## Thank You Gif (optional)

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer! -->
<!-- ![man in sunglasses declaring "it is too much"](https://media.giphy.com/media/2aIZfQdC2V7bBvU5t2/giphy.gif) -->
