### PR TITLE
fix(select): Set initial selected id to the text value

### DIFF
--- a/modules/react/select/lib/hooks/useSelectInput.ts
+++ b/modules/react/select/lib/hooks/useSelectInput.ts
@@ -64,7 +64,8 @@ export const useSelectInput = composeHooks(
       },
       ref: elementRef,
       autoComplete: 'off',
-      defaultValue: model.state.selectedIds[0] || model.state.value,
+      defaultValue:
+        model.navigation.getItem(model.state.selectedIds[0], model).textValue || model.state.value,
     } as const;
   }),
   useComboboxKeyboardTypeAhead,


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

When passing `initialSelectedIds` to the `useSelectModel`, the input was rendering the id instead of the text value. This updates the code to render the text value.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

---

