### PR TITLE
fix(preview): Fix multiline asterisk on preview form field

### DIFF
--- a/modules/preview-react/form-field/lib/FormFieldLabel.tsx
+++ b/modules/preview-react/form-field/lib/FormFieldLabel.tsx
@@ -1,40 +1,46 @@
 import React from 'react';
 
-import {createSubcomponent, useTheme} from '@workday/canvas-kit-react/common';
-import {Flex, FlexProps} from '@workday/canvas-kit-react/layout';
+import {createSubcomponent, ExtractProps} from '@workday/canvas-kit-react/common';
+import {type, space} from '@workday/canvas-kit-react/tokens';
 import {LabelText, Text} from '@workday/canvas-kit-react/text';
 import {useFormFieldLabel, useFormFieldModel} from './hooks';
+import {createStyles, cssVar} from '@workday/canvas-kit-styling';
+import {mergeStyles} from '@workday/canvas-kit-react/layout';
+import {brand} from '@workday/canvas-tokens-web';
 
-export interface FormFieldLabelProps extends FlexProps {
+export interface FormFieldLabelProps extends ExtractProps<typeof LabelText, never> {
   /**
    * The text of the label.
    */
   children: React.ReactNode;
 }
 
-export const FormFieldLabel = createSubcomponent('label')({
+const labelStyles = createStyles({
+  fontWeight: type.properties.fontWeights.medium,
+  minWidth: '180px',
+});
+
+const asteriskStyles = createStyles({
+  marginInlineStart: space.xxxs,
+  fontSize: type.properties.fontSizes[20],
+  fontWeight: type.properties.fontWeights.regular,
+  textDecoration: 'unset',
+  color: cssVar(brand.error.base, '#de2e21'),
+});
+
+export const FormFieldLabel = createSubcomponent(LabelText)({
   displayName: 'FormField.Label',
   modelHook: useFormFieldModel,
   elemPropsHook: useFormFieldLabel,
-})<FormFieldLabelProps>(({gap = 'xxxs', children, ...elemProps}, Element, model) => {
-  const theme = useTheme();
-
+})<FormFieldLabelProps>(({children, ...elemProps}, Element, model) => {
   return (
-    <Flex as={Element} gap={gap} minWidth="180px" {...elemProps}>
-      <LabelText as="span" fontWeight="medium">
-        {children}
-      </LabelText>
+    <LabelText as={Element} {...mergeStyles(elemProps, [labelStyles])}>
+      {children}
       {model.state.isRequired && (
-        <Text
-          fontSize={20}
-          fontWeight="regular"
-          textDecoration="unset"
-          color={theme.canvas.palette.error.main}
-          aria-hidden="true"
-        >
+        <Text cs={asteriskStyles} aria-hidden="true">
           *
         </Text>
       )}
-    </Flex>
+    </LabelText>
   );
 });

--- a/modules/preview-react/package.json
+++ b/modules/preview-react/package.json
@@ -47,7 +47,9 @@
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
     "@workday/canvas-kit-react": "^10.0.18",
+    "@workday/canvas-kit-styling": "^10.0.18",
     "@workday/canvas-system-icons-web": "^3.0.0",
+    "@workday/canvas-tokens-web": "^1.0.0",
     "@workday/design-assets-types": "^0.2.8"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Preview Form field has the same multiline asterisk issue as the main line one, see #2217. This fixes the asterisk so it is always pinned to the end of the text. 

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

### Release Note
We removed a wrapping flex element so elemProps is now spread directly on the `<label>` element and the asterisk is at the end of the label.


---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable


## Screenshots or GIFs (if applicable)

### Before

<img width="553" alt="Screenshot 2023-11-30 at 2 00 31 PM" src="https://github.com/Workday/canvas-kit/assets/1562615/997ae38a-1ac6-4901-89f2-e5efd2b82759">

### After

<img width="605" alt="Screenshot 2023-11-30 at 1 37 50 PM" src="https://github.com/Workday/canvas-kit/assets/1562615/fee612e5-927b-444b-af5c-b10e9c332930">


## Thank You Gif (required)

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer! -->
![a glossy green lambo slowly opening its scissor doors](https://media.giphy.com/media/7zupKWMw5MHfuxGwKG/giphy-downsized-large.gif)
