### PR TITLE
fix: Breadcrumbs first item gets cut-off when two items in array

### DIFF
--- a/modules/react/breadcrumbs/lib/hooks/utils/index.ts
+++ b/modules/react/breadcrumbs/lib/hooks/utils/index.ts
@@ -7,10 +7,10 @@ export const reorganizeHiddenItems = (
   const totalSize = items.length;
   const itemSpace = totalSize - hiddenIds.length;
 
-  if (itemSpace <= 2) {
+  if (totalSize > 2 && itemSpace <= 2) {
     // Keep only last items if there is place for two or less items
     updatedHiddenIds = items.slice(0, totalSize - 1).map(getId);
-  } else if (itemSpace === 3) {
+  } else if (totalSize > 3 && itemSpace === 3) {
     // Always keep first and last item if there is place for 3 items
     updatedHiddenIds = items.slice(1, totalSize - 1).map(getId);
   } else if (itemSpace > 3 && itemSpace < totalSize) {

--- a/modules/react/breadcrumbs/stories/stories_VisualTesting.tsx
+++ b/modules/react/breadcrumbs/stories/stories_VisualTesting.tsx
@@ -115,7 +115,7 @@ export const WithOverflowMenuHavingTwoItems = () => {
 
   const [items] = React.useState<Breadcrumb[]>([
     {id: '1', text: 'Home', link: '/'},
-    {id: '2', text: 'Second Link', link: '#'},
+    {id: '2', text: 'Second Link'},
   ]);
 
   return (

--- a/modules/react/breadcrumbs/stories/stories_VisualTesting.tsx
+++ b/modules/react/breadcrumbs/stories/stories_VisualTesting.tsx
@@ -113,23 +113,29 @@ export const WithOverflowMenuHavingTwoItems = () => {
     text: string;
   }
 
-  const [items] = React.useState<Breadcrumb[]>([
+  const [twoItems] = React.useState<Breadcrumb[]>([
     {id: '1', text: 'Home', link: '/'},
-    {id: '2', text: 'Second Link'},
+    {id: '2', text: 'Current'},
+  ]);
+
+  const [threeItems] = React.useState<Breadcrumb[]>([
+    {id: '1', text: 'Home', link: '/'},
+    {id: '2', text: 'Second Link', link: '#'},
+    {id: '3', text: 'Current'},
   ]);
 
   return (
     <StaticStates>
       <ComponentStatesTable
         rowProps={[
-          {label: 'Lowest level', props: {maxWidth: 150}},
-          {label: '2 items displayed', props: {maxWidth: 250}},
+          {label: 'Overflow with only 2 items total', props: {maxWidth: 150, items: twoItems}},
+          {label: 'Overflow with only 3 items total', props: {maxWidth: 250, items: threeItems}},
         ]}
         columnProps={[{label: 'Default', props: {}}]}
       >
         {props => {
           return (
-            <Breadcrumbs items={items} aria-label="Breadcrumbs">
+            <Breadcrumbs items={props.items} aria-label="Breadcrumbs">
               <Breadcrumbs.List
                 maxWidth={props.maxWidth}
                 overflowButton={<Breadcrumbs.OverflowButton aria-label="More links" />}

--- a/modules/react/breadcrumbs/stories/stories_VisualTesting.tsx
+++ b/modules/react/breadcrumbs/stories/stories_VisualTesting.tsx
@@ -106,6 +106,61 @@ export const WithOverflowMenu = () => {
   );
 };
 
+export const WithOverflowMenuHavingTwoItems = () => {
+  interface Breadcrumb {
+    id: string;
+    link?: string;
+    text: string;
+  }
+
+  const [items] = React.useState<Breadcrumb[]>([
+    {id: '1', text: 'Home', link: '/'},
+    {id: '2', text: 'Second Link', link: '#'},
+  ]);
+
+  return (
+    <StaticStates>
+      <ComponentStatesTable
+        rowProps={[
+          {label: 'Lowest level', props: {maxWidth: 150}},
+          {label: '2 items displayed', props: {maxWidth: 250}},
+        ]}
+        columnProps={[{label: 'Default', props: {}}]}
+      >
+        {props => {
+          return (
+            <Breadcrumbs items={items} aria-label="Breadcrumbs">
+              <Breadcrumbs.List
+                maxWidth={props.maxWidth}
+                overflowButton={<Breadcrumbs.OverflowButton aria-label="More links" />}
+              >
+                {item =>
+                  item.link ? (
+                    <Breadcrumbs.Item>
+                      <Breadcrumbs.Link href={item.link}>{item.text}</Breadcrumbs.Link>
+                    </Breadcrumbs.Item>
+                  ) : (
+                    <Breadcrumbs.CurrentItem>{item.text}</Breadcrumbs.CurrentItem>
+                  )
+                }
+              </Breadcrumbs.List>
+              <Breadcrumbs.Menu.Popper>
+                <Breadcrumbs.Menu.Card maxWidth={300} maxHeight={200}>
+                  <Breadcrumbs.Menu.List>
+                    {(item: Breadcrumb) => (
+                      <Breadcrumbs.Menu.Item>{item.text}</Breadcrumbs.Menu.Item>
+                    )}
+                  </Breadcrumbs.Menu.List>
+                </Breadcrumbs.Menu.Card>
+              </Breadcrumbs.Menu.Popper>
+            </Breadcrumbs>
+          );
+        }}
+      </ComponentStatesTable>
+    </StaticStates>
+  );
+};
+
 export const RTLStates = () => {
   return (
     <StaticStates>


### PR DESCRIPTION
## Summary

Fixes a bug where Breadcrumbs truncates the array of items even if there are only two or three items in the array and an overflow button is present.

Fixes: #2306

## Release Category
Components

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [standard MDX template](https://github.com/Workday/canvas-kit/discussions/1131)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable


## Screenshots or GIFs (if applicable)

Before
![chrome-capture-2023-7-3](https://github.com/Workday/canvas-kit/assets/25821921/c9aacaf4-7f3f-48c1-9b85-09f768e9edd1)

After
![chrome-capture-2023-7-3 (1)](https://github.com/Workday/canvas-kit/assets/25821921/8f238f49-498f-421b-8ba5-6b699b6c03a0)

Story Visual updated

<img width="1441" alt="Screenshot 2023-08-03 at 17 16 14" src="https://github.com/Workday/canvas-kit/assets/25821921/e01fc306-fc56-4060-8740-85eac9f6d044">
