### PR TITLE
fix: Popups render in the target's window

### DIFF
--- a/modules/react/popup/stories/Popup.stories.mdx
+++ b/modules/react/popup/stories/Popup.stories.mdx
@@ -10,6 +10,7 @@ import {FocusRedirect} from './examples/FocusRedirect';
 import {FocusTrap} from './examples/FocusTrap';
 import {RTL} from './examples/RTL';
 import {CustomTarget} from './examples/CustomTarget';
+import {ExternalWindow} from './examples/ExternalWindow';
 import {FullScreen} from './examples/FullScreen';
 
 <Meta title="Components/Popups/Popup" component={Popup} />
@@ -160,6 +161,16 @@ the popup's stack context when entering/exiting fullscreen.
 
 <ExampleCodeBlock code={FullScreen} />
 
+### Opening an external window
+
+A popup can open an external window. This isn't supported directly. The `Popup.Popper` subcomponent
+is replaced with a custom subcomponent that connects to the Popup model and controls the lifecycle
+of the extenal window. Be sure to connect the `unload` event of both the parent `window` and the
+external child `window` to the lifecycle of the Popup model to prevent memory leaks or zombie
+windows.
+
+<ExampleCodeBlock code={ExternalWindow} />
+
 ### RTL
 
 The Popup component automatically handles right-to-left rendering.
@@ -171,8 +182,8 @@ The Popup component automatically handles right-to-left rendering.
 ## Component API
 
 <>
-<SymbolDoc name="Popper" fileName="/react/" />
-<SymbolDoc name="Popup" fileName="/react/" />
+  <SymbolDoc name="Popper" fileName="/react/" />
+  <SymbolDoc name="Popup" fileName="/react/" />
 </>
 
 ## Hooks

--- a/modules/react/popup/stories/examples/ExternalWindow.tsx
+++ b/modules/react/popup/stories/examples/ExternalWindow.tsx
@@ -1,0 +1,179 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import {system} from '@workday/canvas-tokens-web';
+import {createStyles} from '@workday/canvas-kit-styling';
+import {infoIcon} from '@workday/canvas-system-icons-web';
+
+import {
+  CanvasProvider,
+  ContentDirection,
+  createSubcomponent,
+  PartialEmotionCanvasTheme,
+  useMount,
+  useTheme,
+} from '@workday/canvas-kit-react/common';
+import {Tooltip} from '@workday/canvas-kit-react/tooltip';
+import {Popup, usePopupModel} from '@workday/canvas-kit-react/popup';
+import {SecondaryButton} from '@workday/canvas-kit-react/button';
+import {Flex} from '../../../layout';
+
+const mainContentStyles = createStyles({
+  padding: system.space.x4,
+});
+
+export interface ExternalWindowPortalProps {
+  /**
+   * Child components of WindowPortal
+   */
+  children: React.ReactNode;
+  /**
+   * Callback to close the popup
+   */
+  onWindowClose?: () => void;
+  /**
+   * Width of the popup window
+   */
+  width?: number;
+  /**
+   * Height of the popup window
+   */
+  height?: number;
+  /**
+   * The name of the popup window. If another popup opens with the same name, that instance will
+   * be reused. Use caution with setting this value
+   */
+  target?: string;
+}
+
+async function copyAssets(sourceDoc: Document, targetDoc: Document) {
+  for (const font of (sourceDoc as any).fonts.values()) {
+    (targetDoc as any).fonts.add(font);
+
+    font.load();
+  }
+
+  await (targetDoc as any).fonts.ready;
+
+  // The current ES lib version doesn't include iterable interfaces, so we cast as an iterable
+  for (const styleSheet of sourceDoc.styleSheets as StyleSheetList & Iterable<CSSStyleSheet>) {
+    if (styleSheet.cssRules) {
+      // text based styles
+      const styleEl = targetDoc.createElement('style');
+      for (const cssRule of styleSheet.cssRules as CSSRuleList & Iterable<CSSRule>) {
+        styleEl.appendChild(targetDoc.createTextNode(cssRule.cssText));
+      }
+      targetDoc.head.appendChild(styleEl);
+    } else if (styleSheet.href) {
+      // link based styles
+      const linkEl = targetDoc.createElement('link');
+
+      linkEl.rel = 'stylesheet';
+      linkEl.href = styleSheet.href;
+      targetDoc.head.appendChild(linkEl);
+    }
+  }
+}
+
+const ExternalWindowPortal = ({
+  children,
+  width = 300,
+  height = 500,
+  target = '',
+  onWindowClose,
+}: ExternalWindowPortalProps) => {
+  const [portalElement, setPortalElement] = React.useState<HTMLDivElement | null>(null);
+
+  useMount(() => {
+    const newWindow = window.open(
+      '', // url
+      target,
+      `width=${width},height=${height},left=100,top=100,popup=true`
+    );
+
+    if (newWindow) {
+      // copy fonts and styles
+      copyAssets(document, newWindow.document);
+
+      const element = newWindow.document.createElement('div');
+      newWindow.document.body.appendChild(element);
+      setPortalElement(element);
+    } else {
+      onWindowClose();
+    }
+
+    const closeWindow = event => {
+      onWindowClose();
+    };
+
+    // PopupStack.pushStackContext(newWindow.document.body);
+
+    window.addEventListener('unload', closeWindow);
+    newWindow?.addEventListener('unload', closeWindow);
+
+    return () => {
+      // PopupStack.popStackContext(newWindow.document.body);
+      window.removeEventListener('unload', closeWindow);
+      newWindow?.removeEventListener('unload', closeWindow);
+      newWindow?.close();
+    };
+  });
+
+  if (!portalElement) {
+    return null;
+  }
+
+  return ReactDOM.createPortal(<CanvasProvider>{children}</CanvasProvider>, portalElement);
+};
+
+const PopupExternalWindow = createSubcomponent()({
+  displayName: 'Popup.ExternalWindow',
+  modelHook: usePopupModel,
+})<ExternalWindowPortalProps>(({children, ...elemProps}, Element, model) => {
+  if (model.state.visibility === 'visible') {
+    return (
+      <ExternalWindowPortal onWindowClose={model.events.hide} {...elemProps}>
+        {children}
+      </ExternalWindowPortal>
+    );
+  }
+
+  return null;
+});
+
+export const ExternalWindow = () => {
+  // useTheme is filling in the Canvas theme object if any keys are missing
+  const canvasTheme: PartialEmotionCanvasTheme = useTheme({
+    canvas: {
+      // Switch to `ContentDirection.RTL` to change direction
+      direction: ContentDirection.LTR,
+    },
+  });
+
+  const model = usePopupModel();
+
+  return (
+    <CanvasProvider theme={canvasTheme}>
+      <>
+        <main className={mainContentStyles}>
+          <p>Popup that opens a new Operating System Window</p>
+          <Popup model={model}>
+            <Tooltip title="Open External Window Tooltip">
+              <Popup.Target>Open External Window</Popup.Target>
+            </Tooltip>
+            <PopupExternalWindow>
+              <p>External Window Contents! Mouse over the info icon to get a tooltip</p>
+              <Flex gap="s">
+                <Tooltip title="More information">
+                  <SecondaryButton icon={infoIcon} />
+                </Tooltip>
+                <Popup.CloseButton>Close Window</Popup.CloseButton>
+              </Flex>
+            </PopupExternalWindow>
+          </Popup>
+          <p>Popup visibility: {model.state.visibility}</p>
+        </main>
+      </>
+    </CanvasProvider>
+  );
+};

--- a/modules/react/popup/stories/examples/ExternalWindow.tsx
+++ b/modules/react/popup/stories/examples/ExternalWindow.tsx
@@ -106,13 +106,11 @@ const ExternalWindowPortal = ({
       onWindowClose();
     };
 
-    // PopupStack.pushStackContext(newWindow.document.body);
 
     window.addEventListener('unload', closeWindow);
     newWindow?.addEventListener('unload', closeWindow);
 
     return () => {
-      // PopupStack.popStackContext(newWindow.document.body);
       window.removeEventListener('unload', closeWindow);
       newWindow?.removeEventListener('unload', closeWindow);
       newWindow?.close();


### PR DESCRIPTION
## Summary

Popups now render in the same window as their target element.

Fixes #2831 

## Release Category
Components
---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

Unfortunately, opening contents in a new window doesn't work within an `iframe` of a code sandbox correctly, so there cannot be an example code sandbox. I created a new example to showcase this behavior: https://5d854c26ba934e0020f5e98a-fgaxeeknap.chromatic.com/iframe.html?args=&id=components-popups-popup--external-window&viewMode=story

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Documentation

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

<!-- Explain how your reviewer could verify this change  -->

## Screenshots or GIFs (if applicable)

[PopupExternalWindow.webm](https://github.com/user-attachments/assets/c40897e0-3cb5-4d89-853c-3fa6677e2698)


## Thank You Gif (optional)

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer! -->
<!-- ![a smiling Shiba Inu typing on a laptop](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif) -->
