### PR TITLE
fix: Fix commonjs styling transform

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -138,21 +138,6 @@ module.exports = {
       createCompiler({}),
     ];
 
-    if (process.env.STATIC_CSS || configType === 'PRODUCTION') {
-      config.module.rules.push({
-        test: /.+react.+\.tsx?$/, // only React packages
-        include: [modulesPath],
-        loaders: [
-          {
-            loader: require.resolve('ts-loader'),
-            options: {
-              compiler: 'ttypescript',
-            },
-          },
-        ],
-        enforce: 'pre',
-      });
-    }
     return config;
   },
   babel: async options => ({

--- a/modules/styling-transform/lib/styleTransform.ts
+++ b/modules/styling-transform/lib/styleTransform.ts
@@ -519,11 +519,13 @@ export default function styleTransformer(
             return arg;
           });
 
-          return ts.factory.createCallExpression(
-            ts.factory.createIdentifier(styleExpressionName),
-            [],
-            newArguments
-          );
+          (node.arguments as any) = newArguments;
+          // The following code is correct according to TypeScript, but causes the commonjs module to create incorrect code
+          // return ts.factory.createCallExpression(
+          //   ts.factory.createIdentifier(styleExpressionName),
+          //   [],
+          //   newArguments
+          // );
         }
       }
 

--- a/modules/styling-transform/lib/styleTransform.ts
+++ b/modules/styling-transform/lib/styleTransform.ts
@@ -620,7 +620,7 @@ export function transform(
 
   return printer.printFile(
     ts
-      .transform(source, [styleTransformer(program, options)], {module: ts.ModuleKind.CommonJS})
+      .transform(source, [styleTransformer(program, options)])
       .transformed.find(s => (s.fileName = fileName)) || source
   );
 }

--- a/modules/styling-transform/lib/styleTransform.ts
+++ b/modules/styling-transform/lib/styleTransform.ts
@@ -519,13 +519,43 @@ export default function styleTransformer(
             return arg;
           });
 
+          newArguments.forEach(argument => {
+            // TypeScript isn't expecting us to mutate arguments arguments and when emitting will
+            // try to do something where it checks the `parent` node of the argument. Using
+            // `ts.factory.create*`, the `parent` is `undefined` and this check will throw an error.
+            // In order to get past this error, we manually update the `parent` node of each
+            // argument to reference the existing call expression. This allows TypeScript to fully
+            // type check and/or emit.
+            (argument as any).parent = node;
+          });
+
+          /**
+           * We're not supposed to mutate arguments since it is supposed to be read-only. But, if I
+           * return a new callExpression, there is no parent and it is no longer linked to the
+           * import module. This causes incorrect code when the module export type is `commonjs`.
+           * For example:
+           *
+           * ```ts
+           * // with new callExpression
+           * const canvas_kit_styling_1 = require(...)
+           *
+           * createStyles({...})
+           *
+           * // if we instead mutate arguments
+           * const canvas_kit_styling_1 = require(...)
+           *
+           * canvas_kit_styling_1.createStyles({...})
+           * ```
+           *
+           * My best guess as to why it fails when creating a new callExpression is the node's
+           * symbol declaration link gets lost. TypeScript then has no idea `createStyles` comes
+           * from an `ImportDeclaration` declaration node and when emitting `commonjs`, it doesn't
+           * prefix with the `canvas_kit_styling_1`. This is hacky, but the only thing that works
+           * correctly.
+           */
           (node.arguments as any) = newArguments;
-          // The following code is correct according to TypeScript, but causes the commonjs module to create incorrect code
-          // return ts.factory.createCallExpression(
-          //   ts.factory.createIdentifier(styleExpressionName),
-          //   [],
-          //   newArguments
-          // );
+
+          return node;
         }
       }
 
@@ -590,7 +620,7 @@ export function transform(
 
   return printer.printFile(
     ts
-      .transform(source, [styleTransformer(program, options)])
+      .transform(source, [styleTransformer(program, options)], {module: ts.ModuleKind.CommonJS})
       .transformed.find(s => (s.fileName = fileName)) || source
   );
 }

--- a/modules/styling/stories/examples/StylingButton.tsx
+++ b/modules/styling/stories/examples/StylingButton.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import {createStyles} from '@workday/canvas-kit-styling';
-import {createModifiers, createVars, cssVar} from '../../lib/cs';
+import {createStyles, createModifiers, createVars, cssVar} from '@workday/canvas-kit-styling';
 
 interface ButtonProps {
   variant: 'primary' | 'secondary' | 'danger';


### PR DESCRIPTION
## Summary

Fix the styling transformer to correctly write the call expression for `createStyles` for commonjs. Without this change, the `createStyles` is not rewritten to `canvas_kit_styling_1.createStyles`.

## Release Category
Infrastructure
