### PR TITLE
chore: Add nonce support to styling

### DIFF
--- a/modules/react/common/lib/CanvasProvider.tsx
+++ b/modules/react/common/lib/CanvasProvider.tsx
@@ -3,8 +3,7 @@ import {Theme, ThemeProvider, CacheProvider} from '@emotion/react';
 import {InputProvider} from './InputProvider';
 import {defaultCanvasTheme, PartialEmotionCanvasTheme, useTheme} from './theming';
 import {brand} from '@workday/canvas-tokens-web';
-import {cache} from '@emotion/css';
-import {createStyles} from '@workday/canvas-kit-styling';
+import {createStyles, getCache} from '@workday/canvas-kit-styling';
 
 export interface CanvasProviderProps {
   theme?: PartialEmotionCanvasTheme;
@@ -89,6 +88,7 @@ export const CanvasProvider = ({
   ...props
 }: CanvasProviderProps & React.HTMLAttributes<HTMLElement>) => {
   const elemProps = useCanvasThemeToCssVars(theme, props);
+  const cache = getCache();
   return (
     <CacheProvider value={cache}>
       <ThemeProvider theme={theme as Theme}>

--- a/modules/react/layout/lib/utils/mergeStyles.ts
+++ b/modules/react/layout/lib/utils/mergeStyles.ts
@@ -1,4 +1,3 @@
-import {css} from '@emotion/css';
 import {CSToPropsInput, handleCsProp} from '@workday/canvas-kit-styling';
 import {boxStyleFn} from '../Box';
 import {backgroundStyleFnConfigs} from './background';
@@ -71,20 +70,13 @@ export function mergeStyles<T extends {}>(
     return result;
   }, {});
 
-  // We need to determine if style props have been used. If they have, we need to merge all the CSS
-  // classes into a single class name in the order that the class names are listed. This variable
-  // will collect the CSS class name created by Emotion if we detect style props.
-  let stylePropsClassName = '';
+  let styles = {};
 
   // We have style props. We need to create style and merge with our `csToProps` to get the correct
   // merging order for styles
   if (shouldRuntimeMergeStyles) {
-    const styles = boxStyleFn(styleProps);
-    stylePropsClassName = css(styles);
+    styles = boxStyleFn(styleProps);
   }
 
-  return handleCsProp(elemProps, [localCs, stylePropsClassName]) as Omit<
-    T,
-    'cs' | keyof CommonStyleProps
-  >;
+  return handleCsProp(elemProps, [localCs, styles]) as Omit<T, 'cs' | keyof CommonStyleProps>;
 }

--- a/modules/react/layout/spec/mergeStyles.spec.tsx
+++ b/modules/react/layout/spec/mergeStyles.spec.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
 
-import {cache} from '@emotion/css';
-import {jsx, CacheProvider} from '@emotion/react';
+import {jsx} from '@emotion/react';
 import styled from '@emotion/styled';
 import {render as rtlRender, screen} from '@testing-library/react';
 
-// We need to force Emotion's cache wrapper to use the cache from `@emotion/css` for tests to pass
-const CacheWrapper = props => <CacheProvider value={cache} {...props} />;
-// @ts-ignore We want the types to be the same, but I don't care to fix the error
-const render: typeof rtlRender = (ui, options) =>
-  rtlRender(ui, {wrapper: CacheWrapper, ...options});
-
 import {mergeStyles} from '@workday/canvas-kit-react/layout';
 import {createStyles} from '@workday/canvas-kit-styling';
+import {CanvasProvider} from '@workday/canvas-kit-react/common';
+
+// We need to force Emotion's cache wrapper to use the cache from `@workday/canvas-kit-styling`
+// @ts-ignore We want the types to be the same, but I don't care to fix the error
+const render: typeof rtlRender = (ui, options) =>
+  rtlRender(ui, {wrapper: CanvasProvider, ...options});
 
 describe('mergeStyles', () => {
   const padding = {

--- a/modules/react/package.json
+++ b/modules/react/package.json
@@ -44,7 +44,6 @@
     "react": ">=16.14"
   },
   "dependencies": {
-    "@emotion/css": "^11.7.1",
     "@emotion/is-prop-valid": "^1.1.1",
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",

--- a/modules/styling-transform/lib/styleTransform.ts
+++ b/modules/styling-transform/lib/styleTransform.ts
@@ -11,6 +11,7 @@ import {handlePx2Rem} from './utils/handlePx2Rem';
 import {handleCssVar} from './utils/handleCssVar';
 import {Config, NodeTransformer, ObjectTransform, TransformerContext} from './utils/types';
 import {handleKeyframes} from './utils/handleKeyframes';
+import {handleInjectGlobal} from './utils/handleInjectGlobal';
 
 export type NestedStyleObject = {[key: string]: string | NestedStyleObject};
 
@@ -44,6 +45,7 @@ const defaultTransformers = [
   handleCreateVars,
   handleCreateStyles,
   handleCreateStencil,
+  handleInjectGlobal,
 ];
 
 export default function styleTransformer(

--- a/modules/styling-transform/lib/utils/handleInjectGlobal.ts
+++ b/modules/styling-transform/lib/utils/handleInjectGlobal.ts
@@ -1,0 +1,56 @@
+import ts from 'typescript';
+
+import {isImportedFromStyling} from './isImportedFromStyling';
+import {parseObjectToStaticValue} from './parseObjectToStaticValue';
+import {compileCSS, createStyleObjectNode, serializeStyles} from './createStyleObjectNode';
+import {NestedStyleObject, NodeTransformer, TransformerContext} from './types';
+import {parseNodeToStaticValue} from './parseNodeToStaticValue';
+
+export const handleInjectGlobal: NodeTransformer = (node, context) => {
+  const {checker, getFileName} = context;
+
+  if (
+    ts.isTaggedTemplateExpression(node) &&
+    ts.isIdentifier(node.tag) &&
+    node.tag.text === 'injectGlobal' &&
+    isImportedFromStyling(node.tag, checker)
+  ) {
+    const fileName = getFileName(node.getSourceFile()?.fileName || context.fileName);
+    const styleObj = parseNodeToStaticValue(node.template, context).toString(); //?
+
+    return ts.factory.createCallExpression(node.tag, undefined, [
+      createStyleReplacementNode(styleObj, fileName, context),
+    ]);
+  }
+
+  if (
+    ts.isCallExpression(node) &&
+    ts.isIdentifier(node.expression) &&
+    node.expression.text === 'injectGlobal' &&
+    isImportedFromStyling(node.expression, checker)
+  ) {
+    if (ts.isObjectLiteralExpression(node.arguments[0])) {
+      const fileName = getFileName(node.expression.getSourceFile()?.fileName || context.fileName);
+      const styleObj = parseObjectToStaticValue(node.arguments[0], context);
+
+      return ts.factory.updateCallExpression(node, node.expression, undefined, [
+        createStyleReplacementNode(styleObj, fileName, context),
+      ]);
+    }
+  }
+
+  return;
+};
+
+function createStyleReplacementNode(
+  styleObj: NestedStyleObject | string,
+  fileName: string,
+  {styles}: TransformerContext
+) {
+  const serialized = serializeStyles(styleObj); //?
+  const styleOutput = compileCSS(serialized.styles);
+  styles[fileName] = styles[fileName] || [];
+  styles[fileName].push(styleOutput);
+
+  return createStyleObjectNode(serialized.styles, serialized.name);
+}

--- a/modules/styling-transform/spec/utils/handleInjectGlobal.spec.ts
+++ b/modules/styling-transform/spec/utils/handleInjectGlobal.spec.ts
@@ -1,0 +1,76 @@
+import {
+  createProgramFromSource,
+  withDefaultContext,
+  transform,
+} from '@workday/canvas-kit-styling-transform/testing';
+import {compileCSS} from '../../lib/utils/createStyleObjectNode';
+
+describe('handleInjectGlobal', () => {
+  it('should transform an object using injectGlobal', () => {
+    const program = createProgramFromSource(`
+      import {injectGlobal} from '@workday/canvas-kit-styling';
+
+      injectGlobal({
+        '*': {
+          padding: 10
+        }
+      })
+    `);
+
+    const result = transform(program, 'test.ts');
+
+    expect(result).toContain('styles: "*{padding:10px;}');
+  });
+
+  it('should transform a TemplateString using injectGlobal', () => {
+    const program = createProgramFromSource(`
+      import {injectGlobal} from '@workday/canvas-kit-styling';
+
+      injectGlobal\`
+        * {
+          padding: 10px;
+        }
+      \`
+    `);
+
+    const result = transform(program, 'test.ts');
+
+    expect(result).toMatch(
+      /injectGlobal\({ name: "[a-z0-9]+", styles: ".+\*.+{.+padding: 10px;.+}/
+    );
+  });
+
+  it('should add global styles to the compiled CSS from an object', () => {
+    const program = createProgramFromSource(`
+      import {injectGlobal} from '@workday/canvas-kit-styling';
+
+      injectGlobal({
+        '*': {
+          padding: 10
+        }
+      })
+    `);
+
+    const styles = {};
+    transform(program, 'test.ts', withDefaultContext(program.getTypeChecker(), {styles}));
+
+    expect(styles['test.css']).toContainEqual(compileCSS('* { padding: 10px; }'));
+  });
+
+  it('should add global styles to the compiled CSS from a template string', () => {
+    const program = createProgramFromSource(`
+      import {injectGlobal} from '@workday/canvas-kit-styling';
+
+      injectGlobal\`
+        * {
+          padding: 10px;
+        }
+      \`
+    `);
+
+    const styles = {};
+    transform(program, 'test.ts', withDefaultContext(program.getTypeChecker(), {styles}));
+
+    expect(styles['test.css']).toContainEqual(compileCSS('* { padding: 10px; }'));
+  });
+});

--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -948,10 +948,27 @@ export function getInstance(): typeof _instance {
 
 /**
  * Creates a custom instance of Emotion CSS. If this function is never called, the instance will be
- * what gets imported from `@emotion/css`
+ * what gets imported from `@emotion/css`. This function must be called before any Canvas Kit
+ * component is imported or before any other `@workday/canvas-kit-styling` function is called. All
+ * the style utility functions need an instance and will automatically create one if one isn't
+ * already created.
+ *
+ * The style utilities inject styles as soon as they are called which means an instance needs to be
+ * created before any Canvas Kit components are even imported. Your application bootstrap must
+ * import a file that imports `@workday/canvas-kit-styling` and calls `createInstance` _before_ any
+ * other Canvas Kit components are imported.
  */
 export const createInstance: typeof _createInstance = options => {
-  _instance = _createInstance({key: 'css', ...options});
+  if (!_instance) {
+    _instance = _createInstance({key: 'css', ...options});
+  } else {
+    // @ts-ignore
+    if (process && process.env.NODE_ENV === 'development') {
+      console.warn(
+        'An instance has already been created. `createInstance` cannot be called after styles have already been created. Canvas Kit styles are created immediately, so this function must be called before any Canvas Kit components are even imported.'
+      );
+    }
+  }
 
   return _instance;
 };

--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -1,9 +1,11 @@
-import {cache, css, keyframes as keyframesEmotion} from '@emotion/css';
-import {getRegisteredStyles} from '@emotion/utils';
+import * as EmotionCSS from '@emotion/css';
+import _createInstance from '@emotion/css/create-instance';
 import {serializeStyles, Keyframes, SerializedStyles, CSSObject} from '@emotion/serialize';
 import {Properties} from 'csstype';
 
 import {generateUniqueId} from './uniqueId';
+
+let _instance: ReturnType<typeof _createInstance>;
 
 export const createStylesCache: Record<string, boolean> = {};
 
@@ -464,6 +466,8 @@ export type CsToPropsReturn = {className?: string; style?: CSSObjectWithVars};
  * @returns
  */
 export function csToProps(input: CSToPropsInput): CsToPropsReturn {
+  const instance = getInstance();
+
   // input is a string, so it must only be a class name
   if (typeof input === 'string') {
     return {className: input};
@@ -499,7 +503,7 @@ export function csToProps(input: CSToPropsInput): CsToPropsReturn {
     }
 
     if (hasStaticStyles) {
-      const className = css(staticStyles);
+      const className = instance.css(staticStyles);
       return {style: cssVars, className};
     }
     return {style: input};
@@ -576,6 +580,7 @@ export interface CSProps {
 export function createStyles(
   ...args: ({name: string; styles: string} | StyleProps | string)[]
 ): string {
+  const instance = getInstance();
   return args
     .map(input => {
       if (typeof input === 'string') {
@@ -584,7 +589,7 @@ export function createStyles(
 
       // If we were called with a {name, styles} object, it must be optimized. We'll shortcut here
       if (typeof input === 'object' && input.name) {
-        return css.call(null, input as CastStyleProps);
+        return instance.css(input as CastStyleProps);
       }
 
       const convertedStyles = convertAllProperties(input);
@@ -609,8 +614,8 @@ export function createStyles(
       // Without this "fix", anyone using the Emotion babel plugin would get different results than
       // intended when styles are merged.
       const name = generateUniqueId();
-      createStylesCache[`${cache.key}-${name}`] = true;
-      return css.call(null, {name, styles});
+      createStylesCache[`${instance.cache.key}-${name}`] = true;
+      return instance.css({name, styles});
     })
     .join(' ');
 }
@@ -687,6 +692,8 @@ export function handleCsProp<
   localCs?: CSToPropsInput
 ): Omit<T, 'cs'> {
   const {cs, style, className, ...restProps} = elemProps;
+  const instance = getInstance();
+
   // We are going to track if any runtime styles are detected
   let shouldRuntimeMergeStyles = false;
 
@@ -707,12 +714,13 @@ export function handleCsProp<
   // `@emotion/styled` and `@emotion/react` respectively that merge styles in a similar manner.
   // - https://github.com/emotion-js/emotion/blob/f3b268f7c52103979402da919c9c0dd3f9e0e189/packages/styled/src/base.js#L120C51-L138
   // - https://github.com/emotion-js/emotion/blob/f3b268f7c52103979402da919c9c0dd3f9e0e189/packages/react/src/emotion-element.js#L102-L116
-  (returnProps.className || '').split(' ').forEach(name => {
+  const returnClassNames = (returnProps.className || '').split(' ');
+  returnClassNames.forEach(name => {
     // Here we detect if a className is associated with Emotion's cache. Styles created via
     // `createStyles` do not need special runtime merge treatment, but `@emotion/react` and
     // `@emotion/styled` do. The `createStylesCache` tracks all styles injected into the cache via
     // `createStyles`, so those are filtered out.
-    if (!createStylesCache[name] && cache.registered[name]) {
+    if (!createStylesCache[name] && instance.cache.registered[name]) {
       shouldRuntimeMergeStyles = true;
     }
   });
@@ -722,25 +730,7 @@ export function handleCsProp<
   // If runtime styles are detected, we need to do extra work to ensure styles merge according to
   // the rules of Emotion's runtime.
   if (shouldRuntimeMergeStyles) {
-    const registeredStyles: string[] = [];
-
-    // We are using the raw `css` instead of `createStyles` because `css` uses style hashing and
-    // `createStyles` generates a new ID every time. We could use `createStyles` here, but it would
-    // be more wasteful and new styles would be generated each React render cycle. `css` is safe to
-    // use inside a render function while `createStyles` should always be used outside the React
-    // render cycle. The following is `@emotion/utils` and it mutates the passed in
-    // `registeredStyles` array. It uses the cache of registered styles and the original className.
-    // It returns a string with found registered class names removed.
-    returnProps.className = getRegisteredStyles(
-      cache.registered,
-      registeredStyles,
-      returnProps.className || ''
-    );
-
-    // The `className` is mutated again, but with a brand new CSS class name of all the merged
-    // registered styles. This is how Emotion merges styles from the `css` prop and `styled`
-    // components.
-    returnProps.className += css(registeredStyles);
+    returnProps.className = getInstance().cx(returnClassNames);
   }
 
   return {
@@ -944,8 +934,48 @@ export function createStencil<
   return stencil;
 }
 
+/**
+ * Gets the current Emotion CSS instance, falling back to the one from `@emotion/css` if one wasn't
+ * already created. This allows a custom cache to be created as an opt-in
+ */
+export function getInstance(): typeof _instance {
+  if (!_instance) {
+    _instance = EmotionCSS;
+  }
+
+  return _instance;
+}
+
+/**
+ * Creates a custom instance of Emotion CSS. If this function is never called, the instance will be
+ * what gets imported from `@emotion/css`
+ */
+export const createInstance: typeof _createInstance = options => {
+  _instance = _createInstance({key: 'css', ...options});
+
+  return _instance;
+};
+
+/**
+ * Returns the cache used by all style utilities
+ */
+export function getCache() {
+  return getInstance().cache;
+}
+
+// The following code is lifted from
+// https://github.com/emotion-js/emotion/blob/01cca604ca93c5fd3958c41045ecbcac72b65480/packages/css/src/create-instance.js
+// to support custom caches
+
+/**
+ * Create static keyframes. Use as a drop-in replacement to `keyframes` found in `@emotion/css` or
+ * `@emotion/react`
+ */
 export function keyframes<ID extends string>(
   ...args: ({name: ID; styles: string} | StyleProps | TemplateStringsArray)[]
 ): ID {
-  return keyframesEmotion(...(args as any)) as ID;
+  return getInstance().keyframes(...(args as any)) as ID;
 }
+
+export const injectGlobal: typeof EmotionCSS.injectGlobal = (...args: any[]) =>
+  getInstance().injectGlobal(...args);

--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -963,10 +963,6 @@ export function getCache() {
   return getInstance().cache;
 }
 
-// The following code is lifted from
-// https://github.com/emotion-js/emotion/blob/01cca604ca93c5fd3958c41045ecbcac72b65480/packages/css/src/create-instance.js
-// to support custom caches
-
 /**
  * Create static keyframes. Use as a drop-in replacement to `keyframes` found in `@emotion/css` or
  * `@emotion/react`
@@ -977,5 +973,8 @@ export function keyframes<ID extends string>(
   return getInstance().keyframes(...(args as any)) as ID;
 }
 
+/**
+ * Allows injecting of global styles.
+ */
 export const injectGlobal: typeof EmotionCSS.injectGlobal = (...args: any[]) =>
   getInstance().injectGlobal(...args);

--- a/modules/styling/package.json
+++ b/modules/styling/package.json
@@ -53,7 +53,6 @@
     "@emotion/react": "^11.7.1",
     "@emotion/serialize": "^1.0.2",
     "@emotion/styled": "^11.6.0",
-    "@emotion/utils": "^1.0.0",
     "@workday/canvas-kit-react": "^10.3.19",
     "@workday/canvas-tokens-web": "^1.0.0",
     "typescript": "4.2"

--- a/modules/styling/spec/cs.spec.tsx
+++ b/modules/styling/spec/cs.spec.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import {expectTypeOf} from 'expect-type';
 import {Properties} from 'csstype';
 import {SerializedStyles} from '@emotion/serialize';
-import {css, cache} from '@emotion/css';
+import {css} from '@emotion/css';
 import {jsx, CacheProvider} from '@emotion/react';
 import styled from '@emotion/styled';
 import {render as rtlRender, screen} from '@testing-library/react';
@@ -22,8 +22,10 @@ import {
   handleCsProp,
   keyframes,
   CSProps,
+  getCache,
 } from '../lib/cs';
 
+const cache = getCache();
 // We need to force Emotion's cache wrapper to use the cache from `@emotion/css` for tests to pass
 const CacheWrapper = props => <CacheProvider value={cache} {...props} />;
 // @ts-ignore We want the types to be the same, but I don't care to fix the error

--- a/modules/styling/stories/Basics.stories.mdx
+++ b/modules/styling/stories/Basics.stories.mdx
@@ -312,3 +312,55 @@ The HTML will look something like this:
 Notice the stencil adds all the class names that match the base, modifiers, and compound modifiers.
 
 <ExampleCodeBlock code={CreateStencil} />
+
+### Keyframes
+
+The `keyframes` function re-exports the [Emotion CSS keyframes](https://emotion.sh/docs/keyframes)
+function, but is compatible with a custom Emotion instance and is understood by the Static style
+transformer.
+
+## Custom Emotion instance
+
+Static style injection happens during the parsing stages of the files. This means when you `import`
+a component that uses static styling, the styles are injected immediately. This happens way before
+rendering, so using the Emotion [CacheProvider](https://emotion.sh/docs/cache-provider) does not
+work. A custom instance must be created _before_ any style utilities are called - during the
+bootstrapping phase of an application. We don't have a working example because it requires an
+isolated application, but here's an example adding a `nonce` to an application:
+
+```tsx
+// bootstrap-styles.ts
+import {createInstance} from '@workday/canvas-kit-styling';
+
+// assuming this file is being called via a `script` tag and that
+// script tag has a `nonce` attribute set from the server
+createInstance({nonce: document.currentScript.nonce});
+
+// index.ts
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+// call the bootstrap in the import list. This has the side-effect
+// of creating an instance
+import './bootstrap-styles';
+
+import App from './App';
+
+const root = ReactDOM.createRoot(document.querySelector('#root'));
+
+root.render(<App />);
+
+// App.tsx
+import React from 'react';
+
+// The following will create and inject styles. We cannot adjust
+// the Emotion instance after this import
+import {PrimaryButton} from '@workday/canvas-kit-react/button';
+
+// if we call `createInstance` here, we'll get a warning in
+// development mode
+
+export default () => {
+  return <PrimaryButton>Button</PrimaryButton>;
+};
+```

--- a/modules/styling/stories/Basics.stories.mdx
+++ b/modules/styling/stories/Basics.stories.mdx
@@ -313,11 +313,17 @@ Notice the stencil adds all the class names that match the base, modifiers, and 
 
 <ExampleCodeBlock code={CreateStencil} />
 
-### Keyframes
+### `keyframes`
 
 The `keyframes` function re-exports the [Emotion CSS keyframes](https://emotion.sh/docs/keyframes)
 function, but is compatible with a custom Emotion instance and is understood by the Static style
 transformer.
+
+### `injectGlobal`
+
+The `injectGlobal` function re-exports the
+[Emotion CSS injectGlobal](https://emotion.sh/docs/@emotion/css#global-styles) function, but is
+compatible with a custom Emotion instance and is understood by the Static style transformer.
 
 ## Custom Emotion instance
 

--- a/modules/styling/stories/MergingStyles.stories.mdx
+++ b/modules/styling/stories/MergingStyles.stories.mdx
@@ -1,6 +1,7 @@
 import {SymbolDoc} from '@workday/canvas-kit-docs';
 
 import {CreateStencil} from './examples/CreateStencil';
+import {StylingOverrides} from './examples/StylingOverrides';
 
 <Meta title="Styling/Mergiing Styles" />
 


### PR DESCRIPTION
## Summary

Add a way to create an Emotion instance with initialization options, including a `nonce` or custom `stylis` plugins. Before, the Emotion instance created by `@emotion/css` was used. Now `@emotion/css` is used as a fallback if an instance hasn't been created by the time a style utility is called.

Fixes: #2628 

This change adds the following opt-in features:
- Change the default Emotion cache instance used by Canvas Kit and the application
- Allow use of `injectGlobal` from `@workday/canvas-kit-styling` that uses the shared instance.

## Release Category
Infrastructure

### Release Note
This change does not introduce any breaking changes, but creating a custom Emotion instance can introduce a breaking change. A custom instance should only be used if all instances of Canvas Kit on the page are above the version this change is released in and no application code is imported directly from `@emotion/css`. This change updates all internal Canvas Kit styling to use the Emotion instance created in `@workday/canvas-kit-styling`. If no custom instance is created, the one created by `@emotion/css` will be used. If the default instance is used, there should be no breaking changes, but everyone should update their application code to use styling functions from `@workday/canvas-kit-styling` and not `@emotion/css`. SSR using `@emotion/css` is unaffected since server to client hydration only cares about the cache key ("css") and the style's hash, which should be the same even with a custom cache instance.

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)
- [x] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable

## Where Should the Reviewer Start?

https://5d854c26ba934e0020f5e98a-yttfiqwybi.chromatic.com/?path=/docs/styling-basics--create-modifiers, scroll to bottom of the page.
Also the `cs.ts` file.

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Documentation

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

There is no new feature demonstrated. We don't actually create a custom Emotion instance in our Storybook and we
cannot create a `nonce` on Chromatic's servers.
