### PR TITLE
fix: Extend CSSObject types to support CSS variables

### DIFF
--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -8,6 +8,12 @@ import {generateUniqueId} from './uniqueId';
 
 export const createStylesCache: Record<string, boolean> = {};
 
+// CSSType doesn't support CSS custom properties
+// Extending CSSObject types to support them
+type CSSObjectWithVars<T extends CSSObject = CSSObject> = {
+  [P in keyof T]?: T[P] | (string & {});
+};
+
 /**
  * Style properties in a JavaScript camelCase. Everything Emotion allows is also
  * allowed here.
@@ -19,7 +25,11 @@ export type StyleProps =
   | string
   | Keyframes
   | SerializedStyles
-  | CSSObject;
+  | CSSObjectWithVars;
+
+// Casting the types here for internal use only.
+// We can remove this when CSSType supports CSS custom properties
+type CastStyleProps = Exclude<StyleProps, CSSObjectWithVars> | CSSObject;
 
 function convertProperty<T>(value: T): T {
   // Handle the case where the value is a variable without the `var()` wrapping function. It happens
@@ -375,7 +385,7 @@ export function createStyles(
 
       // If we were called with a {name, styles} object, it must be optimized. We'll shortcut here
       if (typeof input === 'object' && input.name) {
-        return css.call(null, input);
+        return css.call(null, input as CastStyleProps);
       }
 
       const convertedStyles = convertAllProperties(input);
@@ -392,7 +402,7 @@ export function createStyles(
       // injected into the document's style sheets before `TertiaryButton.base` styles. This is due
       // to CSS specificity. If everything has the same specificity, last defined wins. More info:
       // https://codesandbox.io/s/stupefied-bartik-9c2jtd?file=/src/App.tsx
-      const {styles} = serializeStyles([convertedStyles]);
+      const {styles} = serializeStyles([convertedStyles as CastStyleProps]);
 
       // use `css.call()` instead of `css()` to trick Emotion's babel plugin to not rewrite our code
       // to remove our generated Id for the name:

--- a/modules/styling/spec/cs.spec.tsx
+++ b/modules/styling/spec/cs.spec.tsx
@@ -43,7 +43,7 @@ describe('createStyles', () => {
         position: 'absolute',
       });
       expectTypeOf<PositionProperty>().toMatchTypeOf<
-        Properties['position'] | Properties['position'][]
+        Properties['position'] | Properties['position'][] | (string & {})
       >();
     });
 


### PR DESCRIPTION
## Summary

Fixes: #2461

[CSSType doesn't support CSS vars](https://github.com/frenic/csstype/issues/126), so we're extending and casting the types to support them for now.

## Release Category

Components

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [x] Code
- [x] Documentation
- [x] Testing
- [x] Codemods

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

<!-- Explain how your reviewer could verify this change  -->

## Screenshots or GIFs (if applicable)

<!-- Does your change affect the UI? If so, please include a screenshot or short gif. -->

## Thank You Gif (optional)

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer! -->
<!-- ![a smiling Shiba Inu typing on a laptop](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif) -->
