### PR TITLE
fix: Prevent style-only props from being forwarded to elements

### DIFF
--- a/modules/labs-react/combobox/lib/Combobox.tsx
+++ b/modules/labs-react/combobox/lib/Combobox.tsx
@@ -6,6 +6,7 @@ import {
   styled,
   useIsRTL,
   useUniqueId,
+  filterOutProps,
 } from '@workday/canvas-kit-react/common';
 import {space, commonColors, borderRadius} from '@workday/canvas-kit-react/tokens';
 import {Card} from '@workday/canvas-kit-react/card';
@@ -113,7 +114,7 @@ const MenuContainer = styled(Card)({
 });
 
 const ResetButton = styled(TertiaryButton, {
-  shouldForwardProp: prop => prop !== 'shouldShow',
+  shouldForwardProp: filterOutProps(['shouldShow']),
 })<{shouldShow: boolean}>(
   {
     position: 'absolute',

--- a/modules/labs-react/combobox/lib/Combobox.tsx
+++ b/modules/labs-react/combobox/lib/Combobox.tsx
@@ -112,7 +112,9 @@ const MenuContainer = styled(Card)({
   overflow: 'hidden',
 });
 
-const ResetButton = styled(TertiaryButton)<{shouldShow: boolean}>(
+const ResetButton = styled(TertiaryButton, {
+  shouldForwardProp: prop => prop !== 'shouldShow',
+})<{shouldShow: boolean}>(
   {
     position: 'absolute',
     margin: `auto ${space.xxxs}`,

--- a/modules/labs-react/expandable/lib/ExpandableIcon.tsx
+++ b/modules/labs-react/expandable/lib/ExpandableIcon.tsx
@@ -29,7 +29,12 @@ export interface ExpandableIconProps extends Omit<ExtractProps<typeof SystemIcon
   iconPosition?: IconPositions;
 }
 
-const StyledEndIcon = styled(SystemIcon)<{visible: boolean} & StyledType>(
+const omittedProps = ['visible'];
+const shouldForwardProp = (prop: string) => {
+  return !omittedProps.includes(prop);
+};
+
+const StyledEndIcon = styled(SystemIcon, {shouldForwardProp})<{visible: boolean} & StyledType>(
   {
     marginLeft: 'auto',
   },
@@ -41,7 +46,7 @@ const StyledEndIcon = styled(SystemIcon)<{visible: boolean} & StyledType>(
   })
 );
 
-const StyledStartIcon = styled(SystemIcon)<{visible: boolean} & StyledType>(
+const StyledStartIcon = styled(SystemIcon, {shouldForwardProp})<{visible: boolean} & StyledType>(
   {
     margin: `0 ${space.xxs} 0 0`,
     padding: space.xxxs,

--- a/modules/labs-react/expandable/lib/ExpandableIcon.tsx
+++ b/modules/labs-react/expandable/lib/ExpandableIcon.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {
   createSubcomponent,
   ExtractProps,
+  filterOutProps,
   styled,
   StyledType,
 } from '@workday/canvas-kit-react/common';
@@ -29,12 +30,9 @@ export interface ExpandableIconProps extends Omit<ExtractProps<typeof SystemIcon
   iconPosition?: IconPositions;
 }
 
-const omittedProps = ['visible'];
-const shouldForwardProp = (prop: string) => {
-  return !omittedProps.includes(prop);
-};
-
-const StyledEndIcon = styled(SystemIcon, {shouldForwardProp})<{visible: boolean} & StyledType>(
+const StyledEndIcon = styled(SystemIcon, {
+  shouldForwardProp: filterOutProps(['visible']),
+})<{visible: boolean} & StyledType>(
   {
     marginLeft: 'auto',
   },
@@ -46,7 +44,9 @@ const StyledEndIcon = styled(SystemIcon, {shouldForwardProp})<{visible: boolean}
   })
 );
 
-const StyledStartIcon = styled(SystemIcon, {shouldForwardProp})<{visible: boolean} & StyledType>(
+const StyledStartIcon = styled(SystemIcon, {
+  shouldForwardProp: filterOutProps(['visible']),
+})<{visible: boolean} & StyledType>(
   {
     margin: `0 ${space.xxs} 0 0`,
     padding: space.xxxs,

--- a/modules/labs-react/search-form/lib/SearchForm.tsx
+++ b/modules/labs-react/search-form/lib/SearchForm.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import {CSSObject} from '@emotion/styled';
 import {colors, space} from '@workday/canvas-kit-react/tokens';
-import {GrowthBehavior, styled, generateUniqueId} from '@workday/canvas-kit-react/common';
+import {
+  GrowthBehavior,
+  styled,
+  generateUniqueId,
+  filterOutProps,
+} from '@workday/canvas-kit-react/common';
 import {TertiaryButton, TertiaryButtonProps} from '@workday/canvas-kit-react/button';
 import {searchIcon, xIcon} from '@workday/canvas-system-icons-web';
 import {FormField, FormFieldLabelPosition} from '@workday/canvas-kit-react/form-field';
@@ -173,7 +178,7 @@ const SearchCombobox = styled(Combobox)({
 });
 
 const SearchIcon = styled(TertiaryButton, {
-  shouldForwardProp: prop => prop !== 'isHidden',
+  shouldForwardProp: filterOutProps(['isHidden']),
 })<Pick<SearchFormProps, 'isCollapsed'> & {isHidden: boolean}>(({isCollapsed, isHidden}) => {
   return {
     position: `absolute`,

--- a/modules/labs-react/search-form/lib/SearchForm.tsx
+++ b/modules/labs-react/search-form/lib/SearchForm.tsx
@@ -172,9 +172,9 @@ const SearchCombobox = styled(Combobox)({
   width: `100%`,
 });
 
-const SearchIcon = styled(TertiaryButton)<
-  Pick<SearchFormProps, 'isCollapsed'> & {isHidden: boolean}
->(({isCollapsed, isHidden}) => {
+const SearchIcon = styled(TertiaryButton, {
+  shouldForwardProp: prop => prop !== 'isHidden',
+})<Pick<SearchFormProps, 'isCollapsed'> & {isHidden: boolean}>(({isCollapsed, isHidden}) => {
   return {
     position: `absolute`,
     margin: isCollapsed ? `auto ${space.xxs}` : `auto ${space.xxxs}`,

--- a/modules/react/avatar/lib/Avatar.tsx
+++ b/modules/react/avatar/lib/Avatar.tsx
@@ -106,7 +106,9 @@ const StyledStack = styled('span')<Pick<AvatarProps, 'size'>>(
   })
 );
 
-const StyledIcon = styled(SystemIconCircle)<{isImageLoaded: boolean}>(
+const StyledIcon = styled(SystemIconCircle, {
+  shouldForwardProp: prop => prop !== 'isImageLoaded',
+})<{isImageLoaded: boolean}>(
   {
     transition: fadeTransition,
   },
@@ -115,7 +117,9 @@ const StyledIcon = styled(SystemIconCircle)<{isImageLoaded: boolean}>(
   })
 );
 
-const StyledImage = styled('img')<{isLoaded: boolean; objectFit?: Property.ObjectFit}>(
+const StyledImage = styled('img', {
+  shouldForwardProp: prop => prop !== 'isLoaded' && prop !== 'objectFit',
+})<{isLoaded: boolean; objectFit?: Property.ObjectFit}>(
   {
     width: '100%',
     height: '100%',

--- a/modules/react/avatar/lib/Avatar.tsx
+++ b/modules/react/avatar/lib/Avatar.tsx
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 import {Property} from 'csstype';
-import {styled, focusRing, hideMouseFocus} from '@workday/canvas-kit-react/common';
+import {styled, focusRing, hideMouseFocus, filterOutProps} from '@workday/canvas-kit-react/common';
 import isPropValid from '@emotion/is-prop-valid';
 import {borderRadius, colors} from '@workday/canvas-kit-react/tokens';
 import {SystemIconCircle, SystemIconCircleSize} from '@workday/canvas-kit-react/icon';
@@ -107,7 +107,7 @@ const StyledStack = styled('span')<Pick<AvatarProps, 'size'>>(
 );
 
 const StyledIcon = styled(SystemIconCircle, {
-  shouldForwardProp: prop => prop !== 'isImageLoaded',
+  shouldForwardProp: filterOutProps(['isImageLoaded']),
 })<{isImageLoaded: boolean}>(
   {
     transition: fadeTransition,
@@ -118,7 +118,7 @@ const StyledIcon = styled(SystemIconCircle, {
 );
 
 const StyledImage = styled('img', {
-  shouldForwardProp: prop => prop !== 'isLoaded' && prop !== 'objectFit',
+  shouldForwardProp: filterOutProps(['isLoaded', 'objectFit']),
 })<{isLoaded: boolean; objectFit?: Property.ObjectFit}>(
   {
     width: '100%',

--- a/modules/react/common/lib/theming/index.ts
+++ b/modules/react/common/lib/theming/index.ts
@@ -1,7 +1,7 @@
 export * from './breakpoints';
 export {createCanvasTheme} from './createCanvasTheme';
 export * from './types';
-export {default as styled, StyleRewriteFn} from './styled';
+export {default as styled, StyleRewriteFn, filterOutProps} from './styled';
 export * from './theme';
 export * from './useTheme';
 export * from './useThemedRing';

--- a/modules/react/common/lib/theming/styled.ts
+++ b/modules/react/common/lib/theming/styled.ts
@@ -10,28 +10,31 @@ const noop = (styles: any) => styles;
 type Interpolations = Array<any>;
 export type StyleRewriteFn = (obj?: CSSProperties) => CSSProperties | undefined;
 
-function styled<Props>(node: any) {
+interface ThemingStyledOptions {
+  shouldForwardProp?: (prop: any) => boolean;
+}
+
+function styled<Props>(node: any, options?: ThemingStyledOptions) {
   return (...args: Interpolation<Props>[]) => {
     const newArgs: Interpolations = args.map(
-      interpolation => (
-        props: Props & {theme: EmotionCanvasTheme & {_styleRewriteFn?: StyleRewriteFn}}
-      ) => {
-        props.theme = useTheme(props.theme);
-        const direction = props.theme.canvas.direction;
-        const maybeFlip = direction === ContentDirection.RTL ? rtlCSSJS : noop;
-        const maybeConvert = props.theme._styleRewriteFn || noop;
-        try {
-          if (typeof interpolation === 'function') {
-            return maybeFlip(maybeConvert(interpolation(props)) as CSSObject);
+      interpolation =>
+        (props: Props & {theme: EmotionCanvasTheme & {_styleRewriteFn?: StyleRewriteFn}}) => {
+          props.theme = useTheme(props.theme);
+          const direction = props.theme.canvas.direction;
+          const maybeFlip = direction === ContentDirection.RTL ? rtlCSSJS : noop;
+          const maybeConvert = props.theme._styleRewriteFn || noop;
+          try {
+            if (typeof interpolation === 'function') {
+              return maybeFlip(maybeConvert(interpolation(props)) as CSSObject);
+            }
+            return maybeFlip(maybeConvert(interpolation) as CSSObject);
+          } catch (e) {
+            return maybeConvert(interpolation);
           }
-          return maybeFlip(maybeConvert(interpolation) as CSSObject);
-        } catch (e) {
-          return maybeConvert(interpolation);
         }
-      }
     );
 
-    return emotionStyled(node)(newArgs);
+    return emotionStyled(node, options)(newArgs);
   };
 }
 

--- a/modules/react/common/lib/theming/styled.ts
+++ b/modules/react/common/lib/theming/styled.ts
@@ -14,6 +14,10 @@ interface ThemingStyledOptions {
   shouldForwardProp?: (prop: any) => boolean;
 }
 
+export const filterOutProps = (omittedProps: string[]) => {
+  return (prop: string) => !omittedProps.includes(prop);
+};
+
 function styled<Props>(node: any, options?: ThemingStyledOptions) {
   return (...args: Interpolation<Props>[]) => {
     const newArgs: Interpolations = args.map(

--- a/modules/react/common/lib/theming/styled.ts
+++ b/modules/react/common/lib/theming/styled.ts
@@ -6,10 +6,6 @@ import rtlCSSJS from 'rtl-css-js';
 
 const noop = (styles: any) => styles;
 
-// Pulled from https://github.com/emotion-js/emotion/blob/master/packages/styled-base/src/utils.js#L6 (not exported)
-type Interpolations = Array<any>;
-export type StyleRewriteFn = (obj?: CSSProperties) => CSSProperties | undefined;
-
 interface ThemingStyledOptions {
   shouldForwardProp?: (prop: any) => boolean;
 }
@@ -17,6 +13,10 @@ interface ThemingStyledOptions {
 export const filterOutProps = (omittedProps: string[]) => {
   return (prop: string) => !omittedProps.includes(prop);
 };
+
+// Pulled from https://github.com/emotion-js/emotion/blob/master/packages/styled-base/src/utils.js#L6 (not exported)
+type Interpolations = Array<any>;
+export type StyleRewriteFn = (obj?: CSSProperties) => CSSProperties | undefined;
 
 function styled<Props>(node: any, options?: ThemingStyledOptions) {
   return (...args: Interpolation<Props>[]) => {

--- a/modules/react/skeleton/lib/parts/skeletonText.tsx
+++ b/modules/react/skeleton/lib/parts/skeletonText.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styled from '@emotion/styled';
 
-import {createComponent, StyledType} from '@workday/canvas-kit-react/common';
+import {createComponent, filterOutProps, StyledType} from '@workday/canvas-kit-react/common';
 import {borderRadius, colors, space} from '@workday/canvas-kit-react/tokens';
 
 const TextContainer = styled('div')<StyledType>({
@@ -22,7 +22,7 @@ export interface SkeletonTextProps {
 }
 
 const Line = styled('div', {
-  shouldForwardProp: prop => prop !== 'backgroundColor' && prop !== 'width',
+  shouldForwardProp: filterOutProps('backgroundColor', 'width'),
 })<
   {
     backgroundColor: string;

--- a/modules/react/skeleton/lib/parts/skeletonText.tsx
+++ b/modules/react/skeleton/lib/parts/skeletonText.tsx
@@ -21,7 +21,9 @@ export interface SkeletonTextProps {
   backgroundColor?: string;
 }
 
-const Line = styled('div')<
+const Line = styled('div', {
+  shouldForwardProp: prop => prop !== 'backgroundColor' && prop !== 'width',
+})<
   {
     backgroundColor: string;
     width: number | string;

--- a/modules/react/skeleton/lib/parts/skeletonText.tsx
+++ b/modules/react/skeleton/lib/parts/skeletonText.tsx
@@ -22,7 +22,7 @@ export interface SkeletonTextProps {
 }
 
 const Line = styled('div', {
-  shouldForwardProp: filterOutProps('backgroundColor', 'width'),
+  shouldForwardProp: filterOutProps(['backgroundColor', 'width']),
 })<
   {
     backgroundColor: string;

--- a/modules/react/tabs/lib/TabsList.tsx
+++ b/modules/react/tabs/lib/TabsList.tsx
@@ -45,7 +45,9 @@ export const useTabsList = composeHooks(
   useListResetCursorOnBlur
 );
 
-const StyledStack = styled(Flex)<StyledType & {maskImage?: string}>(({maskImage}) => ({
+const StyledStack = styled(Flex, {
+  shouldForwardProp: prop => prop !== 'maskImage',
+})<StyledType & {maskImage?: string}>(({maskImage}) => ({
   maskImage: maskImage,
 }));
 
@@ -84,7 +86,7 @@ export const useTouchDirection = () => {
 
   React.useEffect(() => {
     let prevXPos = window.pageXOffset;
-    const handleTouchMove = function(e: TouchEvent) {
+    const handleTouchMove = function (e: TouchEvent) {
       const currXPos = e.touches[0].clientX;
       setIsDragging(true);
       if (currXPos > prevXPos) {
@@ -95,7 +97,7 @@ export const useTouchDirection = () => {
       prevXPos = currXPos;
       e.preventDefault();
     };
-    const handleDragEnd = function() {
+    const handleDragEnd = function () {
       setIsDragging(false);
     };
     window.addEventListener('touchmove', handleTouchMove);

--- a/modules/react/tabs/lib/TabsList.tsx
+++ b/modules/react/tabs/lib/TabsList.tsx
@@ -9,6 +9,7 @@ import {
   useModalityType,
   styled,
   StyledType,
+  filterOutProps,
 } from '@workday/canvas-kit-react/common';
 import {Flex} from '@workday/canvas-kit-react/layout';
 import {
@@ -46,7 +47,7 @@ export const useTabsList = composeHooks(
 );
 
 const StyledStack = styled(Flex, {
-  shouldForwardProp: prop => prop !== 'maskImage',
+  shouldForwardProp: filterOutProps(['maskImage']),
 })<StyledType & {maskImage?: string}>(({maskImage}) => ({
   maskImage: maskImage,
 }));


### PR DESCRIPTION
## Summary

Fixes: #2767.

Refactor styled components to use `shouldForwardProps` to filter out style props to eliminate the warning: `Warning: received <bool type> for a non-boolean attribute <name of attribute>`. 

This warning has been failing a couple of test suites that other people have set up in other projects that use CK components and prevents upgrades to CK11, so I would like to unblock those initiatives.

## Release Category
Components

---
This issue is caused by us passing down style props to the DOM and adding `shouldForwardProps` to filter out these properties solves it.

I've identified all (well all that I can find) areas that require `shouldForwardProps` to filter out style props to prevent this warning. I also added an extra option to include functionality to use `shouldForwardProps` to the overridden `styled` function that many components are using over the base `@emotion` `styled` API.

## Where Should the Reviewer Start?

`modules/react/common/lib/theming/styled.ts`

Please keep note of the `styled` function each component uses, some use the overridden one in `modules/react/common/lib/theming/styled.ts` and some use the base `@emotion` one.

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Areas for Feedback? (optional)

## Screenshots or GIFs (if applicable)

## Thank You Gif (optional)
