### PR TITLE
chore(form-field): Update the preview FormField Stencil

### DIFF
--- a/modules/css/package.json
+++ b/modules/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workday/canvas-kit-css",
-  "version": "10.3.36",
+  "version": "10.3.39",
   "description": "The parent module that contains all Workday Canvas Kit CSS components",
   "author": "Workday, Inc. (https://www.workday.com)",
   "license": "Apache-2.0",

--- a/modules/docs/mdx/11.0-UPGRADE-GUIDE.mdx
+++ b/modules/docs/mdx/11.0-UPGRADE-GUIDE.mdx
@@ -524,7 +524,8 @@ variant prop.
 
 ### Form Field (Preview)
 
-**PR:** [#2472](https://github.com/Workday/canvas-kit/pull/2472)
+**PR:** [#2472](https://github.com/Workday/canvas-kit/pull/2472),
+[#2746](https://github.com/Workday/canvas-kit/pull/2746)
 
 `FormField` in [Preview](#preview) is a compound component and we intend to promote it in a future
 version to replace the `FormField` in [Main](#main). Because of this, we've refactored how errors
@@ -538,6 +539,26 @@ are applied to `FormField` in [Preview](#preview) in order to match the API from
 - `FormField` does **not** support the `useFieldSet` prop that the `FormField` in [Main](#main)
   does. In order to achieve the same behavior, set the `as` prop on the `FormField` element to
   `fieldset` and the `as` prop of `FormField.Label` to `legend`.
+- The required asterisk is now a pseudo element. While the asterisk was never read out loud by
+  screen readers, Testing Library required it in the `*ByLabelText` query. `*ByRole` uses the w3c
+  [accessible name calculation specification](https://www.w3.org/TR/accname-1.2/), but
+  `*ByLabelText` uses
+  [textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent). Additional
+  information: https://github.com/testing-library/dom-testing-library/issues/929
+
+  v10:
+
+  ```ts
+  screen.getByLabelText('Email*'); // Email is a required field and asterisk is included in name
+  screen.getByRole('textbox', {name: 'Email'}); // correctly ignores the `*`
+  ```
+
+  v11:
+
+  ```ts
+  screen.getByLabelText('Email');
+  screen.getByRole('textbox', {name: 'Email'});
+  ```
 
 ```tsx
 // v10 FormField in Preview

--- a/modules/labs-css/package.json
+++ b/modules/labs-css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workday/canvas-kit-labs-css",
-  "version": "10.3.36",
+  "version": "10.3.39",
   "description": "The parent module that contains all Workday Canvas Kit Labs CSS components",
   "author": "Workday, Inc. (https://www.workday.com)",
   "license": "Apache-2.0",

--- a/modules/preview-css/package.json
+++ b/modules/preview-css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workday/canvas-kit-preview-css",
-  "version": "10.3.36",
+  "version": "10.3.39",
   "description": "The parent module that contains all Workday Canvas Kit Preview CSS components",
   "author": "Workday, Inc. (https://www.workday.com)",
   "license": "Apache-2.0",

--- a/modules/preview-react/form-field/index.ts
+++ b/modules/preview-react/form-field/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/FormField';
 export * from './lib/hooks/';
+export {formFieldStencil} from './lib/formFieldStencil';

--- a/modules/preview-react/form-field/index.ts
+++ b/modules/preview-react/form-field/index.ts
@@ -1,3 +1,6 @@
 export * from './lib/FormField';
 export * from './lib/hooks/';
 export {formFieldStencil} from './lib/formFieldStencil';
+export {formFieldContainerStencil} from './lib/FormFieldContainer';
+export {formFieldHintStencil} from './lib/FormFieldHint';
+export {formFieldLabelStencil} from './lib/FormFieldLabel';

--- a/modules/preview-react/form-field/lib/FormField.tsx
+++ b/modules/preview-react/form-field/lib/FormField.tsx
@@ -1,37 +1,24 @@
 import React from 'react';
 
 import {createContainer, GrowthBehavior} from '@workday/canvas-kit-react/common';
-import {Flex, FlexProps, mergeStyles} from '@workday/canvas-kit-react/layout';
-import {createStencil} from '@workday/canvas-kit-styling';
-import {system} from '@workday/canvas-tokens-web';
+import {FlexProps, mergeStyles} from '@workday/canvas-kit-react/layout';
 
-import {useFormFieldModel, useFormFieldOrientation} from './hooks';
+import {useFormFieldModel} from './hooks';
 import {FormFieldInput} from './FormFieldInput';
 import {FormFieldLabel} from './FormFieldLabel';
 import {FormFieldHint} from './FormFieldHint';
 import {FormFieldContainer} from './FormFieldContainer';
+import {formFieldStencil} from './formFieldStencil';
 
 export interface FormFieldProps extends FlexProps, GrowthBehavior {
+  /**
+   * The direction the child elements should stack
+   * @default vertical
+   */
+  orientation?: 'vertical' | 'horizontal';
   children: React.ReactNode;
 }
 
-const formFieldStencil = createStencil({
-  base: {
-    border: 'none',
-    padding: system.space.zero,
-    margin: `${system.space.zero} ${system.space.zero} ${system.space.x6}`,
-  },
-  modifiers: {
-    grow: {
-      true: {
-        width: '100%',
-        '[data-width="ck-formfield-width"]': {
-          width: '100%',
-        },
-      },
-    },
-  },
-});
 /**
  * Use `FormField` to wrap input components to make them accessible. You can customize the field
  * by passing in `TextInput`, `Select`, `RadioGroup` and other form elements to `FormField.Input` through the `as` prop.
@@ -42,6 +29,8 @@ const formFieldStencil = createStencil({
  *    <FormField.Input as={TextInput} value={value} onChange={(e) => console.log(e)} />
  *  </FormField>
  * ```
+ *
+ * @stencil formFieldStencil
  */
 export const FormField = createContainer('div')({
   displayName: 'FormField',
@@ -70,6 +59,8 @@ export const FormField = createContainer('div')({
      *    <FormField.Input as={TextInput} value={value} onChange={(e) => console.log(e)} />
      *  </FormField>
      * ```
+     *
+     * @stencil formFieldLabelStencil
      */
     Label: FormFieldLabel,
     /**
@@ -83,6 +74,8 @@ export const FormField = createContainer('div')({
      *    <FormField.Hint>This is your hint text</FormField.Hint>
      *  </FormField>
      * ```
+     *
+     * @stencil formFieldHintStencil
      */
     Hint: FormFieldHint,
     /**
@@ -97,19 +90,25 @@ export const FormField = createContainer('div')({
      *    </FormField.Container>
      *  </FormField>
      * ```
+     *
+     * @stencil formFieldContainerStencil
      */
     Container: FormFieldContainer,
   },
-})<FormFieldProps>(({children, ...elemProps}, Element, model) => {
-  const layoutProps = useFormFieldOrientation(model.state.orientation);
-
+})<FormFieldProps>(({children, grow, orientation, ...elemProps}, Element, model) => {
   return (
-    <Flex
-      as={Element}
-      {...layoutProps}
-      {...mergeStyles(elemProps, formFieldStencil({grow: elemProps.grow}))}
+    <Element
+      {...mergeStyles(
+        elemProps,
+        formFieldStencil({
+          grow,
+          orientation,
+          error: model.state.error,
+          required: model.state.isRequired,
+        })
+      )}
     >
       {children}
-    </Flex>
+    </Element>
   );
 });

--- a/modules/preview-react/form-field/lib/FormFieldContainer.tsx
+++ b/modules/preview-react/form-field/lib/FormFieldContainer.tsx
@@ -5,7 +5,7 @@ import {handleCsProp, CSProps, createStencil} from '@workday/canvas-kit-styling'
 
 import {useFormFieldModel} from './hooks';
 
-const formFieldContainerStencil = createStencil({
+export const formFieldContainerStencil = createStencil({
   base: {
     display: 'flex',
     flexDirection: 'column',

--- a/modules/preview-react/form-field/lib/FormFieldHint.tsx
+++ b/modules/preview-react/form-field/lib/FormFieldHint.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
+
 import {createSubcomponent, ExtractProps} from '@workday/canvas-kit-react/common';
 import {system, brand} from '@workday/canvas-tokens-web';
-import {createStencil, handleCsProp, parentModifier} from '@workday/canvas-kit-styling';
+import {createStencil, parentModifier} from '@workday/canvas-kit-styling';
+import {Text, textStencil} from '@workday/canvas-kit-react/text';
+import {mergeStyles} from '@workday/canvas-kit-react/layout';
 
 import {useFormFieldHint, useFormFieldModel} from './hooks';
-import {Subtext} from '@workday/canvas-kit-react/text';
 import {formFieldStencil} from './formFieldStencil';
 
 export const formFieldHintStencil = createStencil({
+  extends: textStencil,
   base: {
     margin: `${system.space.x2} ${system.space.zero} ${system.space.zero}`,
 
@@ -15,21 +18,24 @@ export const formFieldHintStencil = createStencil({
       color: brand.error.base,
     },
   },
+  defaultModifiers: {
+    typeLevel: 'subtext.medium',
+  },
 });
 
 export const FormFieldHint = createSubcomponent('p')({
   displayName: 'FormField.Hint',
   modelHook: useFormFieldModel,
   elemPropsHook: useFormFieldHint,
-})<Omit<ExtractProps<typeof Subtext, never>, 'size'>>(({children, ...elemProps}, Element) => {
+})<ExtractProps<typeof Text, never>>(({children, typeLevel, variant, ...elemProps}, Element) => {
   if (!children) {
     // If there is no hint text just skip rendering
     return null;
   }
 
   return (
-    <Subtext as={Element} size="medium" {...handleCsProp(elemProps, formFieldHintStencil())}>
+    <Element {...mergeStyles(elemProps, formFieldHintStencil({typeLevel, variant}))}>
       {children}
-    </Subtext>
+    </Element>
   );
 });

--- a/modules/preview-react/form-field/lib/FormFieldHint.tsx
+++ b/modules/preview-react/form-field/lib/FormFieldHint.tsx
@@ -1,22 +1,18 @@
 import React from 'react';
 import {createSubcomponent, ExtractProps} from '@workday/canvas-kit-react/common';
 import {system, brand} from '@workday/canvas-tokens-web';
-import {createStencil} from '@workday/canvas-kit-styling';
+import {createStencil, handleCsProp, parentModifier} from '@workday/canvas-kit-styling';
 
 import {useFormFieldHint, useFormFieldModel} from './hooks';
 import {Subtext} from '@workday/canvas-kit-react/text';
-import {mergeStyles} from '@workday/canvas-kit-react/layout';
+import {formFieldStencil} from './formFieldStencil';
 
-const formFieldHintStencil = createStencil({
+export const formFieldHintStencil = createStencil({
   base: {
     margin: `${system.space.x2} ${system.space.zero} ${system.space.zero}`,
-  },
-  modifiers: {
-    error: {
-      error: {
-        color: brand.error.base,
-      },
-      alert: {},
+
+    [parentModifier(formFieldStencil.modifiers.error.error)]: {
+      color: brand.error.base,
     },
   },
 });
@@ -25,21 +21,15 @@ export const FormFieldHint = createSubcomponent('p')({
   displayName: 'FormField.Hint',
   modelHook: useFormFieldModel,
   elemPropsHook: useFormFieldHint,
-})<Omit<ExtractProps<typeof Subtext, never>, 'size'>>(
-  ({children, ...elemProps}, Element, model) => {
-    if (!children) {
-      // If there is no hint text just skip rendering
-      return null;
-    }
-
-    return (
-      <Subtext
-        as={Element}
-        size="medium"
-        {...mergeStyles(elemProps, formFieldHintStencil({error: model.state.error}))}
-      >
-        {children}
-      </Subtext>
-    );
+})<Omit<ExtractProps<typeof Subtext, never>, 'size'>>(({children, ...elemProps}, Element) => {
+  if (!children) {
+    // If there is no hint text just skip rendering
+    return null;
   }
-);
+
+  return (
+    <Subtext as={Element} size="medium" {...handleCsProp(elemProps, formFieldHintStencil())}>
+      {children}
+    </Subtext>
+  );
+});

--- a/modules/preview-react/form-field/lib/FormFieldLabel.tsx
+++ b/modules/preview-react/form-field/lib/FormFieldLabel.tsx
@@ -14,7 +14,7 @@ export interface FormFieldLabelProps extends FlexProps {
   children: React.ReactNode;
 }
 
-const formFieldLabelStencil = createStencil({
+export const formFieldLabelStencil = createStencil({
   base: {
     ...system.type.subtext.large,
     fontWeight: system.fontWeight.medium,

--- a/modules/preview-react/form-field/lib/FormFieldLabel.tsx
+++ b/modules/preview-react/form-field/lib/FormFieldLabel.tsx
@@ -30,15 +30,6 @@ export const formFieldLabelStencil = createStencil({
     alignItems: 'center',
     minWidth: px2rem(180),
 
-    '& :where([data-element=asterisk])': {
-      display: 'none',
-      fontSize: system.fontSize.body.large,
-      fontWeight: system.fontWeight.normal,
-      color: brand.error.base,
-      textDecoration: 'unset',
-      marginInlineStart: system.space.x1,
-    },
-
     // asterisk
     [parentModifier(formFieldStencil.modifiers.required.true)]: {
       '&::after': {
@@ -73,9 +64,6 @@ export const FormFieldLabel = createSubcomponent('label')({
   return (
     <Element {...mergeStyles(elemProps, formFieldLabelStencil({typeLevel, variant}))}>
       {children}
-      {/* <span data-element="asterisk" aria-hidden="true">
-        *
-      </span> */}
     </Element>
   );
 });

--- a/modules/preview-react/form-field/lib/FormFieldLabel.tsx
+++ b/modules/preview-react/form-field/lib/FormFieldLabel.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
 
-import {createSubcomponent} from '@workday/canvas-kit-react/common';
-import {useFormFieldLabel, useFormFieldModel} from './hooks';
+import {createSubcomponent, ExtractProps} from '@workday/canvas-kit-react/common';
 import {createStencil, parentModifier, px2rem} from '@workday/canvas-kit-styling';
+import {Text, textStencil} from '@workday/canvas-kit-react/text';
 import {FlexProps, mergeStyles} from '@workday/canvas-kit-react/layout';
 import {brand, system} from '@workday/canvas-tokens-web';
+
+import {useFormFieldLabel, useFormFieldModel} from './hooks';
 import {formFieldStencil} from './formFieldStencil';
 
-export interface FormFieldLabelProps extends FlexProps {
+export interface FormFieldLabelProps
+  extends FlexProps,
+    Omit<ExtractProps<typeof Text, never>, 'display'> {
   /**
    * The text of the label.
    */
@@ -15,8 +19,9 @@ export interface FormFieldLabelProps extends FlexProps {
 }
 
 export const formFieldLabelStencil = createStencil({
+  extends: textStencil,
+  // @ts-ignore Still weird about CSS variables
   base: {
-    ...system.type.subtext.large,
     fontWeight: system.fontWeight.medium,
     color: system.color.text.default,
     paddingInlineStart: system.space.zero,
@@ -25,7 +30,6 @@ export const formFieldLabelStencil = createStencil({
     alignItems: 'center',
     minWidth: px2rem(180),
 
-    // @ts-ignore The nested selectors don't like CSS variables yet
     '& :where([data-element=asterisk])': {
       display: 'none',
       fontSize: system.fontSize.body.large,
@@ -49,15 +53,18 @@ export const formFieldLabelStencil = createStencil({
       width: '100%',
     },
   },
+  defaultModifiers: {
+    typeLevel: 'subtext.large',
+  },
 });
 
 export const FormFieldLabel = createSubcomponent('label')({
   displayName: 'FormField.Label',
   modelHook: useFormFieldModel,
   elemPropsHook: useFormFieldLabel,
-})<FormFieldLabelProps>(({children, ...elemProps}, Element) => {
+})<FormFieldLabelProps>(({children, typeLevel, variant, ...elemProps}, Element) => {
   return (
-    <Element {...mergeStyles(elemProps, formFieldLabelStencil())}>
+    <Element {...mergeStyles(elemProps, formFieldLabelStencil({typeLevel, variant}))}>
       {children}
       <span data-element="asterisk" aria-hidden="true">
         *

--- a/modules/preview-react/form-field/lib/FormFieldLabel.tsx
+++ b/modules/preview-react/form-field/lib/FormFieldLabel.tsx
@@ -39,9 +39,16 @@ export const formFieldLabelStencil = createStencil({
       marginInlineStart: system.space.x1,
     },
 
-    // asterisk element
+    // asterisk
     [parentModifier(formFieldStencil.modifiers.required.true)]: {
-      display: 'inline',
+      '&::after': {
+        content: '"*"',
+        fontSize: system.fontSize.body.large,
+        fontWeight: system.fontWeight.normal,
+        color: brand.error.base,
+        textDecoration: 'unset',
+        marginInlineStart: system.space.x1,
+      },
     },
 
     // orientation modifier from parent FormField
@@ -66,9 +73,9 @@ export const FormFieldLabel = createSubcomponent('label')({
   return (
     <Element {...mergeStyles(elemProps, formFieldLabelStencil({typeLevel, variant}))}>
       {children}
-      <span data-element="asterisk" aria-hidden="true">
+      {/* <span data-element="asterisk" aria-hidden="true">
         *
-      </span>
+      </span> */}
     </Element>
   );
 });

--- a/modules/preview-react/form-field/lib/FormFieldLabel.tsx
+++ b/modules/preview-react/form-field/lib/FormFieldLabel.tsx
@@ -2,34 +2,17 @@ import React from 'react';
 
 import {createSubcomponent} from '@workday/canvas-kit-react/common';
 import {useFormFieldLabel, useFormFieldModel} from './hooks';
-import {createStencil, px2rem} from '@workday/canvas-kit-styling';
-import {mergeStyles} from '@workday/canvas-kit-react/layout';
+import {createStencil, parentModifier, px2rem} from '@workday/canvas-kit-styling';
+import {FlexProps, mergeStyles} from '@workday/canvas-kit-react/layout';
 import {brand, system} from '@workday/canvas-tokens-web';
+import {formFieldStencil} from './formFieldStencil';
 
-export interface FormFieldLabelProps {
+export interface FormFieldLabelProps extends FlexProps {
   /**
    * The text of the label.
    */
   children: React.ReactNode;
-  /**
-   * Will style the text as disabled
-   */
-  disabled?: boolean;
-  /**
-   * Changes the color of the text
-   */
-  variant?: 'error' | 'hint' | 'inverse';
 }
-
-const formFieldLabelAsteriskStencil = createStencil({
-  base: {
-    fontSize: system.fontSize.body.large,
-    fontWeight: system.fontWeight.normal,
-    color: brand.error.base,
-    textDecoration: 'unset',
-    marginInlineStart: system.space.x1,
-  },
-});
 
 const formFieldLabelStencil = createStencil({
   base: {
@@ -41,63 +24,44 @@ const formFieldLabelStencil = createStencil({
     display: 'flex',
     alignItems: 'center',
     minWidth: px2rem(180),
-  },
-  modifiers: {
-    orientation: {
-      horizontal: {
-        float: 'left',
-        maxHeight: system.space.x10,
-      },
-      vertical: {
-        width: '100%',
-      },
+
+    // @ts-ignore The nested selectors don't like CSS variables yet
+    '& :where([data-element=asterisk])': {
+      display: 'none',
+      fontSize: system.fontSize.body.large,
+      fontWeight: system.fontWeight.normal,
+      color: brand.error.base,
+      textDecoration: 'unset',
+      marginInlineStart: system.space.x1,
     },
-    variant: {
-      error: {
-        color: system.color.text.critical.default,
-      },
-      hint: {
-        color: system.color.text.hint,
-      },
-      inverse: {
-        color: system.color.text.inverse,
-      },
+
+    // asterisk element
+    [parentModifier(formFieldStencil.modifiers.required.true)]: {
+      display: 'inline',
     },
-    disabled: {
-      true: {
-        cursor: 'default',
-        color: system.color.text.disabled,
-      },
+
+    // orientation modifier from parent FormField
+    [parentModifier(formFieldStencil.modifiers.orientation.horizontal)]: {
+      float: 'left',
+      maxHeight: system.space.x10,
+    },
+    [parentModifier(formFieldStencil.modifiers.orientation.vertical)]: {
+      width: '100%',
     },
   },
-  compound: [
-    {
-      modifiers: {variant: 'inverse', disabled: true},
-      styles: {
-        opacity: system.opacity.disabled,
-        color: system.color.text.inverse,
-      },
-    },
-  ],
 });
 
 export const FormFieldLabel = createSubcomponent('label')({
   displayName: 'FormField.Label',
   modelHook: useFormFieldModel,
   elemPropsHook: useFormFieldLabel,
-})<FormFieldLabelProps>(({children, disabled, variant, ...elemProps}, Element, model) => {
+})<FormFieldLabelProps>(({children, ...elemProps}, Element) => {
   return (
-    <Element
-      {...mergeStyles(elemProps, [
-        formFieldLabelStencil({orientation: model.state.orientation, disabled, variant}),
-      ])}
-    >
+    <Element {...mergeStyles(elemProps, formFieldLabelStencil())}>
       {children}
-      {model.state.isRequired && (
-        <span aria-hidden="true" {...formFieldLabelAsteriskStencil()}>
-          *
-        </span>
-      )}
+      <span data-element="asterisk" aria-hidden="true">
+        *
+      </span>
     </Element>
   );
 });

--- a/modules/preview-react/form-field/lib/formFieldStencil.ts
+++ b/modules/preview-react/form-field/lib/formFieldStencil.ts
@@ -21,7 +21,6 @@ export const formFieldStencil = createStencil({
       horizontal: {
         flexDirection: 'row',
         gap: system.space.x8,
-        alignItems: undefined,
       },
       vertical: {
         flexDirection: 'column',

--- a/modules/preview-react/form-field/lib/formFieldStencil.ts
+++ b/modules/preview-react/form-field/lib/formFieldStencil.ts
@@ -29,11 +29,7 @@ export const formFieldStencil = createStencil({
       },
     },
     required: {
-      true: {
-        '& [data-element=asterisk]': {
-          display: 'block',
-        },
-      },
+      true: {},
     },
     error: {
       error: {},

--- a/modules/preview-react/form-field/lib/formFieldStencil.ts
+++ b/modules/preview-react/form-field/lib/formFieldStencil.ts
@@ -1,0 +1,47 @@
+import {createStencil} from '@workday/canvas-kit-styling';
+import {system} from '@workday/canvas-tokens-web';
+
+export const formFieldStencil = createStencil({
+  base: {
+    display: 'flex',
+    border: 'none',
+    padding: system.space.zero,
+    margin: `${system.space.zero} ${system.space.zero} ${system.space.x6}`,
+  },
+  modifiers: {
+    grow: {
+      true: {
+        width: '100%',
+        '[data-width="ck-formfield-width"]': {
+          width: '100%',
+        },
+      },
+    },
+    orientation: {
+      horizontal: {
+        flexDirection: 'row',
+        gap: system.space.x8,
+        alignItems: undefined,
+      },
+      vertical: {
+        flexDirection: 'column',
+        gap: system.space.x1,
+        alignItems: 'flex-start',
+      },
+    },
+    required: {
+      true: {
+        '& [data-element=asterisk]': {
+          display: 'block',
+        },
+      },
+    },
+    error: {
+      error: {},
+      alert: {},
+    },
+  },
+  defaultModifiers: {
+    orientation: 'vertical',
+  },
+});

--- a/modules/preview-react/form-field/lib/hooks/useFormFieldModel.tsx
+++ b/modules/preview-react/form-field/lib/hooks/useFormFieldModel.tsx
@@ -9,11 +9,6 @@ export const useFormFieldModel = createModelHook({
      */
     error: undefined as undefined | 'error' | 'alert',
     /**
-     * The direction the child elements should stack
-     * @default vertical
-     */
-    orientation: 'vertical' as 'vertical' | 'horizontal',
-    /**
      * Optional `id` provided to `FormField`'s subcomponents as HTML attributes:
      * - `FormField.Input` will set `aria-describedby` to `hint-${id}`
      * - `FormField.Input` will set `id` to `input-${id}`

--- a/modules/preview-react/form-field/lib/hooks/useFormFieldOrientation.tsx
+++ b/modules/preview-react/form-field/lib/hooks/useFormFieldOrientation.tsx
@@ -3,6 +3,8 @@ import {space} from '@workday/canvas-kit-react/tokens';
 
 /**
  * Adds the necessary layout props to a `FormField` component.
+ *
+ * @deprecated
  */
 export const useFormFieldOrientation = (orientation: 'horizontal' | 'vertical') => {
   let layoutProps: {

--- a/modules/preview-react/form-field/stories/examples/Custom.tsx
+++ b/modules/preview-react/form-field/stories/examples/Custom.tsx
@@ -45,7 +45,7 @@ export const Custom = () => {
   const model = useFormFieldModel({isRequired: true});
 
   return (
-    <Flex cs={formFieldStencil({orientation: 'vertical'})}>
+    <Flex cs={formFieldStencil({orientation: 'horizontal'})}>
       <Label model={model}>My Custom Field</Label>
       <Input model={model} value={value} onChange={handleChange} />
       <Hint model={model}>You can be anything</Hint>

--- a/modules/preview-react/form-field/stories/examples/Custom.tsx
+++ b/modules/preview-react/form-field/stories/examples/Custom.tsx
@@ -4,7 +4,7 @@ import {
   useFormFieldInput,
   useFormFieldLabel,
   useFormFieldModel,
-  useFormFieldOrientation,
+  formFieldStencil,
 } from '@workday/canvas-kit-preview-react/form-field';
 import {useModelContext} from '@workday/canvas-kit-react/common';
 import {Flex} from '@workday/canvas-kit-react/layout';
@@ -44,10 +44,8 @@ export const Custom = () => {
 
   const model = useFormFieldModel({isRequired: true});
 
-  const layoutProps = useFormFieldOrientation('vertical');
-
   return (
-    <Flex {...layoutProps}>
+    <Flex cs={formFieldStencil({orientation: 'vertical'})}>
       <Label model={model}>My Custom Field</Label>
       <Input model={model} value={value} onChange={handleChange} />
       <Hint model={model}>You can be anything</Hint>

--- a/modules/preview-react/text-area/lib/TextArea.tsx
+++ b/modules/preview-react/text-area/lib/TextArea.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import {createContainer, ExtractProps} from '@workday/canvas-kit-react/common';
-import {FormField, useFormFieldOrientation} from '@workday/canvas-kit-preview-react/form-field';
-import {Flex} from '@workday/canvas-kit-react/layout';
+import {FormField, formFieldStencil} from '@workday/canvas-kit-preview-react/form-field';
+import {mergeStyles} from '@workday/canvas-kit-react/layout';
 
 import {TextAreaField} from './TextAreaField';
 import {useTextInputModel} from '@workday/canvas-kit-preview-react/text-input';
@@ -17,6 +17,7 @@ export interface TextAreaProps extends ExtractProps<typeof FormField, never> {
 }
 
 /**
+ * @stencil formFieldStencil
  * @deprecated ⚠️ `TextArea` in Preview has been deprecated and will be removed in a future major version. Please use [`FormField` in Preview](https://workday.github.io/canvas-kit/?path=/story/preview-inputs-form-field--basic) instead.
  */
 export const TextArea = createContainer('div')({
@@ -27,12 +28,20 @@ export const TextArea = createContainer('div')({
     Label: FormField.Label,
     Hint: FormField.Hint,
   },
-})<TextAreaProps>(({children, orientation = 'vertical', ...elemProps}, Element) => {
-  const layoutProps = useFormFieldOrientation(orientation);
-
+})<TextAreaProps>(({children, grow, orientation, ...elemProps}, Element, model) => {
   return (
-    <Flex as={Element} {...layoutProps} {...elemProps}>
+    <Element
+      {...mergeStyles(
+        elemProps,
+        formFieldStencil({
+          grow,
+          orientation,
+          error: model.state.error,
+          required: model.state.isRequired,
+        })
+      )}
+    >
       {children}
-    </Flex>
+    </Element>
   );
 });

--- a/modules/preview-react/text-input/lib/TextInput.tsx
+++ b/modules/preview-react/text-input/lib/TextInput.tsx
@@ -4,9 +4,9 @@ import {createContainer, ExtractProps} from '@workday/canvas-kit-react/common';
 import {
   FormField,
   useFormFieldModel,
-  useFormFieldOrientation,
+  formFieldStencil,
 } from '@workday/canvas-kit-preview-react/form-field';
-import {Flex} from '@workday/canvas-kit-react/layout';
+import {mergeStyles} from '@workday/canvas-kit-react/layout';
 
 import {TextInputField} from './TextInputField';
 
@@ -20,6 +20,7 @@ export interface TextInputProps extends ExtractProps<typeof FormField, never> {
   children: React.ReactNode;
 }
 /**
+ * @stencil formFieldStencil
  * @deprecated ⚠️ `TextInput` in Preview has been deprecated and will be removed in a future major version. Please use [`FormField` in Preview](https://workday.github.io/canvas-kit/?path=/story/preview-inputs-form-field--basic) instead.
  */
 export const TextInput = createContainer('div')({
@@ -31,13 +32,21 @@ export const TextInput = createContainer('div')({
     Hint: FormField.Hint,
   },
 })<ExtractProps<typeof FormField, never>>(
-  ({children, orientation = 'vertical', ...elemProps}, Element) => {
-    const layoutProps = useFormFieldOrientation(orientation);
-
+  ({children, orientation, grow, ...elemProps}, Element, model) => {
     return (
-      <Flex as={Element} {...layoutProps} {...elemProps}>
+      <Element
+        {...mergeStyles(
+          elemProps,
+          formFieldStencil({
+            grow,
+            orientation,
+            error: model.state.error,
+            required: model.state.isRequired,
+          })
+        )}
+      >
         {children}
-      </Flex>
+      </Element>
     );
   }
 );

--- a/modules/preview-react/text-input/spec/TextInput.spec.tsx
+++ b/modules/preview-react/text-input/spec/TextInput.spec.tsx
@@ -79,18 +79,6 @@ describe('Text Input', () => {
     });
   });
 
-  describe('when rendered as required', () => {
-    it('should add an asterisk to the label to indicate that it is required', () => {
-      const {getByText} = render(
-        <TextInput orientation="vertical" isRequired={true}>
-          <TextInput.Label>Test</TextInput.Label>
-        </TextInput>
-      );
-
-      expect(getByText('*')).toHaveAttribute('aria-hidden', 'true');
-    });
-  });
-
   describe('when rendered a hint id', () => {
     it('the input and hint text should have matching ids for accessibility', () => {
       const hintId = 'hintId';

--- a/modules/styling-transform/lib/utils/handleParentModifier.ts
+++ b/modules/styling-transform/lib/utils/handleParentModifier.ts
@@ -14,7 +14,7 @@ export const handleParentModifier = createPropertyTransform((node, context) => {
     node.expression.expression.text === 'parentModifier'
   ) {
     const args = node.expression.arguments.map(arg => parseNodeToStaticValue(arg, context));
-    const hash = args[0].toString().replace('css-', '');
+    const hash = args[0].toString().replace('css-', 'm');
 
     // add a mapping from `css-{hash}` to `{hash}` for extraction string replacement
     names[args[0]] = hash;

--- a/modules/styling-transform/spec/utils/handleCreateStencil.spec.ts
+++ b/modules/styling-transform/spec/utils/handleCreateStencil.spec.ts
@@ -394,7 +394,7 @@ describe('handleCreateStencil', () => {
 
       // runtime selector
       expect(result).toContain(
-        `.${names['buttonStencil.modifiers.size.large'].replace('css-', '')} :where(&){color:blue;}`
+        `.${names['buttonStencil.modifiers.size.large'].replace('css-', 'm')} :where(&){color:blue;}`
       );
 
       // extracted selector

--- a/modules/styling-transform/spec/utils/handleParentModifier.spec.ts
+++ b/modules/styling-transform/spec/utils/handleParentModifier.spec.ts
@@ -50,20 +50,20 @@ describe('handleParentModifier', () => {
   it('should add a mapping from the CSS class name to the hash to the names cache', () => {
     expect(names).toHaveProperty(
       names['buttonStencil.modifiers.size.large'],
-      names['buttonStencil.modifiers.size.large'].replace('css-', '')
+      names['buttonStencil.modifiers.size.large'].replace('css-', 'm')
     );
   });
 
   it('should add a mapping from the hash to the extracted CSS class name to the extractedNames cache', () => {
     expect(extractedNames).toHaveProperty(
-      names['buttonStencil.modifiers.size.large'].replace('css-', ''),
+      names['buttonStencil.modifiers.size.large'].replace('css-', 'm'),
       'css-button--size-large'
     );
   });
 
   it('should transform the runtime to include a selector with only the hash', () => {
     expect(result).toContain(
-      `.${names['buttonStencil.modifiers.size.large'].replace('css-', '')} :where(&){color:blue;}`
+      `.${names['buttonStencil.modifiers.size.large'].replace('css-', 'm')} :where(&){color:blue;}`
     );
   });
 

--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -1066,7 +1066,7 @@ function combineClassNames(input: (string | undefined)[]): string {
  * ```
  */
 export function parentModifier(value: string) {
-  return `.${value.replace('css-', '')} :where(&)`;
+  return `.${value.replace('css-', 'm')} :where(&)`;
 }
 
 /**
@@ -1170,7 +1170,7 @@ export function createStencil<
         // will remain for the `parentModifier` function to still select on. We decided to add these
         // inert class names instead of adding `data-m-*` attributes because the output DOM looks
         // much cleaner and it saves bytes on the bundled output.
-        modifierClasses.replace(/css-/g, ''),
+        modifierClasses.replace(/css-/g, 'm'),
         compound ? _compound(inputModifiers) : '',
       ]),
       style: {...composesReturn?.style, ..._vars(input || {})},

--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -1170,10 +1170,7 @@ export function createStencil<
         // will remain for the `parentModifier` function to still select on. We decided to add these
         // inert class names instead of adding `data-m-*` attributes because the output DOM looks
         // much cleaner and it saves bytes on the bundled output.
-        modifierClasses
-          .split(' ')
-          .map(c => c.replace('css-', ''))
-          .join(' '),
+        modifierClasses.replace(/css-/g, ''),
         compound ? _compound(inputModifiers) : '',
       ]),
       style: {...composesReturn?.style, ..._vars(input || {})},

--- a/modules/styling/spec/cs.spec.tsx
+++ b/modules/styling/spec/cs.spec.tsx
@@ -599,7 +599,7 @@ describe('cs', () => {
       expect(className).toEqual(
         `${myStencil.base} ${
           myStencil.modifiers.size.large
-        } ${myStencil.modifiers.size.large.replace('css-', '')}`
+        } ${myStencil.modifiers.size.large.replace('css-', 'm')}`
       );
     });
 


### PR DESCRIPTION
## Summary

Refactor preview `FormField` Stencil to use `parentModifier` and remove the need for style information in the model and extra modifiers needed in the CSS Kit output

## Release Category
Components

## Breaking Change
The required asterisk is now a pseudo element. While the asterisk was never read out loud by screen readers, Testing Library required it in the `*ByLabelText` query. `*ByRole` uses the w3c [accessible name calculation specification](https://www.w3.org/TR/accname-1.2/), but `*ByLabelText` uses [textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent). Additional information: https://github.com/testing-library/dom-testing-library/issues/929

v10:

```ts
screen.getByLabelText('Email*'); // Email is a required field and asterisk is included in name
screen.getByRole('textbox', {name: 'Email'}); // correctly ignores the `*`
```

v11:

```ts
screen.getByLabelText('Email');
screen.getByRole('textbox', {name: 'Email'});
```

---

**Before**:
```html
<div class="cnvs-preview-form-field cnvs-preview-form-field--orientation-vertical">
  <label class="cnvs-preview-form-field-label cnvs-preview-form-field-label-orientation-veritical">Label</label>
  ...
</div>
```

**After**:
```html
<div class="cnvs-preview-form-field cnvs-preview-form-field--orientation-vertical">
  <label class="cnvs-preview-form-field-label">Label</label>
  ...
</div>
```

All style modifiers can be shared this way.

I also added `data-element="asterisk"` to the asterisk sub-element and removed the extra stencil from `FormFieldLabel` as there's no way for a user to access it.