### PR TITLE
feat: Deprecated Table in Main

### DIFF
--- a/modules/docs/mdx/10.0-UPGRADE_GUIDE.mdx
+++ b/modules/docs/mdx/10.0-UPGRADE_GUIDE.mdx
@@ -13,6 +13,7 @@ any questions.
 	- [useBanner](#useBanner)
 - [Deprecations](#deprecations)
   - [InputIconContainer](#input-icon-container)
+  - [Table](#table)
 - [Token Updates](#token-updates)
   - [Space and Depth](#space-and-depth)
 - [Component Updates](#component-updates)
@@ -69,6 +70,10 @@ and browsers can compute the name of the Banner from the text given inside.
 
 We've deprecated `InputIconContainer` from [Main](#main) because it doesn't handle
 bidirectionality or icons at the start of an input. Please consider using [`InputGroup`](https://workday.github.io/canvas-kit/?path=/story/components-inputs-text-input--icons) instead.
+
+### Table
+
+We've deprecated `Table`, `TableRow` components and all of their exported members. Please consider using [`Table`](https://workday.github.io/canvas-kit/?path=/docs/preview-table--basic) instead as it is more flexible and modern.
 
 ## Token Updates
 

--- a/modules/docs/mdx/10.0-UPGRADE_GUIDE.mdx
+++ b/modules/docs/mdx/10.0-UPGRADE_GUIDE.mdx
@@ -73,7 +73,7 @@ bidirectionality or icons at the start of an input. Please consider using [`Inpu
 
 ### Table
 
-We've deprecated `Table`, `TableRow` components and all of their exported members. Please consider using [`Table`](https://workday.github.io/canvas-kit/?path=/docs/preview-table--basic) instead as it is more flexible and modern.
+We've deprecated `Table` and `TableRow` as well as all of their exported members. Please consider using [`Table in Preview`](https://workday.github.io/canvas-kit/?path=/docs/preview-table--basic) instead.
 
 ## Token Updates
 

--- a/modules/react/table/lib/Table.tsx
+++ b/modules/react/table/lib/Table.tsx
@@ -16,6 +16,11 @@ const TableComponent = styled('table')(type.levels.subtext.large, {
   },
 });
 
+/**
+ * ### ⚠️ `Table` has been deprecated and will be removed in a future major version. ⚠️
+ * - Please consider using [`Table`](https://workday.github.io/canvas-kit/?path=/docs/preview-table--basic) in Preview.
+ * @deprecated
+ */
 export class Table extends React.Component<React.TableHTMLAttributes<HTMLTableElement>> {
   public render() {
     const {children, ...elemProps} = this.props;

--- a/modules/react/table/lib/Table.tsx
+++ b/modules/react/table/lib/Table.tsx
@@ -17,9 +17,8 @@ const TableComponent = styled('table')(type.levels.subtext.large, {
 });
 
 /**
- * ### ⚠️ `Table` has been deprecated and will be removed in a future major version. ⚠️
- * - Please consider using [`Table`](https://workday.github.io/canvas-kit/?path=/docs/preview-table--basic) in Preview.
- * @deprecated
+ * @deprecated ⚠️ `Table` has been deprecated and will be removed in a future major version.
+ * Please consider using [`Table in Preview`](https://workday.github.io/canvas-kit/?path=/docs/preview-table--basic) instead.
  */
 export class Table extends React.Component<React.TableHTMLAttributes<HTMLTableElement>> {
   public render() {

--- a/modules/react/table/lib/TableRow.tsx
+++ b/modules/react/table/lib/TableRow.tsx
@@ -5,6 +5,11 @@ import {colors, space, spaceNumbers, statusColors} from '@workday/canvas-kit-rea
 import {createComponent, StyledType} from '@workday/canvas-kit-react/common';
 import {borderColor, borderWidth, cellBorder} from './Table';
 
+/**
+ * ### ⚠️ `Table` has been deprecated and will be removed in a future major version. ⚠️
+ * - Please consider using [`Table`](https://workday.github.io/canvas-kit/?path=/docs/preview-table--basic) in Preview.
+ * @deprecated
+ */
 export enum TableRowState {
   Error,
   Alert,
@@ -14,6 +19,11 @@ export enum TableRowState {
   Selected,
 }
 
+/**
+ * ### ⚠️ `Table` has been deprecated and will be removed in a future major version. ⚠️
+ * - Please consider using [`Table`](https://workday.github.io/canvas-kit/?path=/docs/preview-table--basic) in Preview.
+ * @deprecated
+ */
 export interface TableRowProps extends React.HTMLAttributes<HTMLTableRowElement> {
   /**
    * The state of the TableRow. Accepts `Error`, `Alert`, `InputError`, `InputAlert`, `Hover`, or `Selected`.
@@ -192,6 +202,11 @@ const StyledTableRow = styled('tr')<TableRowProps>(
   }
 );
 
+/**
+ * ### ⚠️ `Table` has been deprecated and will be removed in a future major version. ⚠️
+ * - Please consider using [`Table`](https://workday.github.io/canvas-kit/?path=/docs/preview-table--basic) in Preview.
+ * @deprecated
+ */
 export const TableRow = createComponent('tr')({
   displayName: 'TableRow',
   Component: (

--- a/modules/react/table/lib/TableRow.tsx
+++ b/modules/react/table/lib/TableRow.tsx
@@ -6,9 +6,8 @@ import {createComponent, StyledType} from '@workday/canvas-kit-react/common';
 import {borderColor, borderWidth, cellBorder} from './Table';
 
 /**
- * ### ⚠️ `Table` has been deprecated and will be removed in a future major version. ⚠️
- * - Please consider using [`Table`](https://workday.github.io/canvas-kit/?path=/docs/preview-table--basic) in Preview.
- * @deprecated
+ * @deprecated ⚠️ `Table` has been deprecated and will be removed in a future major version.
+ * Please consider using [`Table in Preview`](https://workday.github.io/canvas-kit/?path=/docs/preview-table--basic) instead.
  */
 export enum TableRowState {
   Error,
@@ -20,9 +19,8 @@ export enum TableRowState {
 }
 
 /**
- * ### ⚠️ `Table` has been deprecated and will be removed in a future major version. ⚠️
- * - Please consider using [`Table`](https://workday.github.io/canvas-kit/?path=/docs/preview-table--basic) in Preview.
- * @deprecated
+ * @deprecated ⚠️ `Table` has been deprecated and will be removed in a future major version.
+ * Please consider using [`Table in Preview`](https://workday.github.io/canvas-kit/?path=/docs/preview-table--basic) instead.
  */
 export interface TableRowProps extends React.HTMLAttributes<HTMLTableRowElement> {
   /**
@@ -203,9 +201,8 @@ const StyledTableRow = styled('tr')<TableRowProps>(
 );
 
 /**
- * ### ⚠️ `Table` has been deprecated and will be removed in a future major version. ⚠️
- * - Please consider using [`Table`](https://workday.github.io/canvas-kit/?path=/docs/preview-table--basic) in Preview.
- * @deprecated
+ * @deprecated ⚠️ `Table` has been deprecated and will be removed in a future major version.
+ * Please consider using [`Table in Preview`](https://workday.github.io/canvas-kit/?path=/docs/preview-table--basic) instead.
  */
 export const TableRow = createComponent('tr')({
   displayName: 'TableRow',


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Deprecate `Table` in main.

Resolves: #2249 <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

## Release Category
Components

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

`modules/react/table/lib/Table.tsx`
`modules/react/table/lib/TableRow.tsx`
`modules/docs/mdx/10.0-UPGRADE_GUIDE.mdx`
`/.storybook/routes.js/` is already updated with route to Table in Preview https://github.com/Workday/canvas-kit/blob/prerelease/major/.storybook/routes.js#L15