### PR TITLE
fix(collection): Set correct aria-setsize in virtualized collections

### DIFF
--- a/modules/react/collection/lib/useListItemRegister.tsx
+++ b/modules/react/collection/lib/useListItemRegister.tsx
@@ -86,7 +86,7 @@ export const useListItemRegister = createElemPropsHook(useListModel)(
       disabled: elemProps.disabled || state.nonInteractiveIds.includes(localId) ? true : undefined,
       item: null, // remove `item` from prop list
       virtual: null, // remove `virtual` from prop list
-      'aria-setsize': elemProps.virtual?.size,
+      'aria-setsize': elemProps.virtual ? state.UNSTABLE_virtual.totalSize : undefined,
       'aria-posinset': elemProps.virtual ? elemProps.item!.index + 1 : undefined,
       style,
     };


### PR DESCRIPTION
## Summary

Fixes: #2361

Fixes the `useListRegisterItem` to set the proper `aria-setsize`

## Release Category
Components

---
