### PR TITLE
feat: Deprecate InputIconContainer

### DIFF
--- a/modules/docs/mdx/10.0-UPGRADE_GUIDE.mdx
+++ b/modules/docs/mdx/10.0-UPGRADE_GUIDE.mdx
@@ -12,6 +12,7 @@ any questions.
 - [Removals](#removals)
   - [Menu (Preview)](#menu-preview)
 - [Deprecations](#deprecations)
+  - [InputIconContainer](#input-icon-container)
 - [Token Updates](#token-updates)
   - [Space and Depth](#space-and-depth)
 - [Component Updates](#component-updates)
@@ -69,6 +70,12 @@ This change is **not** handled by the codemod due to the differences in API betw
 Preview and the `Menu` in Main.
 
 ## Deprecations
+
+### Input Icon Container
+
+We've deprecated `InputIconContainer` from `TextInput` component, because it doesn't handle
+bidirectionality or icons at the start of an input. `InputGroup` should be used instead of
+deprecated `InputIconContainer`.
 
 ## Token Updates
 

--- a/modules/docs/mdx/10.0-UPGRADE_GUIDE.mdx
+++ b/modules/docs/mdx/10.0-UPGRADE_GUIDE.mdx
@@ -73,7 +73,7 @@ Preview and the `Menu` in Main.
 
 ### Input Icon Container
 
-We've deprecated `InputIconContainer` from `TextInput` component because it doesn't handle
+We've deprecated `InputIconContainer` from Main because it doesn't handle
 bidirectionality or icons at the start of an input. Use [`InputGroup`](https://workday.github.io/canvas-kit/?path=/story/components-inputs-text-input--icons) instead.
 
 ## Token Updates

--- a/modules/docs/mdx/10.0-UPGRADE_GUIDE.mdx
+++ b/modules/docs/mdx/10.0-UPGRADE_GUIDE.mdx
@@ -73,7 +73,7 @@ Preview and the `Menu` in Main.
 
 ### Input Icon Container
 
-We've deprecated `InputIconContainer` from Main because it doesn't handle
+We've deprecated `InputIconContainer` from [Main](#main) because it doesn't handle
 bidirectionality or icons at the start of an input. Use [`InputGroup`](https://workday.github.io/canvas-kit/?path=/story/components-inputs-text-input--icons) instead.
 
 ## Token Updates

--- a/modules/docs/mdx/10.0-UPGRADE_GUIDE.mdx
+++ b/modules/docs/mdx/10.0-UPGRADE_GUIDE.mdx
@@ -73,10 +73,9 @@ Preview and the `Menu` in Main.
 
 ### Input Icon Container
 
-We've deprecated `InputIconContainer` from `TextInput` component, because it doesn't handle
-bidirectionality or icons at the start of an input. `InputGroup` should be used instead of
-deprecated `InputIconContainer`. Example of using `InputGroup` you can find in
-[this story](https://workday.github.io/canvas-kit/?path=/story/components-inputs-text-input--icons).
+We've deprecated `InputIconContainer` from `TextInput` component because it doesn't handle
+bidirectionality or icons at the start of an input. Use `InputGroup` instead.
+Here's an [example](https://workday.github.io/canvas-kit/?path=/story/components-inputs-text-input--icons) of using `InputGroup`.
 
 ## Token Updates
 

--- a/modules/docs/mdx/10.0-UPGRADE_GUIDE.mdx
+++ b/modules/docs/mdx/10.0-UPGRADE_GUIDE.mdx
@@ -75,7 +75,8 @@ Preview and the `Menu` in Main.
 
 We've deprecated `InputIconContainer` from `TextInput` component, because it doesn't handle
 bidirectionality or icons at the start of an input. `InputGroup` should be used instead of
-deprecated `InputIconContainer`.
+deprecated `InputIconContainer`. Example of using `InputGroup` you can find in
+[this story](https://workday.github.io/canvas-kit/?path=/story/components-inputs-text-input--icons).
 
 ## Token Updates
 

--- a/modules/docs/mdx/10.0-UPGRADE_GUIDE.mdx
+++ b/modules/docs/mdx/10.0-UPGRADE_GUIDE.mdx
@@ -74,7 +74,7 @@ Preview and the `Menu` in Main.
 ### Input Icon Container
 
 We've deprecated `InputIconContainer` from [Main](#main) because it doesn't handle
-bidirectionality or icons at the start of an input. Use [`InputGroup`](https://workday.github.io/canvas-kit/?path=/story/components-inputs-text-input--icons) instead.
+bidirectionality or icons at the start of an input. Please consider using [`InputGroup`](https://workday.github.io/canvas-kit/?path=/story/components-inputs-text-input--icons) instead.
 
 ## Token Updates
 

--- a/modules/docs/mdx/10.0-UPGRADE_GUIDE.mdx
+++ b/modules/docs/mdx/10.0-UPGRADE_GUIDE.mdx
@@ -74,8 +74,7 @@ Preview and the `Menu` in Main.
 ### Input Icon Container
 
 We've deprecated `InputIconContainer` from `TextInput` component because it doesn't handle
-bidirectionality or icons at the start of an input. Use `InputGroup` instead.
-Here's an [example](https://workday.github.io/canvas-kit/?path=/story/components-inputs-text-input--icons) of using `InputGroup`.
+bidirectionality or icons at the start of an input. Use [`InputGroup`](https://workday.github.io/canvas-kit/?path=/story/components-inputs-text-input--icons) instead.
 
 ## Token Updates
 

--- a/modules/react/text-input/lib/InputIconContainer.tsx
+++ b/modules/react/text-input/lib/InputIconContainer.tsx
@@ -4,6 +4,11 @@ import {GrowthBehavior} from '@workday/canvas-kit-react/common';
 import {space} from '@workday/canvas-kit-react/tokens';
 import {SystemIcon} from '@workday/canvas-kit-react/icon';
 
+/**
+ * We've deprecated `InputIconContainer` from `TextInput` component
+ * together with `InputIconContainerProps`.
+ * @deprecated
+ */
 export interface InputIconContainerProps extends GrowthBehavior {
   icon?: React.ReactElement<typeof SystemIcon>;
 }
@@ -20,6 +25,9 @@ const IconContainer = styled('div')({
 });
 
 /**
+ * We've deprecated `InputIconContainer` from `TextInput` component, because it doesn't handle
+ * bidirectionality or icons at the start of an input. `InputGroup` should be used instead of
+ * deprecated `InputIconContainer`.
  * @deprecated
  */
 

--- a/modules/react/text-input/lib/InputIconContainer.tsx
+++ b/modules/react/text-input/lib/InputIconContainer.tsx
@@ -7,7 +7,7 @@ import {SystemIcon} from '@workday/canvas-kit-react/icon';
 /**
  * We've deprecated `InputIconContainer` from `TextInput` component
  * together with `InputIconContainerProps`.
-  Please consider using [`InputGroup`](https://workday.github.io/canvas-kit/?path=/docs/components-inputs-text-input--icons).
+ * Please consider using [`InputGroup`](https://workday.github.io/canvas-kit/?path=/docs/components-inputs-text-input--icons).
  * @deprecated
  */
 export interface InputIconContainerProps extends GrowthBehavior {
@@ -28,7 +28,7 @@ const IconContainer = styled('div')({
 /**
  * We've deprecated `InputIconContainer` from `TextInput` component, because it doesn't handle
  * bidirectionality or icons at the start of an input.
-Please consider using [`InputGroup`](https://workday.github.io/canvas-kit/?path=/docs/components-inputs-text-input--icons).
+ * Please consider using [`InputGroup`](https://workday.github.io/canvas-kit/?path=/docs/components-inputs-text-input--icons).
  * @deprecated
  */
 

--- a/modules/react/text-input/lib/InputIconContainer.tsx
+++ b/modules/react/text-input/lib/InputIconContainer.tsx
@@ -19,6 +19,10 @@ const IconContainer = styled('div')({
   right: space.xxs,
 });
 
+/**
+ * @deprecated
+ */
+
 export const InputIconContainer: React.FunctionComponent<React.PropsWithChildren<
   InputIconContainerProps
 >> = ({grow, children, icon}) => (

--- a/modules/react/text-input/lib/InputIconContainer.tsx
+++ b/modules/react/text-input/lib/InputIconContainer.tsx
@@ -5,9 +5,9 @@ import {space} from '@workday/canvas-kit-react/tokens';
 import {SystemIcon} from '@workday/canvas-kit-react/icon';
 
 /**
- * We've deprecated `InputIconContainer` from `TextInput` component
+ * We've deprecated `InputIconContainer` from Main
  * together with `InputIconContainerProps`.
- * Please consider using [`InputGroup`](https://workday.github.io/canvas-kit/?path=/docs/components-inputs-text-input--icons).
+ * Use [`InputGroup`](https://workday.github.io/canvas-kit/?path=/docs/components-inputs-text-input--icons) instead.
  * @deprecated
  */
 export interface InputIconContainerProps extends GrowthBehavior {
@@ -26,9 +26,9 @@ const IconContainer = styled('div')({
 });
 
 /**
- * We've deprecated `InputIconContainer` from `TextInput` component, because it doesn't handle
+ * We've deprecated `InputIconContainer` from Main because it doesn't handle
  * bidirectionality or icons at the start of an input.
- * Please consider using [`InputGroup`](https://workday.github.io/canvas-kit/?path=/docs/components-inputs-text-input--icons).
+ * Use [`InputGroup`](https://workday.github.io/canvas-kit/?path=/docs/components-inputs-text-input--icons) instead.
  * @deprecated
  */
 

--- a/modules/react/text-input/lib/InputIconContainer.tsx
+++ b/modules/react/text-input/lib/InputIconContainer.tsx
@@ -5,9 +5,8 @@ import {space} from '@workday/canvas-kit-react/tokens';
 import {SystemIcon} from '@workday/canvas-kit-react/icon';
 
 /**
- * We've deprecated `InputIconContainer` from Main
- * together with `InputIconContainerProps`.
- * Use [`InputGroup`](https://workday.github.io/canvas-kit/?path=/docs/components-inputs-text-input--icons) instead.
+ * ### ⚠️ We've deprecated `InputIconContainerProps` from Main because it doesn't handle bidirectionality or icons at the start of an input. ⚠️
+ * Please consider using [`InputGroup`](https://workday.github.io/canvas-kit/?path=/docs/components-inputs-text-input--icons) instead.
  * @deprecated
  */
 export interface InputIconContainerProps extends GrowthBehavior {
@@ -26,12 +25,10 @@ const IconContainer = styled('div')({
 });
 
 /**
- * We've deprecated `InputIconContainer` from Main because it doesn't handle
- * bidirectionality or icons at the start of an input.
- * Use [`InputGroup`](https://workday.github.io/canvas-kit/?path=/docs/components-inputs-text-input--icons) instead.
+ * ### ⚠️ We've deprecated `InputIconContainer` from Main because it doesn't handle bidirectionality or icons at the start of an input. ⚠️
+ * Please consider using [`InputGroup`](https://workday.github.io/canvas-kit/?path=/docs/components-inputs-text-input--icons) instead.
  * @deprecated
  */
-
 export const InputIconContainer: React.FunctionComponent<React.PropsWithChildren<
   InputIconContainerProps
 >> = ({grow, children, icon}) => (

--- a/modules/react/text-input/lib/InputIconContainer.tsx
+++ b/modules/react/text-input/lib/InputIconContainer.tsx
@@ -7,6 +7,7 @@ import {SystemIcon} from '@workday/canvas-kit-react/icon';
 /**
  * We've deprecated `InputIconContainer` from `TextInput` component
  * together with `InputIconContainerProps`.
+  Please consider using [`InputGroup`](https://workday.github.io/canvas-kit/?path=/docs/components-inputs-text-input--icons).
  * @deprecated
  */
 export interface InputIconContainerProps extends GrowthBehavior {
@@ -26,8 +27,8 @@ const IconContainer = styled('div')({
 
 /**
  * We've deprecated `InputIconContainer` from `TextInput` component, because it doesn't handle
- * bidirectionality or icons at the start of an input. `InputGroup` should be used instead of
- * deprecated `InputIconContainer`.
+ * bidirectionality or icons at the start of an input.
+Please consider using [`InputGroup`](https://workday.github.io/canvas-kit/?path=/docs/components-inputs-text-input--icons).
  * @deprecated
  */
 


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #2186 

PR contains `InputIconContainer` deprecation.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

### Release Note
`InputIconContainer` has been deprecated, because it does not handle bidirectionally or icons at the start of an input. Please use [`InputGroup`](https://workday.github.io/canvas-kit/?path=/story/components-inputs-text-input--icons) instead.

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable
