### PR TITLE
docs: Render type parameters in external SymbolDoc symbols

### DIFF
--- a/modules/docs/lib/widgets/external.tsx
+++ b/modules/docs/lib/widgets/external.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import {ExternalHyperlink} from '@workday/canvas-kit-react/button';
 
+import {renderTypeParameters} from '../widgetUtils';
 import {ExternalSymbolValue} from '../../docgen/docTypes';
 
 import {registerWidget} from '../Value';
 
 registerWidget<ExternalSymbolValue>('external', ({value}) => (
-  <ExternalHyperlink href={value.url}>{value.name}</ExternalHyperlink>
+  <>
+    <ExternalHyperlink href={value.url}>{value.name}</ExternalHyperlink>
+    {renderTypeParameters(value.typeParameters)}
+  </>
 ));


### PR DESCRIPTION
## Summary

The external `SymbolDoc` type did not render type parameters:

```ts
Record<string, number>
```

This fix updates the external symbol type to include the type parameters.

## Release Category
Documentation

---

## Checklist

- [x] Label `ready for review` has been added to PR

## Screenshot

<img width="197" alt="image" src="https://github.com/Workday/canvas-kit/assets/338257/602e2a48-66b5-4861-b2cb-f16edc729356">

