### PR TITLE
fix: Make variable names safe for Emotion

### DIFF
--- a/modules/styling-transform/lib/utils/parseNodeToStaticValue.ts
+++ b/modules/styling-transform/lib/utils/parseNodeToStaticValue.ts
@@ -267,14 +267,15 @@ export function getValueFromAliasedSymbol(
 }
 
 function getValueFromProcessedNodes(varName: string, context: TransformerContext): string | void {
+  const safeVarName = makeEmotionSafe(varName);
   const {variables} = context;
 
-  if (variables[varName]) {
-    return variables[varName];
+  if (variables[safeVarName]) {
+    return variables[safeVarName];
   }
 
-  if (context.variableScope && variables[`${context.variableScope}${varName}`]) {
-    return variables[`${context.variableScope}${varName}`];
+  if (context.variableScope && variables[`${context.variableScope}${safeVarName}`]) {
+    return variables[`${context.variableScope}${safeVarName}`];
   }
 }
 


### PR DESCRIPTION
## Summary

Makes local variables safe for Emotion since `"label"` is a reserved string in Emotion.

## Release Category
Components
