### PR TITLE
fix: FormField fix alignment for required asterisk

### DIFF
--- a/modules/react/form-field/lib/Label.tsx
+++ b/modules/react/form-field/lib/Label.tsx
@@ -56,6 +56,7 @@ const labelStyles = [
             alignItems: 'center',
           }
         : {
+            display: 'block',
             marginBottom: space.xxxs,
           }),
     };

--- a/modules/react/form-field/lib/Label.tsx
+++ b/modules/react/form-field/lib/Label.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {colors, space, type} from '@workday/canvas-kit-react/tokens';
 import {accessibleHide as accessibleHideCSS, styled} from '@workday/canvas-kit-react/common';
 import {FormFieldLabelPosition, FormFieldLabelPositionBehavior} from './types';
+import {Flex} from '@workday/canvas-kit-react/layout';
 
 export interface LabelProps extends FormFieldLabelPositionBehavior {
   /**
@@ -51,12 +52,9 @@ const labelStyles = [
         ? {
             marginRight: space.l,
             minWidth: 180,
-            display: 'flex',
-            alignItems: 'center',
             maxHeight: space.xl,
           }
         : {
-            display: 'block',
             marginBottom: space.xxxs,
           }),
     };
@@ -107,7 +105,7 @@ class Label extends React.Component<React.PropsWithChildren<LabelProps>> {
           </RequiredAsterisk>,
         ];
     return (
-      <>
+      <Flex alignItems="center">
         {isLegend ? (
           <LegendComponent
             labelPosition={labelPosition}
@@ -118,7 +116,7 @@ class Label extends React.Component<React.PropsWithChildren<LabelProps>> {
         ) : (
           <LabelComponent labelPosition={labelPosition} {...elemProps} children={children} />
         )}
-      </>
+      </Flex>
     );
   }
 }

--- a/modules/react/form-field/lib/Label.tsx
+++ b/modules/react/form-field/lib/Label.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {colors, space, type} from '@workday/canvas-kit-react/tokens';
 import {accessibleHide as accessibleHideCSS, styled} from '@workday/canvas-kit-react/common';
 import {FormFieldLabelPosition, FormFieldLabelPositionBehavior} from './types';
-import {Flex} from '@workday/canvas-kit-react/layout';
 
 export interface LabelProps extends FormFieldLabelPositionBehavior {
   /**
@@ -53,6 +52,8 @@ const labelStyles = [
             marginRight: space.l,
             minWidth: 180,
             maxHeight: space.xl,
+            display: 'flex',
+            alignItems: 'center',
           }
         : {
             marginBottom: space.xxxs,
@@ -99,13 +100,15 @@ class Label extends React.Component<React.PropsWithChildren<LabelProps>> {
     const children = !required
       ? this.props.children
       : [
-          this.props.children,
-          <RequiredAsterisk key={'0'} aria-hidden>
-            *
-          </RequiredAsterisk>,
+          <span>
+            {this.props.children}
+            <RequiredAsterisk key={'0'} aria-hidden>
+              *
+            </RequiredAsterisk>
+          </span>,
         ];
     return (
-      <Flex alignItems="center">
+      <>
         {isLegend ? (
           <LegendComponent
             labelPosition={labelPosition}
@@ -116,7 +119,7 @@ class Label extends React.Component<React.PropsWithChildren<LabelProps>> {
         ) : (
           <LabelComponent labelPosition={labelPosition} {...elemProps} children={children} />
         )}
-      </Flex>
+      </>
     );
   }
 }


### PR DESCRIPTION
## Summary

Fixes: #2217

## Release Category
Components

### Release Note
We've wrapped the contents of the `label` element including the asterisk in a `span`. The asterisk now is at the end of the `label`.

## For the Reviewer

Offline discussion with @mannycarrera4, we want the required asterisk to be at the end of the label when the text label is wrapped. 

![image](https://github.com/Workday/canvas-kit/assets/32447341/658d4c9f-bdc0-4f91-89a2-84ab472afdfb)


**Before**

<img width="648" alt="image" src="https://github.com/Workday/canvas-kit/assets/32447341/71e6f220-20f8-4173-8c0b-b1012cd46210">

**After**

![image](https://github.com/Workday/canvas-kit/assets/32447341/5411283a-cb71-4860-9d12-9a284b7bc10d)
