### PR TITLE
fix: Add CSS var fallbacks on Preview

### DIFF
--- a/modules/preview-react/loading-sparkles/lib/LoadingSparkles.tsx
+++ b/modules/preview-react/loading-sparkles/lib/LoadingSparkles.tsx
@@ -1,9 +1,15 @@
 import * as React from 'react';
-import {keyframes} from '@emotion/css';
 import {system} from '@workday/canvas-tokens-web';
 import {createComponent} from '@workday/canvas-kit-react/common';
 import {SystemIcon} from '@workday/canvas-kit-react/icon';
-import {createStyles, CSProps, cssVar, handleCsProp, px2rem} from '@workday/canvas-kit-styling';
+import {
+  createStyles,
+  CSProps,
+  cssVar,
+  handleCsProp,
+  px2rem,
+  keyframes,
+} from '@workday/canvas-kit-styling';
 
 import {sparkleIcon} from './sparkleIcon';
 
@@ -23,7 +29,7 @@ const AI_COLORS = {
   dragonFruit400: '#8C17D2',
   dragonFruit500: '#6B11A3',
   dragonFruit600: '#4A0D71',
-};
+} as const;
 
 /**
  * The animation for the sparkle.

--- a/modules/preview-react/package.json
+++ b/modules/preview-react/package.json
@@ -24,8 +24,8 @@
     "watch": "yarn build:es6 -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
-    "build:cjs": "tsc -p tsconfig.cjs.json",
-    "build:es6": "tsc -p tsconfig.es6.json",
+    "build:cjs": "ttsc -p tsconfig.cjs.json",
+    "build:es6": "ttsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
     "build": "npm-run-all --parallel build:cjs build:es6",
     "prepack": "node ../../utils/publish.js pre preview-react",
@@ -44,7 +44,6 @@
     "react": ">=16.14"
   },
   "dependencies": {
-    "@emotion/css": "^11.7.1",
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
     "@workday/canvas-kit-react": "^10.3.11",

--- a/modules/preview-react/tsconfig.json
+++ b/modules/preview-react/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "plugins": [
       {
-        "transform": "../styling-transform/lib/styleTransform"
+        "transform": "../styling-transform/lib/styleTransform.ts"
       }
     ]
   }


### PR DESCRIPTION
## Summary

The style transform was not being run on preview components and therefore the CSS variable fallbacks were never automatically added. This change fixes that by running the style transform on the preview package.

## Release Category
Components

---

## Checklist

- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)
