### PR TITLE
fix(select): Remove visual selection on Select input

### DIFF
--- a/modules/react/select/lib/Select.tsx
+++ b/modules/react/select/lib/Select.tsx
@@ -8,12 +8,14 @@ import {
 import {Combobox} from '@workday/canvas-kit-react/combobox';
 
 import {InputGroup, TextInput} from '@workday/canvas-kit-react/text-input';
+import {mergeStyles} from '@workday/canvas-kit-react/layout';
 import {SystemIcon} from '@workday/canvas-kit-react/icon';
 import {caretDownSmallIcon} from '@workday/canvas-system-icons-web';
 import {useSelectModel} from './hooks/useSelectModel';
 import {useSelectCard} from './hooks/useSelectCard';
 import {useSelectInput} from './hooks/useSelectInput';
 import {CanvasSystemIcon} from '@workday/design-assets-types';
+import {createStyles} from '@workday/canvas-kit-styling';
 
 export interface SelectInputProps extends ExtractProps<typeof TextInput> {
   /**
@@ -23,6 +25,15 @@ export interface SelectInputProps extends ExtractProps<typeof TextInput> {
    */
   inputStartIcon?: CanvasSystemIcon;
 }
+
+const selectInputStyles = createStyles({
+  caretColor: 'transparent',
+  cursor: 'default',
+  '&::selection': {
+    backgroundColor: 'transparent',
+  },
+});
+
 export const SelectInput = createSubcomponent(TextInput)({
   modelHook: useSelectModel,
   elemPropsHook: useSelectInput,
@@ -38,8 +49,7 @@ export const SelectInput = createSubcomponent(TextInput)({
         <InputGroup.Input
           as={Element}
           placeholder={placeholder}
-          style={{caretColor: 'transparent', cursor: 'default'}}
-          {...elemProps}
+          {...mergeStyles(elemProps, [selectInputStyles])}
         ></InputGroup.Input>
         <InputGroup.InnerEnd position="absolute" pointerEvents="none">
           <SystemIcon icon={caretDownSmallIcon} />


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #2409 <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

The new Select component highlights text on double click/focus. This makes it look like you can typeahead/search. This PR visually removes the background color of the highlight.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

This is my first time trying the new styling stuff, so let me know if I did it correctly!!!

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)
- [x] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

Open storybook to the new Select input, make a selection, then double click the text.

## Screenshots or GIFs (if applicable)

Before:
<img width="289" alt="Screenshot 2023-11-16 at 2 20 33 PM" src="https://github.com/Workday/canvas-kit/assets/1562615/ef013722-c6ad-46e8-bf65-2ae731d6a6cb">
so, please include a screenshot or short gif. -->

After:
<img width="302" alt="Screenshot 2023-11-16 at 2 25 06 PM" src="https://github.com/Workday/canvas-kit/assets/1562615/41f488c9-3ffb-493b-96fb-477da41c41e3">

## Thank You Gif (optional)

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer! -->
![a sneaky goose hiding behind a rock](https://media.giphy.com/media/QBRlZja1wrVCK1rEqy/giphy.gif)
