### PR TITLE
fix(styling): Fix parent selectors in compat mode

### DIFF
--- a/modules/styling-transform/lib/styleTransform.ts
+++ b/modules/styling-transform/lib/styleTransform.ts
@@ -12,6 +12,7 @@ import {handleCssVar} from './utils/handleCssVar';
 import {Config, NodeTransformer, ObjectTransform, TransformerContext} from './utils/types';
 import {handleKeyframes} from './utils/handleKeyframes';
 import {handleInjectGlobal} from './utils/handleInjectGlobal';
+import {handleParentModifier} from './utils/handleParentModifier';
 
 export type NestedStyleObject = {[key: string]: string | NestedStyleObject};
 
@@ -140,7 +141,7 @@ export function withDefaultContext(
     objectTransforms: [] as ObjectTransform[],
     transform: handleTransformers(transformers || defaultTransformers),
     ...input,
-    propertyTransforms: [handleCalc, handlePx2Rem, handleCssVar].concat(
+    propertyTransforms: [handleCalc, handlePx2Rem, handleCssVar, handleParentModifier].concat(
       input.propertyTransforms || []
     ),
   } as TransformerContext;

--- a/modules/styling-transform/lib/utils/handleCreateStencil.ts
+++ b/modules/styling-transform/lib/utils/handleCreateStencil.ts
@@ -14,7 +14,7 @@ import {getHash} from './getHash';
  * Handle all arguments of the CallExpression `createStencil()`
  */
 export const handleCreateStencil: NodeTransformer = (node, context) => {
-  const {checker, prefix, names, extractedNames} = context;
+  const {checker, names, extractedNames} = context;
   /**
    * This will match whenever a `createStencil()` call expression is encountered. It will loop
    * over all the config to extract variables and styles.
@@ -423,11 +423,11 @@ function createStyleReplacementNode(
   className: string,
   context: TransformerContext
 ) {
-  const {prefix, names, extractedNames} = context;
+  const {names, extractedNames} = context;
   const serialized = serializeStyles(node, styleObj, `.${className}{%s}`, context);
 
   const varName = getVarName(node);
-  const value = `${prefix}-${serialized.name}`;
+  const value = `css-${serialized.name}`;
   names[varName] = value;
   extractedNames[value] = getClassName(varName, context);
 

--- a/modules/styling-transform/lib/utils/handleParentModifier.ts
+++ b/modules/styling-transform/lib/utils/handleParentModifier.ts
@@ -1,0 +1,29 @@
+import ts from 'typescript';
+
+import {parentModifier} from '@workday/canvas-kit-styling';
+import {createPropertyTransform} from '../createPropertyTransform';
+import {parseNodeToStaticValue} from './parseNodeToStaticValue';
+
+export const handleParentModifier = createPropertyTransform((node, context) => {
+  const {names, extractedNames} = context;
+
+  if (
+    ts.isComputedPropertyName(node) &&
+    ts.isCallExpression(node.expression) &&
+    ts.isIdentifier(node.expression.expression) &&
+    node.expression.expression.text === 'parentModifier'
+  ) {
+    const args = node.expression.arguments.map(arg => parseNodeToStaticValue(arg, context));
+    const hash = args[0].toString().replace('css-', '');
+
+    // add a mapping from `css-{hash}` to `{hash}` for extraction string replacement
+    names[args[0]] = hash;
+
+    // map the `{hash}` to the extracted CSS class name
+    extractedNames[hash] = extractedNames[args[0]];
+
+    return parentModifier(args[0].toString());
+  }
+
+  return;
+});

--- a/modules/styling-transform/spec/utils/handleParentModifier.spec.ts
+++ b/modules/styling-transform/spec/utils/handleParentModifier.spec.ts
@@ -1,0 +1,82 @@
+import ts from 'typescript';
+
+import {createProgramFromSource} from '../createProgramFromSource';
+
+import {transform, withDefaultContext, _reset} from '../../lib/styleTransform';
+import {compileCSS} from '../../lib/utils/createStyleObjectNode';
+
+describe('handleParentModifier', () => {
+  let program: ts.Program;
+  let result: string;
+
+  const styles = {};
+  const names = {};
+  const extractedNames = {};
+
+  beforeAll(() => {
+    _reset();
+    program = createProgramFromSource(`
+      import {createStencil, parentModifier} from '@workday/canvas-kit-styling';
+
+      const buttonStencil = createStencil({
+        vars: {
+          color: 'red'
+        },
+        base: {},
+        modifiers: {
+          size: {
+            large: {padding: 20},
+            small: {padding: 10}
+          }
+        }
+      })
+
+      const childStencil = createStencil({
+        base: {
+          [parentModifier(buttonStencil.modifiers.size.large)]: {
+            color: 'blue',
+          }
+        }
+      })
+    `);
+
+    result = transform(
+      program,
+      'test.ts',
+      withDefaultContext(program.getTypeChecker(), {styles, names, extractedNames})
+    );
+  });
+
+  it('should add a mapping from the CSS class name to the hash to the names cache', () => {
+    expect(names).toHaveProperty(
+      names['buttonStencil.modifiers.size.large'],
+      names['buttonStencil.modifiers.size.large'].replace('css-', '')
+    );
+  });
+
+  it('should add a mapping from the hash to the extracted CSS class name to the extractedNames cache', () => {
+    expect(extractedNames).toHaveProperty(
+      names['buttonStencil.modifiers.size.large'].replace('css-', ''),
+      'css-button--size-large'
+    );
+  });
+
+  it('should transform the runtime to include a selector with only the hash', () => {
+    expect(result).toContain(
+      `.${names['buttonStencil.modifiers.size.large'].replace('css-', '')} :where(&){color:blue;}`
+    );
+  });
+
+  it('should extract CSS to include the fully qualified modifier name', () => {
+    expect(styles['test.css']).toContainEqual(
+      compileCSS(`
+          .css-child {
+            box-sizing: border-box;
+          }
+          .css-button--size-large :where(.css-child) {
+            color: blue;
+          }
+      `)
+    );
+  });
+});

--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -1153,6 +1153,7 @@ export function createStencil<
     // Only override defaults if a value is defined
     for (const key in input) {
       if (input[key]) {
+        // @ts-ignore
         inputModifiers[key] = input[key];
       }
     }

--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -1050,6 +1050,26 @@ function combineClassNames(input: (string | undefined)[]): string {
 }
 
 /**
+ * This function is used in conjunction with Stencils to get a selector to match the current element
+ * and a parent modifier. The selector will match a parent element with a modifier applied and the current
+ * element. It should be used on the `base` config of a Stencil.
+ *
+ * ```ts
+ * const childStencil = createStencil({
+ *   base: {
+ *     // base styles
+ *     [parentModifier(parentStencil.modifiers.size.large)]: {
+ *       // maybe adjust padding of this element
+ *     }
+ *   }
+ * })
+ * ```
+ */
+export function parentModifier(value: string) {
+  return `.${value.replace('css-', '')} :where(&)`;
+}
+
+/**
  * Creates a reuseable Stencil for styling elements. It takes vars, base styles, modifiers, and
  * compound modifiers.
  */
@@ -1087,6 +1107,7 @@ export function createStencil<
             result[modifierKey] = createStyles(
               typeof modifier === 'function' ? modifier(_vars) : modifier
             );
+
             return result;
           }, {});
 
@@ -1127,14 +1148,25 @@ export function createStencil<
       )
     : () => '';
 
-  const stencil: Stencil<M, V, E, ID> = ((input: {}) => {
-    const inputModifiers = {...composes?.defaultModifiers, ...defaultModifiers, ...input};
+  const stencil: Stencil<M, V, E, ID> = ((input: Record<string, string>) => {
+    const inputModifiers = {...composes?.defaultModifiers, ...defaultModifiers};
+    // Only override defaults if a value is defined
+    for (const key in input) {
+      if (input[key]) {
+        inputModifiers[key] = input[key];
+      }
+    }
     const composesReturn = composes?.(inputModifiers as any);
+    const modifierClasses = _modifiers(inputModifiers);
     return {
       className: combineClassNames([
         composesReturn?.className,
         _base,
-        _modifiers(inputModifiers),
+        modifierClasses,
+        modifierClasses
+          .split(' ')
+          .map(c => c.replace('css-', ''))
+          .join(' '),
         compound ? _compound(inputModifiers) : '',
       ]),
       style: {...composesReturn?.style, ..._vars(input || {})},

--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -1163,6 +1163,12 @@ export function createStencil<
         composesReturn?.className,
         _base,
         modifierClasses,
+        // For compat mode, we need to add inert class names of modifiers where the `css-` prefix is
+        // removed. For example, `css-base css-mod-1` will become `css-base css-mod-1 mod-1`. The
+        // modifier class without the prefix will be ignored by the Emotion CSS `cx` function and
+        // will remain for the `parentModifier` function to still select on. We decided to add these
+        // inert class names instead of adding `data-m-*` attributes because the output DOM looks
+        // much cleaner and it saves bytes on the bundled output.
         modifierClasses
           .split(' ')
           .map(c => c.replace('css-', ''))

--- a/modules/styling/spec/cs.spec.tsx
+++ b/modules/styling/spec/cs.spec.tsx
@@ -823,9 +823,6 @@ describe('cs', () => {
               width: '0',
             },
           },
-          foo: {
-            true: {},
-          },
         },
       });
 


### PR DESCRIPTION
## Summary

PR #2741 added the ability to target parent modifier class names to build selectors, but doesn't work in compat mode because compat mode merges all the CSS class names into a single, new class name. I added a `parentModifiers` function that handles this for both React Kit and CSS Kit and updated stencils to add inert class names for the purpose of always matching a selector.

I also fixed a bug where passing `undefined` to a Stencil for a modifier key resulted in overriding `defaultModifiers`.

## Release Category
Styling

---

**Before**:

React static mode
```tsx
<div {...mergeStyles(elemProps, myStencil({ size: 'large' }))} />
```

HTML
```html
<div class="css-12345 css-abcde"></div>
```

Styles
```css
.css-abcde :where(.css-123ab) {
  ...
}
```

React compat mode
```tsx
<div {...mergeStyles(elemProps, [myStencil({ size: 'large' }), {maxWidth: 100}])} />
```

HTML
```html
<div class="css-merged"></div>
```

Styles
```css
.css-abcde :where(.css-123ab) {
  ...
}
```

Since compat mode merges class names together, the selector no longer works. This change forces the Stencil to add a class name of the modifier without the `css-` prefix. This still encodes needed information without the class name being removed by Emotion's `cx` function when style merging. The class names are inert directly (no selector matches), but are used by the `parentModifier` function.

**After**

React compat mode
```tsx
<div {...mergeStyles(elemProps, [myStencil({ size: 'large' }), {maxWidth: 100}])} />
```

HTML
```html
<div class="css-merged abcde"></div>
```

Styles
```css
.abcde :where(.css-123ab) {
  ...
}
```

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

Tests