### PR TITLE
fix: Fixes popperOptions rerendering bug

### DIFF
--- a/modules/react/menu/lib/MenuPopper.tsx
+++ b/modules/react/menu/lib/MenuPopper.tsx
@@ -9,26 +9,25 @@ export interface MenuPopperProps extends ExtractProps<typeof Popper> {}
 
 export const useMenuPopper = usePopupPopper;
 
+// We moved this out of the component function to prevent rebuilding this object on re-renders.
+const popperOptions = {
+  modifiers: [
+    {
+      name: 'offset',
+      options: {
+        offset: () => [0, 4],
+      },
+    },
+  ],
+};
+
 export const MenuPopper = createSubcomponent('div')({
   displayName: 'Menu.Popper',
   modelHook: useMenuModel,
   elemPropsHook: useMenuPopper,
 })<MenuPopperProps>(({children, ...elemProps}) => {
   return (
-    <Popper
-      placement="bottom-start"
-      popperOptions={{
-        modifiers: [
-          {
-            name: 'offset',
-            options: {
-              offset: () => [0, 4],
-            },
-          },
-        ],
-      }}
-      {...elemProps}
-    >
+    <Popper placement="bottom-start" popperOptions={popperOptions} {...elemProps}>
       {children}
     </Popper>
   );

--- a/modules/react/popup/lib/PopupPopper.tsx
+++ b/modules/react/popup/lib/PopupPopper.tsx
@@ -26,25 +26,25 @@ export interface PopupPopperProps extends PopperProps {
   popperOptions?: Partial<PopperOptions>;
 }
 
+// We moved this out of the component function to prevent rebuilding this object on re-renders.
+const popperOptions = {
+  modifiers: [
+    {
+      name: 'offset',
+      options: {
+        offset: () => [0, 4],
+      },
+    },
+  ],
+};
+
 export const PopupPopper = createSubcomponent('div')({
   displayName: 'Popup.Popper',
   modelHook: usePopupModel,
   elemPropsHook: usePopupPopper,
 })<PopupPopperProps>(({children, ...elemProps}) => {
   return (
-    <Popper
-      popperOptions={{
-        modifiers: [
-          {
-            name: 'offset',
-            options: {
-              offset: () => [0, 4],
-            },
-          },
-        ],
-      }}
-      {...elemProps}
-    >
+    <Popper {...elemProps} popperOptions={popperOptions} {...elemProps}>
       {children}
     </Popper>
   );


### PR DESCRIPTION
## Summary

Fixes: #2435

There appear to be some scenarios where having `popperOptions` defined in the React render loop creates an infinite loop of recalculations within PopperJS and cause the browser to freeze up. This particular incident occurred when nested popups were closed multiple times.

## Release Category

Components

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Documentation
- [ ] Testing
- [ ] Codemods

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

<!-- Explain how your reviewer could verify this change  -->

## Screenshots or GIFs (if applicable)

<!-- Does your change affect the UI? If so, please include a screenshot or short gif. -->

## Thank You Gif (optional)

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer! -->
<!-- ![a smiling Shiba Inu typing on a laptop](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif) -->
