### PR TITLE
fix: Update cs prop to create a class instead of style

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,7 +3,6 @@ module.exports = {
     test: {
       presets: ['@babel/preset-env', '@babel/preset-typescript', ['@babel/preset-react']],
       plugins: [
-        '@emotion',
         '@babel/plugin-transform-runtime',
         ['@babel/proposal-class-properties', {loose: true}],
       ], // https://github.com/storybookjs/storybook/issues/14805 and https://github.com/storybookjs/storybook/issues/14805#issuecomment-889504884 ],

--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -268,7 +268,7 @@ export function csToProps(input: CSToPropsInput): CsToPropsReturn {
     const staticStyles: CSSObject = {};
     const cssVars: Record<string, string> = {};
     for (const key in input) {
-      if (key.charAt(0) === '-') {
+      if (key.startsWith('--')) {
         cssVars[key] = (input as any)[key];
       } else {
         (staticStyles as any)[key] = (input as any)[key];

--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -260,6 +260,26 @@ export function csToProps(input: CSToPropsInput): CsToPropsReturn {
   // At this point, `input` is either an array or a `Record<T, string>`. If it isn't an array, it
   // must be a style object for setting CSS variables. So set the `style` attribute
   if (!Array.isArray(input)) {
+    // The input is an object. We'll separate variables from static styles. If static styles are
+    // detected here, a dynamic mode should be detected and done for development. The transform
+    // should take care of extracting static styles out of a render function and this function
+    // should not be run.
+    let hasStaticStyles = false;
+    const staticStyles: CSSObject = {};
+    const cssVars: Record<string, string> = {};
+    for (const key in input) {
+      if (key.charAt(0) === '-') {
+        cssVars[key] = (input as any)[key];
+      } else {
+        (staticStyles as any)[key] = (input as any)[key];
+        hasStaticStyles = true;
+      }
+    }
+
+    if (hasStaticStyles) {
+      const className = css(staticStyles);
+      return {style: cssVars, className};
+    }
     return {style: input};
   }
 

--- a/modules/styling/spec/cs.spec.ts
+++ b/modules/styling/spec/cs.spec.ts
@@ -1,8 +1,10 @@
+/* eslint-disable @emotion/no-vanilla */
 import {setUniqueSeed} from '../lib/uniqueId';
 import {createStyles, cssVar, createVars, createModifiers, csToProps, CS} from '../lib/cs';
 import {expectTypeOf} from 'expect-type';
 import {Properties} from 'csstype';
 import {SerializedStyles} from '@emotion/serialize';
+import {css} from '@emotion/css';
 
 describe('createStyles', () => {
   beforeEach(() => {
@@ -227,6 +229,17 @@ describe('createStyles', () => {
         [myVariables.color]: 'red',
         [innerVariables.fill]: 'blue',
       });
+    });
+
+    it('should handle statically embedded styles', () => {
+      const baseClassName = createStyles({padding: 20});
+      const inlineStyleOverride = css({padding: 10}); // hash should be the same
+      const actual = csToProps([baseClassName, {padding: 10}]);
+
+      expect(actual).not.toHaveProperty('style', {
+        padding: 10,
+      });
+      expect(actual).toHaveProperty('className', expect.stringContaining(inlineStyleOverride));
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "@babel/preset-typescript": "^7.1.0",
     "@commitlint/cli": "^8.3.5",
     "@commitlint/config-conventional": "^8.1.0",
-    "@emotion/babel-plugin": "^11.9.2",
     "@emotion/eslint-plugin": "^11.7.0",
     "@emotion/is-prop-valid": "^1.1.1",
     "@storybook/addon-essentials": "^6.5.9",


### PR DESCRIPTION
## Summary

Adding static styles to the `cs` prop creates a `style` attribute. This fix updates `cs` prop handling to create a CSS class instead.

The following is now supported officially:

```tsx
cs={{ padding: 10 }}
```

Instead of creating `style={{padding:10}}`, it will now invoke `@emotion/css` and will return a className.

## Release Category
Components

---

## Checklist

- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

`cs.spec.ts`

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Testing
