### PR TITLE
chore: Update @workday/canvas-tokens-web version

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,2 +1,2 @@
 workspaces-experimental true
---install.frozen-lockfile true
+

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,2 +1,2 @@
 workspaces-experimental true
---install.frozen-lockfile false
+--install.frozen-lockfile true

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,2 +1,2 @@
 workspaces-experimental true
-
+--install.frozen-lockfile false

--- a/modules/docs/package.json
+++ b/modules/docs/package.json
@@ -49,7 +49,7 @@
     "@workday/canvas-kit-react": "^10.3.33",
     "@workday/canvas-kit-styling": "^10.3.33",
     "@workday/canvas-system-icons-web": "^3.0.0",
-    "@workday/canvas-tokens-web": "^1.3.0",
+    "@workday/canvas-tokens-web": "^1.3.1",
     "markdown-to-jsx": "^6.10.3",
     "ts-node": "^10.9.1"
   },

--- a/modules/preview-react/package.json
+++ b/modules/preview-react/package.json
@@ -49,7 +49,7 @@
     "@workday/canvas-kit-react": "^10.3.33",
     "@workday/canvas-kit-styling": "^10.3.33",
     "@workday/canvas-system-icons-web": "^3.0.0",
-    "@workday/canvas-tokens-web": "^1.3.0",
+    "@workday/canvas-tokens-web": "^1.3.1",
     "@workday/design-assets-types": "^0.2.8"
   },
   "devDependencies": {

--- a/modules/react/package.json
+++ b/modules/react/package.json
@@ -52,7 +52,7 @@
     "@workday/canvas-kit-popup-stack": "^10.3.33",
     "@workday/canvas-kit-styling": "^10.3.33",
     "@workday/canvas-system-icons-web": "^3.0.0",
-    "@workday/canvas-tokens-web": "^1.3.0",
+    "@workday/canvas-tokens-web": "^1.3.1",
     "@workday/design-assets-types": "^0.2.8",
     "chroma-js": "^2.1.0",
     "csstype": "^3.0.2",

--- a/modules/styling-transform/package.json
+++ b/modules/styling-transform/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@emotion/serialize": "^1.0.2",
     "@workday/canvas-kit-styling": "^10.3.33",
-    "@workday/canvas-tokens-web": "^1.3.0",
+    "@workday/canvas-tokens-web": "^1.3.1",
     "stylis": "4.0.13",
     "typescript": "4.2"
   },

--- a/modules/styling/package.json
+++ b/modules/styling/package.json
@@ -54,7 +54,7 @@
     "@emotion/serialize": "^1.0.2",
     "@emotion/styled": "^11.6.0",
     "@workday/canvas-kit-react": "^10.3.33",
-    "@workday/canvas-tokens-web": "^1.3.0",
+    "@workday/canvas-tokens-web": "^1.3.1",
     "typescript": "4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -133,6 +133,6 @@
     "@workday/canvas-accent-icons-web": "^3.0.9",
     "@workday/canvas-applet-icons-web": "^2.0.9",
     "@workday/canvas-system-icons-web": "^3.0.0",
-    "@workday/canvas-tokens-web": "^1.3.0"
+    "@workday/canvas-tokens-web": "^1.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5119,10 +5119,10 @@
   dependencies:
     "@workday/design-assets-types" "0.2.8"
 
-"@workday/canvas-tokens-web@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@workday/canvas-tokens-web/-/canvas-tokens-web-1.3.0.tgz#e4a47348f8ccfbb848b0ca16b73555ef1a6df11a"
-  integrity sha512-BL3aUhhq+sSkwiBvmJJgCrrBWAnlKILrDsPyJCMXE+kXdE+fGQNZyP6AfJnhRli4sK59iPmhCqcF1Up1a5rVUw==
+"@workday/canvas-tokens-web@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@workday/canvas-tokens-web/-/canvas-tokens-web-1.3.1.tgz#c4cfe0bfdf1926ee87178f08a2aaa6c6c4ede89a"
+  integrity sha512-4W6P8XHjPvIMpiD04KspeKTX0aFLoIhYiCqQsOhB55A6h6fA2ZPGS0uBdSxSIezbgeYEU0/6PXHY1aQjOT5UUw==
 
 "@workday/design-assets-types@0.2.10":
   version "0.2.10"


### PR DESCRIPTION
## Summary

Update @workday/canvas-tokens-web version to 1.3.1

## Release Category
Infrastructure