### PR TITLE
fix: Add jsdoc element in backticks for Avatar

### DIFF
--- a/modules/react/avatar/lib/Avatar.tsx
+++ b/modules/react/avatar/lib/Avatar.tsx
@@ -38,7 +38,7 @@ export interface AvatarProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
   as?: 'div';
   /**
    * The object-fit CSS property sets how the content of a replaced element,
-   * such as an <img> or <video>, should be resized to fit its container.
+   * such as an `<img>` or `<video>`, should be resized to fit its container.
    * See [object-fit](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit).
    * If your image is not a square, you can use this property to ensure the image is rendered properly.
    */


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

The site was seeing `<img>` and `<video>` as elements in the jsdoc and creating empty elements. But putting these elements in backticks, it prevents the site from interpreting them as elements and rather as part of the jsdoc.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Documentation



---

