### PR TITLE
feat: Add keyframe support to static style parser

### DIFF
--- a/modules/styling-transform/lib/styleTransform.ts
+++ b/modules/styling-transform/lib/styleTransform.ts
@@ -53,11 +53,10 @@ const defaultTransformers = [
 export default function styleTransformer(
   program: ts.Program,
   {
-    prefix = 'css',
     variables = {},
-    keyframes = {},
     fallbackFiles = [],
     transformers = defaultTransformers,
+    ...transformContext
   }: Partial<StyleTransformerOptions> = {
     prefix: 'css',
     variables: {},
@@ -91,7 +90,13 @@ export default function styleTransformer(
       // eslint-disable-next-line no-param-reassign
       node = ts.visitEachChild(node, visit, context);
 
-      return handleTransformers(node, {checker, prefix, variables: vars, keyframes})(transformers);
+      return handleTransformers(node, {
+        checker,
+        prefix: 'css',
+        variables: vars,
+        keyframes,
+        ...transformContext,
+      })(transformers);
     };
 
     return node => ts.visitNode(node, visit);

--- a/modules/styling-transform/lib/styleTransform.ts
+++ b/modules/styling-transform/lib/styleTransform.ts
@@ -10,18 +10,21 @@ import {handleCalc} from './utils/handleCalc';
 import {handlePx2Rem} from './utils/handlePx2Rem';
 import {handleFocusRing} from './utils/handleFocusRing';
 import {handleCssVar} from './utils/handleCssVar';
-import {NodeTransformer} from './utils/types';
+import {NodeTransformer, TransformerContext} from './utils/types';
+import {handleKeyframes} from './utils/handleKeyframes';
 
 export type NestedStyleObject = {[key: string]: string | NestedStyleObject};
 
 export interface StyleTransformerOptions {
   prefix: string;
-  variables: Record<string, string>;
+  variables: TransformerContext['variables'];
+  keyframes: TransformerContext['keyframes'];
   fallbackFiles?: string[];
   transformers?: NodeTransformer[];
 }
 
-let vars: Record<string, string> = {};
+let vars: TransformerContext['variables'] = {};
+let keyframes: TransformerContext['keyframes'] = {};
 let loadedFallbacks = false;
 
 /**
@@ -29,6 +32,7 @@ let loadedFallbacks = false;
  */
 export function _reset() {
   vars = {};
+  keyframes = {};
   loadedFallbacks = false;
 }
 
@@ -40,6 +44,7 @@ const defaultTransformers = [
   handleFocusRing,
   handleCalc,
   handlePx2Rem,
+  handleKeyframes,
   handleCreateVars,
   handleCreateStyles,
   handleCreateStencil,
@@ -50,11 +55,13 @@ export default function styleTransformer(
   {
     prefix = 'css',
     variables = {},
+    keyframes = {},
     fallbackFiles = [],
     transformers = defaultTransformers,
   }: Partial<StyleTransformerOptions> = {
     prefix: 'css',
     variables: {},
+    keyframes: {},
     transformers: defaultTransformers,
   }
 ): ts.TransformerFactory<ts.SourceFile> {
@@ -84,7 +91,7 @@ export default function styleTransformer(
       // eslint-disable-next-line no-param-reassign
       node = ts.visitEachChild(node, visit, context);
 
-      return handleTransformers(node, checker, prefix, vars)(transformers);
+      return handleTransformers(node, {checker, prefix, variables: vars, keyframes})(transformers);
     };
 
     return node => ts.visitNode(node, visit);
@@ -98,8 +105,7 @@ export default function styleTransformer(
 export function transform(
   program: ts.Program,
   fileName: string,
-  options?: Partial<StyleTransformerOptions>,
-  transformers?: NodeTransformer[]
+  options?: Partial<StyleTransformerOptions>
 ) {
   const source =
     program.getSourceFile(fileName) || ts.createSourceFile(fileName, '', ts.ScriptTarget.ES2019);
@@ -108,27 +114,20 @@ export function transform(
 
   return printer.printFile(
     ts
-      .transform(source, [styleTransformer(program, {...options, transformers})])
+      .transform(source, [styleTransformer(program, options)])
       .transformed.find(s => s.fileName === fileName) || source
   );
 }
 
 const handleTransformers =
-  (node: ts.Node, checker: ts.TypeChecker, prefix: string, variables: Record<string, string>) =>
-  (
-    transformers: ((
-      node: ts.Node,
-      checker: ts.TypeChecker,
-      prefix: string,
-      variables: Record<string, string>
-    ) => ts.Node | void)[]
-  ) => {
+  (node: ts.Node, context: TransformerContext) =>
+  (transformers: ((node: ts.Node, context: TransformerContext) => ts.Node | void)[]) => {
     return (
       transformers.reduce((result, transformer) => {
         if (result) {
           return result;
         }
-        return transformer(node, checker, prefix, variables);
+        return transformer(node, context);
       }, undefined as ts.Node | void) || node
     );
   };

--- a/modules/styling-transform/lib/utils/createStyleObjectNode.ts
+++ b/modules/styling-transform/lib/utils/createStyleObjectNode.ts
@@ -10,8 +10,12 @@ import {NestedStyleObject} from './parseObjectToStaticValue';
  * string, styles: serializedStyles}`. The `name` is hard-coded here to work with both server-side
  * and client-side style injection. This results in a stable style key for Emotion while also
  * optimizing style serialization.
+ *
+ * If `name` is provided, the name will be whatever `name` is, replacing "{hash}" with the hash
+ * created via `serializeStyles`. For example: 'animation-{hash}' will be converted into
+ * 'animation-abc123'
  */
-export function createStyleObjectNode(styleObj: NestedStyleObject) {
+export function createStyleObjectNode(styleObj: NestedStyleObject | string, name?: string) {
   const serialized = serializeStyles([styleObj]);
   const styleText = serialized.styles;
   const styleExpression = ts.factory.createStringLiteral(styleText);
@@ -23,7 +27,9 @@ export function createStyleObjectNode(styleObj: NestedStyleObject) {
       ts.factory.createPropertyAssignment(
         ts.factory.createIdentifier('name'),
         // TODO - we may need this to be a static variable for the CSS package
-        ts.factory.createStringLiteral(generateUniqueId()) // We might be using values that are resolved at runtime, but should still be static. We're only supporting the `cs` function running once per file, so a stable id based on a hash is not necessary
+        ts.factory.createStringLiteral(
+          name ? name.replace('{hash}', serialized.name) : generateUniqueId()
+        ) // We might be using values that are resolved at runtime, but should still be static. We're only supporting the `cs` function running once per file, so a stable id based on a hash is not necessary
       ),
       ts.factory.createPropertyAssignment(
         ts.factory.createIdentifier('styles'),
@@ -32,4 +38,18 @@ export function createStyleObjectNode(styleObj: NestedStyleObject) {
     ],
     false
   );
+}
+
+/**
+ * Returns the name created by `createStyleObjectNode`
+ */
+export function getStaticCssClassName(node: ts.Node): string {
+  if (
+    ts.isObjectLiteralExpression(node) &&
+    ts.isPropertyAssignment(node.properties[0]) &&
+    ts.isStringLiteral(node.properties[0].initializer)
+  ) {
+    return node.properties[0].initializer.text;
+  }
+  return '';
 }

--- a/modules/styling-transform/lib/utils/handleCalc.ts
+++ b/modules/styling-transform/lib/utils/handleCalc.ts
@@ -19,14 +19,14 @@ import {NodeTransformer} from './types';
  * etc. The transform can handle template string literals with different spans, so we'll convert to
  * those as an intermediate step.
  */
-export const handleCalc: NodeTransformer = (node, checker) => {
+export const handleCalc: NodeTransformer = (node, context) => {
   if (
     ts.isCallExpression(node) &&
     ts.isPropertyAccessExpression(node.expression) &&
     ts.isIdentifier(node.expression.expression) &&
     node.expression.expression.text === 'calc' &&
     ts.isIdentifier(node.expression.name) &&
-    isImportedFromStyling(node.expression.expression, checker)
+    isImportedFromStyling(node.expression.expression, context.checker)
   ) {
     if (node.expression.name.text === 'add') {
       return replaceWithTemplateString(node.arguments[0], node.arguments[1], ' + ');

--- a/modules/styling-transform/lib/utils/handleCreateStyles.ts
+++ b/modules/styling-transform/lib/utils/handleCreateStyles.ts
@@ -5,7 +5,8 @@ import {createStyleObjectNode} from './createStyleObjectNode';
 import {NodeTransformer} from './types';
 import {isImportedFromStyling} from './isImportedFromStyling';
 
-export const handleCreateStyles: NodeTransformer = (node, checker, prefix, variables) => {
+export const handleCreateStyles: NodeTransformer = (node, context) => {
+  const {checker, prefix, variables} = context;
   /**
    * Check if the node is a call expression that looks like:
    *
@@ -49,7 +50,7 @@ export const handleCreateStyles: NodeTransformer = (node, checker, prefix, varia
       // An `ObjectLiteralExpression` is an object like `{foo:'bar'}`:
       // https://ts-ast-viewer.com/#code/MYewdgzgLgBFCmBbADjAvDA3gKBjAZiCAFwwDkARgIYBOZ2AvkA
       if (ts.isObjectLiteralExpression(arg)) {
-        const styleObj = parseObjectToStaticValue(arg, checker, prefix, variables);
+        const styleObj = parseObjectToStaticValue(arg, context);
 
         return createStyleObjectNode(styleObj);
       }
@@ -65,7 +66,7 @@ export const handleCreateStyles: NodeTransformer = (node, checker, prefix, varia
         }
 
         // The type must be a object
-        const styleObj = parseStyleObjFromType(type, checker, prefix, variables);
+        const styleObj = parseStyleObjFromType(type, context);
 
         return createStyleObjectNode(styleObj);
       }

--- a/modules/styling-transform/lib/utils/handleCreateStyles.ts
+++ b/modules/styling-transform/lib/utils/handleCreateStyles.ts
@@ -6,7 +6,7 @@ import {NodeTransformer} from './types';
 import {isImportedFromStyling} from './isImportedFromStyling';
 
 export const handleCreateStyles: NodeTransformer = (node, context) => {
-  const {checker, prefix, variables} = context;
+  const {checker} = context;
   /**
    * Check if the node is a call expression that looks like:
    *

--- a/modules/styling-transform/lib/utils/handleCreateVars.ts
+++ b/modules/styling-transform/lib/utils/handleCreateVars.ts
@@ -6,7 +6,7 @@ import {getVarName} from './getVarName';
 import {makeEmotionSafe} from './makeEmotionSafe';
 import {NodeTransformer} from './types';
 
-export const handleCreateVars: NodeTransformer = (node, _checker, prefix, vars) => {
+export const handleCreateVars: NodeTransformer = (node, {prefix, variables}) => {
   /**
    * This will create a variable
    */
@@ -16,12 +16,12 @@ export const handleCreateVars: NodeTransformer = (node, _checker, prefix, vars) 
     node.expression.text === 'createVars'
   ) {
     const id = slugify(getVarName(node)).replace('-vars', '');
-    const variables = node.arguments
+    const vars = node.arguments
       .map(arg => ts.isStringLiteral(arg) && arg.text)
       .filter(Boolean) as string[];
 
-    variables.forEach(v => {
-      vars[`${id}-${makeEmotionSafe(v)}`] = `--${prefix}-${id}-${makeEmotionSafe(v)}`;
+    vars.forEach(v => {
+      variables[`${id}-${makeEmotionSafe(v)}`] = `--${prefix}-${id}-${makeEmotionSafe(v)}`;
     });
 
     return ts.factory.createCallExpression(
@@ -37,7 +37,7 @@ export const handleCreateVars: NodeTransformer = (node, _checker, prefix, vars) 
             ts.factory.createPropertyAssignment(
               ts.factory.createIdentifier('args'),
               ts.factory.createArrayLiteralExpression(
-                variables.map(val => ts.factory.createStringLiteral(val)),
+                vars.map(val => ts.factory.createStringLiteral(val)),
                 false
               )
             ),

--- a/modules/styling-transform/lib/utils/handleCssVar.ts
+++ b/modules/styling-transform/lib/utils/handleCssVar.ts
@@ -11,7 +11,7 @@ import {NodeTransformer} from './types';
  * The value parser will figure out what to do from there. We don't have access to variables at this
  * point, so we forward CallExpression arguments in ways the value parser understands.
  */
-export const handleCssVar: NodeTransformer = (node, checker, prefix, vars) => {
+export const handleCssVar: NodeTransformer = node => {
   // cssVar(a)
   // cssVar(a, b)
 

--- a/modules/styling-transform/lib/utils/handleFocusRing.ts
+++ b/modules/styling-transform/lib/utils/handleFocusRing.ts
@@ -5,7 +5,7 @@ import {base, brand} from '@workday/canvas-tokens-web';
 import {NodeTransformer} from './types';
 import {parseNodeToStaticValue} from './parseNodeToStaticValue';
 
-export const handleFocusRing: NodeTransformer = (node, checker, prefix, vars) => {
+export const handleFocusRing: NodeTransformer = (node, context) => {
   // { ...focusRing() }
   /**
    * A spread assignment looks like:
@@ -46,7 +46,7 @@ export const handleFocusRing: NodeTransformer = (node, checker, prefix, vars) =>
         });
       }
 
-      const inset = parseNodeToStaticValue(defaults.inset, checker, prefix, vars);
+      const inset = parseNodeToStaticValue(defaults.inset, context);
 
       let boxShadow: ts.TemplateExpression;
       switch (inset) {

--- a/modules/styling-transform/lib/utils/handleKeyframes.ts
+++ b/modules/styling-transform/lib/utils/handleKeyframes.ts
@@ -1,0 +1,57 @@
+import ts from 'typescript';
+
+import {NodeTransformer} from './types';
+import {parseNodeToStaticValue} from './parseNodeToStaticValue';
+import {getVarName} from './getVarName';
+import {createStyleObjectNode, getStaticCssClassName} from './createStyleObjectNode';
+import {isImportedFromStyling} from './isImportedFromStyling';
+import {parseObjectToStaticValue} from './parseObjectToStaticValue';
+
+export const handleKeyframes: NodeTransformer = (node, context) => {
+  const {checker, keyframes} = context;
+  // keyframes`css`
+  if (
+    ts.isTaggedTemplateExpression(node) &&
+    ts.isIdentifier(node.tag) &&
+    node.tag.text === 'keyframes' &&
+    isImportedFromStyling(node.tag, checker)
+  ) {
+    // parseNodeToStaticValue can parse templates. Pass it through there to get a single static string
+    const styleObjNode = createStyleObjectNode(
+      parseNodeToStaticValue(node.template, context),
+      '{hash}'
+    );
+
+    const identifierName = getVarName(node);
+    const name = getStaticCssClassName(styleObjNode);
+    keyframes[identifierName] = `animation-${name}`;
+
+    return ts.factory.createCallExpression(ts.factory.createIdentifier('keyframes'), undefined, [
+      styleObjNode,
+    ]);
+  }
+
+  // keyframes({})
+  if (
+    ts.isCallExpression(node) &&
+    ts.isIdentifier(node.expression) &&
+    node.expression.text === 'keyframes' &&
+    isImportedFromStyling(node.expression, checker)
+  ) {
+    if (ts.isObjectLiteralExpression(node.arguments[0])) {
+      const styleObj = parseObjectToStaticValue(node.arguments[0], context);
+
+      const styleObjNode = createStyleObjectNode(styleObj, '{hash}');
+
+      const identifierName = getVarName(node);
+      const name = getStaticCssClassName(styleObjNode);
+      keyframes[identifierName] = `animation-${name}`;
+
+      return ts.factory.createCallExpression(ts.factory.createIdentifier('keyframes'), undefined, [
+        styleObjNode,
+      ]);
+    }
+  }
+
+  return;
+};

--- a/modules/styling-transform/lib/utils/handlePx2Rem.ts
+++ b/modules/styling-transform/lib/utils/handlePx2Rem.ts
@@ -6,12 +6,12 @@ import {NodeTransformer} from './types';
 /**
  * Handle the CallExpression `px2rem` to do static conversion and remove the CallExpression.
  */
-export const handlePx2Rem: NodeTransformer = (node, checker) => {
+export const handlePx2Rem: NodeTransformer = (node, context) => {
   if (
     ts.isCallExpression(node) &&
     ts.isIdentifier(node.expression) &&
     node.expression.text === 'px2rem' &&
-    isImportedFromStyling(node.expression, checker)
+    isImportedFromStyling(node.expression, context.checker)
   ) {
     const [pxArgument, baseArgument] = node.arguments;
     const base =

--- a/modules/styling-transform/lib/utils/parseNodeToStaticValue.ts
+++ b/modules/styling-transform/lib/utils/parseNodeToStaticValue.ts
@@ -4,16 +4,13 @@ import {slugify} from '@workday/canvas-kit-styling';
 
 import {makeEmotionSafe} from './makeEmotionSafe';
 import {getErrorMessage} from './getErrorMessage';
+import {TransformerContext} from './types';
 
 /**
  * This is the workhorse of statically analyzing style values
  */
-export function parseNodeToStaticValue(
-  node: ts.Node,
-  checker: ts.TypeChecker,
-  prefix: string = 'css',
-  variables: Record<string, string> = {}
-): string {
+export function parseNodeToStaticValue(node: ts.Node, context: TransformerContext): string {
+  const {checker, variables, keyframes} = context;
   /**
    * String literals like 'red' or empty Template Expressions like `red`
    */
@@ -38,6 +35,10 @@ export function parseNodeToStaticValue(
     if (variables[varName]) {
       return variables[varName];
     }
+
+    if (keyframes[varName]) {
+      return keyframes[varName];
+    }
   }
 
   // [a.b]
@@ -47,6 +48,10 @@ export function parseNodeToStaticValue(
     if (variables[varName]) {
       return variables[varName];
     }
+
+    if (keyframes[varName]) {
+      return keyframes[varName];
+    }
   }
 
   /**
@@ -55,7 +60,7 @@ export function parseNodeToStaticValue(
    * ```
    */
   if (ts.isTemplateExpression(node)) {
-    return getStyleValueFromTemplateExpression(node, checker, prefix, variables);
+    return getStyleValueFromTemplateExpression(node, context);
   }
 
   /**
@@ -65,6 +70,10 @@ export function parseNodeToStaticValue(
   if (ts.isIdentifier(node)) {
     if (variables[node.text]) {
       return variables[node.text];
+    }
+
+    if (keyframes[node.text]) {
+      return keyframes[node.text];
     }
   }
 
@@ -101,11 +110,7 @@ export function parseNodeToStaticValue(
   throw new Error(
     `Unknown type at: "${node.getText()}". Received "${typeValue}"\n${getErrorMessage(
       node
-    )}\nFor static analysis of styles, please make sure all types resolve to string or numeric literals. Please use 'const' instead of 'let'. If using an object, cast using "as const" or use an interface with string or numeric literals. Variables: ${JSON.stringify(
-      variables,
-      null,
-      '  '
-    )}`
+    )}\nFor static analysis of styles, please make sure all types resolve to string or numeric literals. Please use 'const' instead of 'let'. If using an object, cast using "as const" or use an interface with string or numeric literals.`
   );
 }
 
@@ -155,19 +160,15 @@ function getVariableNameParts(input: string): [string, string] {
  */
 function getStyleValueFromTemplateExpression(
   node: ts.Node | undefined,
-  checker: ts.TypeChecker,
-  prefix = 'css',
-  variables: Record<string, string> = {}
+  context: TransformerContext
 ): string {
   if (!node) {
     return '';
   }
   if (ts.isTemplateExpression(node)) {
     return (
-      getStyleValueFromTemplateExpression(node.head, checker, prefix, variables) +
-      node.templateSpans
-        .map(value => getStyleValueFromTemplateExpression(value, checker, prefix, variables))
-        .join('')
+      getStyleValueFromTemplateExpression(node.head, context) +
+      node.templateSpans.map(value => getStyleValueFromTemplateExpression(value, context)).join('')
     );
   }
 
@@ -177,8 +178,8 @@ function getStyleValueFromTemplateExpression(
 
   if (ts.isTemplateSpan(node)) {
     return (
-      parseNodeToStaticValue(node.expression, checker, prefix, variables) +
-      getStyleValueFromTemplateExpression(node.literal, checker, prefix, variables)
+      parseNodeToStaticValue(node.expression, context) +
+      getStyleValueFromTemplateExpression(node.literal, context)
     );
   }
 

--- a/modules/styling-transform/lib/utils/types.ts
+++ b/modules/styling-transform/lib/utils/types.ts
@@ -1,5 +1,12 @@
 import ts from 'typescript';
 
+export type TransformerContext = {
+  checker: ts.TypeChecker;
+  prefix: string;
+  variables: Record<string, string>;
+  keyframes: Record<string, string>;
+};
+
 /**
  * Transformer function type. A transformer will be called by the TypeScript AST transformer visitor
  * from the bottom of the tree to the top (inside-out/leaf first, root last). If a transformer knows
@@ -7,9 +14,4 @@ import ts from 'typescript';
  * returning a node shortcuts processing. The visitor will call all NodeTransformers until a match
  * is met.
  */
-export type NodeTransformer = (
-  node: ts.Node,
-  checker: ts.TypeChecker,
-  prefix: string,
-  variables: Record<string, string>
-) => ts.Node | void;
+export type NodeTransformer = (node: ts.Node, context: TransformerContext) => ts.Node | void;

--- a/modules/styling-transform/spec/utils/handleCreateStencil.spec.ts
+++ b/modules/styling-transform/spec/utils/handleCreateStencil.spec.ts
@@ -35,13 +35,18 @@ describe('handleCreateStencil', () => {
     `);
 
     const sourceFile = program.getSourceFile('test.ts');
-    const vars: Record<string, string> = {};
+    const variables: Record<string, string> = {};
 
     const node = findNodes(sourceFile, 'createStencil', ts.isCallExpression)[0];
 
-    handleCreateStencil(node, program.getTypeChecker(), 'css', vars);
+    handleCreateStencil(node, {
+      checker: program.getTypeChecker(),
+      prefix: 'css',
+      variables,
+      keyframes: {},
+    });
 
-    expect(vars).toHaveProperty('button-color', '--css-button-color');
+    expect(variables).toHaveProperty('button-color', '--css-button-color');
   });
 
   it('should parse base styles into statically optimized versions', () => {

--- a/modules/styling-transform/spec/utils/handleCreateVars.spec.ts
+++ b/modules/styling-transform/spec/utils/handleCreateVars.spec.ts
@@ -12,14 +12,19 @@ describe('handleCreateVars', () => {
     `);
 
     const sourceFile = program.getSourceFile('test.ts');
-    const vars: Record<string, string> = {};
+    const variables: Record<string, string> = {};
 
     const node = findNodes(sourceFile, 'createVars', ts.isCallExpression)[0];
 
-    handleCreateVars(node, program.getTypeChecker(), 'css', vars);
+    handleCreateVars(node, {
+      checker: program.getTypeChecker(),
+      prefix: 'css',
+      variables,
+      keyframes: {},
+    });
 
-    expect(vars).toHaveProperty('my-color', '--css-my-color');
-    expect(vars).toHaveProperty('my-background', '--css-my-background');
+    expect(variables).toHaveProperty('my-color', '--css-my-color');
+    expect(variables).toHaveProperty('my-background', '--css-my-background');
   });
 
   it('should add nested variables to the cache when the arguments are strings', () => {
@@ -30,12 +35,17 @@ describe('handleCreateVars', () => {
     `);
 
     const sourceFile = program.getSourceFile('test.ts');
-    const vars: Record<string, string> = {};
+    const variables: Record<string, string> = {};
 
     const node = findNodes(sourceFile, 'createVars', ts.isCallExpression)[0];
 
-    handleCreateVars(node, program.getTypeChecker(), 'css', vars);
+    handleCreateVars(node, {
+      checker: program.getTypeChecker(),
+      prefix: 'css',
+      variables,
+      keyframes: {},
+    });
 
-    expect(vars).toHaveProperty('my-foo-color', '--css-my-foo-color');
+    expect(variables).toHaveProperty('my-foo-color', '--css-my-foo-color');
   });
 });

--- a/modules/styling-transform/spec/utils/handleKeyframes.spec.ts
+++ b/modules/styling-transform/spec/utils/handleKeyframes.spec.ts
@@ -1,0 +1,76 @@
+import ts from 'typescript';
+
+import {transform, _reset} from '../../lib/styleTransform';
+import {createProgramFromSource} from '../createProgramFromSource';
+import {findNodes} from '../findNodes';
+import {handleKeyframes} from '../../lib/utils/handleKeyframes';
+
+describe('handleKeyframes', () => {
+  beforeEach(() => {
+    _reset();
+  });
+
+  it('should transform TaggedTemplateExpressions', () => {
+    const program = createProgramFromSource(`
+      import {keyframes} from '@workday/canvas-kit-styling';
+
+      const buttonAnimation = keyframes\`
+        from {
+          transform: scale(0.85);
+        }
+
+        to {
+          transform: scale(1.0);
+        }
+      \`
+    `);
+
+    const result = transform(program, 'test.ts', {transformers: [handleKeyframes]});
+
+    expect(result).toMatch(/keyframes\({ name: "[a-z0-9]+"/);
+  });
+
+  it('should transform TaggedTemplateExpressions', () => {
+    const program = createProgramFromSource(`
+      import {keyframes} from '@workday/canvas-kit-styling';
+
+      const buttonAnimation = keyframes\`\`
+    `);
+
+    const keyframes = {};
+    const sourceFile = program.getSourceFile('test.ts');
+    const node = findNodes(sourceFile, '', ts.isTaggedTemplateExpression)[0];
+
+    handleKeyframes(node, {
+      checker: program.getTypeChecker(),
+      prefix: 'css',
+      variables: {},
+      keyframes,
+    });
+
+    expect(keyframes).toHaveProperty(
+      'buttonAnimation',
+      expect.stringMatching(/animation-[a-z0-9]+/)
+    );
+  });
+
+  it('should transform CallExpression', () => {
+    const program = createProgramFromSource(`
+      import {keyframes} from '@workday/canvas-kit-styling';
+
+      const buttonAnimation = keyframes({
+        from: {
+          transform: 'scale(0.85)'
+        },
+
+        to: {
+          transform: 'scale(1.0)'
+        }
+      })
+    `);
+
+    const result = transform(program, 'test.ts', {transformers: [handleKeyframes]});
+
+    expect(result).toMatch(/keyframes\({ name: "[a-z0-9]+"/);
+  });
+});

--- a/modules/styling-transform/spec/utils/parseNodeToStaticValue.spec.ts
+++ b/modules/styling-transform/spec/utils/parseNodeToStaticValue.spec.ts
@@ -148,7 +148,14 @@ describe('parseNodeToStaticValue', () => {
     const sourceFile = program.getSourceFile('test.ts');
     const node = findNodes(sourceFile, '', ts.isElementAccessExpression)[0];
 
-    expect(parseNodeToStaticValue(node, program.getTypeChecker())).toEqual('12px');
+    expect(
+      parseNodeToStaticValue(node, {
+        checker: program.getTypeChecker(),
+        prefix: 'css',
+        variables: {},
+        keyframes: {},
+      })
+    ).toEqual('12px');
   });
 
   it('should return the string value of a ElementAccessExpression', () => {
@@ -161,7 +168,14 @@ describe('parseNodeToStaticValue', () => {
     const sourceFile = program.getSourceFile('test.ts');
     const node = findNodes(sourceFile, '', ts.isElementAccessExpression)[0];
 
-    expect(parseNodeToStaticValue(node, program.getTypeChecker())).toEqual('12px');
+    expect(
+      parseNodeToStaticValue(node, {
+        checker: program.getTypeChecker(),
+        prefix: 'css',
+        variables: {},
+        keyframes: {},
+      })
+    ).toEqual('12px');
   });
 
   it('should return the string value of a ComputedPropertyName of a variable', () => {

--- a/modules/styling-transform/spec/utils/parseNodeToStaticValue.spec.ts
+++ b/modules/styling-transform/spec/utils/parseNodeToStaticValue.spec.ts
@@ -14,7 +14,14 @@ describe('parseNodeToStaticValue', () => {
     const sourceFile = program.getSourceFile('test.ts');
     const node = findNodes(sourceFile, '', ts.isStringLiteral)[0];
 
-    expect(parseNodeToStaticValue(node, program.getTypeChecker())).toEqual('foo');
+    expect(
+      parseNodeToStaticValue(node, {
+        checker: program.getTypeChecker(),
+        prefix: 'css',
+        variables: {},
+        keyframes: {},
+      })
+    ).toEqual('foo');
   });
 
   it('should return the string value of a NumericLiteral', () => {
@@ -25,7 +32,14 @@ describe('parseNodeToStaticValue', () => {
     const sourceFile = program.getSourceFile('test.ts');
     const node = findNodes(sourceFile, '', ts.isNumericLiteral)[0];
 
-    expect(parseNodeToStaticValue(node, program.getTypeChecker())).toEqual('12px');
+    expect(
+      parseNodeToStaticValue(node, {
+        checker: program.getTypeChecker(),
+        prefix: 'css',
+        variables: {},
+        keyframes: {},
+      })
+    ).toEqual('12px');
   });
 
   it('should return the string value of a string Identifier', () => {
@@ -36,7 +50,14 @@ describe('parseNodeToStaticValue', () => {
     const sourceFile = program.getSourceFile('test.ts');
     const node = findNodes(sourceFile, '', ts.isIdentifier)[0];
 
-    expect(parseNodeToStaticValue(node, program.getTypeChecker())).toEqual('bar');
+    expect(
+      parseNodeToStaticValue(node, {
+        checker: program.getTypeChecker(),
+        prefix: 'css',
+        variables: {},
+        keyframes: {},
+      })
+    ).toEqual('bar');
   });
 
   it('should return the string value of a numerical Identifier', () => {
@@ -47,7 +68,14 @@ describe('parseNodeToStaticValue', () => {
     const sourceFile = program.getSourceFile('test.ts');
     const node = findNodes(sourceFile, '', ts.isIdentifier)[0];
 
-    expect(parseNodeToStaticValue(node, program.getTypeChecker())).toEqual('12px');
+    expect(
+      parseNodeToStaticValue(node, {
+        checker: program.getTypeChecker(),
+        prefix: 'css',
+        variables: {},
+        keyframes: {},
+      })
+    ).toEqual('12px');
   });
 
   it('should return the string value of a PropertyAccessExpression', () => {
@@ -60,7 +88,14 @@ describe('parseNodeToStaticValue', () => {
     const sourceFile = program.getSourceFile('test.ts');
     const node = findNodes(sourceFile, '', ts.isPropertyAccessExpression)[0];
 
-    expect(parseNodeToStaticValue(node, program.getTypeChecker())).toEqual('baz');
+    expect(
+      parseNodeToStaticValue(node, {
+        checker: program.getTypeChecker(),
+        prefix: 'css',
+        variables: {},
+        keyframes: {},
+      })
+    ).toEqual('baz');
   });
 
   it('should return the string value of a PropertyAccessExpression', () => {
@@ -73,7 +108,14 @@ describe('parseNodeToStaticValue', () => {
     const sourceFile = program.getSourceFile('test.ts');
     const node = findNodes(sourceFile, '', ts.isPropertyAccessExpression)[0];
 
-    expect(parseNodeToStaticValue(node, program.getTypeChecker())).toEqual('12px');
+    expect(
+      parseNodeToStaticValue(node, {
+        checker: program.getTypeChecker(),
+        prefix: 'css',
+        variables: {},
+        keyframes: {},
+      })
+    ).toEqual('12px');
   });
 
   it('should return the string value of a PropertyAccessExpression of a variable', () => {
@@ -85,8 +127,13 @@ describe('parseNodeToStaticValue', () => {
     const node = findNodes(sourceFile, '', ts.isPropertyAccessExpression)[0];
 
     expect(
-      parseNodeToStaticValue(node, program.getTypeChecker(), 'css', {
-        'foo-bar': '--css-foo-bar',
+      parseNodeToStaticValue(node, {
+        checker: program.getTypeChecker(),
+        prefix: 'css',
+        variables: {
+          'foo-bar': '--css-foo-bar',
+        },
+        keyframes: {},
       })
     ).toEqual('--css-foo-bar');
   });
@@ -128,8 +175,13 @@ describe('parseNodeToStaticValue', () => {
     const node = findNodes(sourceFile, '', ts.isComputedPropertyName)[0];
 
     expect(
-      parseNodeToStaticValue(node, program.getTypeChecker(), 'css', {
-        'foo-bar': '--css-foo-bar',
+      parseNodeToStaticValue(node, {
+        checker: program.getTypeChecker(),
+        prefix: 'css',
+        variables: {
+          'foo-bar': '--css-foo-bar',
+        },
+        keyframes: {},
       })
     ).toEqual('--css-foo-bar');
   });
@@ -146,6 +198,31 @@ describe('parseNodeToStaticValue', () => {
     const sourceFile = program.getSourceFile('test.ts');
     const node = findNodes(sourceFile, '', ts.isComputedPropertyName)[0];
 
-    expect(parseNodeToStaticValue(node, program.getTypeChecker())).toEqual('--bar');
+    expect(
+      parseNodeToStaticValue(node, {
+        checker: program.getTypeChecker(),
+        prefix: 'css',
+        variables: {},
+        keyframes: {},
+      })
+    ).toEqual('--bar');
+  });
+
+  it('should handle keyframes', () => {
+    const program = createProgramFromSource(`
+      \`\${myAnimation} 1s ease\`
+    `);
+
+    const sourceFile = program.getSourceFile('test.ts');
+    const node = findNodes(sourceFile, '', ts.isTemplateExpression)[0];
+
+    expect(
+      parseNodeToStaticValue(node, {
+        checker: program.getTypeChecker(),
+        prefix: 'css',
+        variables: {},
+        keyframes: {myAnimation: 'animation-abc123'},
+      })
+    ).toEqual('animation-abc123 1s ease');
   });
 });

--- a/modules/styling-transform/spec/utils/parseObjectToStaticValue.spec.ts
+++ b/modules/styling-transform/spec/utils/parseObjectToStaticValue.spec.ts
@@ -16,7 +16,14 @@ describe('parseObjectToStaticValue', () => {
     const sourceFile = program.getSourceFile('test.ts');
     const node = findNodes(sourceFile, '', ts.isObjectLiteralExpression)[0];
 
-    expect(parseObjectToStaticValue(node, program.getTypeChecker())).toEqual({
+    expect(
+      parseObjectToStaticValue(node, {
+        checker: program.getTypeChecker(),
+        prefix: 'css',
+        variables: {},
+        keyframes: {},
+      })
+    ).toEqual({
       bar: '12px',
     });
   });
@@ -33,7 +40,14 @@ describe('parseObjectToStaticValue', () => {
     const sourceFile = program.getSourceFile('test.ts');
     const node = findNodes(sourceFile, '', ts.isObjectLiteralExpression)[0];
 
-    expect(parseObjectToStaticValue(node, program.getTypeChecker())).toEqual({
+    expect(
+      parseObjectToStaticValue(node, {
+        checker: program.getTypeChecker(),
+        prefix: 'css',
+        variables: {},
+        keyframes: {},
+      })
+    ).toEqual({
       '&:hover': {
         padding: '12px',
       },
@@ -54,7 +68,14 @@ describe('parseObjectToStaticValue', () => {
     const sourceFile = program.getSourceFile('test.ts');
     const node = findNodes(sourceFile, '', ts.isObjectLiteralExpression)[2];
 
-    expect(parseObjectToStaticValue(node, program.getTypeChecker())).toEqual({
+    expect(
+      parseObjectToStaticValue(node, {
+        checker: program.getTypeChecker(),
+        prefix: 'css',
+        variables: {},
+        keyframes: {},
+      })
+    ).toEqual({
       '&:hover': {
         padding: '12px',
       },
@@ -75,7 +96,14 @@ describe('parseObjectToStaticValue', () => {
     const sourceFile = program.getSourceFile('test.ts');
     const node = findNodes(sourceFile, '', ts.isObjectLiteralExpression)[2];
 
-    expect(parseObjectToStaticValue(node, program.getTypeChecker())).toEqual({
+    expect(
+      parseObjectToStaticValue(node, {
+        checker: program.getTypeChecker(),
+        prefix: 'css',
+        variables: {},
+        keyframes: {},
+      })
+    ).toEqual({
       '&:hover': {
         padding: '12px',
       },
@@ -98,7 +126,14 @@ describe('parseObjectToStaticValue', () => {
     const sourceFile = program.getSourceFile('test.ts');
     const node = findNodes(sourceFile, '', ts.isObjectLiteralExpression)[1];
 
-    expect(parseObjectToStaticValue(node, program.getTypeChecker())).toEqual({
+    expect(
+      parseObjectToStaticValue(node, {
+        checker: program.getTypeChecker(),
+        prefix: 'css',
+        variables: {},
+        keyframes: {},
+      })
+    ).toEqual({
       fontSize: '12px',
     });
   });
@@ -114,8 +149,13 @@ describe('parseObjectToStaticValue', () => {
     const node = findNodes(sourceFile, '', ts.isObjectLiteralExpression)[0];
 
     expect(
-      parseObjectToStaticValue(node, program.getTypeChecker(), 'css', {
-        '--fallback': '12px',
+      parseObjectToStaticValue(node, {
+        checker: program.getTypeChecker(),
+        prefix: 'css',
+        variables: {
+          '--fallback': '12px',
+        },
+        keyframes: {},
       })
     ).toEqual({
       padding: 'var(--fallback, 12px)',
@@ -133,8 +173,13 @@ describe('parseObjectToStaticValue', () => {
     const node = findNodes(sourceFile, '', ts.isObjectLiteralExpression)[0];
 
     expect(
-      parseObjectToStaticValue(node, program.getTypeChecker(), 'css', {
-        '--fallback': '12px',
+      parseObjectToStaticValue(node, {
+        checker: program.getTypeChecker(),
+        prefix: 'css',
+        variables: {
+          '--fallback': '12px',
+        },
+        keyframes: {},
       })
     ).toEqual({
       padding: 'var(--foobar, var(--fallback, 12px))',

--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -1,4 +1,4 @@
-import {cache, css} from '@emotion/css';
+import {cache, css, keyframes as keyframesEmotion} from '@emotion/css';
 import {getRegisteredStyles} from '@emotion/utils';
 import {serializeStyles, Keyframes, SerializedStyles, CSSObject} from '@emotion/serialize';
 import {Properties} from 'csstype';
@@ -942,4 +942,10 @@ export function createStencil<
   stencil.modifiers = _modifiers as any as StencilModifierReturn<M, V>;
 
   return stencil;
+}
+
+export function keyframes<ID extends string>(
+  ...args: ({name: ID; styles: string} | StyleProps | TemplateStringsArray)[]
+): ID {
+  return keyframesEmotion(...(args as any)) as ID;
 }

--- a/modules/styling/spec/cs.spec.tsx
+++ b/modules/styling/spec/cs.spec.tsx
@@ -20,6 +20,7 @@ import {
   CompoundModifier,
   createStencil,
   handleCsProp,
+  keyframes,
 } from '../lib/cs';
 
 // We need to force Emotion's cache wrapper to use the cache from `@emotion/css` for tests to pass
@@ -877,5 +878,28 @@ describe('handleCsProp', () => {
 
     expect(screen.getByTestId('base')).toHaveStyle({padding: padding.styledComponent});
     expect(screen.getByTestId('base')).not.toHaveClass(baseStyles);
+  });
+});
+
+describe('keyframes', () => {
+  it('should return an animation name', () => {
+    const name = keyframes({});
+
+    expect(name).toContain('animation-');
+  });
+
+  it('should return a string when name is not preknown', () => {
+    const name = keyframes({});
+
+    expectTypeOf(name).toBeString();
+  });
+
+  it('should return a string literal when name is not preknown', () => {
+    const name = keyframes({
+      name: 'foo',
+      styles: '',
+    });
+
+    expectTypeOf(name).toMatchTypeOf<'foo'>();
   });
 });


### PR DESCRIPTION
## Summary

Add `keyframe` support to the static style parser. Refactored transformers a bit to use a `context` object instead of multiple parameters. This makes the transforms a bit more flexible and keeps parameter count down.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Infrastructure

---

## Checklist

- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

`handleKeyframes.spec.ts`

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [x] Code
- [x] Testing

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

Add `keyframes` somewhere in a React file.

```
(cd modules/react; yarn clean && yarn build:es6)
```

Run `yarn clean` when done
