### PR TITLE
fix: Set a default theme in canvas provider

### DIFF
--- a/modules/react/common/lib/CanvasProvider.tsx
+++ b/modules/react/common/lib/CanvasProvider.tsx
@@ -5,7 +5,7 @@ import {defaultCanvasTheme, PartialEmotionCanvasTheme, useTheme} from './theming
 import {brand} from '@workday/canvas-tokens-web';
 
 export interface CanvasProviderProps {
-  theme: PartialEmotionCanvasTheme;
+  theme?: PartialEmotionCanvasTheme;
 }
 
 const mappedKeys = {
@@ -18,7 +18,7 @@ const mappedKeys = {
 };
 
 const useCanvasThemeToCssVars = (
-  theme: PartialEmotionCanvasTheme,
+  theme: PartialEmotionCanvasTheme | undefined,
   elemProps: React.HTMLAttributes<HTMLElement>
 ) => {
   const filledTheme = useTheme(theme);
@@ -42,7 +42,7 @@ const useCanvasThemeToCssVars = (
 
 export const CanvasProvider = ({
   children,
-  theme,
+  theme = {canvas: defaultCanvasTheme},
   ...props
 }: CanvasProviderProps & React.HTMLAttributes<HTMLElement>) => {
   const elemProps = useCanvasThemeToCssVars(theme, props);
@@ -50,7 +50,7 @@ export const CanvasProvider = ({
     <ThemeProvider theme={theme as Theme}>
       <InputProvider />
       <div
-        dir={(theme.canvas && theme.canvas.direction) || defaultCanvasTheme.direction}
+        dir={theme?.canvas?.direction || defaultCanvasTheme.direction}
         {...(elemProps as React.HTMLAttributes<HTMLDivElement>)}
       >
         {children}


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

We needed to pass a default canvas theme in the canvas provider in cases where consumers don't pass a theme

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components



---
