### PR TITLE
fix: Fix Popup ExternalWindow example import

### DIFF
--- a/modules/react/popup/stories/Popup.stories.mdx
+++ b/modules/react/popup/stories/Popup.stories.mdx
@@ -161,7 +161,7 @@ the popup's stack context when entering/exiting fullscreen.
 
 <ExampleCodeBlock code={FullScreen} />
 
-### Opening an external window
+### Opening an External Window
 
 A popup can open an external window. This isn't supported directly. The `Popup.Popper` subcomponent
 is replaced with a custom subcomponent that connects to the Popup model and controls the lifecycle

--- a/modules/react/popup/stories/examples/ExternalWindow.tsx
+++ b/modules/react/popup/stories/examples/ExternalWindow.tsx
@@ -16,7 +16,7 @@ import {
 import {Tooltip} from '@workday/canvas-kit-react/tooltip';
 import {Popup, usePopupModel} from '@workday/canvas-kit-react/popup';
 import {SecondaryButton} from '@workday/canvas-kit-react/button';
-import {Flex} from '../../../layout';
+import {Flex} from '@workday/canvas-kit-react/layout';
 
 const mainContentStyles = createStyles({
   padding: system.space.x4,
@@ -105,7 +105,6 @@ const ExternalWindowPortal = ({
     const closeWindow = event => {
       onWindowClose();
     };
-
 
     window.addEventListener('unload', closeWindow);
     newWindow?.addEventListener('unload', closeWindow);


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes an issue introduced in #2829 where an example imported `Flex` using a [relative path](https://github.com/Workday/canvas-kit/pull/2829/files#diff-eb9d95064ad483df88214fab614969e7f3111bdbdcd06348c6f349d520880d64R19) to `../../../layout` rather than `@workday/canvas-kit-react/layout`. The relative path does not work for consumers of `@workday/canvas-kit-docs` (i.e., the Canvas Site).

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Documentation

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

Verify the ExternalWindow example for Popup still works correctly.