### PR TITLE
ci: Fix forward-merge version conflicts [skip release]

### DIFF
--- a/utils/fix-package-json-versions.js
+++ b/utils/fix-package-json-versions.js
@@ -1,0 +1,29 @@
+/**
+ * This function rewrites all the dependencies that a matches as mono dependencies to the correct
+ * versions provided by the `monoDependencies` parameter
+ *
+ * @param {string} packageContents
+ * @param {{name: string, version: string}[]} monoDependencies All dependency strings that are part
+ * of the mono repo
+ *
+ * @returns {string}
+ */
+function fixPackageJsonVersions(packageContents, monoDependencies) {
+  const lines = packageContents.split('\n').map(line => {
+    return line.replace(/"(.+)": "\^([0-9\.]+)"/, (substr, ...args) => {
+      /** @type {[string, string]} */
+      const [dependency] = args;
+
+      const matchedDependency = monoDependencies.find(dep => dep.name === dependency);
+
+      if (matchedDependency) {
+        return `"${dependency}": "^${matchedDependency.version}"`;
+      }
+      return substr;
+    });
+  });
+
+  return lines.join('\n');
+}
+
+module.exports = fixPackageJsonVersions;

--- a/utils/resolve-package-json.js
+++ b/utils/resolve-package-json.js
@@ -1,0 +1,60 @@
+const semver = require('semver');
+
+function resolvePackageJson(/** @type {string} */ input) {
+  const conflictRegex = /<<<<<<< .+\n([\s\S]*?)\n?=======\n([\s\S]*?)\n?>>>>>>> .+\n/;
+
+  return input.replace(new RegExp(conflictRegex, 'gm'), (substring, ...args) => {
+    /** @type {[string, string]} */
+    const [current, incoming] = args;
+
+    let final = '';
+
+    const currentLines = current.split('\n');
+    const incomingLines = incoming.split('\n');
+
+    const currentVersions = currentLines.map(getPropertyAndValues).filter(v => v);
+    const incomingVersions = incomingLines.map(getPropertyAndValues).filter(v => v);
+
+    const currentProperties = currentVersions.map(p => p.property);
+    const incomingProperties = incomingVersions.map(p => p.property);
+
+    const totalProperties = [...new Set([...currentProperties, ...incomingProperties])];
+
+    totalProperties.forEach(property => {
+      if (currentProperties.includes(property) && !incomingProperties.includes(property)) {
+        // only in current. Assume dependency was removed. If this is incorrect, a manual PR will be
+        // created and it will be resolved in a way that the dependency is in both branches and
+        // we'll only hit this case the first time it happens
+        // Do nothing
+      } else if (!currentProperties.includes(property) && incomingProperties.includes(property)) {
+        // only in incoming
+        const line = incomingLines.find(l => l.includes(`"${property}"`));
+
+        final += line + '\n';
+      } else {
+        const currentVersion = currentVersions.find(v => v.property === property).value;
+        const incomingVersion = incomingVersions.find(v => v.property === property).value;
+
+        if (
+          semver.gt(currentVersion.replace(/[\^\~]/, ''), incomingVersion.replace(/[\^\~]/, ''))
+        ) {
+          const line = currentLines.find(l => l.includes(`"${property}"`));
+
+          final += line + '\n';
+        }
+      }
+    });
+
+    return final;
+  });
+
+  function getPropertyAndValues(/** @type {string} */ line) {
+    const match = line.match(/"(.+)": "(.+)"/);
+    if (match) {
+      const [_, property, value] = match;
+      return {property, value};
+    }
+  }
+}
+
+module.exports = resolvePackageJson;

--- a/utils/spec/fix-package-json-versions.spec.ts
+++ b/utils/spec/fix-package-json-versions.spec.ts
@@ -1,0 +1,36 @@
+import fixPackageJsonVersions from '../fix-package-json-versions';
+import {stripIndent} from 'common-tags';
+
+describe('updatePackageJson', () => {
+  it('should replace a matched dependency with the provided version', () => {
+    const input = stripIndent`
+    {
+      "@workday/canvas-kit-styling": "^10.3.3",
+    }`;
+
+    const expected = stripIndent`
+    {
+      "@workday/canvas-kit-styling": "^10.3.9",
+    }`;
+
+    expect(
+      fixPackageJsonVersions(input, [{name: '@workday/canvas-kit-styling', version: '10.3.9'}])
+    ).toEqual(expected);
+  });
+
+  it('should do anything to non-matched dependencies', () => {
+    const input = stripIndent`
+    {
+      "react": "^18.1.0",
+    }`;
+
+    const expected = stripIndent`
+    {
+      "react": "^18.1.0",
+    }`;
+
+    expect(
+      fixPackageJsonVersions(input, [{name: '@workday/canvas-kit-styling', version: '10.3.9'}])
+    ).toEqual(expected);
+  });
+});

--- a/utils/spec/resolve-package-json.spec.ts
+++ b/utils/spec/resolve-package-json.spec.ts
@@ -1,0 +1,99 @@
+import resolvePackageJson from '../resolve-package-json';
+import {stripIndent} from 'common-tags';
+
+describe('updatePackageJson', () => {
+  it('should update version strings to the latest', () => {
+    const input = stripIndent`
+    {
+    <<<<<<< merge/prerelease/minor-into-prerelease/major
+      "version": "10.3.3",
+    =======
+      "version": "10.2.5",
+    >>>>>>> prerelease/major
+    }`;
+
+    const expected = stripIndent`
+    {
+      "version": "10.3.3",
+    }`;
+
+    expect(resolvePackageJson(input)).toEqual(expected);
+  });
+
+  it('should remove versions from current if they are not in incoming', () => {
+    const input = stripIndent`
+      {
+      <<<<<<< merge/prerelease/minor-into-prerelease/major
+        "version": "10.3.3",
+      =======
+      >>>>>>> prerelease/major
+      }`;
+
+    const expected = stripIndent`
+        {
+        }`;
+
+    expect(resolvePackageJson(input)).toEqual(expected);
+  });
+
+  it('should add versions from current if they are not in incoming', () => {
+    const input = stripIndent`
+      {
+      <<<<<<< merge/prerelease/minor-into-prerelease/major
+      =======
+        "version": "10.3.3",
+      >>>>>>> prerelease/major
+      }`;
+
+    const expected = stripIndent`
+      {
+        "version": "10.3.3",
+      }`;
+
+    expect(resolvePackageJson(input)).toEqual(expected);
+  });
+
+  it('should handle multiple conflicts', () => {
+    const input = stripIndent`
+      {
+        "name": "@workday/canvas-kit-styling-transform",
+      <<<<<<< merge/prerelease/minor-into-prerelease/major
+        "version": "10.3.3",
+      =======
+        "version": "10.2.5",
+      >>>>>>> prerelease/major
+        "dependencies": {
+          "@emotion/serialize": "^1.0.2",
+      <<<<<<< merge/prerelease/minor-into-prerelease/major
+          "@workday/canvas-kit-styling": "^10.3.3",
+      =======
+          "@workday/canvas-kit-styling": "^10.3.2",
+          "@workday/canvas-tokens-web": "^1.0.2",
+      >>>>>>> prerelease/major
+          "stylis": "4.0.13",
+          "typescript": "4.2"
+        },
+        "devDependencies": {
+          "common-tags": "^1.8.0"
+        }
+      }`;
+
+    const expected = stripIndent`
+      {
+        "name": "@workday/canvas-kit-styling-transform",
+        "version": "10.3.3",
+        "dependencies": {
+          "@emotion/serialize": "^1.0.2",
+          "@workday/canvas-kit-styling": "^10.3.3",
+          "@workday/canvas-tokens-web": "^1.0.2",
+          "stylis": "4.0.13",
+          "typescript": "4.2"
+        },
+        "devDependencies": {
+          "common-tags": "^1.8.0"
+        }
+      }`;
+
+    expect(resolvePackageJson(input)).toEqual(expected);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes a common merge issue with our `package.json` files when `support` and `master` have different versions and `master` has an additional dependency next to it. For example:
  ```
  <<<<<<< merge/prerelease/minor-into-prerelease/major
      "@workday/canvas-kit-styling": "^10.3.3",
  =======
      "@workday/canvas-kit-styling": "^10.3.2",
      "@workday/canvas-tokens-web": "^1.0.2",
  >>>>>>> prerelease/major
  ```
  It will now resolve correctly.
- Fixes an issue where `prerelease/major` adds a mono-repo dependency like `@workday/canvas-kit-styling` and it doesn't get updated by the forward merge and the forward merge fails with a depcheck stating all dependencies need the same version strings. Merge conflicts don't find it, so the forward-merge adds an additional process to gather all mono-repo dependency versions and force-rewrites all `package.json` to have the correct versions.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Infrastructure

---

## Checklist

- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

Tests
