### PR TITLE
fix(button): Fix icon colors in buttons and SegmentedControl

### DIFF
--- a/modules/react/button/lib/BaseButton.tsx
+++ b/modules/react/button/lib/BaseButton.tsx
@@ -147,7 +147,7 @@ const baseButtonStyles = createStyles({
     boxShadow: 'none',
     opacity: cssVar(buttonVars.disabled.opacity, '1'),
   },
-  '& span .wd-icon-fill': {
+  '& span .wd-icon-fill, & span .wd-icon-accent, & span .wd-icon-accent2': {
     transitionDuration: '40ms',
     fill: cssVar(buttonVars.default.icon, base.blackPepper400),
   },
@@ -158,10 +158,7 @@ const baseButtonStyles = createStyles({
     backgroundColor: cssVar(buttonVars.focus.background, 'transparent'),
     borderColor: cssVar(buttonVars.focus.border, 'transparent'),
     color: cssVar(buttonVars.focus.label, base.blackPepper400),
-    '& span .wd-icon-fill': {
-      fill: cssVar(buttonVars.focus.icon, base.blackPepper400),
-    },
-    '.wd-icon-background ~ .wd-icon-accent, .wd-icon-background ~ .wd-icon-accent2': {
+    '& span .wd-icon-fill, & span .wd-icon-accent, & span .wd-icon-accent2': {
       fill: cssVar(buttonVars.focus.icon, base.blackPepper400),
     },
     ...focusRing({
@@ -175,10 +172,7 @@ const baseButtonStyles = createStyles({
     backgroundColor: cssVar(buttonVars.hover.background, base.blackPepper500),
     borderColor: cssVar(buttonVars.hover.border, 'transparent'),
     color: cssVar(buttonVars.hover.label, base.blackPepper500),
-    '& span .wd-icon-fill': {
-      fill: cssVar(buttonVars.hover.icon, base.blackPepper500),
-    },
-    '.wd-icon-background ~ .wd-icon-accent, .wd-icon-background ~ .wd-icon-accent2': {
+    '& span .wd-icon-fill, & span .wd-icon-accent, & span .wd-icon-accent2': {
       fill: cssVar(buttonVars.hover.icon, base.blackPepper500),
     },
   },
@@ -187,10 +181,7 @@ const baseButtonStyles = createStyles({
     backgroundColor: cssVar(buttonVars.active.background, 'transparent'),
     borderColor: cssVar(buttonVars.active.border, 'transparent'),
     color: cssVar(buttonVars.active.label, base.blackPepper400),
-    '& span .wd-icon-fill': {
-      fill: cssVar(buttonVars.active.icon, base.blackPepper400),
-    },
-    '.wd-icon-background ~ .wd-icon-accent, .wd-icon-background ~ .wd-icon-accent2': {
+    '& span .wd-icon-fill, & span .wd-icon-accent, & span .wd-icon-accent2': {
       fill: cssVar(buttonVars.active.icon, base.blackPepper400),
     },
   },
@@ -198,10 +189,7 @@ const baseButtonStyles = createStyles({
     backgroundColor: cssVar(buttonVars.disabled.background, 'transparent'),
     borderColor: cssVar(buttonVars.disabled.border, 'transparent'),
     color: cssVar(buttonVars.disabled.label, base.blackPepper400),
-    '& span .wd-icon-fill': {
-      fill: cssVar(buttonVars.disabled.icon, base.blackPepper400),
-    },
-    '.wd-icon-background ~ .wd-icon-accent, .wd-icon-background ~ .wd-icon-accent2': {
+    '& span .wd-icon-fill, & span .wd-icon-accent, & span .wd-icon-accent2': {
       fill: cssVar(buttonVars.disabled.icon, base.blackPepper400),
     },
   },

--- a/modules/react/segmented-control/stories/stories_VisualTesting.tsx
+++ b/modules/react/segmented-control/stories/stories_VisualTesting.tsx
@@ -8,6 +8,7 @@ import {
   worksheetsIcon,
   deviceTabletIcon,
   percentageIcon,
+  cColumnClusteredIcon,
 } from '@workday/canvas-system-icons-web';
 
 import {SegmentedControl} from '../index';
@@ -65,6 +66,39 @@ export const SegmentedControlStates = () => (
             aria-label="Percent View"
             className={props.value === 'percent-view' ? props.className : undefined}
           />
+        </SegmentedControl>
+      )}
+    </ComponentStatesTable>
+  </StaticStates>
+);
+
+export const SegmentedControlButtonStates = () => (
+  <StaticStates>
+    <ComponentStatesTable
+      rowProps={[
+        {label: 'Bar Chart', props: {value: 'off', icon: cColumnClusteredIcon}},
+        {label: 'Bar Chart Selected', props: {value: 'on', icon: cColumnClusteredIcon}},
+        {label: 'Device Tablet', props: {value: 'off', icon: deviceTabletIcon}},
+        {label: 'Bar Chart Selected', props: {value: 'on', icon: deviceTabletIcon}},
+        {label: 'Worksheet', props: {value: 'off', icon: worksheetsIcon}},
+        {label: 'Bar Chart Selected', props: {value: 'on', icon: worksheetsIcon}},
+      ]}
+      columnProps={[
+        {label: 'Default', props: {className: ''}},
+        {label: 'Focus', props: {className: 'focus'}},
+        {label: 'Active', props: {className: 'active'}},
+      ]}
+    >
+      {props => (
+        <SegmentedControl value={props.value}>
+          <SegmentedControl.Button
+            size={props.size}
+            icon={props.icon}
+            value="on"
+            aria-label="Clustered"
+            className={props.className}
+          />
+          <></>
         </SegmentedControl>
       )}
     </ComponentStatesTable>


### PR DESCRIPTION
## Summary

Fixes: #2622 

This continues with the intended change to icons in `SegmentedControl` that were broken with icons with background layers. The intent was to treat all icon fill layers the same in `SegmentedControl` and we failed to do that properly. This change simplifies the icon fill selectors and ensures the icons always look as intended and don't require guess work from icon designers.

## Release Category
Components

### Release Note
This change may trigger a visual regression with certain icons in buttons and `SegmentedControl` buttons. This change is intentional and fixes an accidental regression between v9 and v10. There should be no other breaking changes.

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)
- [x] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable

## Where Should the Reviewer Start?

Visual regression test story and the basic SegmentedControl story

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Testing

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

https://5d854c26ba934e0020f5e98a-zgkrlvcqwf.chromatic.com/?path=/story/testing-buttons-segmented-control--segmented-control-button-states

<!-- Explain how your reviewer could verify this change  -->

## Screenshots or GIFs (if applicable)
![image](https://github.com/Workday/canvas-kit/assets/338257/a42c0c65-0e18-4912-a831-5eb70085bf8b)

![image](https://github.com/Workday/canvas-kit/assets/338257/1cab476a-5b31-47f0-8be6-5e8e34fd30cb)

