### PR TITLE
fix(select): Clicking the input closes the menu

### DIFF
--- a/cypress/integration/Autocomplete.spec.ts
+++ b/cypress/integration/Autocomplete.spec.ts
@@ -55,6 +55,16 @@ describe('Autocomplete', () => {
         cy.findByRole('combobox').click();
       });
 
+      context('when the combobox is clicked', () => {
+        beforeEach(() => {
+          cy.findByRole('combobox').click();
+        });
+
+        it('should close the menu', () => {
+          cy.findByRole('listbox').should('not.exist');
+        });
+      });
+
       it('should set the aria-owns to reference the listbox element', () => {
         cy.findByRole('combobox').should(haveAttrMatchingIdOf('aria-controls', '[role=listbox]'));
       });

--- a/cypress/integration/Select.spec.ts
+++ b/cypress/integration/Select.spec.ts
@@ -104,6 +104,16 @@ describe('Select', () => {
           cy.findByRole('combobox').click();
         });
 
+        context('when the combobox is clicked', () => {
+          beforeEach(() => {
+            cy.findByRole('combobox').click();
+          });
+
+          it('should close the menu', () => {
+            cy.findByRole('listbox').should('not.exist');
+          });
+        });
+
         context(
           'when a character is typed (provided no other characters have been typed in the last 500ms), the select should advance assistive focus to the first matching option beyond the currently selected option (cycling back to the beginning of the options if necessary) and scroll that option into view',
           () => {

--- a/modules/react/select/lib/Select.tsx
+++ b/modules/react/select/lib/Select.tsx
@@ -67,27 +67,6 @@ export const SelectInput = createSubcomponent(TextInput)({
     Element,
     model
   ) => {
-    const {localRef, elementRef} = useLocalRef(ref);
-
-    // We need to create a proxy between the multiple inputs. We need to redirect a few methods to
-    // the visible input
-    React.useImperativeHandle(
-      elementRef,
-      () => {
-        if (localRef.current) {
-          localRef.current.focus = (options?: FocusOptions) => {
-            textInputProps.ref.current!.focus(options);
-          };
-          localRef.current.blur = () => {
-            textInputProps.ref.current!.blur();
-          };
-        }
-
-        return localRef.current!;
-      },
-      [textInputProps.ref, localRef]
-    );
-
     return (
       <InputGroup>
         {inputStartIcon && model.state.selectedIds.length > 0 && (
@@ -106,7 +85,7 @@ export const SelectInput = createSubcomponent(TextInput)({
           onInput={onInput}
           value={value}
           name={name}
-          ref={elementRef}
+          ref={ref}
         />
         {/* Visual input */}
         <InputGroup.Input

--- a/modules/react/select/lib/Select.tsx
+++ b/modules/react/select/lib/Select.tsx
@@ -4,7 +4,6 @@ import {
   ExtractProps,
   createContainer,
   Themeable,
-  useLocalRef,
 } from '@workday/canvas-kit-react/common';
 import {Combobox} from '@workday/canvas-kit-react/combobox';
 

--- a/modules/react/select/lib/hooks/useSelectInput.ts
+++ b/modules/react/select/lib/hooks/useSelectInput.ts
@@ -28,8 +28,34 @@ export const useSelectInput = composeHooks(
   useComboboxMoveCursorToSelected,
   createElemPropsHook(useSelectModel)(
     (model, ref, elemProps: {keySofar?: string; placeholder?: string; value?: string} = {}) => {
-      const {elementRef} = useLocalRef<HTMLInputElement>(ref as any);
-      const textInputRef = React.useRef<HTMLInputElement>(null);
+      // const textInputRef = React.useRef<HTMLInputElement>(null);
+      const {elementRef: textInputElementRef, localRef: textInputRef} = useLocalRef(
+        // PopupModel says the targetRef is a `HTMLButtonElement`, but it is a `HTMLInputElement`
+        model.state.targetRef as any as React.Ref<HTMLInputElement>
+      );
+
+      const {localRef, elementRef} = useLocalRef(ref as React.Ref<HTMLInputElement>);
+
+      // We need to create a proxy between the multiple inputs. We need to redirect a few methods to
+      // the visible input
+      React.useImperativeHandle(
+        elementRef,
+        () => {
+          if (localRef.current) {
+            localRef.current.focus = (options?: FocusOptions) => {
+              textInputRef.current!.focus(options);
+            };
+            localRef.current.blur = () => {
+              textInputRef.current!.blur();
+            };
+          }
+
+          return localRef.current!;
+        },
+        [textInputRef, localRef]
+      );
+
+      // Remap the Popup model's targetRef to be the visible ref. `ref` and `model.state.targetRef` are already linked. We have to override that.
 
       // Update the text value of the input
       const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -151,14 +177,13 @@ export const useSelectInput = composeHooks(
           textInputRef.current?.focus();
         },
         textInputProps: {
-          ref: textInputRef,
+          ref: textInputElementRef,
           onChange: noop,
           value:
             model.state.selectedIds.length > 0 && model.state.items.length > 0
               ? model.navigation.getItem(model.state.selectedIds[0], model).textValue
               : '',
         },
-        ref: elementRef,
         'aria-haspopup': 'menu',
       } as const;
     }


### PR DESCRIPTION
## Summary

Redirect the `PopupModel.state.targetRef` to the user input element instead of the hidden server input element. Tests were added to specify this behavior.

Fixes: #2868 

## Release Category
Components

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

Tests

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Testing
