### PR TITLE
fix: Fixed getFirstFocusableElement to recognize RadioGroup

### DIFF
--- a/modules/react/common/lib/utils/elements.ts
+++ b/modules/react/common/lib/utils/elements.ts
@@ -29,13 +29,22 @@ export const isFocusable = (element: Element): boolean => {
 
 /**
  * Get the first focusable element in a container.
+ *
+ * Returns an array of elements if the first focusable element is a radio group
  */
-export const getFirstFocusableElement = (container: HTMLElement): HTMLElement | null => {
+export const getFirstFocusableElement = (
+  container: HTMLElement
+): Element[] | HTMLElement | null => {
   const elements = container.querySelectorAll('*');
 
   for (let i = 0; i < elements.length; i++) {
     const element = elements.item(i);
     if (element && isFocusable(element) && element.getAttribute('tabindex') !== '-1') {
+      if (isRadioInput(element)) {
+        const radioGroup = getRadioGroup(container, element);
+
+        return radioGroup.length > 1 ? Array.from(radioGroup) : element;
+      }
       return element as HTMLElement;
     }
   }


### PR DESCRIPTION
## Summary

Fixes: #2384 <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

Mimic the functionality of `getLastFocusableElement` according to the slack convo with @NicholasBoll.