### PR TITLE
fix: Style merging in compat mode

### DIFF
--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -361,8 +361,8 @@ export type ModifierReturn<T extends ModifierConfig> = T &
  */
 export function createModifiers<M extends ModifierConfig>(input: M): ModifierReturn<M> {
   const modifierFn = (modifiers: Partial<ModifierValues<M>>) => {
-    return Object.keys(modifiers)
-      .filter(key => input[key] && (input as any)[key][modifiers[key]])
+    return Object.keys(input)
+      .filter(key => (input as any)[key][modifiers[key]])
       .map(key => (input as any)[key][modifiers[key]])
       .join(' ');
   };
@@ -877,6 +877,14 @@ type VariableValuesStencil<
   ? {[K in keyof V]?: string}
   : {[K1 in keyof V]?: {[K2 in keyof V[K1]]: string}};
 
+function onlyDefined<T>(input: T | undefined): input is T {
+  return !!input;
+}
+
+function onlyUnique<T>(value: any, index: number, array: T[]) {
+  return array.indexOf(value) === index;
+}
+  
 /**
  * Creates a reuseable Stencil for styling elements. It takes vars, base styles, modifiers, and
  * compound modifiers.
@@ -931,7 +939,10 @@ export function createStencil<
         modifiers ? _modifiers(inputModifiers) : '',
         compound ? _compound(inputModifiers) : '',
       ]
-        .filter(v => v) // filter out empty strings
+        .filter(onlyDefined) // filter out empty strings
+        .join(' ')
+        .split(' ')
+        .filter(onlyUnique)
         .join(' '),
       style: _vars(input || {}),
     };

--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -513,7 +513,12 @@ export function csToProps(input: CSToPropsInput): CsToPropsReturn {
   // object with `style` and `className` attributes to spread on an element
   return input.map(csToProps).reduce((result, val) => {
     return {
-      className: [result.className, val.className].filter(v => v).join(' '),
+      className: [result.className, val.className]
+        .filter(v => v)
+        .join(' ')
+        .split(' ')
+        .filter(onlyUnique)
+        .join(' '),
       style: {...result.style, ...val.style},
     };
   }, {} as CsToPropsReturn);

--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -361,10 +361,11 @@ export type ModifierReturn<T extends ModifierConfig> = T &
  */
 export function createModifiers<M extends ModifierConfig>(input: M): ModifierReturn<M> {
   const modifierFn = (modifiers: Partial<ModifierValues<M>>) => {
-    return Object.keys(input)
-      .filter(key => (input as any)[key][modifiers[key]])
-      .map(key => (input as any)[key][modifiers[key]])
-      .join(' ');
+    return combineClassNames(
+      Object.keys(input)
+        .filter(key => (input as any)[key][modifiers[key]])
+        .map(key => (input as any)[key][modifiers[key]])
+    );
   };
 
   Object.keys(input).forEach(key => {
@@ -414,8 +415,8 @@ export function createCompoundModifiers<M extends ModifierConfig>(
   compound: CompoundModifier<M>[]
 ): ModifierReturn<M> {
   return (modifiers => {
-    return compound
-      .map(compoundModifier => {
+    return combineClassNames(
+      compound.map(compoundModifier => {
         const match = Object.keys(compoundModifier.modifiers).reduce(
           (result, compoundModifierKey) => {
             return (
@@ -430,8 +431,7 @@ export function createCompoundModifiers<M extends ModifierConfig>(
         }
         return '';
       })
-      .filter(v => v)
-      .join(' ');
+    );
   }) as ModifierReturn<M>;
 }
 
@@ -513,12 +513,7 @@ export function csToProps(input: CSToPropsInput): CsToPropsReturn {
   // object with `style` and `className` attributes to spread on an element
   return input.map(csToProps).reduce((result, val) => {
     return {
-      className: [result.className, val.className]
-        .filter(v => v)
-        .join(' ')
-        .split(' ')
-        .filter(onlyUnique)
-        .join(' '),
+      className: combineClassNames([result.className, val.className]),
       style: {...result.style, ...val.style},
     };
   }, {} as CsToPropsReturn);
@@ -884,6 +879,18 @@ function onlyDefined<T>(input: T | undefined): input is T {
 function onlyUnique<T>(value: any, index: number, array: T[]) {
   return array.indexOf(value) === index;
 }
+
+/**
+ * Combines an array of space-delimited CSS class names into a single string of space-delimited
+ * class names. Duplicate class names are removed.
+ */
+function combineClassNames(input: (string | undefined)[]): string {
+  return input
+    .join(' ')
+    .split(' ')
+    .filter((s, i, a) => onlyDefined(s) && onlyUnique(s, i, a))
+    .join(' ');
+}
   
 /**
  * Creates a reuseable Stencil for styling elements. It takes vars, base styles, modifiers, and
@@ -934,16 +941,11 @@ export function createStencil<
   const stencil: Stencil<M, V, ID> = input => {
     const inputModifiers = {...defaultModifiers, ...input};
     return {
-      className: [
+      className: combineClassNames([
         _base,
         modifiers ? _modifiers(inputModifiers) : '',
         compound ? _compound(inputModifiers) : '',
-      ]
-        .filter(onlyDefined) // filter out empty strings
-        .join(' ')
-        .split(' ')
-        .filter(onlyUnique)
-        .join(' '),
+      ]),
       style: _vars(input || {}),
     };
   };

--- a/modules/styling/spec/cs.spec.tsx
+++ b/modules/styling/spec/cs.spec.tsx
@@ -562,6 +562,24 @@ describe('createStyles', () => {
       expect(typeof myStencil.modifiers.size.large).toEqual('string');
     });
 
+    it('should apply modifiers in the correct order regardless of the order they are defined when calling the stencil', () => {
+      const myStencil = createStencil({
+        base: {},
+        modifiers: {
+          size: {
+            large: {},
+          },
+          position: {
+            start: {},
+          },
+        },
+      });
+
+      expect(myStencil({position: 'start', size: 'large'}).className).toEqual(
+        `${myStencil.base} ${myStencil.modifiers.size.large} ${myStencil.modifiers.position.start}`
+      );
+    });
+
     it('should default modifiers if no modifier override is passed', () => {
       const myStencil = createStencil({
         base: {


### PR DESCRIPTION
## Summary

Fixes: #2718

Fixed style merging in compat mode that can result in incorrect styles

## Release Category
Components

## Release Note

This fixes an issue where styles would merge incorrectly in compatibility mode. Compatibility mode is triggered when our component is augmented by a style prop, wrapped with `styled`, passed a `css` prop, or passed a `cs` prop with object styles. This fix ensures that `modifiers` via `createModifiers` or `createStencil` merge styles the same way in both static and compat modes. See the linked issue for more details.

---

## Checklist

- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

Test file

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

You can verify the test fails if the cs file is reverted
