### PR TITLE
fix(select): Redirect focus to visual input

### DIFF
--- a/modules/preview-react/_examples/stories/examples/TextInputWithReactHookForm.tsx
+++ b/modules/preview-react/_examples/stories/examples/TextInputWithReactHookForm.tsx
@@ -59,7 +59,11 @@ const validationSchema: SchemaOf<LoginSchema> = object({
   role: string().required(roleRequired),
 });
 
-const options = ['Developer', 'Designer', 'Product Manager'];
+const options = [
+  {id: '1', label: 'Developer'},
+  {id: '2', label: 'Designer'},
+  {id: '3', label: 'Product Manager'},
+];
 
 export const TextInputWithReactHookForm = () => {
   const {
@@ -70,7 +74,7 @@ export const TextInputWithReactHookForm = () => {
     defaultValues: {
       email: 'example@baz.com',
       password: 'foobarbaz',
-      role: 'Designer',
+      role: '',
     },
     resolver: useYupValidationResolver(validationSchema),
     mode: 'onTouched',
@@ -94,17 +98,17 @@ export const TextInputWithReactHookForm = () => {
   };
 
   return (
-    <form onSubmit={onSubmit} action=".">
+    <form onSubmit={onSubmit} action="." noValidate={true}>
       <Flex gap="xs" flexDirection="column" alignItems="flex-start">
         <FormField orientation="vertical" isRequired={true} hasError={!!errors.role}>
-          <Select items={options}>
+          <Select items={options} getTextValue={item => item.label}>
             <FormField.Label>What is your role?</FormField.Label>
             <FormField.Input as={Select.Input} {...register('role')} width="280px" />
             <Select.Popper>
               <Select.Card>
                 <Select.List maxHeight={200}>
                   {item => {
-                    return <Select.Item>{item}</Select.Item>;
+                    return <Select.Item>{item.label}</Select.Item>;
                   }}
                 </Select.List>
               </Select.Card>

--- a/modules/react/combobox/lib/hooks/useComboboxInput.ts
+++ b/modules/react/combobox/lib/hooks/useComboboxInput.ts
@@ -70,7 +70,7 @@ export const useComboboxInput = composeHooks(
       },
       value: model.state.value,
       role: 'combobox',
-      'aria-haspopup': true,
+      'aria-haspopup': 'true' as React.AriaAttributes['aria-haspopup'],
       'aria-expanded': model.state.visibility === 'visible',
       'aria-autocomplete': 'list',
       'aria-controls': `${model.state.id}-list`,

--- a/modules/react/select/lib/hooks/useSelectInput.ts
+++ b/modules/react/select/lib/hooks/useSelectInput.ts
@@ -155,6 +155,7 @@ export const useSelectInput = composeHooks(
               : '',
         },
         ref: elementRef,
+        'aria-haspopup': 'menu',
       } as const;
     }
   ),


### PR DESCRIPTION
## Summary

Forward `onFocus` to  `Select` and forward `focus()` and `blur()` to the visual input.

Fixes: #2716

## Release Category
Components

---

## Checklist

- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
