### PR TITLE
docs: Fix Table example

### DIFF
--- a/modules/preview-react/_examples/stories/examples/Table/WithSelectableRows.tsx
+++ b/modules/preview-react/_examples/stories/examples/Table/WithSelectableRows.tsx
@@ -125,7 +125,7 @@ export const SelectableRows = () => {
       </Heading>
       <Table aria-labelledby={headingID}>
         <Table.Row gridTemplateColumns="3.5rem repeat(2, 1fr)">
-          <Table.Header cs={tableHeaderStyles}>
+          <Table.Cell cs={tableHeaderStyles}>
             <Tooltip title="Select All">
               <Checkbox
                 checked={selectAllState === 'checked'}
@@ -133,7 +133,7 @@ export const SelectableRows = () => {
                 onChange={handleSelectAll}
               />
             </Tooltip>
-          </Table.Header>
+          </Table.Cell>
           <Table.Header scope="col" cs={tableHeaderStyles}>
             Toppings
           </Table.Header>


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

This PR fixes the Selectable Table Row example to make it more screen reader friendly.

## Release Category
Documentation

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Documentation
- [ ] Testing
- [ ] Codemods

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

<!-- Explain how your reviewer could verify this change  -->

## Screenshots or GIFs (if applicable)

<!-- Does your change affect the UI? If so, please include a screenshot or short gif. -->

## Thank You Gif (optional)

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer! -->
<!-- ![a smiling Shiba Inu typing on a laptop](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif) -->
