### PR TITLE
fix: Wrap css variables passed into stencil and vars

### DIFF
--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -195,7 +195,7 @@ export function createVars<
     args.forEach(key => {
       if (input[key as ToString<T>]) {
         // @ts-ignore TS complains about `key` not in object `{}`
-        vars[result[key]] = input[key];
+        vars[result[key]] = convertProperty(input[key]);
       }
     });
     return vars;
@@ -278,7 +278,7 @@ export function createDefaultedVars<
       if (typeof (input as any)[key] === 'string') {
         if ((result as any)[key]) {
           // Don't add an undefined key
-          vars[(result as any)[key]] = (input as any)[key];
+          vars[(result as any)[key]] = convertProperty((input as any)[key]);
         }
       }
       if (typeof (input as any)[key] === 'object') {
@@ -286,7 +286,7 @@ export function createDefaultedVars<
           if (typeof (input as any)[key][subKey] === 'string') {
             // Don't add an undefined key
             if ((result as any)[key][subKey]) {
-              vars[(result as any)[key][subKey]] = (input as any)[key][subKey];
+              vars[(result as any)[key][subKey]] = convertProperty((input as any)[key][subKey]);
             }
           }
         }

--- a/modules/styling/spec/cs.spec.tsx
+++ b/modules/styling/spec/cs.spec.tsx
@@ -159,7 +159,7 @@ describe('createStyles', () => {
 
     it('should return a function that takes in an object with the values and return a style object with wrapped css prop', () => {
       const myVars = createVars('color');
-      expect(myVars({color: '--foo-prop'})).toHaveProperty(myVars.color, 'var(--foo-prop)');
+      expect(myVars({color: '--my-var'})).toHaveProperty(myVars.color, 'var(--my-var)');
     });
 
     it('should make types Emotion safe when ID is known', () => {
@@ -667,19 +667,16 @@ describe('createStyles', () => {
     });
 
     it('should return a function that takes in an object with the values and wrap passed css variables', () => {
-      const myStencil = createStencil(
-        {
-          vars: {
-            color: 'red',
-          },
-          base: {},
+      const myStencil = createStencil({
+        vars: {
+          color: 'red',
         },
-        'foo'
-      );
+        base: {},
+      });
 
-      expect(myStencil({color: '--foo-prop'}).style).toHaveProperty(
-        '--foo-color',
-        'var(--foo-prop)'
+      expect(myStencil({color: '--my-var'}).style).toHaveProperty(
+        myStencil.vars.color,
+        'var(--my-var)'
       );
     });
 

--- a/modules/styling/spec/cs.spec.tsx
+++ b/modules/styling/spec/cs.spec.tsx
@@ -157,6 +157,11 @@ describe('createStyles', () => {
       expect(myVars({color: 'red'})).toHaveProperty(myVars.color, 'red');
     });
 
+    it('should return a function that takes in an object with the values and return a style object with wrapped css prop', () => {
+      const myVars = createVars('color');
+      expect(myVars({color: '--foo-prop'})).toHaveProperty(myVars.color, 'var(--foo-prop)');
+    });
+
     it('should make types Emotion safe when ID is known', () => {
       const myVars = createVars({id: 'foo', args: ['label']});
 
@@ -659,6 +664,23 @@ describe('createStyles', () => {
       expectTypeOf(myStencil.vars.color).toEqualTypeOf<'--foo-color'>();
 
       expect(myStencil).toHaveProperty('vars.color', expect.stringMatching(/--foo-color/));
+    });
+
+    it('should return a function that takes in an object with the values and wrap passed css variables', () => {
+      const myStencil = createStencil(
+        {
+          vars: {
+            color: 'red',
+          },
+          base: {},
+        },
+        'foo'
+      );
+
+      expect(myStencil({color: '--foo-prop'}).style).toHaveProperty(
+        '--foo-color',
+        'var(--foo-prop)'
+      );
     });
 
     it('should handle variables and pass them to the base function', () => {


### PR DESCRIPTION
## Summary

Fixes: #2613

Fixed issue with stencil and vars with not wrapping css variable by `var()` in css code for values passed inside on component level.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [x] Code
- [x] Testing

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->