### PR TITLE
fix: Add CSS fallback to custom transforms

### DIFF
--- a/modules/react/common/lib/styles/focusRing.ts
+++ b/modules/react/common/lib/styles/focusRing.ts
@@ -86,8 +86,9 @@ export function focusRing(options: FocusRingOptions = {}, theme?: Theme): CSSObj
     width = 2,
     separation = 0,
     animate = true,
-    innerColor = base.frenchVanilla100,
-    outerColor = brand.common.focusOutline,
+    // hard code CSS fallbacks for dynamic styles that don't use the static style transform
+    innerColor = cssVar(base.frenchVanilla100, 'rgba(255,255,255,1)'),
+    outerColor = cssVar(brand.common.focusOutline, 'rgba(8,117,225,1)'),
     inset,
   } = options;
 

--- a/modules/styling-transform/index.ts
+++ b/modules/styling-transform/index.ts
@@ -4,5 +4,7 @@ export {parseNodeToStaticValue} from './lib/utils/parseNodeToStaticValue';
 export {parseObjectToStaticValue} from './lib/utils/parseObjectToStaticValue';
 export {createObjectTransform} from './lib/createObjectTransform';
 export {createPropertyTransform} from './lib/createPropertyTransform';
+export {styleTransformer};
 
+// be compatible with ttypescript which expects a default export
 export default styleTransformer;

--- a/modules/styling-transform/lib/utils/parseObjectToStaticValue.ts
+++ b/modules/styling-transform/lib/utils/parseObjectToStaticValue.ts
@@ -16,6 +16,25 @@ export function parseObjectToStaticValue(
     });
   }
 
+  return wrapStyleObj(styleObj, context);
+}
+
+/**
+ * Wrap all values and nested object values with a maybeWrapCSSVariables call
+ */
+function wrapStyleObj(styleObj: NestedStyleObject, context: TransformerContext): NestedStyleObject {
+  for (const key in styleObj) {
+    if (styleObj.hasOwnProperty(key)) {
+      const value = styleObj[key];
+      if (typeof value === 'object') {
+        styleObj[key] = wrapStyleObj(value, context);
+      }
+      if (typeof value === 'string') {
+        styleObj[key] = maybeWrapCSSVariables(value, context.variables);
+      }
+    }
+  }
+
   return styleObj;
 }
 
@@ -39,7 +58,7 @@ function parsePropertyToStaticValue(node: ts.Node, context: TransformerContext):
 
   // If there's a spread, we're expecting an object to be returned. We'll see if there's an object transform for this node
   if (ts.isSpreadAssignment(node)) {
-    const obj = handleObjectTransforms(node.expression, context);
+    const obj = handleObjectTransforms(node.expression, context); //?
 
     if (obj) {
       return obj;
@@ -62,10 +81,7 @@ function parsePropertyToStaticValue(node: ts.Node, context: TransformerContext):
         // nested
         styleObj[key] = parseObjectToStaticValue(node.initializer, context);
       } else {
-        styleObj[key] = maybeWrapCSSVariables(
-          parseNodeToStaticValue(node.initializer, context),
-          context.variables
-        );
+        styleObj[key] = parseNodeToStaticValue(node.initializer, context);
       }
 
       return styleObj;
@@ -82,11 +98,7 @@ function parsePropertyToStaticValue(node: ts.Node, context: TransformerContext):
         // nested
         styleObj[key] = parseObjectToStaticValue(node.type!, context);
       } else {
-        styleObj[key] =
-          maybeWrapCSSVariables(
-            parseNodeToStaticValue(node.type!, context).toString(),
-            context.variables
-          ) || '';
+        styleObj[key] = parseNodeToStaticValue(node.type!, context).toString() || '';
       }
 
       return styleObj;
@@ -123,7 +135,7 @@ export function parseStyleObjFromType(type: ts.Type, context: TransformerContext
 
     if (propType.isStringLiteral()) {
       // This isn't a component variable, it is a static CSS variable
-      result[property.name] = maybeWrapCSSVariables(propType.value, context.variables);
+      result[property.name] = propType.value;
       return result;
     }
 
@@ -143,7 +155,7 @@ export function parseStyleObjFromType(type: ts.Type, context: TransformerContext
  * Wrap all unwrapped CSS Variables. For example, `{padding: '--foo'}` will be replaced with
  * `{padding: 'var(--foo)'}`. It also works on variables in the middle of the property.
  */
-function maybeWrapCSSVariables(
+export function maybeWrapCSSVariables(
   input: string | number,
   variables: Record<string, string>
 ): string | number {
@@ -153,16 +165,25 @@ function maybeWrapCSSVariables(
   // matches an string starting with `--` that isn't already wrapped in a `var()`. It tries to match
   // any character that isn't a valid separator in CSS
   return input.replace(
-    /([a-z]*[ (]*)(--[^\s;,'})]+)/gi,
-    (match: string, prefix: string, variable: string) => {
-      if (prefix.startsWith('var(')) {
+    /([a-z]*[ (]*)(--[^\s;,'})]+)(\){0,1})/gi,
+    (match: string, prefix: string, variable: string, postfix: string) => {
+      // shortcut for var() wrappers that already have a fallback
+      if (prefix.startsWith('var(') && postfix !== ')') {
         return match;
       }
+
+      // find a possible fallback
       const fallbackVariable = getFallbackVariable(variable, variables);
       const fallback = fallbackVariable
         ? `, ${maybeWrapCSSVariables(fallbackVariable, variables)}`
         : '';
-      return `${prefix}var(${variable}${fallback})`;
+
+      // if this a var wrapper without a fallback
+      if (prefix.startsWith('var(') && postfix === ')') {
+        return `${prefix}${variable}${fallback}${postfix}`;
+      }
+      // if this is not a var wrapper at all
+      return `${prefix}var(${variable}${fallback})${postfix}`;
     }
   );
 }

--- a/modules/styling-transform/lib/utils/parseObjectToStaticValue.ts
+++ b/modules/styling-transform/lib/utils/parseObjectToStaticValue.ts
@@ -58,7 +58,7 @@ function parsePropertyToStaticValue(node: ts.Node, context: TransformerContext):
 
   // If there's a spread, we're expecting an object to be returned. We'll see if there's an object transform for this node
   if (ts.isSpreadAssignment(node)) {
-    const obj = handleObjectTransforms(node.expression, context); //?
+    const obj = handleObjectTransforms(node.expression, context);
 
     if (obj) {
       return obj;

--- a/utils/style-transform/spec/handleFocusRing.spec.ts
+++ b/utils/style-transform/spec/handleFocusRing.spec.ts
@@ -2,6 +2,7 @@ import {focusRing} from '@workday/canvas-kit-react/common';
 import {
   createProgramFromSource,
   findNodes,
+  transform,
   withDefaultContext,
 } from '@workday/canvas-kit-styling-transform/testing';
 
@@ -49,5 +50,33 @@ describe('handleFocusRing', () => {
         outerColor: 'red',
       })
     );
+  });
+
+  it('should wrap CSS vars with fallbacks', () => {
+    const program = createProgramFromSource(`
+      import {createStyles} from '@workday/canvas-kit-styling';
+
+      const myStyles = createStyles({
+        ...focusRing({
+          width: 10,
+          separation: 1,
+          innerColor: '--foo-bar',
+          outerColor: 'red'
+        })
+      })
+    `);
+
+    const result = transform(
+      program,
+      'test.ts',
+      withDefaultContext(program.getTypeChecker(), {
+        variables: {
+          '--foo-bar': 'red',
+        },
+        objectTransforms: [handleFocusRing],
+      })
+    );
+
+    expect(result).toContain('var(--foo-bar, red)');
   });
 });


### PR DESCRIPTION
## Summary

This change moves `maybeWrapCSSVariables` to a external wrapper function that recurses through all the style object values to wrap any unwrapped CSS variables and also adds a fallback if necessary. The code was originally dispersed around parsing, but has now been put in a consistent place to make sure CSS var wrapping doesn't get missed.

This change also adds hard-coded var fallbacks for dynamic uses so we don't accidentally introduce a dependency on the new tokens before we're ready to require them.

Fixes: #2603 


## Release Category
Infrastructure

---

## Checklist

- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

Tests

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [x] Code
- [x] Testing
