### PR TITLE
fix(select): Update aria-haspopup to 'menu'

### DIFF
--- a/cypress/integration/Select.spec.ts
+++ b/cypress/integration/Select.spec.ts
@@ -238,7 +238,7 @@ describe('Select', () => {
     });
   });
 
-  context.only(`given the "Basic" story is rendered`, () => {
+  context(`given the "Basic" story is rendered`, () => {
     beforeEach(() => {
       h.stories.load('Components/Inputs/Select', 'Basic');
     });

--- a/cypress/integration/Select.spec.ts
+++ b/cypress/integration/Select.spec.ts
@@ -238,9 +238,25 @@ describe('Select', () => {
     });
   });
 
-  context(`given the "Basic" story is rendered`, () => {
+  context.only(`given the "Basic" story is rendered`, () => {
     beforeEach(() => {
       h.stories.load('Components/Inputs/Select', 'Basic');
+    });
+
+    it('should have a combobox role', () => {
+      cy.findByRole('combobox').should('have.attr', 'role', 'combobox');
+    });
+
+    it('should have an `aria-popup="menu"`', () => {
+      cy.findByRole('combobox').should('have.attr', 'aria-haspopup', 'menu');
+    });
+
+    it('should have an `aria-expanded="false"`', () => {
+      cy.findByRole('combobox').should('have.attr', 'aria-expanded', 'false');
+    });
+
+    it('should have an `aria-autocomplete="list"`', () => {
+      cy.findByRole('combobox').should('have.attr', 'aria-autocomplete', 'list');
     });
 
     context('when the menu is opened', () => {

--- a/modules/react/select/lib/hooks/useSelectInput.ts
+++ b/modules/react/select/lib/hooks/useSelectInput.ts
@@ -22,6 +22,10 @@ function noop() {
  * `useSelectInput` extends {@link useComboboxInput useComboboxInput}  and {@link useComboboxKeyboardTypeAhead useComboboxKeyboardTypeAhead} and adds type ahead functionality and Select-specific [keyboard support](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only/).
  */
 export const useSelectInput = composeHooks(
+  useComboboxInput,
+  useComboboxKeyboardTypeAhead,
+  useComboboxResetCursorToSelected,
+  useComboboxMoveCursorToSelected,
   createElemPropsHook(useSelectModel)(
     (model, ref, elemProps: {keySofar?: string; placeholder?: string; value?: string} = {}) => {
       const {elementRef} = useLocalRef<HTMLInputElement>(ref as any);
@@ -158,9 +162,5 @@ export const useSelectInput = composeHooks(
         'aria-haspopup': 'menu',
       } as const;
     }
-  ),
-  useComboboxKeyboardTypeAhead,
-  useComboboxResetCursorToSelected,
-  useComboboxMoveCursorToSelected,
-  useComboboxInput
+  )
 );


### PR DESCRIPTION
## Summary

Update `aria-haspopup` to `menu` in `Select.Input`. This was added some time ago, but the order of composed hooks overwrote the value.

## Release Category
Components

---

## Checklist

- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

Tests
