### PR TITLE
fix: Fix stencil types to handle vars and deeply nested styles

### DIFF
--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -448,7 +448,7 @@ export type CSToPropsInput =
   | CSSObjectWithVars
   | CSToPropsInput[];
 
-export type CsToPropsReturn = {className?: string; style?: Record<string, string>};
+export type CsToPropsReturn = {className?: string; style?: CSSObjectWithVars};
 /**
  * A function that takes in a single input, or an array. The type of the input is either:
  *
@@ -502,7 +502,7 @@ export function csToProps(input: CSToPropsInput): CsToPropsReturn {
       const className = css(staticStyles);
       return {style: cssVars, className};
     }
-    return {style: input as Record<string, string>};
+    return {style: input};
   }
 
   // An array. it is the only thing left. We iterate and recurse over the array to produce a single

--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -445,10 +445,10 @@ export type CSToPropsInput =
   | undefined
   | CS
   | CsToPropsReturn
-  | Properties<string | number>
+  | CSSObjectWithVars
   | CSToPropsInput[];
 
-export type CsToPropsReturn = {className?: string; style?: Properties<string | number>};
+export type CsToPropsReturn = {className?: string; style?: Record<string, string>};
 /**
  * A function that takes in a single input, or an array. The type of the input is either:
  *
@@ -502,7 +502,7 @@ export function csToProps(input: CSToPropsInput): CsToPropsReturn {
       const className = css(staticStyles);
       return {style: cssVars, className};
     }
-    return {style: input};
+    return {style: input as Record<string, string>};
   }
 
   // An array. it is the only thing left. We iterate and recurse over the array to produce a single
@@ -874,7 +874,7 @@ export type Stencil<
 type VariableValuesStencil<
   V extends Record<string, string> | Record<string, Record<string, string>>
 > = V extends Record<string, string>
-  ? {[K in keyof V]?: V[K]}
+  ? {[K in keyof V]?: string}
   : {[K1 in keyof V]?: {[K2 in keyof V[K1]]: string}};
 
 /**

--- a/modules/styling/spec/cs.spec.tsx
+++ b/modules/styling/spec/cs.spec.tsx
@@ -21,6 +21,7 @@ import {
   createStencil,
   handleCsProp,
   keyframes,
+  CSProps,
 } from '../lib/cs';
 
 // We need to force Emotion's cache wrapper to use the cache from `@emotion/css` for tests to pass
@@ -648,6 +649,24 @@ describe('createStyles', () => {
       expect(myStencil).toHaveProperty('vars.color', expect.stringMatching(/--[a-z0-9]+-color/));
     });
 
+    it('should coerce a variable input to a type of string', () => {
+      const myStencil = createStencil({
+        vars: {
+          foo: '--base-color' as '--base-color',
+        },
+        base: {},
+      });
+
+      type Options = Parameters<typeof myStencil>[0];
+
+      expectTypeOf<Options['foo']>().toEqualTypeOf<string>();
+
+      // make sure we can call the function with a string
+      myStencil({
+        foo: '--another-color',
+      });
+    });
+
     it('should return access to variables with an ID for use in other components', () => {
       const myStencil = createStencil(
         {
@@ -772,6 +791,11 @@ describe('handleCsProp', () => {
     expect(returnProps).toHaveProperty('style', {position: 'absolute'});
   });
 
+  it('should handle deeply nested styles', () => {
+    // make sure there's no type error
+    handleCsProp({}, {'&:hover': {padding: 10}});
+  });
+
   it('should allow overriding via the style attribute', () => {
     render(<BaseComponent style={{padding: padding.styleAttribute}} />);
 
@@ -791,6 +815,15 @@ describe('handleCsProp', () => {
     // class name, but both class names should be listed
     expect(screen.getByTestId('base')).toHaveClass(baseStyles);
     expect(screen.getByTestId('base')).toHaveClass(overrideStyles);
+  });
+
+  it('should allow deeply nested styles in the cs prop', () => {
+    interface Props extends CSProps {}
+
+    const MyComponent = (props: Props) => null;
+
+    // no assertion, just make sure there's no type error
+    const temp = <MyComponent cs={{'&:hover': {padding: 10}}} />;
   });
 
   it('should allow the css prop to override base styles', () => {


### PR DESCRIPTION
## Summary

Fixes stencils to handle variables and deeply nested style objects in both the `cs` prop and `handleCsProp` function.

## Release Category
Styling

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

Specifications

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Testing

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

Replicate test code
