### PR TITLE
fix: Forward numeric style prop transform handling to Emotion

### DIFF
--- a/modules/styling-transform/lib/utils/handleCalc.ts
+++ b/modules/styling-transform/lib/utils/handleCalc.ts
@@ -4,18 +4,6 @@ import {calc} from '@workday/canvas-kit-styling';
 import {createPropertyTransform} from '../createPropertyTransform';
 import {parseNodeToStaticValue} from './parseNodeToStaticValue';
 
-/**
- * Operands are either a number or a CSS variable. The property parser will always return a string
- * where numbers are converted to strings with a suffix of 'px'
- */
-function toOperand(input: string): string | number {
-  if (input.includes('px')) {
-    return parseInt(input.replace('px', ''), 10);
-  }
-
-  return input;
-}
-
 export const handleCalc = createPropertyTransform((node, context) => {
   if (
     ts.isCallExpression(node) &&
@@ -31,13 +19,13 @@ export const handleCalc = createPropertyTransform((node, context) => {
     const method = node.expression.name.text;
 
     if (method === 'add' || method === 'subtract') {
-      return calc[method](toStaticValue(args[0]), toStaticValue(args[1]));
+      return calc[method](toStaticValue(args[0]).toString(), toStaticValue(args[1]).toString());
     }
     if (method === 'multiply' || method === 'divide') {
-      return calc[method](toStaticValue(args[0]), toOperand(toStaticValue(args[1])));
+      return calc[method](toStaticValue(args[0]).toString(), toStaticValue(args[1]));
     }
     if (method === 'negate') {
-      return calc.negate(toStaticValue(args[0]));
+      return calc.negate(toStaticValue(args[0]).toString());
     }
   }
 

--- a/modules/styling-transform/lib/utils/handleCreateStencil.ts
+++ b/modules/styling-transform/lib/utils/handleCreateStencil.ts
@@ -77,7 +77,7 @@ export const handleCreateStencil: NodeTransformer = (node, context) => {
           tempVariables[makeEmotionSafe(node.name.text)] = varValue;
 
           // Evaluate the variable defaults
-          stencilVariables[varValue] = parseNodeToStaticValue(node.initializer, context);
+          stencilVariables[varValue] = parseNodeToStaticValue(node.initializer, context).toString();
         }
       }
 

--- a/modules/styling-transform/lib/utils/handleCssVar.ts
+++ b/modules/styling-transform/lib/utils/handleCssVar.ts
@@ -12,7 +12,7 @@ export const handleCssVar = createPropertyTransform((node, context) => {
   ) {
     const args = node.arguments.map(arg => parseNodeToStaticValue(arg, context));
 
-    return cssVar(args[0].toString(), (args[1] || context.variables[args[0]]).toString());
+    return cssVar(args[0] as string, (args[1] as string) || context.variables[args[0]]);
   }
 
   return;

--- a/modules/styling-transform/lib/utils/handleCssVar.ts
+++ b/modules/styling-transform/lib/utils/handleCssVar.ts
@@ -12,7 +12,7 @@ export const handleCssVar = createPropertyTransform((node, context) => {
   ) {
     const args = node.arguments.map(arg => parseNodeToStaticValue(arg, context));
 
-    return cssVar(args[0], args[1] || context.variables[args[0]]);
+    return cssVar(args[0].toString(), (args[1] || context.variables[args[0]]).toString());
   }
 
   return;

--- a/modules/styling-transform/lib/utils/handleKeyframes.ts
+++ b/modules/styling-transform/lib/utils/handleKeyframes.ts
@@ -18,7 +18,7 @@ export const handleKeyframes: NodeTransformer = (node, context) => {
   ) {
     const fileName = getFileName(node.getSourceFile()?.fileName || context.fileName);
     // parseNodeToStaticValue can parse templates. Pass it through there to get a single static string
-    const styleObj = parseNodeToStaticValue(node.template, context);
+    const styleObj = parseNodeToStaticValue(node.template, context).toString();
     const identifierName = getVarName(node);
 
     return ts.factory.createCallExpression(node.tag, undefined, [

--- a/modules/styling-transform/lib/utils/handlePx2Rem.ts
+++ b/modules/styling-transform/lib/utils/handlePx2Rem.ts
@@ -4,19 +4,18 @@ import {px2rem} from '@workday/canvas-kit-styling';
 import {createPropertyTransform} from '../createPropertyTransform';
 import {parseNodeToStaticValue} from './parseNodeToStaticValue';
 
-function toNumber(input: string): number {
-  return parseInt(input.replace('px', ''), 10);
-}
-
 export const handlePx2Rem = createPropertyTransform((node, context) => {
   if (
     ts.isCallExpression(node) &&
     ts.isIdentifier(node.expression) &&
     node.expression.text === 'px2rem'
   ) {
-    const args = node.arguments.map(arg => toNumber(parseNodeToStaticValue(arg, context)));
+    const args = node.arguments.map(arg => parseNodeToStaticValue(arg, context));
 
-    return px2rem(args[0], args[1]);
+    return px2rem(
+      parseFloat(args[0] as string),
+      args[1] ? parseFloat(args[1] as string) : undefined
+    );
   }
 
   return;

--- a/modules/styling-transform/lib/utils/parseNodeToStaticValue.ts
+++ b/modules/styling-transform/lib/utils/parseNodeToStaticValue.ts
@@ -15,7 +15,10 @@ function handlePropertyTransforms(node: ts.Node, context: TransformerContext): s
 /**
  * This is the workhorse of statically analyzing style values
  */
-export function parseNodeToStaticValue(node: ts.Node, context: TransformerContext): string {
+export function parseNodeToStaticValue(
+  node: ts.Node,
+  context: TransformerContext
+): string | number {
   const {checker, variables, keyframes} = context;
 
   const value = handlePropertyTransforms(node, context);
@@ -32,7 +35,7 @@ export function parseNodeToStaticValue(node: ts.Node, context: TransformerContex
 
   // 12
   if (ts.isNumericLiteral(node)) {
-    return `${node.text}px`;
+    return parseFloat(node.text);
   }
 
   // undefined
@@ -127,13 +130,13 @@ export function parseNodeToStaticValue(node: ts.Node, context: TransformerContex
   );
 }
 
-function parseTypeToStaticValue(type: ts.Type): string | void {
+function parseTypeToStaticValue(type: ts.Type): string | number | void {
   if (type.isStringLiteral()) {
     return type.value;
   }
 
   if (type.isNumberLiteral()) {
-    return `${type.value}px`;
+    return type.value;
   }
 }
 

--- a/modules/styling-transform/lib/utils/types.ts
+++ b/modules/styling-transform/lib/utils/types.ts
@@ -12,7 +12,7 @@ export type TransformerContext = {
   fileName: string;
 };
 
-export type NestedStyleObject = {[key: string]: string | NestedStyleObject};
+export type NestedStyleObject = {[key: string]: number | string | NestedStyleObject};
 
 /**
  * Transformer function type. A transformer will be called by the TypeScript AST transformer visitor

--- a/modules/styling-transform/spec/utils/parseNodeToStaticValue.spec.ts
+++ b/modules/styling-transform/spec/utils/parseNodeToStaticValue.spec.ts
@@ -20,7 +20,7 @@ describe('parseNodeToStaticValue', () => {
     );
   });
 
-  it('should return the string value of a NumericLiteral', () => {
+  it('should return the number value of a NumericLiteral', () => {
     const program = createProgramFromSource(`
       12
     `);
@@ -28,9 +28,7 @@ describe('parseNodeToStaticValue', () => {
     const sourceFile = program.getSourceFile('test.ts');
     const node = findNodes(sourceFile, '', ts.isNumericLiteral)[0];
 
-    expect(parseNodeToStaticValue(node, withDefaultContext(program.getTypeChecker()))).toEqual(
-      '12px'
-    );
+    expect(parseNodeToStaticValue(node, withDefaultContext(program.getTypeChecker()))).toEqual(12);
   });
 
   it('should return the string value of a string Identifier', () => {
@@ -54,9 +52,7 @@ describe('parseNodeToStaticValue', () => {
     const sourceFile = program.getSourceFile('test.ts');
     const node = findNodes(sourceFile, '', ts.isIdentifier)[0];
 
-    expect(parseNodeToStaticValue(node, withDefaultContext(program.getTypeChecker()))).toEqual(
-      '12px'
-    );
+    expect(parseNodeToStaticValue(node, withDefaultContext(program.getTypeChecker()))).toEqual(12);
   });
 
   it('should return the string value of a PropertyAccessExpression', () => {
@@ -84,9 +80,7 @@ describe('parseNodeToStaticValue', () => {
     const sourceFile = program.getSourceFile('test.ts');
     const node = findNodes(sourceFile, '', ts.isPropertyAccessExpression)[0];
 
-    expect(parseNodeToStaticValue(node, withDefaultContext(program.getTypeChecker()))).toEqual(
-      '12px'
-    );
+    expect(parseNodeToStaticValue(node, withDefaultContext(program.getTypeChecker()))).toEqual(12);
   });
 
   it('should return the string value of a PropertyAccessExpression of a variable', () => {

--- a/utils/style-transform/handleFocusRing.ts
+++ b/utils/style-transform/handleFocusRing.ts
@@ -4,10 +4,6 @@ import {parseNodeToStaticValue, createObjectTransform} from '@workday/canvas-kit
 import {focusRing} from '@workday/canvas-kit-react/common';
 import {NestedStyleObject} from '@workday/canvas-kit-styling-transform/lib/utils/types';
 
-function toNumber(input: string): number {
-  return parseInt(input.replace('px', ''), 10);
-}
-
 export const handleFocusRing = createObjectTransform((node, context) => {
   if (
     ts.isCallExpression(node) &&
@@ -25,7 +21,7 @@ export const handleFocusRing = createObjectTransform((node, context) => {
         if (ts.isPropertyAssignment(property) && ts.isIdentifier(property.name)) {
           const key = property.name.text;
           if (['width', 'separation'].includes(key)) {
-            args[key] = toNumber(parseNodeToStaticValue(property.initializer, context));
+            args[key] = parseNodeToStaticValue(property.initializer, context);
           } else if (key !== 'animate') {
             args[key] = parseNodeToStaticValue(property.initializer, context);
           }


### PR DESCRIPTION
## Summary

Fixes: #2587

The static style transform was always turning numbers into strings with a `px` suffix. This isn't correct and Emotion has extra logic to turn a number into the correct string. For example, an opacity doesn't have a unit. This fix updates the logic to forward numbers straight to Emotion to process which should give a correct result.

## Release Category
Infrastructure

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [x] Code
- [x] Testing
