### PR TITLE
docs: Improve the "accessible" example of loading dots

### DIFF
--- a/modules/react/loading-dots/stories/LoadingDots.stories.mdx
+++ b/modules/react/loading-dots/stories/LoadingDots.stories.mdx
@@ -29,7 +29,19 @@ yarn add @workday/canvas-kit-react
 
 <ExampleCodeBlock code={RTL} />
 
-### Accessible Example
+### Adding screen reader support to loading animations
+
+Sometimes, letting users know when content has finished loading is just as important as asking users
+to "please wait" while content is loading. The disappearance of an animation is information that
+might need description. In this example, we are using `AriaLiveRegion` and `AccessibleHide`
+components included in Canvas to describe both the appearance and disappearance of `LoadingDots`.
+
+- When idle, render an empty live region
+- When loading, render `LoadingDots` inside the live region,
+- When complete, render `AccessibleHide` inside the live region expressing "Complete!"
+- We can assign a name to `AriaLiveRegion` component by passing in `aria-label="Loading"`
+- We can declare `LoadingDots` a labeled graphic by passing `role="img"` and
+  `aria-label="Please wait..."` into the component
 
 <ExampleCodeBlock code={Accessible} />
 

--- a/modules/react/loading-dots/stories/examples/Accessible.tsx
+++ b/modules/react/loading-dots/stories/examples/Accessible.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {LoadingDots} from '@workday/canvas-kit-react/loading-dots';
-import {canvas} from '@workday/canvas-kit-react/tokens';
+import {base, system} from '@workday/canvas-tokens-web';
 import {Flex} from '@workday/canvas-kit-react/layout';
 import {SecondaryButton} from '@workday/canvas-kit-react/button';
 import {createStyles} from '@workday/canvas-kit-styling';
@@ -9,8 +9,8 @@ import {AccessibleHide, AriaLiveRegion} from '@workday/canvas-kit-react/common';
 export const Accessible = () => {
   const [loadingState, setLoadingState] = React.useState('idle');
   const loadingStyles = createStyles({
-    backgroundColor: canvas.colors.licorice300,
-    padding: '1rem',
+    backgroundColor: base.licorice300,
+    padding: system.space.x3,
   });
 
   React.useEffect(() => {
@@ -26,7 +26,7 @@ export const Accessible = () => {
   };
 
   return (
-    <Flex gap={canvas.space.s}>
+    <Flex gap={`var(${system.space.x4})`}>
       <SecondaryButton onClick={handleLoad}>Start</SecondaryButton>
       <AriaLiveRegion aria-label="Loading">
         {loadingState === 'loading' && (

--- a/modules/react/loading-dots/stories/examples/Accessible.tsx
+++ b/modules/react/loading-dots/stories/examples/Accessible.tsx
@@ -1,6 +1,39 @@
 import React from 'react';
 import {LoadingDots} from '@workday/canvas-kit-react/loading-dots';
+import {canvas} from '@workday/canvas-kit-react/tokens';
+import {Flex} from '@workday/canvas-kit-react/layout';
+import {SecondaryButton} from '@workday/canvas-kit-react/button';
+import {createStyles} from '@workday/canvas-kit-styling';
+import {AccessibleHide, AriaLiveRegion} from '@workday/canvas-kit-react/common';
 
 export const Accessible = () => {
-  return <LoadingDots aria-live="polite" aria-label="Loading Users" />;
+  const [loadingState, setLoadingState] = React.useState('idle');
+  const loadingStyles = createStyles({
+    backgroundColor: canvas.colors.licorice300,
+    padding: '1rem',
+  });
+
+  React.useEffect(() => {
+    if (loadingState === 'loading') {
+      setTimeout(() => {
+        setLoadingState('success');
+      }, 4000);
+    }
+  }, [loadingState]);
+
+  const handleLoad = () => {
+    setLoadingState('loading');
+  };
+
+  return (
+    <Flex gap={canvas.space.s}>
+      <SecondaryButton onClick={handleLoad}>Start</SecondaryButton>
+      <AriaLiveRegion aria-label="Loading">
+        {loadingState === 'loading' && (
+          <LoadingDots className={loadingStyles} role="img" aria-label="Please wait..." />
+        )}
+        {loadingState === 'success' && <AccessibleHide>Complete.</AccessibleHide>}
+      </AriaLiveRegion>
+    </Flex>
+  );
 };

--- a/modules/react/loading-dots/stories/examples/Accessible.tsx
+++ b/modules/react/loading-dots/stories/examples/Accessible.tsx
@@ -3,7 +3,7 @@ import {LoadingDots} from '@workday/canvas-kit-react/loading-dots';
 import {base, system} from '@workday/canvas-tokens-web';
 import {Flex} from '@workday/canvas-kit-react/layout';
 import {SecondaryButton} from '@workday/canvas-kit-react/button';
-import {createStyles} from '@workday/canvas-kit-styling';
+import {createStyles, cssVar} from '@workday/canvas-kit-styling';
 import {AccessibleHide, AriaLiveRegion} from '@workday/canvas-kit-react/common';
 
 export const Accessible = () => {
@@ -26,7 +26,7 @@ export const Accessible = () => {
   };
 
   return (
-    <Flex gap={`var(${system.space.x4})`}>
+    <Flex gap={cssVar(system.space.x4)}>
       <SecondaryButton onClick={handleLoad}>Start</SecondaryButton>
       <AriaLiveRegion aria-label="Loading">
         {loadingState === 'loading' && (

--- a/modules/react/loading-dots/stories/examples/Accessible.tsx
+++ b/modules/react/loading-dots/stories/examples/Accessible.tsx
@@ -6,19 +6,24 @@ import {SecondaryButton} from '@workday/canvas-kit-react/button';
 import {createStyles, cssVar} from '@workday/canvas-kit-styling';
 import {AccessibleHide, AriaLiveRegion} from '@workday/canvas-kit-react/common';
 
+const loadingStyles = createStyles({
+  backgroundColor: base.licorice300,
+  padding: system.space.x3,
+});
+
 export const Accessible = () => {
   const [loadingState, setLoadingState] = React.useState('idle');
-  const loadingStyles = createStyles({
-    backgroundColor: base.licorice300,
-    padding: system.space.x3,
-  });
 
   React.useEffect(() => {
-    if (loadingState === 'loading') {
-      setTimeout(() => {
+    const timer = setTimeout(() => {
+      if (loadingState === 'loading') {
         setLoadingState('success');
-      }, 4000);
-    }
+      }
+    }, 4000);
+
+    return () => {
+      clearTimeout(timer);
+    };
   }, [loadingState]);
 
   const handleLoad = () => {


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

The Soap400 color for the `LoadingDots` component does not meet WCAG guidelines for non-text contrast while used on light background colors. For this example, I used a darker background color that allows Soap400 to meet the minimum 3:1 contrast ratio. I also added better screen reader support with the `AriaLiveRegion` component that both lets users know about the loading status, and when loading has completed. 

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Documentation 

### Release Note
Accessible `LoadingDots` example has been updated, by changing background to a darker color that allows `soap400` to meet the minimum 3:1 contrast ratio and adding better screen reader support with the `AriaLiveRegion` component.

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

The "Accessible" example of the `LoadingDots` component, and the storybook mdx file. 

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [x] Code
- [x] Documentation

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

<!-- Explain how your reviewer could verify this change  -->

1. Turn on your favorite screen reader
2. Recommend using VoiceOver w/ Safari and NVDA w/ Chrome 
3. Activate the Start button
4. Expecting: "Loading, please wait..." 
5. After 4 seconds, expecting: "Loading, complete"

NOTE: The term "loading" is coming from an `aria-label` string on the `status` region. The order in which "loading" is described might vary based on screen reader. 

## Screenshots or GIFs (if applicable)

<!-- Does your change affect the UI? If so, please include a screenshot or short gif. -->

<img width="1037" alt="CK LoadingDots" src="https://github.com/Workday/canvas-kit/assets/40372497/cb7a14e3-84b3-44c1-a204-f40e455759ef">

I used licorice300 for a background color of the `LoadingDots` accessible example. 
