### PR TITLE
fix: Force PrimaryButton text color in all states

### DIFF
--- a/modules/react/button/lib/PrimaryButton.tsx
+++ b/modules/react/button/lib/PrimaryButton.tsx
@@ -31,15 +31,19 @@ const getPrimaryButtonColors = (variant: 'inverse' | undefined, theme: EmotionCa
         },
         hover: {
           background: themePrimary.dark,
+          label: themePrimary.contrast,
         },
         active: {
           background: themePrimary.darkest,
+          label: themePrimary.contrast,
         },
         focus: {
           background: themePrimary.main,
+          label: themePrimary.contrast,
         },
         disabled: {
           background: themePrimary.main,
+          label: themePrimary.contrast,
         },
       };
 


### PR DESCRIPTION
## Summary

The `PrimaryButton` styling works great when there are no conflicting styles. However, the state pseudo selectors take an unopinionated approach on the text color of the button, which makes it easily overridden by globally scoped css (particularly when using `as="a"`). 

In platforms like [Docusaurus](https://docusaurus.io/), it's common to have styling for `a:hover`. Since `PrimaryButton` does not have any `color` set for `:hover` (or other states), this gets overridden by a simple global specifier, resulting in something that looks like this:

![image](https://github.com/Workday/canvas-kit/assets/908478/ba51519a-36ac-4927-8c17-713f15e1a287)

While I could add another style for `a[type="button"]:hover { color: #fff }`, this would cause other problems because we have no way of determining via DOM a `PrimaryButton` from a `SecondaryButton`. If this rule were applied to a SecondaryButton, the text would be invisible on a white background.

The simplest approach here IMO was to take a slightly more assertive approach in specifying the color for all states. I don't believe this should have any negative effects, and I don't think it should be a breaking change.

I believe buttons have been largely re-written in v10 👑 , so this may need to be ported to the prerelease branch as well.

Thanks for the consideration!

## Release Category
Components


---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

![](https://media.giphy.com/media/3oKGz8Mr8stJzA0JDW/giphy.gif)
