### PR TITLE
fix(popup): Update useReturnFocus to check if focused element is visible in scroll parent and viewport.

### DIFF
--- a/modules/react/popup/lib/hooks/useReturnFocus.tsx
+++ b/modules/react/popup/lib/hooks/useReturnFocus.tsx
@@ -32,6 +32,20 @@ function getFocusableElement(element: Element | null): Element | null {
 }
 
 /**
+ * Is the element outside of bounds. An element is outside of bounds if it is less than half visible.
+ */
+function isElementOutsideOfBounds(element: HTMLElement, boundingRect: DOMRect) {
+  const elementRect = element.getBoundingClientRect();
+
+  return (
+    elementRect.top + elementRect.height / 2 < boundingRect.top || // is the top half of the target element visible?
+    elementRect.bottom - elementRect.height / 2 > boundingRect.bottom || // is the bottom half of the target element visible?
+    elementRect.left + elementRect.width / 2 < boundingRect.left || // is the left half of the target element visible?
+    elementRect.right - elementRect.width / 2 > boundingRect.right // is the right half of the target element visible?
+  );
+}
+
+/**
  * Returns focus to the target element when the popup is hidden. This works well with
  * {@link useInitialFocus}. This should be used with {@link useFocusRedirect} or
  * {@link useFocusTrap} for a complete focus management solution.
@@ -100,16 +114,14 @@ export const useReturnFocus = createElemPropsHook(usePopupModel)(model => {
       }
       const scrollParent = getScrollParent(element);
       const scrollParentRect = scrollParent.getBoundingClientRect();
-      const elementRect = element.getBoundingClientRect();
+      const viewportRect = DOMRect.fromRect({width: window.innerWidth, height: window.innerHeight});
 
       // Don't change focus if user focused on a different element like a `input` or the target
       // element isn't on at least halfway rendered on the screen.
       if (
         (elementRef.current && getFocusableElement(elementRef.current)) || // did the user click on a focusable element?
-        elementRect.top + elementRect.height / 2 < scrollParentRect.top || // is the top half of the target element visible?
-        elementRect.bottom - elementRect.height / 2 > scrollParentRect.bottom || // is the bottom half of the target element visible?
-        elementRect.left + elementRect.width / 2 < scrollParentRect.left || // is the left half of the target element visible?
-        elementRect.right - elementRect.width / 2 > scrollParentRect.right // is the right half of the target element visible?
+        isElementOutsideOfBounds(element, scrollParentRect) || // Is the element not visible in its scroll parent?
+        isElementOutsideOfBounds(element, viewportRect) // Is the element not visible in the viewport?
       ) {
         // reset the focus element and bail early
         elementRef.current = null;

--- a/modules/react/popup/lib/hooks/useReturnFocus.tsx
+++ b/modules/react/popup/lib/hooks/useReturnFocus.tsx
@@ -34,7 +34,7 @@ function getFocusableElement(element: Element | null): Element | null {
 /**
  * Is the element outside of bounds. An element is outside of bounds if it is less than half visible.
  */
-function isElementOutsideOfBounds(element: HTMLElement, boundingRect: DOMRect) {
+function isElementOutOfBounds(element: HTMLElement, boundingRect: DOMRect) {
   const elementRect = element.getBoundingClientRect();
 
   return (
@@ -120,8 +120,8 @@ export const useReturnFocus = createElemPropsHook(usePopupModel)(model => {
       // element isn't on at least halfway rendered on the screen.
       if (
         (elementRef.current && getFocusableElement(elementRef.current)) || // did the user click on a focusable element?
-        isElementOutsideOfBounds(element, scrollParentRect) || // Is the element not visible in its scroll parent?
-        isElementOutsideOfBounds(element, viewportRect) // Is the element not visible in the viewport?
+        isElementOutOfBounds(element, scrollParentRect) || // Is the element not visible in its scroll parent?
+        isElementOutOfBounds(element, viewportRect) // Is the element not visible in the viewport?
       ) {
         // reset the focus element and bail early
         elementRef.current = null;


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #2349 

`useReturnFocus` has been updated to consider whether the element that received focus is visible on the screen. This includes checking if the element is visible in the scroll parent as well as in the viewport. Previously, focus would only be returned if the element was visible in its scroll parent but not necessarily in the viewport.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

---

## Checklist

- [X] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)

## Testing Manually

Check the CodeSandbox I created for testing this change: [CodeSanbox](https://codesandbox.io/s/damp-voice-qq7prl?file=/src/useReturnFocus.ts).

- Test focus returning to the Popup target depending on scroll position in document.body and in an element that has scroll.
- You should observe that for both examples, focus will not be returned if the target is off the screen.

<!-- Explain how your reviewer could verify this change  -->

## Screenshots or GIFs (if applicable)

![2023-10-02_12-00-16 (1)](https://github.com/Workday/canvas-kit/assets/22104116/ba28e400-497e-4554-839a-8f0686ea05e7)
