### PR TITLE
fix(segmented-control): Fix size styling

### DIFF
--- a/modules/react/segmented-control/lib/SegmentedControlButton.tsx
+++ b/modules/react/segmented-control/lib/SegmentedControlButton.tsx
@@ -57,6 +57,7 @@ const StyledButton = styled(BaseButton)<ButtonContainerProps & StyledType>(
     borderRadius: borderRadius.zero,
     border: `1px solid ${colors.soap500}`,
     borderLeft: 'none',
+    minWidth: 'auto',
 
     '&:first-of-type': {
       borderRadius: `${borderRadius.m} 0 0 ${borderRadius.m}`,

--- a/modules/react/segmented-control/stories/stories_VisualTesting.tsx
+++ b/modules/react/segmented-control/stories/stories_VisualTesting.tsx
@@ -31,29 +31,35 @@ export const SegmentedControlStates = () => (
       columnProps={[
         {label: 'Default', props: {className: ''}},
         {label: 'Focus', props: {className: 'focus'}}, // Test changing border radius for focused button
+        {label: 'Small', props: {size: 'small'}},
+        {label: 'Large', props: {size: 'large'}},
       ]}
     >
       {props => (
         <SegmentedControl value={props.value}>
           <SegmentedControl.Button
+            size={props.size}
             icon={listViewIcon}
             value="list-view"
             aria-label="List View"
             className={props.value === 'list-view' ? props.className : undefined}
           />
           <SegmentedControl.Button
+            size={props.size}
             icon={worksheetsIcon}
             value="table-view"
             aria-label="Table View"
             disabled={true}
           />
           <SegmentedControl.Button
+            size={props.size}
             icon={deviceTabletIcon}
             value="device-view"
             aria-label="Device View"
             className={props.value === 'device-view' ? props.className : undefined}
           />
           <SegmentedControl.Button
+            size={props.size}
             icon={percentageIcon}
             value="percent-view"
             aria-label="Percent View"


### PR DESCRIPTION
## Summary

Fixes: #2605

- Add a `minWidth` style override to `SegmentedControl.Button` to prevent rectangular segmented control buttons.
- Add a visual regression test for `size` in `SegmentedControl`

## Release Category
Components

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Testing
