### PR TITLE
fix: Quiet InputProvider logs for SSR

### DIFF
--- a/modules/react/common/lib/InputProvider.tsx
+++ b/modules/react/common/lib/InputProvider.tsx
@@ -139,7 +139,7 @@ export class InputProvider extends React.Component<React.PropsWithChildren<Input
     } catch (e) {
       // Don't log if window is undefined (i.e. we are in an SSR environment), 
       // because we can assume the entire implementation will not work and is not needed.
-      if (window) {
+      if (typeof window !== 'undefined') {
         console.warn('Failed to retrieve input status from session storage' + e);
       }
     }

--- a/modules/react/common/lib/InputProvider.tsx
+++ b/modules/react/common/lib/InputProvider.tsx
@@ -137,8 +137,11 @@ export class InputProvider extends React.Component<React.PropsWithChildren<Input
       storedInput = window.sessionStorage.getItem('what-input') as InputType;
       storedIntent = window.sessionStorage.getItem('what-intent') as InputType;
     } catch (e) {
-      /* istanbul ignore next line for coverage */
-      console.warn('Failed to retrieve input status from session storage' + e);
+      // Don't log if window is undefined (i.e. we are in an SSR environment), 
+      // because we can assume the entire implementation will not work and is not needed.
+      if (window) {
+        console.warn('Failed to retrieve input status from session storage' + e);
+      }
     }
 
     this.currentInput = storedInput || InputType.Initial;


### PR DESCRIPTION
## Summary

This change silences the `InputProvider` error logs when fetching from local storage in an SSR context. This error prints for every page of SSR sites, so it can really take over log output in builds. 

## Release Category
Components

---

## Checklist

- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Thank You Gif (optional)

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExOHZ1b2dseTBoMnl4NWllOWQ5emhtZTA2NTMxdnhtZjBvdHZqaHBnZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/tsX3YMWYzDPjAARfeg/giphy.gif)
