### PR TITLE
fix: Default createStyles vars to empty object

### DIFF
--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -866,7 +866,7 @@ type VariableValuesStencil<
  */
 export function createStencil<
   M extends StencilModifierConfig<V>,
-  V extends Record<string, string> | Record<string, Record<string, string>>,
+  V extends Record<string, string> | Record<string, Record<string, string>> = {},
   ID extends string = never
 >(config: StencilConfig<M, V, ID>, id?: ID): Stencil<M, V, ID> {
   const {vars, base, modifiers, compound, defaultModifiers} = config;


### PR DESCRIPTION
## Summary

Allow booleans on modifiers in Stencils. We need to default the `vars` config in Stencils to allow the `MaybeBoolean` type to work. Otherwise we'll get `vars` defaulting to `Record<string, string> | Record<Record<string, string>` which won't be compatible if `modifiers` have a `boolean` type. This won't work: `<Record<string, string> & { someKey?: boolean }`. `Record<string, string>` is too overly permissive and we need to default `vars` to an empty object to avoid widening the type.

## Release Category
Components
