### PR TITLE
ci: Fix resolve-package-json merge file [skip release]

### DIFF
--- a/utils/resolve-package-json.js
+++ b/utils/resolve-package-json.js
@@ -41,6 +41,10 @@ function resolvePackageJson(/** @type {string} */ input) {
           const line = currentLines.find(l => l.includes(`"${property}"`));
 
           final += line + '\n';
+        } else {
+          const line = incomingLines.find(l => l.includes(`"${property}"`));
+
+          final += line + '\n';
         }
       }
     });

--- a/utils/spec/resolve-package-json.spec.ts
+++ b/utils/spec/resolve-package-json.spec.ts
@@ -96,4 +96,41 @@ describe('updatePackageJson', () => {
 
     expect(resolvePackageJson(input)).toEqual(expected);
   });
+
+  it('should handle multiple conflicts in the same group', () => {
+    const input = stripIndent`
+      {
+        "dependencies": {
+          "@emotion/serialize": "^1.0.2",
+      <<<<<<< merge/prerelease/minor-into-prerelease/major
+          "@workday/canvas-kit-styling": "^10.3.1",
+          "@workday/canvas-tokens-web": "^1.0.0",
+      =======
+          "@workday/canvas-kit-styling": "^10.3.3",
+          "@workday/canvas-tokens-web": "^1.0.2",
+      >>>>>>> prerelease/major
+          "stylis": "4.0.13",
+          "typescript": "4.2"
+        },
+        "devDependencies": {
+          "common-tags": "^1.8.0"
+        }
+      }`;
+
+    const expected = stripIndent`
+      {
+        "dependencies": {
+          "@emotion/serialize": "^1.0.2",
+          "@workday/canvas-kit-styling": "^10.3.3",
+          "@workday/canvas-tokens-web": "^1.0.2",
+          "stylis": "4.0.13",
+          "typescript": "4.2"
+        },
+        "devDependencies": {
+          "common-tags": "^1.8.0"
+        }
+      }`;
+
+    expect(resolvePackageJson(input)).toEqual(expected);
+  });
 });


### PR DESCRIPTION
## Summary

There were only tests when the incoming version was lower than the current version, but not the other way around. This caused the merge script to remove a dependency that was newer. In `prerelease/major`, the tokens dependency is `1.0.2` while in master it is `1.0.0`. This fix should resolve that.

## Release Category
Infrastructure
