### PR TITLE
feat: Add flex styles to mergeStyles

### DIFF
--- a/modules/react/layout/lib/utils/mergeStyles.ts
+++ b/modules/react/layout/lib/utils/mergeStyles.ts
@@ -4,6 +4,7 @@ import {backgroundStyleFnConfigs} from './background';
 import {borderStyleFnConfigs} from './border';
 import {colorStyleFnConfigs} from './color';
 import {depthStyleFnConfigs} from './depth';
+import {flexStyleFnConfigs} from './flex';
 import {flexItemStyleFnConfigs} from './flexItem';
 import {gridItemStyleFnConfigs} from './gridItem';
 import {layoutStyleFnConfigs} from './layout';
@@ -19,6 +20,7 @@ const stylePropHash = [
   ...borderStyleFnConfigs,
   ...colorStyleFnConfigs,
   ...depthStyleFnConfigs,
+  ...flexStyleFnConfigs,
   ...flexItemStyleFnConfigs,
   ...gridItemStyleFnConfigs,
   ...layoutStyleFnConfigs,

--- a/modules/react/layout/lib/utils/mergeStyles.ts
+++ b/modules/react/layout/lib/utils/mergeStyles.ts
@@ -1,5 +1,6 @@
 import {CSToPropsInput, handleCsProp} from '@workday/canvas-kit-styling';
 import {boxStyleFn} from '../Box';
+import {flex} from '../utils/flex';
 import {backgroundStyleFnConfigs} from './background';
 import {borderStyleFnConfigs} from './border';
 import {colorStyleFnConfigs} from './color';
@@ -77,7 +78,7 @@ export function mergeStyles<T extends {}>(
   // We have style props. We need to create style and merge with our `csToProps` to get the correct
   // merging order for styles
   if (shouldRuntimeMergeStyles) {
-    styles = boxStyleFn(styleProps);
+    styles = {...boxStyleFn(styleProps), ...flex(styleProps)};
   }
 
   return handleCsProp(elemProps, [localCs, styles]) as Omit<T, 'cs' | keyof CommonStyleProps>;


### PR DESCRIPTION
## Summary

Flex style props are not part of `mergeStyles`. This will cause breaking changes if we remove style props from a component when an application uses flex style props. For example,

```tsx
<ListBox flexDirection="row">...</ListBox>
```

If we used a `flexDirection` style prop in v10, but move it to a Stencil in v11, the `flexDirection="row"` will no longer work. This is because `mergeStyles` is covering all style props except for flex style props like `flexDirection`. The `flexDirection` prop will be prop drilled all the way down to the `Flex` layout component which will now be applied under the `flexDirection: 'column'` of the Stencil, changing the behavior of the style prop. It is not our intention to break style props in v11, so the `mergeStyles` should handle all style props so that passing style props this way always overrides.

## Release Category
Components

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)
