### PR TITLE
fix: Fixed some mistaken merge conflicts

### DIFF
--- a/modules/docs/docgen/spec/createProgramFromSource.ts
+++ b/modules/docs/docgen/spec/createProgramFromSource.ts
@@ -42,13 +42,13 @@ export function createProgramFromSource(...args: any[]) {
         (name.startsWith('lib')
           ? ts.createSourceFile(
               name,
-              ts.sys.readFile(`node_modules/typescript/lib/${name}`),
+              ts.sys.readFile(`node_modules/typescript/lib/${name}`)!,
               languageVersion
             )
           : name === 'node_modules/react.ts'
           ? ts.createSourceFile(
               name,
-              ts.sys.readFile(`node_modules/@types/react/index.d.ts`),
+              ts.sys.readFile(`node_modules/@types/react/index.d.ts`)!,
               languageVersion
             )
           : defaultCompilerHost.getSourceFile(name, languageVersion))

--- a/modules/labs-react/combobox/lib/Combobox.tsx
+++ b/modules/labs-react/combobox/lib/Combobox.tsx
@@ -355,7 +355,7 @@ export const Combobox = ({
     const autoCompleteItemCount = interactiveAutocompleteItems.length;
     const firstItem = 0;
     const lastItem = autoCompleteItemCount - 1;
-    let nextIndex = null;
+    let nextIndex: number | null = null;
 
     setIsOpened(true);
 

--- a/modules/preview-react/text-input/spec/TextInput.spec.tsx
+++ b/modules/preview-react/text-input/spec/TextInput.spec.tsx
@@ -142,7 +142,7 @@ describe('Text Input', () => {
           <TextInput.Field />
         </TextInput>
       );
-      const uniqueId = container.querySelector('input').getAttribute('id');
+      const uniqueId = container.querySelector('input')!.getAttribute('id');
       expect(container.querySelector('input')).toHaveAttribute('id', uniqueId);
     });
   });

--- a/modules/react/button/spec/Button.spec.tsx
+++ b/modules/react/button/spec/Button.spec.tsx
@@ -10,15 +10,17 @@ import {
 import {render, fireEvent} from '@testing-library/react';
 import {ElementComponent} from '@workday/canvas-kit-react/common';
 
-([
-  PrimaryButton,
-  SecondaryButton,
-  TertiaryButton,
-  DeleteButton,
-  DeprecatedButton,
-  // We need to cast as `any` and cast as a specific button because TS will complain about no call signatures...
-] as any[]).forEach((ButtonComponent: ElementComponent<'button', ButtonProps>) => {
-  describe(ButtonComponent.displayName, () => {
+(
+  [
+    PrimaryButton,
+    SecondaryButton,
+    TertiaryButton,
+    DeleteButton,
+    DeprecatedButton,
+    // We need to cast as `any` and cast as a specific button because TS will complain about no call signatures...
+  ] as any[]
+).forEach((ButtonComponent: ElementComponent<'button', ButtonProps>) => {
+  describe(ButtonComponent.displayName!, () => {
     const cb = jest.fn();
     afterEach(() => {
       cb.mockReset();
@@ -66,7 +68,7 @@ import {ElementComponent} from '@workday/canvas-kit-react/common';
 
     describe('when rendered with a button ref', () => {
       it('should set the ref to the checkbox input element', () => {
-        const ref = {current: null};
+        const ref = {current: null as null | HTMLButtonElement};
 
         render(<ButtonComponent ref={ref} />);
 

--- a/modules/react/collection/spec/useCursorModel.spec.tsx
+++ b/modules/react/collection/spec/useCursorModel.spec.tsx
@@ -26,8 +26,8 @@ type CursorListState = ReturnType<typeof useCursorListModel>['state'];
 const createState = (input: Partial<CursorListState>): CursorListState => {
   return {
     nonInteractiveIds: [],
-    ...(input as CursorListState),
-  };
+    ...input,
+  } as CursorListState;
 };
 
 const createItem = (id, index) => ({id, index, value: id, textValue: id});

--- a/modules/react/common/spec/components.spec.tsx
+++ b/modules/react/common/spec/components.spec.tsx
@@ -239,7 +239,9 @@ describe('createHook', () => {
 
     const props = hook(emptyModel, {bar: 'baz'}, {current: divElement});
 
-    expectTypeOf(props).toEqualTypeOf<{foo: string} & {bar: string} & {ref: React.Ref<unknown>}>();
+    expectTypeOf(props).toEqualTypeOf<
+      {foo: string} & {bar: string} & {ref: React.Ref<unknown> | undefined}
+    >();
     expect(props).toEqual({foo: 'bar', bar: 'baz', ref: {current: divElement}});
   });
 
@@ -289,7 +291,7 @@ describe('createHook', () => {
 describe('useForkRef', () => {
   it('should set the current value of the second ref if the first ref is undefined', () => {
     const ref1 = undefined;
-    const ref2 = {current: null};
+    const ref2 = {current: 'foo'};
 
     const ref = useForkRef(ref1, ref2);
 
@@ -299,7 +301,7 @@ describe('useForkRef', () => {
   });
 
   it('should set the current value of the first ref if the second ref is undefined', () => {
-    const ref1 = {current: null};
+    const ref1 = {current: 'foo'};
     const ref2 = undefined;
 
     const ref = useForkRef(ref1, ref2);
@@ -310,8 +312,8 @@ describe('useForkRef', () => {
   });
 
   it('should set the current value of both refs if both refs are RefObjects', () => {
-    const ref1 = {current: null};
-    const ref2 = {current: null};
+    const ref1 = {current: 'ref1'};
+    const ref2 = {current: 'ref2'};
 
     const ref = useForkRef(ref1, ref2);
 
@@ -449,8 +451,9 @@ describe('composeHooks', () => {
     // This test is covering all previous tests, but with more hooks.
     // This test should only fail if the implementation doesn't handle more than 2 hooks
     const model = {state: {foo: 'bar'}, events: {}};
-    const hooks = [1, 2, 3, 4, 5, 6, 7, 8, 9].map(number => (myModel, props) =>
-      mergeProps({id: number, foo: number, [`hook${number}`]: model.state.foo}, props)
+    const hooks = [1, 2, 3, 4, 5, 6, 7, 8, 9].map(
+      number => (myModel, props) =>
+        mergeProps({id: number, foo: number, [`hook${number}`]: model.state.foo}, props)
     );
 
     const props = (composeHooks as any).apply(null, hooks as any)(myModel, {foo: 'baz'}, null);

--- a/modules/react/common/spec/mergeProps.spec.tsx
+++ b/modules/react/common/spec/mergeProps.spec.tsx
@@ -71,9 +71,7 @@ describe('mergeProps', () => {
     const target = {
       onClick: targetSpy,
     };
-    const source = {
-      onClick: undefined,
-    };
+    const source = {};
 
     const mergedProps = mergeProps(target, source);
     mergedProps.onClick({event: 'foo'});

--- a/modules/react/form-field/spec/FormField.spec.tsx
+++ b/modules/react/form-field/spec/FormField.spec.tsx
@@ -137,7 +137,7 @@ describe('FormField', () => {
           <input type="text" />
         </FormField>
       );
-      const uniqueId = container.querySelector('input').getAttribute('id');
+      const uniqueId = container.querySelector('input')!.getAttribute('id');
       expect(container.querySelector('input')).toHaveAttribute('id', uniqueId);
     });
   });

--- a/modules/styling-transform/spec/createProgramFromSource.ts
+++ b/modules/styling-transform/spec/createProgramFromSource.ts
@@ -80,7 +80,7 @@ export function createProgramFromSource(...args: any[]) {
       if (name.startsWith('lib')) {
         return ts.createSourceFile(
           name,
-          ts.sys.readFile(`node_modules/typescript/lib/${name}`),
+          ts.sys.readFile(`node_modules/typescript/lib/${name}`)!,
           languageVersion
         );
       }

--- a/modules/styling-transform/spec/findNodes.ts
+++ b/modules/styling-transform/spec/findNodes.ts
@@ -25,7 +25,10 @@ export function findNodes<N extends (node: ts.Node) => boolean>(
   node.forEachChild(child => {
     // The AST doesn't have parent nodes, but they are required for testing purposes.
     (child as any).parent = node;
-    nodes.push(...findNodes(child, name, predicate));
+    const childNodes = findNodes(child, name, predicate);
+    if (childNodes) {
+      nodes.push(...childNodes);
+    }
   });
 
   return nodes as any;

--- a/modules/styling-transform/spec/utils/getErrorMessage.spec.ts
+++ b/modules/styling-transform/spec/utils/getErrorMessage.spec.ts
@@ -14,8 +14,8 @@ describe('getErrorMessage', () => {
       };
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, 'baz', ts.isIdentifier)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, 'baz', ts.isIdentifier)![0];
 
     const ctx = withDefaultContext(program.getTypeChecker(), {});
 

--- a/modules/styling-transform/spec/utils/getVarName.spec.ts
+++ b/modules/styling-transform/spec/utils/getVarName.spec.ts
@@ -11,9 +11,9 @@ describe('getVarName', () => {
       const foo = 'bar';
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
+    const sourceFile = program.getSourceFile('test.ts')!;
 
-    const node = findNodes(sourceFile, 'foo', ts.isVariableDeclaration)[0];
+    const node = findNodes(sourceFile, 'foo', ts.isVariableDeclaration)![0];
 
     expect(getVarName(node)).toEqual('foo');
   });
@@ -28,9 +28,9 @@ describe('getVarName', () => {
       };
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
+    const sourceFile = program.getSourceFile('test.ts')!;
 
-    const node = findNodes(sourceFile, 'baz', ts.isPropertyAssignment)[0];
+    const node = findNodes(sourceFile, 'baz', ts.isPropertyAssignment)![0];
 
     expect(getVarName(node)).toEqual('foo-bar-baz');
   });
@@ -45,9 +45,9 @@ describe('getVarName', () => {
       });
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
+    const sourceFile = program.getSourceFile('test.ts')!;
 
-    const node = findNodes(sourceFile, 'baz', ts.isPropertyAssignment)[0];
+    const node = findNodes(sourceFile, 'baz', ts.isPropertyAssignment)![0];
 
     expect(getVarName(node)).toEqual('foo-bar-baz');
   });
@@ -62,9 +62,9 @@ describe('getVarName', () => {
       };
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
+    const sourceFile = program.getSourceFile('test.ts')!;
 
-    const node = findNodes(sourceFile, 'baz', ts.isPropertyAssignment)[0];
+    const node = findNodes(sourceFile, 'baz', ts.isPropertyAssignment)![0];
 
     expect(getVarName(node.name)).toEqual('foo-bar-baz');
   });

--- a/modules/styling-transform/spec/utils/handleCalc.spec.ts
+++ b/modules/styling-transform/spec/utils/handleCalc.spec.ts
@@ -15,8 +15,8 @@ describe('handleCalc', () => {
       calc.add('20px', '2rem')
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isCallExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isCallExpression)![0];
 
     const result = handleCalc(node, withDefaultContext(program.getTypeChecker()));
 
@@ -30,8 +30,8 @@ describe('handleCalc', () => {
       calc.add(foo, '2rem')
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isCallExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isCallExpression)![0];
 
     const result = handleCalc(node, withDefaultContext(program.getTypeChecker()));
 
@@ -43,8 +43,8 @@ describe('handleCalc', () => {
       calc.add(myVars.foo, '2rem')
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isCallExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isCallExpression)![0];
 
     const result = handleCalc(
       node,
@@ -61,8 +61,8 @@ describe('handleCalc', () => {
       calc.subtract('20px', '2rem')
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isCallExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isCallExpression)![0];
 
     const result = handleCalc(node, withDefaultContext(program.getTypeChecker()));
 
@@ -76,8 +76,8 @@ describe('handleCalc', () => {
       calc.subtract(foo, '2rem')
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isCallExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isCallExpression)![0];
 
     const result = handleCalc(node, withDefaultContext(program.getTypeChecker()));
 
@@ -89,8 +89,8 @@ describe('handleCalc', () => {
       calc.subtract(myVars.foo, '2rem')
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isCallExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isCallExpression)![0];
 
     const result = handleCalc(
       node,
@@ -107,8 +107,8 @@ describe('handleCalc', () => {
       calc.multiply('20px', '2')
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isCallExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isCallExpression)![0];
 
     const result = handleCalc(node, withDefaultContext(program.getTypeChecker()));
 
@@ -122,8 +122,8 @@ describe('handleCalc', () => {
       calc.multiply(foo, '2')
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isCallExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isCallExpression)![0];
 
     const result = handleCalc(node, withDefaultContext(program.getTypeChecker()));
 
@@ -135,8 +135,8 @@ describe('handleCalc', () => {
       calc.multiply(myVars.foo, '2')
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isCallExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isCallExpression)![0];
 
     const result = handleCalc(
       node,
@@ -153,8 +153,8 @@ describe('handleCalc', () => {
       calc.divide('20px', '2')
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isCallExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isCallExpression)![0];
 
     const result = handleCalc(node, withDefaultContext(program.getTypeChecker()));
 
@@ -168,8 +168,8 @@ describe('handleCalc', () => {
       calc.divide(foo, '2')
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isCallExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isCallExpression)![0];
 
     const result = handleCalc(node, withDefaultContext(program.getTypeChecker()));
 
@@ -181,8 +181,8 @@ describe('handleCalc', () => {
       calc.divide(myVars.foo, '2')
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isCallExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isCallExpression)![0];
 
     const result = handleCalc(
       node,
@@ -199,8 +199,8 @@ describe('handleCalc', () => {
       calc.negate('20px')
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isCallExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isCallExpression)![0];
 
     const result = handleCalc(node, withDefaultContext(program.getTypeChecker()));
 
@@ -214,8 +214,8 @@ describe('handleCalc', () => {
       calc.negate(foo)
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isCallExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isCallExpression)![0];
 
     const result = handleCalc(node, withDefaultContext(program.getTypeChecker()));
 
@@ -227,8 +227,8 @@ describe('handleCalc', () => {
       calc.negate(myVars.foo)
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isCallExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isCallExpression)![0];
 
     const result = handleCalc(
       node,

--- a/modules/styling-transform/spec/utils/handleCreateStencil.spec.ts
+++ b/modules/styling-transform/spec/utils/handleCreateStencil.spec.ts
@@ -7,7 +7,7 @@ import {handleCreateStencil} from '../../lib/utils/handleCreateStencil';
 import {transform, withDefaultContext, _reset} from '../../lib/styleTransform';
 import {compileCSS} from '../../lib/utils/createStyleObjectNode';
 
-function getFile<K extends string, T extends Record<K, any>>(styles: T, name: string): T[K] {
+function getFile<K extends string, T extends Record<K, any>>(styles: T, name: string): T[K] | void {
   for (const style in styles) {
     if (style.includes(name)) {
       // @ts-ignore
@@ -49,10 +49,10 @@ describe('handleCreateStencil', () => {
         })
       `);
 
-      const sourceFile = program.getSourceFile('test.ts');
+      const sourceFile = program.getSourceFile('test.ts')!;
       const variables: Record<string, string> = {};
 
-      const node = findNodes(sourceFile, 'createStencil', ts.isCallExpression)[0];
+      const node = findNodes(sourceFile, 'createStencil', ts.isCallExpression)![0];
 
       handleCreateStencil(
         node,
@@ -331,8 +331,8 @@ describe('handleCreateStencil', () => {
       `);
 
       const styles = {};
-      const sourceFile = program.getSourceFile('test.ts');
-      const node = findNodes(sourceFile, 'createStencil', ts.isCallExpression)[0];
+      const sourceFile = program.getSourceFile('test.ts')!;
+      const node = findNodes(sourceFile, 'createStencil', ts.isCallExpression)![0];
 
       handleCreateStencil(node, withDefaultContext(program.getTypeChecker(), {styles}));
 
@@ -381,8 +381,8 @@ describe('handleCreateStencil', () => {
       `);
 
       const styles = {};
-      const sourceFile = program.getSourceFile('test.ts');
-      const node = findNodes(sourceFile, 'createStencil', ts.isCallExpression)[0];
+      const sourceFile = program.getSourceFile('test.ts')!;
+      const node = findNodes(sourceFile, 'createStencil', ts.isCallExpression)![0];
 
       handleCreateStencil(node, withDefaultContext(program.getTypeChecker(), {styles}));
 
@@ -425,8 +425,8 @@ describe('handleCreateStencil', () => {
       `);
 
       const styles = {};
-      const sourceFile = program.getSourceFile('test.ts');
-      const node = findNodes(sourceFile, 'createStencil', ts.isCallExpression)[0];
+      const sourceFile = program.getSourceFile('test.ts')!;
+      const node = findNodes(sourceFile, 'createStencil', ts.isCallExpression)![0];
 
       handleCreateStencil(node, withDefaultContext(program.getTypeChecker(), {styles}));
 

--- a/modules/styling-transform/spec/utils/handleCreateStyles.spec.ts
+++ b/modules/styling-transform/spec/utils/handleCreateStyles.spec.ts
@@ -595,8 +595,8 @@ describe('createStyles', () => {
     `);
 
     const styles = {};
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, 'createStyles', ts.isCallExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, 'createStyles', ts.isCallExpression)![0];
 
     handleCreateStyles(node, withDefaultContext(program.getTypeChecker(), {styles}));
 

--- a/modules/styling-transform/spec/utils/handleCreateVars.spec.ts
+++ b/modules/styling-transform/spec/utils/handleCreateVars.spec.ts
@@ -12,10 +12,10 @@ describe('handleCreateVars', () => {
       const myVars = createVars('color', 'background')
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
+    const sourceFile = program.getSourceFile('test.ts')!;
     const variables: Record<string, string> = {};
 
-    const node = findNodes(sourceFile, 'createVars', ts.isCallExpression)[0];
+    const node = findNodes(sourceFile, 'createVars', ts.isCallExpression)![0];
 
     handleCreateVars(
       node,
@@ -35,10 +35,10 @@ describe('handleCreateVars', () => {
       }
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
+    const sourceFile = program.getSourceFile('test.ts')!;
     const variables: Record<string, string> = {};
 
-    const node = findNodes(sourceFile, 'createVars', ts.isCallExpression)[0];
+    const node = findNodes(sourceFile, 'createVars', ts.isCallExpression)![0];
 
     handleCreateVars(
       node,

--- a/modules/styling-transform/spec/utils/handleCssVar.spec.ts
+++ b/modules/styling-transform/spec/utils/handleCssVar.spec.ts
@@ -13,8 +13,8 @@ describe('handleCssVar', () => {
       cssVar('--some-var')
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, 'cssVar')[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, 'cssVar')![0];
 
     const result = handleCssVar(node, withDefaultContext(program.getTypeChecker()));
 
@@ -28,8 +28,8 @@ describe('handleCssVar', () => {
       cssVar(someVar)
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, 'cssVar')[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, 'cssVar')![0];
 
     const result = handleCssVar(node, withDefaultContext(program.getTypeChecker()));
 
@@ -41,8 +41,8 @@ describe('handleCssVar', () => {
       cssVar('--some-var', '--fallback')
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, 'cssVar')[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, 'cssVar')![0];
 
     const result = handleCssVar(node, withDefaultContext(program.getTypeChecker()));
 
@@ -54,8 +54,8 @@ describe('handleCssVar', () => {
       cssVar('--some-var', cssVar('--fallback', 'red'))
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, 'cssVar')[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, 'cssVar')![0];
 
     const result = handleCssVar(node, withDefaultContext(program.getTypeChecker()));
 
@@ -67,8 +67,8 @@ describe('handleCssVar', () => {
       cssVar('--some-var'))
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, 'cssVar')[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, 'cssVar')![0];
 
     const result = handleCssVar(
       node,

--- a/modules/styling-transform/spec/utils/handleKeyframes.spec.ts
+++ b/modules/styling-transform/spec/utils/handleKeyframes.spec.ts
@@ -38,8 +38,8 @@ describe('handleKeyframes', () => {
     `);
 
     const variables = {};
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isTaggedTemplateExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isTaggedTemplateExpression)![0];
 
     handleKeyframes(
       node,
@@ -91,8 +91,8 @@ describe('handleKeyframes', () => {
 
     const styles = {};
     const variables = {};
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, 'keyframes', ts.isCallExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, 'keyframes', ts.isCallExpression)![0];
 
     handleKeyframes(node, withDefaultContext(program.getTypeChecker(), {styles, variables}));
 

--- a/modules/styling-transform/spec/utils/handlePx2Rem.spec.ts
+++ b/modules/styling-transform/spec/utils/handlePx2Rem.spec.ts
@@ -13,8 +13,8 @@ describe('handlePx2Rem', () => {
       px2rem(20)
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, 'px2rem')[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, 'px2rem')![0];
 
     const result = handlePx2Rem(node, withDefaultContext(program.getTypeChecker()));
 
@@ -26,8 +26,8 @@ describe('handlePx2Rem', () => {
       px2rem(20, 10)
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, 'px2rem')[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, 'px2rem')![0];
 
     const result = handlePx2Rem(node, withDefaultContext(program.getTypeChecker()));
 

--- a/modules/styling-transform/spec/utils/parseNodeToStaticValue.spec.ts
+++ b/modules/styling-transform/spec/utils/parseNodeToStaticValue.spec.ts
@@ -12,8 +12,8 @@ describe('parseNodeToStaticValue', () => {
       'foo'
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isStringLiteral)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isStringLiteral)![0];
 
     expect(parseNodeToStaticValue(node, withDefaultContext(program.getTypeChecker()))).toEqual(
       'foo'
@@ -25,8 +25,8 @@ describe('parseNodeToStaticValue', () => {
       12
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isNumericLiteral)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isNumericLiteral)![0];
 
     expect(parseNodeToStaticValue(node, withDefaultContext(program.getTypeChecker()))).toEqual(12);
   });
@@ -36,8 +36,8 @@ describe('parseNodeToStaticValue', () => {
       const foo = 'bar';
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isIdentifier)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isIdentifier)![0];
 
     expect(parseNodeToStaticValue(node, withDefaultContext(program.getTypeChecker()))).toEqual(
       'bar'
@@ -49,8 +49,8 @@ describe('parseNodeToStaticValue', () => {
       const foo = 12;
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isIdentifier)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isIdentifier)![0];
 
     expect(parseNodeToStaticValue(node, withDefaultContext(program.getTypeChecker()))).toEqual(12);
   });
@@ -62,8 +62,8 @@ describe('parseNodeToStaticValue', () => {
       foo.bar
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isPropertyAccessExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isPropertyAccessExpression)![0];
 
     expect(parseNodeToStaticValue(node, withDefaultContext(program.getTypeChecker()))).toEqual(
       'baz'
@@ -77,8 +77,8 @@ describe('parseNodeToStaticValue', () => {
       foo.bar.baz
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isPropertyAccessExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isPropertyAccessExpression)![0];
 
     expect(parseNodeToStaticValue(node, withDefaultContext(program.getTypeChecker()))).toEqual(12);
   });
@@ -88,8 +88,8 @@ describe('parseNodeToStaticValue', () => {
       foo.bar
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isPropertyAccessExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isPropertyAccessExpression)![0];
 
     expect(
       parseNodeToStaticValue(
@@ -110,8 +110,8 @@ describe('parseNodeToStaticValue', () => {
       foo[1]
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isElementAccessExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isElementAccessExpression)![0];
 
     expect(parseNodeToStaticValue(node, withDefaultContext(program.getTypeChecker()))).toEqual(
       '12px'
@@ -125,8 +125,8 @@ describe('parseNodeToStaticValue', () => {
       foo[0]
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isElementAccessExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isElementAccessExpression)![0];
 
     expect(parseNodeToStaticValue(node, withDefaultContext(program.getTypeChecker()))).toEqual(
       '12px'
@@ -140,8 +140,8 @@ describe('parseNodeToStaticValue', () => {
       }
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isComputedPropertyName)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isComputedPropertyName)![0];
 
     expect(
       parseNodeToStaticValue(
@@ -164,8 +164,8 @@ describe('parseNodeToStaticValue', () => {
       }
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isComputedPropertyName)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isComputedPropertyName)![0];
 
     expect(parseNodeToStaticValue(node, withDefaultContext(program.getTypeChecker()))).toEqual(
       '--bar'
@@ -177,8 +177,8 @@ describe('parseNodeToStaticValue', () => {
       \`\${myAnimation} 1s ease\`
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isTemplateExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isTemplateExpression)![0];
 
     expect(
       parseNodeToStaticValue(

--- a/modules/styling-transform/spec/utils/parseObjectToStaticValue.spec.ts
+++ b/modules/styling-transform/spec/utils/parseObjectToStaticValue.spec.ts
@@ -75,8 +75,8 @@ describe('parseObjectToStaticValue', () => {
       }
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isObjectLiteralExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isObjectLiteralExpression)![0];
 
     expect(parseObjectToStaticValue(node, withDefaultContext(program.getTypeChecker()))).toEqual({
       bar: '12px',
@@ -92,8 +92,8 @@ describe('parseObjectToStaticValue', () => {
       }
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isObjectLiteralExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isObjectLiteralExpression)![0];
 
     expect(parseObjectToStaticValue(node, withDefaultContext(program.getTypeChecker()))).toEqual({
       '&:hover': {
@@ -113,8 +113,8 @@ describe('parseObjectToStaticValue', () => {
       const bar = { ...foo }
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isObjectLiteralExpression)[2];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isObjectLiteralExpression)![2];
 
     expect(parseObjectToStaticValue(node, withDefaultContext(program.getTypeChecker()))).toEqual({
       '&:hover': {
@@ -132,8 +132,8 @@ describe('parseObjectToStaticValue', () => {
       const bar = { ...foo }
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isObjectLiteralExpression)[1];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isObjectLiteralExpression)![1];
 
     expect(parseObjectToStaticValue(node, withDefaultContext(program.getTypeChecker()))).toEqual({
       color: 'var(--var-color)',
@@ -151,8 +151,8 @@ describe('parseObjectToStaticValue', () => {
       const bar = { ...foo }
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isObjectLiteralExpression)[2];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isObjectLiteralExpression)![2];
 
     expect(parseObjectToStaticValue(node, withDefaultContext(program.getTypeChecker()))).toEqual({
       '&:hover': {
@@ -174,8 +174,8 @@ describe('parseObjectToStaticValue', () => {
       }
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isObjectLiteralExpression)[1];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isObjectLiteralExpression)![1];
 
     expect(parseObjectToStaticValue(node, withDefaultContext(program.getTypeChecker()))).toEqual({
       fontSize: '12px',
@@ -189,8 +189,8 @@ describe('parseObjectToStaticValue', () => {
       }
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isObjectLiteralExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isObjectLiteralExpression)![0];
 
     expect(
       parseObjectToStaticValue(
@@ -213,8 +213,8 @@ describe('parseObjectToStaticValue', () => {
       }
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, '', ts.isObjectLiteralExpression)[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isObjectLiteralExpression)![0];
 
     expect(
       parseObjectToStaticValue(

--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -1119,14 +1119,12 @@ export function createStencil<
       }
 
       // @ts-ignore
-      _modifiers[modifier][value] = [
+      _modifiers[modifier][value] = combineClassNames([
         // @ts-ignore
         composesModifier[modifier][value],
         // @ts-ignore
         _modifiers[modifier][value],
-      ]
-        .filter(onlyDefined)
-        .join(' ');
+      ]);
     });
   });
 
@@ -1152,16 +1150,13 @@ export function createStencil<
         _base,
         _modifiers(inputModifiers),
         compound ? _compound(inputModifiers) : '',
-      ])
-        .split(' ')
-        .filter(onlyUnique)
-        .join(' '),
+      ]),
       style: {...composesReturn?.style, ..._vars(input || {})},
     };
   }) as any;
 
   stencil.vars = _vars;
-  stencil.base = [composes?.base, _base].filter(onlyDefined).join(' ');
+  stencil.base = combineClassNames([composes?.base, _base]);
   stencil.modifiers = _modifiers as any; // The return type is conditional and TypeScript doesn't like that here
   stencil.defaultModifiers = {...composes?.defaultModifiers, ...defaultModifiers} as any;
   stencil.__extends = composes as any; // The return type is conditional and TypeScript doesn't like that here

--- a/modules/styling/spec/cs.spec.tsx
+++ b/modules/styling/spec/cs.spec.tsx
@@ -32,12 +32,12 @@ const CacheWrapper = props => <CacheProvider value={cache} {...props} />;
 const render: typeof rtlRender = (ui, options) =>
   rtlRender(ui, {wrapper: CacheWrapper, ...options});
 
-describe('createStyles', () => {
+describe('cs', () => {
   describe('createStyles', () => {
     it('should accept an object of CSS Properties', () => {
       type Input = Exclude<
         Parameters<typeof createStyles>[0],
-        string | number | boolean | SerializedStyles
+        string | number | boolean | SerializedStyles | undefined
       >;
       type PositionProperty = Input['position'];
       const temp: PositionProperty = 'absolute';
@@ -537,6 +537,15 @@ describe('createStyles', () => {
       expect(screen.getByTestId('test1')).toHaveStyle({padding: '10px'});
       expect(screen.getByTestId('test2')).toHaveStyle({padding: '20px'});
       expect(myStencil({size: 'large'}).className.split(' ')).toHaveLength(2);
+
+      // type signature of stencil call expression
+      type Arg = Parameters<typeof myStencil>[0];
+      expectTypeOf<Arg>().toMatchTypeOf<
+        | undefined
+        | {
+            size?: 'large';
+          }
+      >();
     });
 
     it('should set the `modifiers` property with the className of the modifier', () => {
@@ -677,9 +686,9 @@ describe('createStyles', () => {
         base: {},
       });
 
-      type Options = Parameters<typeof myStencil>[0];
+      type Options = Exclude<Parameters<typeof myStencil>[0], undefined>;
 
-      expectTypeOf<Options['foo']>().toEqualTypeOf<string>();
+      expectTypeOf<Options['foo']>().toEqualTypeOf<string | undefined>();
 
       // make sure we can call the function with a string
       myStencil({
@@ -800,7 +809,7 @@ describe('createStyles', () => {
         },
       });
 
-      type Arg = Parameters<typeof myStencil>[0];
+      type Arg = Exclude<Parameters<typeof myStencil>[0], undefined>;
       expectTypeOf<Arg>().toHaveProperty('width');
       expectTypeOf<Arg['width']>().toMatchTypeOf<(string & {}) | 'zero' | undefined>();
 
@@ -817,6 +826,331 @@ describe('createStyles', () => {
 
       // match base and width modifier
       expect(result2.className).toEqual(`${myStencil.base} ${myStencil.modifiers.width.zero}`);
+    });
+
+    it('should convert "true" modifiers into boolean', () => {
+      const myStencil = createStencil({
+        vars: {
+          foo: 'red',
+        },
+        base: {},
+        modifiers: {
+          size: {
+            large: {},
+          },
+          grow: {
+            true: {},
+          },
+        },
+        // make sure boolean modifiers are valid in compound config
+        compound: [{modifiers: {size: 'large', grow: true}, styles: {}}],
+      });
+
+      type Args = Exclude<Parameters<typeof myStencil>[0], undefined>;
+
+      expectTypeOf<Args>().toHaveProperty('grow');
+      expectTypeOf<Args['grow']>().toEqualTypeOf<boolean | undefined>();
+
+      // Make sure the function call passes type checks. Even though we tested the type parameter,
+      // the actual function call may still fail type checks. We need to make sure type conditionals
+      // distribute in the correct order
+      myStencil({
+        grow: true,
+      });
+    });
+
+    describe('when extending', () => {
+      it('should have both stencil class names', () => {
+        const baseStencil = createStencil({
+          base: {},
+        });
+
+        const extendedStencil = createStencil({
+          extends: baseStencil,
+          base: {},
+        });
+
+        expect(extendedStencil()).toHaveProperty(
+          'className',
+          expect.stringMatching(/css-[a-z0-9]+ css-[a-z0-9]+/)
+        );
+      });
+
+      it('should extend modifiers and return modifier class names', () => {
+        const baseStencil = createStencil({
+          base: {},
+          modifiers: {
+            size: {
+              large: {},
+            },
+          },
+        });
+
+        const extendedStencil = createStencil({
+          extends: baseStencil,
+          base: {},
+          modifiers: {
+            extra: {
+              true: {},
+            },
+          },
+        });
+
+        expect(extendedStencil.modifiers).toHaveProperty(
+          'size.large',
+          baseStencil.modifiers.size.large
+        );
+        expect(extendedStencil.modifiers).toHaveProperty('extra.true');
+        extendedStencil({size: 'large'});
+
+        expect(extendedStencil({size: 'large'})).toHaveProperty(
+          'className',
+          expect.stringContaining(baseStencil.modifiers.size.large)
+        );
+
+        // types
+        expectTypeOf(extendedStencil).toHaveProperty('modifiers');
+        expectTypeOf(extendedStencil.modifiers).toHaveProperty('size');
+        expectTypeOf(extendedStencil.modifiers.size).toHaveProperty('large');
+        expectTypeOf(extendedStencil.modifiers.size.large).toEqualTypeOf<string>();
+        expectTypeOf(extendedStencil.modifiers).toHaveProperty('extra');
+        expectTypeOf(extendedStencil.modifiers.extra).toHaveProperty('true');
+        expectTypeOf(extendedStencil.modifiers.extra.true).toEqualTypeOf<string>();
+
+        // calling the stencil
+        type Args = Exclude<Parameters<typeof extendedStencil>[0], undefined>;
+        expectTypeOf<Args>().toEqualTypeOf<{
+          size?: 'large';
+          extra?: boolean;
+        }>();
+
+        // make sure it actually works when calling it. The type test can pass via extracting parameters
+        // while the actual function call fails
+        extendedStencil({
+          extra: true,
+        });
+      });
+
+      it('should extend compound modifiers and return all compound modifiers', () => {
+        const baseStencil = createStencil({
+          vars: {
+            color: 'red',
+          },
+          base: {},
+          modifiers: {
+            size: {
+              large: {},
+            },
+          },
+          compound: [{modifiers: {size: 'large'}, styles: {}}],
+        });
+
+        const extendedStencil = createStencil({
+          extends: baseStencil,
+          vars: {
+            background: 'blue',
+          },
+          base: {},
+          modifiers: {
+            extra: {
+              true: {},
+            },
+          },
+          compound: [
+            {modifiers: {size: 'large'}, styles: {}},
+            {modifiers: {size: 'large', extra: true}, styles: {}},
+          ],
+        });
+
+        extendedStencil({color: 'blue', background: 'red'});
+
+        const {className} = extendedStencil({size: 'large'});
+
+        expect(className.split(' ')).toHaveProperty('length', 5);
+
+        // calling the stencil
+        type Args = Exclude<Parameters<typeof extendedStencil>[0], undefined>;
+        expectTypeOf<Args>().toEqualTypeOf<{
+          size?: 'large';
+          extra?: boolean;
+          color?: string;
+          background?: string;
+        }>();
+
+        // Verify the actual function call does not give an error for boolean even if the type test says it works
+        extendedStencil({
+          extra: true,
+        });
+      });
+
+      it('should set default modifiers using base modifiers', () => {
+        const baseStencil = createStencil({
+          base: {},
+          modifiers: {
+            size: {
+              large: {width: '100rem'},
+            },
+          },
+        });
+
+        const extendedStencil = createStencil({
+          extends: baseStencil,
+          base: {},
+          modifiers: {
+            extra: {
+              true: {},
+            },
+          },
+          defaultModifiers: {size: 'large'},
+        });
+
+        // calling the stencil
+        type Args = Exclude<Parameters<typeof extendedStencil>[0], undefined>;
+        expectTypeOf<Args>().toEqualTypeOf<{
+          size?: 'large';
+          extra?: boolean;
+        }>();
+      });
+
+      it('should extend variables', () => {
+        const baseStencil = createStencil({
+          vars: {
+            color: 'red',
+          },
+          base: {},
+        });
+
+        const extendedStencil = createStencil({
+          vars: {
+            background: 'blue',
+          },
+          extends: baseStencil,
+          base: {},
+        });
+
+        expectTypeOf(extendedStencil.vars.color).toEqualTypeOf<string>();
+        expect(extendedStencil).toHaveProperty(
+          'vars.color',
+          expect.stringMatching(/--[0-9a-z]+-color/i)
+        );
+
+        expectTypeOf(extendedStencil.vars.background).toEqualTypeOf<string>();
+        expect(extendedStencil).toHaveProperty(
+          'vars.background',
+          expect.stringMatching(/--[0-9a-z]+-background/i)
+        );
+      });
+
+      it('should extend variables with IDs', () => {
+        const baseStencil = createStencil(
+          {
+            vars: {
+              color: 'red',
+            },
+            base: {},
+          },
+          'base'
+        );
+
+        const extendedStencil = createStencil(
+          {
+            extends: baseStencil,
+            vars: {
+              background: 'blue',
+            },
+            base({color, background}) {
+              expectTypeOf(color).toMatchTypeOf<string>();
+              expectTypeOf(background).toMatchTypeOf<string>();
+              return {};
+            },
+          },
+          'extended'
+        );
+
+        expectTypeOf(extendedStencil.vars.color).toEqualTypeOf<'--base-color'>();
+        expectTypeOf(extendedStencil.vars.background).toEqualTypeOf<'--extended-background'>();
+        expectTypeOf(extendedStencil.vars.$$defaults).toHaveProperty('--base-color');
+        expectTypeOf(extendedStencil.vars.$$defaults).toHaveProperty('--extended-background');
+        expectTypeOf(extendedStencil.vars.$$defaults['--base-color']).toMatchTypeOf<string>();
+        expectTypeOf(
+          extendedStencil.vars.$$defaults['--extended-background']
+        ).toMatchTypeOf<string>();
+
+        expect(extendedStencil).toHaveProperty('vars.color', '--base-color');
+
+        expect(extendedStencil).toHaveProperty('vars.background', '--extended-background');
+      });
+
+      it('should extend, adding class names in the correct order', () => {
+        const baseStencil = createStencil(
+          {
+            base: {
+              color: 'red',
+            },
+            modifiers: {
+              size: {
+                large: {
+                  color: 'pink',
+                },
+                small: {
+                  color: 'lightgreen',
+                },
+              },
+              position: {
+                only: {},
+                start: {},
+              },
+            },
+            compound: [
+              {
+                modifiers: {size: 'large', position: 'only'},
+                styles: {},
+              },
+            ],
+          },
+          'base'
+        );
+
+        const extendedStencil = createStencil(
+          {
+            extends: baseStencil,
+            base: {
+              color: 'green',
+            },
+            modifiers: {
+              size: {
+                large: {},
+                small: {},
+              },
+            },
+            compound: [
+              {
+                modifiers: {size: 'large', position: 'only'},
+                styles: {
+                  color: 'var(--extended-compound-icon-only)',
+                },
+              },
+            ],
+          },
+          'extended'
+        );
+
+        expect(extendedStencil.base.split(' ')).toHaveLength(2);
+        expect(extendedStencil.base).toMatch(new RegExp(`^${baseStencil.base}`));
+        expect(extendedStencil.modifiers.size.large.split(' ')).toHaveLength(2);
+        expect(extendedStencil.modifiers.size.large).toMatch(
+          new RegExp(`^${baseStencil.modifiers.size.large}`)
+        );
+
+        // Expect all base styles, modifiers, and compound modifiers to be included
+        const {className} = extendedStencil({size: 'large', position: 'only'});
+        expect(className).toContain(baseStencil.base);
+        expect(className).toContain(baseStencil.modifiers.size.large);
+        expect(className).toContain(baseStencil.modifiers.position.only);
+
+        // baseStencil.base, baseStencil large, baseStencil only position, baseStencil compound, extendedStencil.base, extendedStencil large, extendedStencil compound
+        expect(className.split(' ')).toHaveLength(7);
+      });
     });
   });
 });

--- a/modules/styling/spec/tsconfig.json
+++ b/modules/styling/spec/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "extends": "../../../tsconfig.spec.json",
-  "compilerOptions": {
-    "strictNullChecks": true
-  }
+  "extends": "../../../tsconfig.spec.json"
 }

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["./jest/testing-library__jest-dom.d.ts", "./jest/verifyComponent.d.ts", "**/*.spec.tsx", "**/*.spec.ts","jest/setupTests.ts"],
+  "include": [
+    "./jest/testing-library__jest-dom.d.ts",
+    "./jest/verifyComponent.d.ts",
+    "**/*.spec.tsx",
+    "**/*.spec.ts",
+    "jest/setupTests.ts"
+  ],
   "exclude": ["cypress"],
   "compilerOptions": {
     "declaration": false,
@@ -10,7 +16,7 @@
     "preserveConstEnums": true,
     "allowUnreachableCode": false,
     "noImplicitAny": false,
-    "strictNullChecks": false,
+    "strictNullChecks": true,
     "noUnusedLocals": false,
     "types": ["jest"],
     "incremental": false

--- a/utils/style-transform/spec/handleFocusRing.spec.ts
+++ b/utils/style-transform/spec/handleFocusRing.spec.ts
@@ -14,8 +14,8 @@ describe('handleFocusRing', () => {
       focusRing()
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, 'focusRing')[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, 'focusRing')![0];
 
     const result = handleFocusRing(node, withDefaultContext(program.getTypeChecker()));
 
@@ -32,8 +32,8 @@ describe('handleFocusRing', () => {
       })
     `);
 
-    const sourceFile = program.getSourceFile('test.ts');
-    const node = findNodes(sourceFile, 'focusRing')[0];
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, 'focusRing')![0];
 
     const result = handleFocusRing(
       node,


### PR DESCRIPTION
## Summary

This commit adds back code that was accidentally removed during the last merge and fixes some merge conflicts that had the wrong merge. I also enabled `strictNullChecks` on specs. It should have failed the build, not allowing a lot of mistaken merge conflicts.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Infrastructure

---

## Checklist

- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)
