### PR TITLE
fix(select): Add conditional for Select in React.StrictMode

### DIFF
--- a/modules/react/select/lib/Select.tsx
+++ b/modules/react/select/lib/Select.tsx
@@ -74,12 +74,14 @@ export const SelectInput = createSubcomponent(TextInput)({
     React.useImperativeHandle(
       elementRef,
       () => {
-        localRef.current!.focus = (options?: FocusOptions) => {
-          textInputProps.ref.current!.focus(options);
-        };
-        localRef.current!.blur = () => {
-          textInputProps.ref.current!.blur();
-        };
+        if (localRef.current) {
+          localRef.current.focus = (options?: FocusOptions) => {
+            textInputProps.ref.current!.focus(options);
+          };
+          localRef.current.blur = () => {
+            textInputProps.ref.current!.blur();
+          };
+        }
 
         return localRef.current!;
       },

--- a/modules/react/select/spec/Select.spec.tsx
+++ b/modules/react/select/spec/Select.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render, fireEvent} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
 
 import {Select} from '../lib/Select';
 
@@ -14,7 +14,7 @@ describe('Select', () => {
 
   describe('when rendered with a single child', () => {
     it('should not throw an error', () => {
-      const {getAllByRole} = render(
+      render(
         <Select items={['Foo']} initialVisibility="visible">
           <Select.Input id="contact-select" />
           <Select.Popper>
@@ -28,13 +28,32 @@ describe('Select', () => {
           </Select.Popper>
         </Select>
       );
-      expect(getAllByRole('option')).toHaveLength(1);
+      expect(screen.getAllByRole('option')).toHaveLength(1);
+    });
+
+    it('should render in React Strict Mode', () => {
+      render(
+        <React.StrictMode>
+          <Select items={['Foo']} initialVisibility="visible">
+            <Select.Input id="contact-select" />
+            <Select.Popper>
+              <Select.Card maxHeight="200px">
+                <Select.List>
+                  {item => {
+                    return <Select.Item>{item}</Select.Item>;
+                  }}
+                </Select.List>
+              </Select.Card>
+            </Select.Popper>
+          </Select>
+        </React.StrictMode>
+      );
     });
   });
 
   describe('when rendered with disabled attribute', () => {
     it('should render a disabled select', () => {
-      const {getByRole} = render(
+      render(
         <Select items={['Foo']}>
           <Select.Input disabled id="contact-select" />
           <Select.Popper>
@@ -48,14 +67,14 @@ describe('Select', () => {
           </Select.Popper>
         </Select>
       );
-      expect(getByRole(role)).toHaveProperty('disabled', true);
+      expect(screen.getByRole(role)).toHaveProperty('disabled', true);
     });
   });
 
   describe('when rendered with a value', () => {
     it('it should render a select whose selected option matches value', () => {
       const selectedValue = 'Foo';
-      const {getAllByDisplayValue} = render(
+      render(
         <Select items={['Foo']} initialSelectedIds={['Foo']}>
           <Select.Input id="contact-select" />
           <Select.Popper>
@@ -69,7 +88,7 @@ describe('Select', () => {
           </Select.Popper>
         </Select>
       );
-      expect(getAllByDisplayValue(selectedValue)[0]).toBeDefined();
+      expect(screen.getAllByDisplayValue(selectedValue)[0]).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes the `Select` component when using `React.StrictMode` by adding a ref value guard in the `useImperativeHandle` hook.

## Release Category
Components

---
