### PR TITLE
fix: Fix runtime style merging in handleCsProps

### DIFF
--- a/modules/react/layout/lib/utils/mergeStyles.ts
+++ b/modules/react/layout/lib/utils/mergeStyles.ts
@@ -1,7 +1,6 @@
-import {getRegisteredStyles} from '@emotion/utils';
 // eslint-disable-next-line @emotion/no-vanilla
-import {cache, css} from '@emotion/css';
-import {csToProps, CSToPropsInput, createStylesCache} from '@workday/canvas-kit-styling';
+import {css} from '@emotion/css';
+import {CSToPropsInput, handleCsProp} from '@workday/canvas-kit-styling';
 import {boxStyleFn} from '../Box';
 import {backgroundStyleFnConfigs} from './background';
 import {borderStyleFnConfigs} from './border';
@@ -40,71 +39,23 @@ function isStyleProps(prop: string): boolean {
 }
 
 /**
- * This is an opinionated function that will force style merging with Emotion's runtime APIs,
- * including [styled components](https://emotion.sh/docs/styled) and the [css
- * prop](https://emotion.sh/docs/css-prop). It will also handle style props for as long as those are
- * supported. `mergeStyles` is exported from the layout package since it supports style props
- * defined in the layout packages.
- *
- * It works by detecting styles added via Emotion's runtime APIs and forcing styling merging if use
- * of runtime APIs have been detected. If only `createStyles` were used to style a component, the
- * faster non-runtime styling will be used.
- *
- * You can use `mergeStyles` if you wish to use {@link createStyles} on your own components and want
- * your components to be compatible with Emotion's runtime styling APIs.
- *
- * ```tsx
- * import {createStyles, CSProps} from '@workday/canvas-kit-styling';
- * import {mergeStyles} from '@workday/canvas-kit-react/layout';
- *
- * interface MyComponentProps extends CSProps {
- *   // other props
- * }
- *
- * const myStyles = createStyles({
- *   background: 'green',
- *   height: 40,
- *   width: 40
- * })
- *
- * const MyComponent = ({children, ...elemProps}: MyComponentProps) => {
- *   return (
- *     <div
- *       {...mergeStyles(elemProps, [myStyles])}
- *     >
- *       {children}
- *     </div>
- *   )
- * }
- *
- * const StyledMyComponent(MyComponent)({
- *   background: 'red'
- * })
- *
- * const myOverridingStyles = createStyles({
- *   background: 'blue'
- * })
- *
- * // now everything works. Without `mergeStyles`, the last component would be a red box
- * export default () => (
- *   <>
- *     <MyComponent>Green box</MyComponent>
- *     <StyledMyComponent>Red box</StyledMyComponent>
- *     <StyledMyComponent cs={myOverridingStyles}>Blue box</StyledMyComponent>
- *   </>
- * )
- * ```
- *
+ * This function has the same signature as {@link handleCsProp} and also calls `handleCsProps`, but
+ * adds support for style props. It can be used as a drop-in replacement for `handleCsProps`.
  */
 export function mergeStyles<T extends {}>(
+  /**
+   * All the props to be spread onto an element. The `cs` prop will be removed an reduced to
+   * `className` and `style` props which should be safe on every element.
+   */
   allProps: T,
-  cs: CSToPropsInput
+  /**
+   * Optional local style created by `createStyles`. Using this parameter, you can style your
+   * element while supporting proper style merging order.
+   */
+  localCs?: CSToPropsInput
 ): Omit<T, 'cs' | keyof CommonStyleProps> {
   const styleProps = {};
   let shouldRuntimeMergeStyles = false;
-  // TypeScript can't handle a type where I declare T extends `{className?: string}` for some
-  // reason, so we'll do a `as any` any time we check for possible props on `allProps`
-  let className = (allProps as any).className || '';
 
   // separate style props from all other props. `cs` is special and should be forwarded to the
   // `handleCsProp` function.
@@ -114,10 +65,8 @@ export function mergeStyles<T extends {}>(
       // @ts-ignore
       styleProps[prop] = allProps[prop];
     } else {
-      if (prop !== 'cs') {
-        // @ts-ignore
-        result[prop] = allProps[prop];
-      }
+      // @ts-ignore
+      result[prop] = allProps[prop];
     }
 
     return result;
@@ -135,43 +84,7 @@ export function mergeStyles<T extends {}>(
     stylePropsClassName = css(styles);
   }
 
-  const returnProps = csToProps([
-    cs,
-    stylePropsClassName, // if style props are not defined, this will be an empty string, which is fine
-    className, // This will come from `styled` components or the `css` prop or if a user manually sets the `className` prop
-    (allProps as any).cs, // doesn't matter if `cs` is undefined. csToProps will handle undefined. Thanks anyways, TypeScript
-    (allProps as any).style, // doesn't matter if `style` is undefined. csToProps will handle undefined. Thanks anyways, TypeScript
-  ]);
-
-  // see if we need to do style merging based off use of Emotion runtime APIs. We do this by testing
-  // the Emotion cache for a match to any class names we find, filtering out those created via
-  // `createStyles`. If only `createStyles` is detected, there is no reason to merge styles
-  (returnProps.className || '').split(' ').forEach(name => {
-    if (!createStylesCache[name] && cache.registered[name]) {
-      shouldRuntimeMergeStyles = true;
-    }
-  });
-
-  if (shouldRuntimeMergeStyles) {
-    const registeredStyles: string[] = [];
-
-    // We are using the raw `css` instead of `createStyles` because `css` uses style hashing and
-    // `createStyles` generates a new ID every time. We could use `createStyles` here, but it
-    // would be more wasteful and new styles would be generated each React render cycle. `css` is
-    // safe to use inside a render function while `createStyles` should always be used outside the
-    // React render cycle.
-    className = getRegisteredStyles(
-      cache.registered,
-      registeredStyles,
-      returnProps.className || ''
-    );
-
-    className += css(registeredStyles);
-  } else {
-    className = returnProps.className;
-  }
-
-  return {...elemProps, ...returnProps, ...{className}} as any as Omit<
+  return handleCsProp(elemProps, [localCs, stylePropsClassName]) as Omit<
     T,
     'cs' | keyof CommonStyleProps
   >;

--- a/modules/react/package.json
+++ b/modules/react/package.json
@@ -48,7 +48,6 @@
     "@emotion/is-prop-valid": "^1.1.1",
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
-    "@emotion/utils": "^1.0.0",
     "@popperjs/core": "^2.5.4",
     "@workday/canvas-colors-web": "^2.0.0",
     "@workday/canvas-kit-popup-stack": "^10.0.18",

--- a/modules/styling/package.json
+++ b/modules/styling/package.json
@@ -53,6 +53,7 @@
     "@emotion/react": "^11.7.1",
     "@emotion/serialize": "^1.0.2",
     "@emotion/styled": "^11.6.0",
+    "@emotion/utils": "^1.0.0",
     "@workday/canvas-kit-react": "^10.0.18",
     "@workday/canvas-tokens-web": "^1.0.0",
     "typescript": "4.2"

--- a/modules/styling/spec/cs.spec.tsx
+++ b/modules/styling/spec/cs.spec.tsx
@@ -1,10 +1,30 @@
+import React from 'react';
+
 /* eslint-disable @emotion/no-vanilla */
-import {setUniqueSeed} from '../lib/uniqueId';
-import {createStyles, cssVar, createVars, createModifiers, csToProps, CS} from '../lib/cs';
 import {expectTypeOf} from 'expect-type';
 import {Properties} from 'csstype';
 import {SerializedStyles} from '@emotion/serialize';
-import {css} from '@emotion/css';
+import {css, cache} from '@emotion/css';
+import {jsx, CacheProvider} from '@emotion/react';
+import styled from '@emotion/styled';
+import {render as rtlRender, screen} from '@testing-library/react';
+
+import {
+  createStyles,
+  cssVar,
+  createVars,
+  createModifiers,
+  csToProps,
+  CS,
+  handleCsProp,
+} from '../lib/cs';
+import {setUniqueSeed} from '../lib/uniqueId';
+
+// We need to force Emotion's cache wrapper to use the cache from `@emotion/css` for tests to pass
+const CacheWrapper = props => <CacheProvider value={cache} {...props} />;
+// @ts-ignore We want the types to be the same, but I don't care to fix the error
+const render: typeof rtlRender = (ui, options) =>
+  rtlRender(ui, {wrapper: CacheWrapper, ...options});
 
 describe('createStyles', () => {
   beforeEach(() => {
@@ -241,5 +261,156 @@ describe('createStyles', () => {
       });
       expect(actual).toHaveProperty('className', expect.stringContaining(inlineStyleOverride));
     });
+  });
+});
+
+describe('handleCsProp', () => {
+  const padding = {
+    base: '1px',
+    styleAttribute: '2px',
+    createStyles: '3px',
+    styledComponent: '4px',
+    cssProp: '5px',
+    styleProp: '6px',
+  } as const;
+  const baseStyles = createStyles({
+    padding: padding.base,
+  });
+
+  const BaseComponent = (props: any) => (
+    <div data-testid="base" {...handleCsProp(props, baseStyles)} />
+  );
+
+  it('should apply the base styles', () => {
+    render(<BaseComponent />);
+
+    expect(screen.getByTestId('base')).toHaveStyle({padding: padding.base});
+  });
+
+  it('should allow overriding via the style attribute', () => {
+    render(<BaseComponent style={{padding: padding.styleAttribute}} />);
+
+    expect(screen.getByTestId('base')).toHaveStyle({padding: padding.styleAttribute});
+  });
+
+  it('should allow the cs prop to override base styles', () => {
+    const overrideStyles = createStyles({
+      padding: padding.createStyles,
+    });
+
+    render(<BaseComponent cs={overrideStyles} />);
+
+    expect(screen.getByTestId('base')).toHaveStyle({padding: padding.createStyles});
+
+    // When no style props or runtime styling is detected, styles should not be merged into a single
+    // class name, but both class names should be listed
+    expect(screen.getByTestId('base')).toHaveClass(baseStyles);
+    expect(screen.getByTestId('base')).toHaveClass(overrideStyles);
+  });
+
+  it('should allow the css prop to override base styles', () => {
+    render(jsx(BaseComponent, {css: {padding: padding.cssProp}}));
+
+    expect(screen.getByTestId('base')).toHaveStyle({padding: padding.cssProp});
+    expect(screen.getByTestId('base')).not.toHaveClass(baseStyles);
+  });
+
+  it('should allow a styled component to override base styles', () => {
+    const StyledBaseComponent = styled(BaseComponent)({
+      padding: padding.styledComponent,
+    });
+
+    render(<StyledBaseComponent />);
+
+    expect(screen.getByTestId('base')).toHaveStyle({padding: padding.styledComponent});
+    expect(screen.getByTestId('base')).not.toHaveClass(baseStyles);
+  });
+
+  it('should prioritize the cs prop over the css prop', () => {
+    const overrideStyles = createStyles({
+      padding: padding.createStyles,
+    });
+
+    render(jsx(BaseComponent, {css: {padding: padding.cssProp}, cs: overrideStyles}));
+
+    expect(screen.getByTestId('base')).toHaveStyle({padding: padding.createStyles});
+    expect(screen.getByTestId('base')).not.toHaveClass(baseStyles);
+  });
+
+  it('should prioritize the cs prop over a styled component', () => {
+    const StyledBaseComponent = styled(BaseComponent)({
+      padding: padding.styledComponent,
+    });
+    const overrideStyles = createStyles({
+      padding: padding.createStyles,
+    });
+
+    render(<StyledBaseComponent cs={overrideStyles} />);
+
+    expect(screen.getByTestId('base')).toHaveStyle({padding: padding.createStyles});
+    expect(screen.getByTestId('base')).not.toHaveClass(baseStyles);
+  });
+
+  it('should prioritize the cs prop over a styled component and style props', () => {
+    const StyledBaseComponent = styled(BaseComponent)({
+      padding: padding.styledComponent,
+    });
+    const overrideStyles = createStyles({
+      padding: padding.createStyles,
+    });
+
+    render(<StyledBaseComponent cs={overrideStyles} padding={padding.styleProp} />);
+
+    expect(screen.getByTestId('base')).toHaveStyle({padding: padding.createStyles});
+    expect(screen.getByTestId('base')).not.toHaveClass(baseStyles);
+  });
+
+  it('should prioritize the cs prop over the css prop, styled component, and style props', () => {
+    const StyledBaseComponent = styled(BaseComponent)({
+      padding: padding.styledComponent,
+    });
+    const overrideStyles = createStyles({
+      padding: padding.createStyles,
+    });
+
+    render(
+      jsx(StyledBaseComponent, {
+        cs: overrideStyles,
+        css: {padding: padding.cssProp},
+        padding: padding.styleProp,
+      })
+    );
+
+    expect(screen.getByTestId('base')).toHaveStyle({padding: padding.createStyles});
+    expect(screen.getByTestId('base')).not.toHaveClass(baseStyles);
+  });
+
+  it('should prioritize the css prop over a styled component', () => {
+    const StyledBaseComponent = styled(BaseComponent)({
+      padding: padding.styledComponent,
+    });
+
+    render(jsx(StyledBaseComponent, {css: {padding: padding.cssProp}}));
+
+    expect(screen.getByTestId('base')).toHaveStyle({padding: padding.cssProp});
+    expect(screen.getByTestId('base')).not.toHaveClass(baseStyles);
+  });
+
+  it('should prioritize the css prop over style props', () => {
+    render(jsx(BaseComponent, {css: {padding: padding.cssProp}, padding: padding.styleProp}));
+
+    expect(screen.getByTestId('base')).toHaveStyle({padding: padding.cssProp});
+    expect(screen.getByTestId('base')).not.toHaveClass(baseStyles);
+  });
+
+  it('should prioritize a style component over style props', () => {
+    const StyledBaseComponent = styled(BaseComponent)({
+      padding: padding.styledComponent,
+    });
+
+    render(<StyledBaseComponent padding={padding.styleProp} />);
+
+    expect(screen.getByTestId('base')).toHaveStyle({padding: padding.styledComponent});
+    expect(screen.getByTestId('base')).not.toHaveClass(baseStyles);
   });
 });

--- a/modules/styling/stories/API.stories.mdx
+++ b/modules/styling/stories/API.stories.mdx
@@ -57,6 +57,8 @@ And the CSS will look like:
 
 <ExampleCodeBlock code={CreateModifiers} />
 
+<SymbolDoc name="handleCsProp" />
+
 <SymbolDoc name="mergeStyles" />
 
 ## Styling Precedence


### PR DESCRIPTION
## Summary

Fixes the same issue that #2379 addresses, but in `handleCsProps` instead of just in `mergeStyles`. Now they do the same thing, except `mergeStyles` also handles style props.

## Release Category
Components

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

Always start with tests: `modules/styling/spec/cs.spec.tsx`

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Documentation
- [ ] Testing

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

The Style Overrides story covers this already and the correct style merging is covered by tests, but you can verify the class names on the buttons.
