### PR TITLE
fix: Fix forwarding of the style attribute

### DIFF
--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -1,8 +1,8 @@
-import React from 'react';
 // eslint-disable-next-line @emotion/no-vanilla
 import {cache, css} from '@emotion/css';
 import {getRegisteredStyles} from '@emotion/utils';
 import {serializeStyles, Keyframes, SerializedStyles, CSSObject} from '@emotion/serialize';
+import {Properties} from 'csstype';
 
 import {generateUniqueId} from './uniqueId';
 
@@ -237,10 +237,10 @@ export type CSToPropsInput =
   | undefined
   | CS
   | CsToPropsReturn
-  | React.CSSProperties
+  | Properties<string | number>
   | CSToPropsInput[];
 
-export type CsToPropsReturn = {className?: string; style?: React.CSSProperties};
+export type CsToPropsReturn = {className?: string; style?: Properties<string | number>};
 /**
  * A function that takes in a single input, or an array. The type of the input is either:
  *
@@ -464,7 +464,7 @@ export function handleCsProp<
   T extends CSProps & {
     className?: string | undefined;
 
-    style?: React.CSSProperties | undefined;
+    style?: Properties<string | number> | undefined;
   }
 >(
   /**
@@ -489,7 +489,7 @@ export function handleCsProp<
   // _does_ care because it uses the `classList` order to determine style merging. Therefore we
   // should always be careful to order class names knowing we need to support runtime merging if
   // runtime styles are detected.
-  const returnProps = csToProps([localCs, className, cs, style]);
+  const returnProps = csToProps([localCs, className, cs]);
 
   // The following is basically what Emotion does internally to merge styles from different
   // components into a single className. We will do this here for backwards compatibility with
@@ -508,6 +508,8 @@ export function handleCsProp<
       shouldRuntimeMergeStyles = true;
     }
   });
+
+  returnProps.style = {...returnProps.style, ...style};
 
   // If runtime styles are detected, we need to do extra work to ensure styles merge according to
   // the rules of Emotion's runtime.

--- a/modules/styling/spec/cs.spec.tsx
+++ b/modules/styling/spec/cs.spec.tsx
@@ -287,6 +287,13 @@ describe('handleCsProp', () => {
     expect(screen.getByTestId('base')).toHaveStyle({padding: padding.base});
   });
 
+  it('should forward the style attribute', () => {
+    const returnProps = handleCsProp({style: {position: 'absolute'}});
+
+    expect(returnProps).toHaveProperty('className', '');
+    expect(returnProps).toHaveProperty('style', {position: 'absolute'});
+  });
+
   it('should allow overriding via the style attribute', () => {
     render(<BaseComponent style={{padding: padding.styleAttribute}} />);
 


### PR DESCRIPTION
## Summary

Fixes: #2452

The `style` attribute was being converted into a class name. The styles were being added and passing visual tests, but doing so in an unoptimized way. We use the `style` attribute for styles that change frequently to avoid expensive Style recalculations and we accidentally broke that.

## Release Category
Components

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)
- [x] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [x] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [x] Code
- [x] Testing

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

You could try adding a `style` attribute to any example. Without this change, the style attribute gets removed and the styles get merged into the element's main CSS class.

