### PR TITLE
fix: Prevent undefined from overriding model defaultConfig

### DIFF
--- a/modules/react/common/lib/utils/models.ts
+++ b/modules/react/common/lib/utils/models.ts
@@ -523,10 +523,21 @@ export const createModelHook = <TDefaultConfig extends {}, TRequiredConfig exten
     const configRef = React.useRef<Record<string, any>>({});
     const eventsRef = React.useRef<Record<string, any>>({});
 
-    const {state, events, ...rest} = fnRef.current({
-      ...defaultConfig,
-      ...config,
-    });
+    // We want to apply defaults, but if we merge config together using a spread, a value of
+    // `undefined` will override which will cause issues when config values are not expected to be
+    // undefined
+    const finalConfig: Record<string, any> = {...defaultConfig};
+    for (const key in config || {}) {
+      if (
+        config[key] !== undefined ||
+        // @ts-ignore if `defaultConfig` has a property of `key`, it has `key` in the index signature. Come on, TypeScript
+        (defaultConfig.hasOwnProperty(key) && defaultConfig[key] === undefined)
+      ) {
+        finalConfig[key] = config[key];
+      }
+    }
+
+    const {state, events, ...rest} = fnRef.current(finalConfig);
 
     // update all the refs with current values
     stateRef.current = state;

--- a/modules/react/common/spec/models.spec.tsx
+++ b/modules/react/common/spec/models.spec.tsx
@@ -271,4 +271,40 @@ describe('createModelHook', () => {
       shouldSelect?: (value: string, state: {baz: string}) => boolean;
     }>();
   });
+
+  it('should override defaultConfig values with `undefined` if `undefined` is allowed', () => {
+    const useTestModel = createModelHook({
+      defaultConfig: {
+        foo: undefined,
+      },
+    })(config => {
+      return {state: {foo: config.foo}, events: {}};
+    });
+
+    const {result} = renderHook(() =>
+      useTestModel({
+        foo: undefined,
+      })
+    );
+
+    expect(result.current.state).toHaveProperty('foo', undefined);
+  });
+
+  it('should not override defaultConfig values with `undefined` if `undefined` is not allowed', () => {
+    const useTestModel = createModelHook({
+      defaultConfig: {
+        foo: 'foo',
+      },
+    })(config => {
+      return {state: {foo: config.foo}, events: {}};
+    });
+
+    const {result} = renderHook(() =>
+      useTestModel({
+        foo: undefined,
+      })
+    );
+
+    expect(result.current.state).toHaveProperty('foo', 'foo');
+  });
 });

--- a/modules/react/common/spec/models.spec.tsx
+++ b/modules/react/common/spec/models.spec.tsx
@@ -293,7 +293,7 @@ describe('createModelHook', () => {
   it('should not override defaultConfig values with `undefined` if `undefined` is not allowed', () => {
     const useTestModel = createModelHook({
       defaultConfig: {
-        foo: 'foo',
+        foo: 'bar',
       },
     })(config => {
       return {state: {foo: config.foo}, events: {}};
@@ -305,6 +305,6 @@ describe('createModelHook', () => {
       })
     );
 
-    expect(result.current.state).toHaveProperty('foo', 'foo');
+    expect(result.current.state).toHaveProperty('foo', 'bar');
   });
 });


### PR DESCRIPTION
## Summary

Fixes: #2756

Models use the object spread operator to allow `config` to override `defaultConfig`. If `undefined` is passed to a key, it would cause `undefined` to be assigned to config even if the model didn't allow for that. Instead of using an object spread, `config` keys are looped over to check for `undefined` values.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

---

Extended change information:

```tsx
const useMyModel = createModelHook({
  defaultConfig: {
    foo: 'bar'
  },
  requiredConfig: {}
})(config => {
  return {
    state: {
      foo: config.foo // type is `{foo: string}`
    },
    events: {}
  }
})


const model = useMyModel({
  foo: undefined
})
```

**Before**
```tsx
model.state.foo // undefined
```

**After**
```tsx
model.state.foo // 'bar'
```
