### PR TITLE
feat: Add initial v11 setup

### DIFF
--- a/modules/codemod/index.js
+++ b/modules/codemod/index.js
@@ -4,7 +4,13 @@
 const {spawn} = require('child_process');
 const chalk = require('chalk');
 
-const {_: commands, path, ignoreConfig, ignorePattern, verbose} = require('yargs')
+const {
+  _: commands,
+  path,
+  ignoreConfig,
+  ignorePattern,
+  verbose,
+} = require('yargs')
   .scriptName('canvas-kit-codemod')
   .usage(chalk.bold.blueBright('$0 <transform> [path]'))
   .options({
@@ -61,6 +67,13 @@ const {_: commands, path, ignoreConfig, ignorePattern, verbose} = require('yargs
       describe: chalk.gray('The path to execute the transform in (recursively).'),
     });
   })
+  .command('v11 [path]', chalk.gray('Canvas Kit v10 > v11 upgrade transform'), yargs => {
+    yargs.positional('path', {
+      type: 'string',
+      default: '.',
+      describe: chalk.gray('The path to execute the transform in (recursively).'),
+    });
+  })
   .demandCommand(1, chalk.red.bold('You must provide a transform to apply.'))
   .strictCommands()
   .fail((msg, err, yargs) => {
@@ -84,9 +97,10 @@ const ignoreConfigArg = ignoreConfig ? `--ignore-config=${ignoreConfig}` : '';
 console.log(ignorePattern);
 
 console.log(chalk.blueBright(`\nApplying ${transform} transform to '${path}'\n`));
-const args = `-t ${__dirname}/dist/es6/${transform} ${path} --parser tsx --extensions js,jsx,ts,tsx ${ignoreConfigArg} --ignore-pattern=${ignorePattern} --verbose=${verbose}`.split(
-  ' '
-);
+const args =
+  `-t ${__dirname}/dist/es6/${transform} ${path} --parser tsx --extensions js,jsx,ts,tsx ${ignoreConfigArg} --ignore-pattern=${ignorePattern} --verbose=${verbose}`.split(
+    ' '
+  );
 
 const proc = spawn(`jscodeshift`, args);
 

--- a/modules/codemod/lib/v11/__remove_this__.ts
+++ b/modules/codemod/lib/v11/__remove_this__.ts
@@ -1,0 +1,11 @@
+import {Transform} from 'jscodeshift';
+
+// placeholder codemod
+const transform: Transform = (file, api) => {
+  const j = api.jscodeshift;
+
+  const root = j(file.source);
+  return root.toSource();
+};
+
+export default transform;

--- a/modules/codemod/lib/v11/index.ts
+++ b/modules/codemod/lib/v11/index.ts
@@ -1,0 +1,14 @@
+import {Transform} from 'jscodeshift';
+
+import placeholderCodemod from './__remove_this__';
+
+const transform: Transform = (file, api, options) => {
+  // These will run in order. If your transform depends on others, place yours after dependent transforms
+  const fixes = [
+    // add codemods here
+    placeholderCodemod,
+  ];
+  return fixes.reduce((source, fix) => fix({...file, source}, api, options) as string, file.source);
+};
+
+export default transform;

--- a/modules/codemod/lib/v11/spec/__remove_this__.spec.ts
+++ b/modules/codemod/lib/v11/spec/__remove_this__.spec.ts
@@ -1,0 +1,12 @@
+import {expectTransformFactory} from './expectTransformFactory';
+import transform from '../__remove_this__';
+
+const expectTransform = expectTransformFactory(transform);
+
+describe('Example Codemod', () => {
+  it('should not modify the code', () => {
+    const input = "const foo = 'bar';";
+    const expected = "const foo = 'bar';";
+    expectTransform(input, expected);
+  });
+});

--- a/modules/codemod/lib/v11/spec/expectTransformFactory.ts
+++ b/modules/codemod/lib/v11/spec/expectTransformFactory.ts
@@ -1,0 +1,6 @@
+import {runInlineTest} from 'jscodeshift/dist/testUtils';
+
+export const expectTransformFactory =
+  (fn: Function) => (input: string, expected: string, options?: Record<string, any>) => {
+    return runInlineTest(fn, options, {source: input}, expected, {parser: 'tsx'});
+  };

--- a/modules/docs/mdx/11.0-UPGRADE-GUIDE.mdx
+++ b/modules/docs/mdx/11.0-UPGRADE-GUIDE.mdx
@@ -1,0 +1,72 @@
+import {Meta} from '@storybook/addon-docs';
+
+<Meta title="Guides/Upgrade Guides/v11.0" />
+
+# Canvas Kit 11.0 Upgrade Guide
+
+This guide contains an overview of the changes in Canvas Kit v11. Please
+[reach out](https://github.com/Workday/canvas-kit/issues/new?labels=bug&template=bug.md) if you have
+any questions.
+
+- [Codemod](#codemod)
+
+## Codemod
+
+We've provided a [codemod](https://github.com/Workday/canvas-kit/tree/master/modules/codemod) to
+automatically update your code to work with most of the breaking changes in v11. **Breaking changes
+handled by the codemod are marked with 🤖 in the Upgrade Guide.**
+
+A codemod is a script that makes programmatic transformations on your codebase by traversing the
+[AST](https://www.codeshiftcommunity.com/docs/understanding-asts), identifying patterns, and making
+prescribed changes. This greatly decreases opportunities for error and reduces the number of manual
+updates, which allows you to focus on changes that need your attention. **We highly recommend you
+use the codemod for these reasons.**
+
+If you're new to running codemods or if it's been a minute since you've used one, there are a few
+things you'll want to keep in mind.
+
+- Our codemods are meant to be run sequentially. For example, if you're using v7 of Canvas Kit,
+  you'll need to run the v8 and v9 codemod before you run v11.
+- The codemod will update your code to be compatible with the specified version, but it will **not**
+  remove outdated dependencies or upgrade dependencies to the latest version. You'll need to upgrade
+  dependencies on your own.
+  - We recommend upgrading dependencies before running the codemod.
+  - Always review your `package.json` files to make sure your dependency versions look correct.
+- The codemod will not handle every breaking change in v11. You will likely need to make some manual
+  changes to be compatible. Use our Upgrade Guide as a checklist.
+- Codemods are not bulletproof.
+  - Conduct a thorough PR and QA review of all changes to ensure no regressions were introduced.
+  - As a safety precaution, we recommend committing the changes from the codemod as a single
+    isolated commit (separate from other changes) so you can roll back more easily if necessary.
+
+We're here to help! Automatic changes to your codebase can feel scary. You can always reach out to
+our team. We'd be very happy to walk you through the process to set you up for success.
+
+### Instructions
+
+The easiest way to run our codemod is to use `npx`.
+
+```sh
+> npx @workday/canvas-kit-codemod v11 [path]
+```
+
+Be sure to provide specific directories that need to be updated via the `[path]` argument. This
+decreases the amount of AST the codemod needs to traverse and reduces the chances of the script
+having an error. For example, if your source code lives in `src/`, use `src/` as your `[path]`. Or,
+if you have a monorepo with three packages using Canvas Kit, provide those specific packages as your
+`[path]`.
+
+Alternatively, if you're unable to run the codemod successfully using `npx`, you can install the
+codemod package as a dev dependency, run it with `yarn`, and then remove the package after you're
+finished.
+
+```sh
+> yarn add @workday/canvas-kit-codemod --dev
+> yarn canvas-kit-codemod v11 [path]
+> yarn remove @workday/canvas-kit-codemod
+```
+
+> The codemod only works on `.js`, `.jsx`, `.ts`, and `.tsx` files. You'll need to manually edit
+> other file types (`.json`, `.mdx`, `.md`, etc.). You may need to run your linter after executing
+> the codemod, as its resulting formatting (spacing, quotes, etc.) may not match your project
+> conventions.


### PR DESCRIPTION
## Summary

Fixes: #2473 

Adds initial codemod for V11 and updates maintaining doc

## Release Category
Infrastructure

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [standard MDX template](https://github.com/Workday/canvas-kit/discussions/1131)

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)
- [x] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [x] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [x] Documentation
- [ ] Testing
- [ ] Codemods

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

<!-- Explain how your reviewer could verify this change  -->

## Screenshots or GIFs (if applicable)

<!-- Does your change affect the UI? If so, please include a screenshot or short gif. -->

## Thank You Gif (optional)

![a dog on a skateboard](https://media.giphy.com/media/Oa9vbfzmq78C9dTUUd/giphy.gif)
