### PR TITLE
fix: Add ElementAccessExpression support to the parser

### DIFF
--- a/modules/styling-transform/lib/utils/parseNodeToStaticValue.ts
+++ b/modules/styling-transform/lib/utils/parseNodeToStaticValue.ts
@@ -68,6 +68,14 @@ export function parseNodeToStaticValue(
     }
   }
 
+  if (ts.isElementAccessExpression(node)) {
+    const value = parseTypeToStaticValue(checker.getTypeAtLocation(node));
+
+    if (value) {
+      return value;
+    }
+  }
+
   // If we got here, we cannot statically analyze by the AST alone. We have to check the type of the
   // correct AST Node
 

--- a/modules/styling-transform/spec/utils/parseNodeToStaticValue.spec.ts
+++ b/modules/styling-transform/spec/utils/parseNodeToStaticValue.spec.ts
@@ -91,6 +91,32 @@ describe('parseNodeToStaticValue', () => {
     ).toEqual('--css-foo-bar');
   });
 
+  it('should return the string value of a ElementAccessExpression', () => {
+    const program = createProgramFromSource(`
+      const foo = { 1: '12px'} as const;
+
+      foo[1]
+    `);
+
+    const sourceFile = program.getSourceFile('test.ts');
+    const node = findNodes(sourceFile, '', ts.isElementAccessExpression)[0];
+
+    expect(parseNodeToStaticValue(node, program.getTypeChecker())).toEqual('12px');
+  });
+
+  it('should return the string value of a ElementAccessExpression', () => {
+    const program = createProgramFromSource(`
+      const foo = ['12px'] as const;
+
+      foo[0]
+    `);
+
+    const sourceFile = program.getSourceFile('test.ts');
+    const node = findNodes(sourceFile, '', ts.isElementAccessExpression)[0];
+
+    expect(parseNodeToStaticValue(node, program.getTypeChecker())).toEqual('12px');
+  });
+
   it('should return the string value of a ComputedPropertyName of a variable', () => {
     const program = createProgramFromSource(`
       const temp = {


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #2516 <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

Added `ElementAccessExpression` support to the type parser.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Infrastructure