### PR TITLE
fix: SidePanel Examples aria-labelledby Update

### DIFF
--- a/modules/preview-react/side-panel/stories/examples/Basic.tsx
+++ b/modules/preview-react/side-panel/stories/examples/Basic.tsx
@@ -7,7 +7,7 @@ import {
 } from '@workday/canvas-kit-preview-react/side-panel';
 import {Flex} from '@workday/canvas-kit-react/layout';
 import {Text} from '@workday/canvas-kit-react/text';
-import {AccessibleHide, CanvasProvider} from '@workday/canvas-kit-react/common';
+import {CanvasProvider} from '@workday/canvas-kit-react/common';
 import {AccentIcon} from '@workday/canvas-kit-react/icon';
 import {rocketIcon} from '@workday/canvas-accent-icons-web';
 // local helper hook for setting content direction;
@@ -39,9 +39,9 @@ export const Basic = () => {
           {panelState === 'expanded' ? (
             expandedContent
           ) : (
-            <AccessibleHide {...labelProps} aria-hidden="true">
+            <span hidden {...labelProps}>
               Tasks Panel
-            </AccessibleHide>
+            </span>
           )}
         </SidePanel>
         <Flex

--- a/modules/preview-react/side-panel/stories/examples/Basic.tsx
+++ b/modules/preview-react/side-panel/stories/examples/Basic.tsx
@@ -39,9 +39,9 @@ export const Basic = () => {
           {panelState === 'expanded' ? (
             expandedContent
           ) : (
-            <span hidden {...labelProps}>
+            <Text as="span" hidden {...labelProps}>
               Tasks Panel
-            </span>
+            </Text>
           )}
         </SidePanel>
         <Flex

--- a/modules/preview-react/side-panel/stories/examples/Basic.tsx
+++ b/modules/preview-react/side-panel/stories/examples/Basic.tsx
@@ -39,7 +39,7 @@ export const Basic = () => {
           {panelState === 'expanded' ? (
             expandedContent
           ) : (
-            <Text as="span" hidden {...labelProps}>
+            <Text hidden {...labelProps}>
               Tasks Panel
             </Text>
           )}

--- a/modules/preview-react/side-panel/stories/examples/Basic.tsx
+++ b/modules/preview-react/side-panel/stories/examples/Basic.tsx
@@ -7,7 +7,7 @@ import {
 } from '@workday/canvas-kit-preview-react/side-panel';
 import {Flex} from '@workday/canvas-kit-react/layout';
 import {Text} from '@workday/canvas-kit-react/text';
-import {CanvasProvider} from '@workday/canvas-kit-react/common';
+import {AccessibleHide, CanvasProvider} from '@workday/canvas-kit-react/common';
 import {AccentIcon} from '@workday/canvas-kit-react/icon';
 import {rocketIcon} from '@workday/canvas-accent-icons-web';
 // local helper hook for setting content direction;
@@ -20,26 +20,28 @@ export const Basic = () => {
     expanded ? 'expanded' : 'collapsed'
   );
 
+  const expandedContent = (
+    <Flex alignItems="center" paddingY="s" paddingX="s">
+      <Flex marginInlineEnd="s">
+        <AccentIcon icon={rocketIcon} />
+      </Flex>
+      <Text as="h3" typeLevel="body.large" color="licorice500" fontWeight="bold" {...labelProps}>
+        Tasks Panel
+      </Text>
+    </Flex>
+  );
+
   return (
     <CanvasProvider theme={{canvas: {direction}}}>
       <Flex height={320}>
         <SidePanel {...panelProps} onStateTransition={setPanelState}>
           <SidePanel.ToggleButton {...controlProps} />
-          {panelState === 'expanded' && (
-            <Flex alignItems="center" paddingY="s" paddingX="s">
-              <Flex marginInlineEnd="s">
-                <AccentIcon icon={rocketIcon} />
-              </Flex>
-              <Text
-                as="h3"
-                typeLevel="body.large"
-                color="licorice500"
-                fontWeight="bold"
-                {...labelProps}
-              >
-                Tasks Panel
-              </Text>
-            </Flex>
+          {panelState === 'expanded' ? (
+            expandedContent
+          ) : (
+            <AccessibleHide {...labelProps} aria-hidden="true">
+              Tasks Panel
+            </AccessibleHide>
           )}
         </SidePanel>
         <Flex

--- a/modules/preview-react/side-panel/stories/examples/RightOrigin.tsx
+++ b/modules/preview-react/side-panel/stories/examples/RightOrigin.tsx
@@ -35,7 +35,7 @@ const RightPanel = () => {
       {panelState === 'expanded' ? (
         expandedContent
       ) : (
-            <Text as="span" hidden {...labelProps}>
+            <Text hidden {...labelProps}>
               Tasks Panel
             </Text>
       )}

--- a/modules/preview-react/side-panel/stories/examples/RightOrigin.tsx
+++ b/modules/preview-react/side-panel/stories/examples/RightOrigin.tsx
@@ -21,21 +21,23 @@ const RightPanel = () => {
     expanded ? 'expanded' : 'collapsed'
   );
 
+  const expandedContent = (
+    <Flex alignItems="center" justifyContent="flex-end" paddingY="s" paddingX="s">
+      <Text as="h3" typeLevel="body.large" color="licorice500" fontWeight="bold" {...labelProps}>
+        Tasks Panel
+      </Text>
+    </Flex>
+  );
+
   return (
     <StyledSidePanel {...panelProps} onStateTransition={setPanelState} origin="right">
       <SidePanel.ToggleButton {...controlProps} />
-      {panelState === 'expanded' && (
-        <Flex alignItems="center" justifyContent="flex-end" paddingY="s" paddingX="s">
-          <Text
-            as="h3"
-            typeLevel="body.large"
-            color="licorice500"
-            fontWeight="bold"
-            {...labelProps}
-          >
-            Tasks Panel
-          </Text>
-        </Flex>
+      {panelState === 'expanded' ? (
+        expandedContent
+      ) : (
+        <span hidden {...labelProps}>
+          Tasks Panel
+        </span>
       )}
     </StyledSidePanel>
   );

--- a/modules/preview-react/side-panel/stories/examples/RightOrigin.tsx
+++ b/modules/preview-react/side-panel/stories/examples/RightOrigin.tsx
@@ -35,9 +35,9 @@ const RightPanel = () => {
       {panelState === 'expanded' ? (
         expandedContent
       ) : (
-        <span hidden {...labelProps}>
-          Tasks Panel
-        </span>
+            <Text as="span" hidden {...labelProps}>
+              Tasks Panel
+            </Text>
       )}
     </StyledSidePanel>
   );

--- a/modules/preview-react/side-panel/stories/examples/Variant.tsx
+++ b/modules/preview-react/side-panel/stories/examples/Variant.tsx
@@ -34,7 +34,7 @@ export const AlternatePanel = () => {
           {panelState === 'expanded' ? (
             expandedContent
           ) : (
-            <Text as="span" hidden {...labelProps}>
+            <Text hidden {...labelProps}>
               Tasks Panel
             </Text>
           )}

--- a/modules/preview-react/side-panel/stories/examples/Variant.tsx
+++ b/modules/preview-react/side-panel/stories/examples/Variant.tsx
@@ -34,9 +34,9 @@ export const AlternatePanel = () => {
           {panelState === 'expanded' ? (
             expandedContent
           ) : (
-            <span hidden {...labelProps}>
-              Alternate Panel
-            </span>
+            <Text as="span" hidden {...labelProps}>
+              Tasks Panel
+            </Text>
           )}
         </SidePanel>
         <Flex

--- a/modules/preview-react/side-panel/stories/examples/Variant.tsx
+++ b/modules/preview-react/side-panel/stories/examples/Variant.tsx
@@ -7,7 +7,7 @@ import {
 } from '@workday/canvas-kit-preview-react/side-panel';
 import {Flex} from '@workday/canvas-kit-react/layout';
 import {Text} from '@workday/canvas-kit-react/text';
-import {AccessibleHide, CanvasProvider} from '@workday/canvas-kit-react/common';
+import {CanvasProvider} from '@workday/canvas-kit-react/common';
 // local helper hook for setting content direction;
 import {useDirection} from './useDirection';
 
@@ -34,9 +34,9 @@ export const AlternatePanel = () => {
           {panelState === 'expanded' ? (
             expandedContent
           ) : (
-            <AccessibleHide {...labelProps} aria-hidden="true">
+            <span hidden {...labelProps}>
               Alternate Panel
-            </AccessibleHide>
+            </span>
           )}
         </SidePanel>
         <Flex

--- a/modules/preview-react/side-panel/stories/examples/Variant.tsx
+++ b/modules/preview-react/side-panel/stories/examples/Variant.tsx
@@ -7,7 +7,7 @@ import {
 } from '@workday/canvas-kit-preview-react/side-panel';
 import {Flex} from '@workday/canvas-kit-react/layout';
 import {Text} from '@workday/canvas-kit-react/text';
-import {CanvasProvider} from '@workday/canvas-kit-react/common';
+import {AccessibleHide, CanvasProvider} from '@workday/canvas-kit-react/common';
 // local helper hook for setting content direction;
 import {useDirection} from './useDirection';
 
@@ -18,23 +18,25 @@ export const AlternatePanel = () => {
     expanded ? 'expanded' : 'collapsed'
   );
 
+  const expandedContent = (
+    <Flex alignItems="center" paddingY="s" paddingX="s">
+      <Text as="h3" typeLevel="body.large" color="licorice500" fontWeight="bold" {...labelProps}>
+        Alternate Panel
+      </Text>
+    </Flex>
+  );
+
   return (
     <CanvasProvider theme={{canvas: {direction}}}>
       <Flex height={320} backgroundColor="soap100">
         <SidePanel {...panelProps} onStateTransition={setPanelState} variant="alternate">
           <SidePanel.ToggleButton {...controlProps} />
-          {panelState === 'expanded' && (
-            <Flex alignItems="center" paddingY="s" paddingX="s">
-              <Text
-                as="h3"
-                typeLevel="body.large"
-                color="licorice500"
-                fontWeight="bold"
-                {...labelProps}
-              >
-                Alternate Panel
-              </Text>
-            </Flex>
+          {panelState === 'expanded' ? (
+            expandedContent
+          ) : (
+            <AccessibleHide {...labelProps} aria-hidden="true">
+              Alternate Panel
+            </AccessibleHide>
           )}
         </SidePanel>
         <Flex


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #2523  <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

For the Basic example, Alternate example, and Right-to-left example, they should display a hidden `<span>` with `labelProps` when in the collapsed state. This helps keep the `aria-labelledby` reference on the toggle button valid while collapsed. 

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Documentation 

### Release Note
Updates the Basic example, Alternate example, and Right-to-left example to display a hidden <span/> element when in the collapsed state. 

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)
- [x] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->
`modules/preview-react/side-panel/stories/examples/Basic.tsx`
`modules/preview-react/side-panel/stories/examples/Variant.tsx`
`modules/preview-react/side-panel/stories/examples/RightOrigin.tsx`

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

While using VoiceOver on MacOS:
1. Turn on VoiceOver: Cmd + Power button 3x
2. Open Safari and navigate to Storybook > Preview > SidePanel > Basic
3. Verify SidePanel is in opened expanded state, 
4. Set rotor to "Landmarks" : Ctrl + Opt + Cmd + Right Arrow
5. Jump to next region: Ctrl + Opt + Cmd + Down Arrow
6. Repeat until on "Tasks Panel, region" 
7. Navigate to toggle button: Ctrl + Opt + Right Arrow
8. Activate toggle button: Ctrl + Opt + Space
9. Repeat steps 5 - 8 above, validate both the landmark region still exists and the toggle button still has a name. 
10. Open DevTools > Accessibility tree and inspect the Toggle button
11. Validate the `aria-labelledby` id reference is still valid, and the `name:` matches the title of the side panel example
12. Repeat: validate the SidePanel `<section>` element also has a valid `name`

<!-- Explain how your reviewer could verify this change  -->
