### PR TITLE
feat: Add per-module prefix

### DIFF
--- a/modules/styling-transform/lib/styleTransform.ts
+++ b/modules/styling-transform/lib/styleTransform.ts
@@ -126,6 +126,7 @@ export function withDefaultContext<T extends TransformerContext>(
   input: Partial<T> = {}
 ): T {
   return {
+    prefix: 'css',
     getPrefix: path => input.prefix || 'css',
     variables: {},
     styles,

--- a/modules/styling-transform/lib/styleTransform.ts
+++ b/modules/styling-transform/lib/styleTransform.ts
@@ -94,6 +94,7 @@ export default function styleTransformer(
     const visit: ts.Visitor = node => {
       if (!transformContext.fileName) {
         transformContext.fileName = node.getSourceFile()?.fileName;
+        transformContext.prefix = transformContext.getPrefix(transformContext.fileName);
       }
 
       if (
@@ -125,7 +126,7 @@ export function withDefaultContext<T extends TransformerContext>(
   input: Partial<T> = {}
 ): T {
   return {
-    prefix: 'css',
+    getPrefix: path => input.prefix || 'css',
     variables: {},
     styles,
     keyframes,

--- a/modules/styling-transform/lib/utils/types.ts
+++ b/modules/styling-transform/lib/utils/types.ts
@@ -3,6 +3,7 @@ import ts from 'typescript';
 export type TransformerContext = {
   checker: ts.TypeChecker;
   prefix: string;
+  getPrefix: (path: string) => string;
   variables: Record<string, string>;
   keyframes: Record<string, string>;
   styles: StylesOutput;
@@ -129,6 +130,12 @@ export interface Config {
   objectTransforms?: ObjectTransform[];
 
   propertyTransforms?: PropertyTransform[];
+
+  /**
+   * Optional function for getting a prefix given a file path. This is useful if you want to have a
+   * different prefix for each module in a monorepo.
+   */
+  getPrefix?: (path: string) => string;
 }
 
 export type ObjectTransform = (

--- a/styling.config.ts
+++ b/styling.config.ts
@@ -4,6 +4,18 @@ import {handleFocusRing} from './utils/style-transform/handleFocusRing';
 
 const config: Config = {
   prefix: 'cnvs',
+  getPrefix(path) {
+    return path.replace(/.+modules\/([^/]+)\/([^/]+)\/.+/, (_, modulePath, subPath) => {
+      if (modulePath === 'preview-react') {
+        return 'cnvs-preview';
+      }
+      if (modulePath === 'labs-react') {
+        return 'cnvs-labs';
+      }
+
+      return 'cnvs';
+    });
+  },
   extractCSS: true,
   getFileName(path) {
     return path

--- a/styling.config.ts
+++ b/styling.config.ts
@@ -5,16 +5,17 @@ import {handleFocusRing} from './utils/style-transform/handleFocusRing';
 const config: Config = {
   prefix: 'cnvs',
   getPrefix(path) {
-    return path.replace(/.+modules\/([^/]+)\/([^/]+)\/.+/, (_, modulePath, subPath) => {
+    const match = path.match(/.+modules\/([^/]+)\/([^/]+)\/.+/);
+    if (match) {
+      const modulePath = match[1];
       if (modulePath === 'preview-react') {
         return 'cnvs-preview';
       }
       if (modulePath === 'labs-react') {
         return 'cnvs-labs';
       }
-
-      return 'cnvs';
-    });
+    }
+    return 'cnvs';
   },
   extractCSS: true,
   getFileName(path) {

--- a/styling.config.ts
+++ b/styling.config.ts
@@ -5,16 +5,12 @@ import {handleFocusRing} from './utils/style-transform/handleFocusRing';
 const config: Config = {
   prefix: 'cnvs',
   getPrefix(path) {
-    const match = path.match(/.+modules\/([^/]+)\/([^/]+)\/.+/);
+    const match = path.match(/.+modules\/(preview|labs)-react\/([^/]+)\/.+/);
+
     if (match) {
-      const modulePath = match[1];
-      if (modulePath === 'preview-react') {
-        return 'cnvs-preview';
-      }
-      if (modulePath === 'labs-react') {
-        return 'cnvs-labs';
-      }
+      return `cnvs-${match[1]}`;
     }
+
     return 'cnvs';
   },
   extractCSS: true,


### PR DESCRIPTION
## Summary

Adds a per-module prefix so that `labs` and `preview` can have different prefixes to avoid collisions.


## Release Category
Infrastructure

---

## Checklist

- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [x] Code

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

Run `yarn build`

## Screenshots or GIFs (if applicable)

![image](https://github.com/Workday/canvas-kit/assets/338257/ac0fd2b6-260c-4654-86db-c35b64657b13)
