### PR TITLE
fix: Fix TS error for boolean modifiers in compound stencils styles

### DIFF
--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -741,7 +741,7 @@ export type StencilModifierConfig<
 > = Record<string, Record<string, StylesReturn<V>>>;
 
 export type StencilCompoundConfig<M> = {
-  modifiers: {[K in keyof M]?: keyof M[K]};
+  modifiers: {[K in keyof M]?: MaybeBoolean<keyof M[K]>};
   styles: SerializedStyles | CSSObject;
 };
 


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #2506 <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

Fixing TS error for boolean modifiers in compound stencils styles.

```ts
// this shows TS error
compound: [
    {
      modifiers: {variant: 'inverse', disabled: true},
      styles: {...}
    }
]
```

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Infrastructure
