### PR TITLE
fix: Fix keyframes transform for commonjs modules

### DIFF
--- a/modules/styling-transform/lib/utils/handleKeyframes.ts
+++ b/modules/styling-transform/lib/utils/handleKeyframes.ts
@@ -21,7 +21,9 @@ export const handleKeyframes: NodeTransformer = (node, context) => {
     const styleObj = parseNodeToStaticValue(node.template, context);
     const identifierName = getVarName(node);
 
-    return createStyleReplacementNode(styleObj, identifierName, fileName, context);
+    return ts.factory.createCallExpression(node.tag, undefined, [
+      createStyleReplacementNode(styleObj, identifierName, fileName, context),
+    ]);
   }
 
   // keyframes({})
@@ -36,7 +38,9 @@ export const handleKeyframes: NodeTransformer = (node, context) => {
       const styleObj = parseObjectToStaticValue(node.arguments[0], context);
       const identifierName = getVarName(node);
 
-      return createStyleReplacementNode(styleObj, identifierName, fileName, context);
+      return ts.factory.updateCallExpression(node, node.expression, undefined, [
+        createStyleReplacementNode(styleObj, identifierName, fileName, context),
+      ]);
     }
   }
 
@@ -57,7 +61,5 @@ function createStyleReplacementNode(
 
   keyframes[identifierName] = animationName;
 
-  return ts.factory.createCallExpression(ts.factory.createIdentifier('keyframes'), undefined, [
-    createStyleObjectNode(serialized.styles, serialized.name),
-  ]);
+  return createStyleObjectNode(serialized.styles, serialized.name);
 }


### PR DESCRIPTION
## Summary

Fixes the style transform for keyframes in commonjs module export type. If the `keyframe` is a call expression node type, the `ts.factory.updateCallExpression` is used instead of creating a new one. Creating a new AST node has a negative effect on TypeScript's own `commonjs` module transformation where it looses access to the original parent node and doesn't transform the import correctly.

## Release Category
Components
