### PR TITLE
fix(combobox): Show selected state when multiple is enabled

### DIFF
--- a/modules/react/combobox/lib/ComboboxMenuItem.tsx
+++ b/modules/react/combobox/lib/ComboboxMenuItem.tsx
@@ -44,7 +44,7 @@ export const useComboboxMenuItem = composeHooks(
       event.preventDefault();
     };
 
-    const selected = model.state.selectedIds[0] === id;
+    const selected = model.state.selectedIds.includes(id);
 
     return {
       role: 'option',

--- a/modules/react/combobox/lib/ComboboxMenuItem.tsx
+++ b/modules/react/combobox/lib/ComboboxMenuItem.tsx
@@ -11,6 +11,7 @@ import {SystemIcon} from '@workday/canvas-kit-react/icon';
 import {
   useListItemAllowChildStrings,
   useListItemRegister,
+  isSelected,
 } from '@workday/canvas-kit-react/collection';
 import {OverflowTooltip} from '@workday/canvas-kit-react/tooltip';
 
@@ -44,9 +45,7 @@ export const useComboboxMenuItem = composeHooks(
       event.preventDefault();
     };
 
-    const selected =
-      (model.state.selectedIds === 'all' && !model.state.unselectedIds.includes(id)) ||
-      model.state.selectedIds.includes(id);
+    const selected = isSelected(id, model.state);
 
     return {
       role: 'option',

--- a/modules/react/combobox/lib/ComboboxMenuItem.tsx
+++ b/modules/react/combobox/lib/ComboboxMenuItem.tsx
@@ -44,7 +44,9 @@ export const useComboboxMenuItem = composeHooks(
       event.preventDefault();
     };
 
-    const selected = model.state.selectedIds.includes(id);
+    const selected =
+      (model.state.selectedIds === 'all' && !model.state.unselectedIds.includes(id)) ||
+      model.state.selectedIds.includes(id);
 
     return {
       role: 'option',


### PR DESCRIPTION
## Summary

Fixes selected state when the selection mode is set to `multiple`

## Release Category
Components

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code