### PR TITLE
fix(styling): Fix variables in stencil config

### DIFF
--- a/modules/styling-transform/lib/utils/handleCreateStencil.ts
+++ b/modules/styling-transform/lib/utils/handleCreateStencil.ts
@@ -91,7 +91,11 @@ export const handleCreateStencil: NodeTransformer = (node, context) => {
           tempVariables[makeEmotionSafe(node.name.text)] = varValue;
 
           // Evaluate the variable defaults
-          stencilVariables[varValue] = parseNodeToStaticValue(node.initializer, context).toString();
+          const value = parseNodeToStaticValue(node.initializer, context).toString();
+          if (value) {
+            // Only add the stencil variable if there's a value. An empty string means no default.
+            stencilVariables[varValue] = value;
+          }
         }
       }
 

--- a/modules/styling-transform/spec/utils/handleCreateStencil.spec.ts
+++ b/modules/styling-transform/spec/utils/handleCreateStencil.spec.ts
@@ -83,6 +83,23 @@ describe('handleCreateStencil', () => {
     expect(result).toContain('styles: "--css-button-color:red;padding:12px;"');
   });
 
+  it('should not parse variables in the base styles if the value is an empty string', () => {
+    const program = createProgramFromSource(`
+    import {createStencil} from '@workday/canvas-kit-styling';
+
+    const buttonStencil = createStencil({
+      vars: {
+        color: ''
+      },
+      base: {padding: 12}
+    })
+  `);
+
+    const result = transform(program, 'test.ts', withDefaultContext(program.getTypeChecker())); //?
+
+    expect(result).toContain('styles: "padding:12px;"');
+  });
+
   it('should handle parsing variables in base styles via an ArrowFunction and ParenthesizedExpression', () => {
     const program = createProgramFromSource(`
       import {createStencil} from '@workday/canvas-kit-styling';

--- a/modules/styling-transform/spec/utils/handleCreateStencil.spec.ts
+++ b/modules/styling-transform/spec/utils/handleCreateStencil.spec.ts
@@ -95,7 +95,7 @@ describe('handleCreateStencil', () => {
     })
   `);
 
-    const result = transform(program, 'test.ts', withDefaultContext(program.getTypeChecker())); //?
+    const result = transform(program, 'test.ts', withDefaultContext(program.getTypeChecker()));
 
     expect(result).toContain('styles: "padding:12px;"');
   });

--- a/modules/styling/spec/cs.spec.tsx
+++ b/modules/styling/spec/cs.spec.tsx
@@ -35,7 +35,7 @@ describe('createStyles', () => {
     it('should accept an object of CSS Properties', () => {
       type Input = Exclude<
         Parameters<typeof createStyles>[0],
-        string | number | boolean | SerializedStyles
+        string | number | boolean | SerializedStyles | undefined
       >;
       type PositionProperty = Input['position'];
       const temp: PositionProperty = 'absolute';
@@ -538,9 +538,12 @@ describe('createStyles', () => {
 
       // type signature of stencil call expression
       type Arg = Parameters<typeof myStencil>[0];
-      expectTypeOf<Arg>().toMatchTypeOf<{
-        size?: 'large';
-      }>();
+      expectTypeOf<Arg>().toMatchTypeOf<
+        | undefined
+        | {
+            size?: 'large';
+          }
+      >();
     });
 
     it('should set the `modifiers` property with the className of the modifier', () => {
@@ -663,9 +666,9 @@ describe('createStyles', () => {
         base: {},
       });
 
-      type Options = Parameters<typeof myStencil>[0];
+      type Options = Exclude<Parameters<typeof myStencil>[0], undefined>;
 
-      expectTypeOf<Options['foo']>().toEqualTypeOf<string>();
+      expectTypeOf<Options['foo']>().toEqualTypeOf<string | undefined>();
 
       // make sure we can call the function with a string
       myStencil({
@@ -783,7 +786,7 @@ describe('createStyles', () => {
         compound: [{modifiers: {size: 'large', grow: true}, styles: {}}],
       });
 
-      type Args = Parameters<typeof myStencil>[0];
+      type Args = Exclude<Parameters<typeof myStencil>[0], undefined>;
 
       expectTypeOf<Args>().toHaveProperty('grow');
       expectTypeOf<Args['grow']>().toEqualTypeOf<boolean | undefined>();
@@ -855,7 +858,7 @@ describe('createStyles', () => {
         expectTypeOf(extendedStencil.modifiers.extra.true).toEqualTypeOf<string>();
 
         // calling the stencil
-        type Args = Parameters<typeof extendedStencil>[0];
+        type Args = Exclude<Parameters<typeof extendedStencil>[0], undefined>;
         expectTypeOf<Args>().toEqualTypeOf<{
           size?: 'large';
           extra?: boolean;
@@ -906,7 +909,7 @@ describe('createStyles', () => {
         expect(className.split(' ')).toHaveProperty('length', 5);
 
         // calling the stencil
-        type Args = Parameters<typeof extendedStencil>[0];
+        type Args = Exclude<Parameters<typeof extendedStencil>[0], undefined>;
         expectTypeOf<Args>().toEqualTypeOf<{
           size?: 'large';
           extra?: boolean;

--- a/modules/styling/spec/tsconfig.json
+++ b/modules/styling/spec/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "../../../tsconfig.spec.json"
+  "extends": "../../../tsconfig.spec.json",
+  "compilerOptions": {
+    "strictNullChecks": true
+  }
 }

--- a/modules/styling/stories/Basics.stories.mdx
+++ b/modules/styling/stories/Basics.stories.mdx
@@ -91,6 +91,7 @@ Here's a simplified example:
 const myStencil = createStencil({
   vars: {
     defaultColor: 'red' // default value
+    nonDefaultedColor: '', // will allow for uninitialization
   },
   base: ({defaultColor}) => {
     color: defaultColor // `defaultColor` is '--abc123-defaultColor', not 'red'
@@ -137,6 +138,35 @@ variables. Variables are useful if you want to expose changing properties regard
 For example, Buttons use variables for colors of all states (hover, active, focus, disabled, and
 nested icons). Without variables, overriding the focus color would require deeply nested selector
 overrides.
+
+#### Cascading Variables
+
+Notice the `nonDefaultedColor` is not included in the base styles like `defaultColor` was. If a
+variable has an empty string, it will can be uninitialized. Stencil variables with a default value
+will create a "cascade barrier". A cascade barrier prevents the variable from "leaking" into the
+component. For example, if a `Card` component was rendered within another `Card` component, the
+variables from the parent `Card` would not leak into the child `Card` component. But there are times
+where a component expects a parent component to set a CSS variable and that it should cascade to the
+component. An example of this is the relationship between `SystemIcon` and `Button`. The `Button`
+components set the `SystemIcon` variables and they should cascade into the `SystemIcon` component.
+
+**Note:** Non-cascade variables _could_ be initialized. If you use uninitialized variables, be sure
+to use a fallback in your styles.
+
+```tsx
+const myStencil = createStencil({
+  vars: {
+    color: '', // uninitialized
+  },
+  base({color}) {
+    return {
+      // provide a fallback. A uninitialized CSS variable will fall back to `initial`.
+      // for the `color` CSS property, that's most likely black (default text color)
+      color: cssVar(color, 'red'),
+    };
+  },
+});
+```
 
 #### Nested Variables
 


### PR DESCRIPTION
## Summary

Fixes variables used inside a stencil. Before this used to cause problems when `color` is expected to be a string:
```tsx
const myStencil = createStencil({
  vars: {
    color
  },
  base({color}) {
    color // `string | undefined`, but should aways be a `string`
  }
})
```

This change also introduces the concept of uninitialized stencil variables. It always worked, but I've added documentation and support in the static style parser.

I also fixed a but where JSDoc of a stencil variable did not get forwarded properly.

## Release Category
Styling

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

Tests

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [x] Code
- [x] Documentation
- [x] Testing
