### PR TITLE
fix: Make overflow items inert

### DIFF
--- a/modules/react/breadcrumbs/lib/BreadcrumbsItem.tsx
+++ b/modules/react/breadcrumbs/lib/BreadcrumbsItem.tsx
@@ -1,10 +1,5 @@
 import * as React from 'react';
-import {
-  composeHooks,
-  createSubcomponent,
-  createElemPropsHook,
-  useIsRTL,
-} from '@workday/canvas-kit-react/common';
+import {composeHooks, createSubcomponent, useIsRTL} from '@workday/canvas-kit-react/common';
 import {
   useListItemRegister,
   useOverflowListItemMeasure,

--- a/modules/react/breadcrumbs/lib/BreadcrumbsItem.tsx
+++ b/modules/react/breadcrumbs/lib/BreadcrumbsItem.tsx
@@ -33,27 +33,7 @@ export interface BreadcrumbsItemProps extends FlexProps {
   'data-id'?: string;
 }
 
-export const useBreadcrumbsItem = composeHooks(
-  useOverflowListItemMeasure,
-  createElemPropsHook(useBreadcrumbsModel)(
-    (
-      {state},
-      _,
-      elemProps: {
-        'data-id'?: string;
-        item?: {id: string};
-      } = {}
-    ) => {
-      const [localId] = React.useState(elemProps['data-id'] || elemProps.item?.id || '');
-
-      return {
-        inert: state.nonInteractiveIds.includes(localId) ? '' : undefined,
-        disabled: undefined,
-      };
-    }
-  ),
-  useListItemRegister
-);
+export const useBreadcrumbsItem = composeHooks(useOverflowListItemMeasure, useListItemRegister);
 
 export const BreadcrumbsItem = createSubcomponent('li')({
   displayName: 'Breadcrumbs.Item',

--- a/modules/react/collection/lib/useOverflowListItemMeasure.tsx
+++ b/modules/react/collection/lib/useOverflowListItemMeasure.tsx
@@ -46,6 +46,7 @@ export const useOverflowListItemMeasure = createElemPropsHook(useOverflowListMod
       ref: elementRef,
       'aria-hidden': hidden || undefined,
       style: hidden ? hiddenStyles : {},
+      inert: hidden ? '' : undefined,
     };
   }
 );


### PR DESCRIPTION
## Summary

All items hidden by overflow should be [inert](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert)

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

---

## Checklist

- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Documentation
