### PR TITLE
ci: Fix SymbolDoc

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -67,15 +67,15 @@ module.exports = {
         include: [modulesPath],
         exclude: /examples|stories|spec|codemod|docs/,
         loaders: [
-          // loaders are run in reverse order. symbol-doc-loader needs to be done first
+          // loaders are run in reverse order. style-transform-loader needs to be done first
           {
-            loader: path.resolve(__dirname, 'style-transform-loader'),
+            loader: path.resolve(__dirname, 'symbol-doc-loader'),
             options: {
               Doc,
             },
           },
           {
-            loader: path.resolve(__dirname, 'symbol-doc-loader'),
+            loader: path.resolve(__dirname, 'style-transform-loader'),
             options: {
               Doc,
             },

--- a/.storybook/style-transform-loader.js
+++ b/.storybook/style-transform-loader.js
@@ -5,6 +5,13 @@ const {transform} = require('@workday/canvas-kit-styling-transform/testing');
 /** @typedef {import('webpack').loader.Loader} Loader */
 /** @typedef {import('webpack').loader.LoaderContext} LoaderContext */
 
+// Tracks files that have been processed. If a file is already processed, it
+// means the file has been updated and we need to update the Typescript program
+// so the changes are reflected in our doc output. If we don't update the TS
+// program, the docs will be processed with the outdated cache of the file
+// contents.
+const filesProcessedMap = new Map();
+
 /**
  * @this {LoaderContext}
  * @param {Parameters<Loader>[0]} source
@@ -14,6 +21,11 @@ function styleTransformLoader(source) {
     /** @type {any} */
     Doc,
   } = getOptions(this);
+
+  if (filesProcessedMap.has(this.resourcePath)) {
+    Doc.update();
+  }
+  filesProcessedMap.set(this.resourcePath, true);
 
   return transform(Doc.program, this.resourcePath);
 }

--- a/.storybook/symbol-doc-loader.js
+++ b/.storybook/symbol-doc-loader.js
@@ -4,13 +4,6 @@ const {getOptions} = require('loader-utils');
 
 const routeKeys = Object.keys(routes);
 
-// Tracks files that have been processed. If a file is already processed, it
-// means the file has been updated and we need to update the Typescript program
-// so the changes are reflected in our doc output. If we don't update the TS
-// program, the docs will be processed with the outdated cache of the file
-// contents.
-const filesProcessedMap = new Map();
-
 /** @typedef {import('webpack').loader.Loader} Loader */
 /** @typedef {import('webpack').loader.LoaderContext} LoaderContext */
 
@@ -23,11 +16,6 @@ function symbolDocLoader(source) {
     /** @type {any} */
     Doc,
   } = getOptions(this);
-
-  if (filesProcessedMap.has(this.resourcePath)) {
-    Doc.update();
-  }
-  filesProcessedMap.set(this.resourcePath, true);
 
   const docs = Doc.parser.getExportedSymbols(this.resourcePath);
 


### PR DESCRIPTION
## Summary

Fixes an issue introduced with the style transform where `SymbolDoc` stopped working because the style transform overrode the webpack doc loader

## Release Category
Documentation

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

[<!-- Explain how your reviewer could verify this change  -->](https://5d854c26ba934e0020f5e98a-xklgwshvzc.chromatic.com/?path=/docs/components-buttons--primary)

Look at the component API docs

## Screenshots or GIFs (if applicable)

![image](https://github.com/Workday/canvas-kit/assets/338257/b7de8c85-ce77-4e93-baff-450544ab6e2d)
