### PR TITLE
fix: Updated ButtonColors interface to deprecated focusRing from focus

### DIFF
--- a/modules/docs/lib/Value.tsx
+++ b/modules/docs/lib/Value.tsx
@@ -8,6 +8,7 @@ import {MdxJSToJSX} from './MDXElements';
 import {Table} from './Table';
 import {capitalize, IndentLevelContext, RenderContext, indent} from './widgetUtils';
 import {DescriptionTooltip} from './DescriptionTooltip';
+import {colors} from '@workday/canvas-kit-react/tokens';
 
 const widgets: Record<string, React.FC<ValueProps>> = {};
 
@@ -52,18 +53,19 @@ export const PropertiesInline = ({properties}: {properties: types.ObjectProperty
           <React.Fragment key={index}>
             <br />
             {indent(level + 1)}
-            {p.description ? (
+            {p.description || p.tags.deprecated ? (
               <DescriptionTooltip
                 type="describe"
                 style={{maxWidth: '50em'}}
-                title={<MdxJSToJSX>{p.description}</MdxJSToJSX>}
+                title={<MdxJSToJSX>{p.description || p.tags.deprecated}</MdxJSToJSX>}
               >
                 <span
                   className="token property"
                   style={{
                     cursor: 'pointer',
-                    textDecoration: 'underline',
+                    textDecoration: p.tags.deprecated ? 'line-through' : 'underline',
                     textDecorationStyle: 'dotted',
+                    color: p.tags.deprecated ? colors.cinnamon600 : colors.plum600,
                   }}
                 >
                   {p.name}

--- a/modules/react/button/lib/types.ts
+++ b/modules/react/button/lib/types.ts
@@ -17,7 +17,7 @@ export interface ButtonColors {
   active?: ButtonStateColors;
   focus?: ButtonStateColors & {
     /**
-     * @deprecated `focusRing` within focus, is deprecated and will not work with our current method of styling. This will be removed in a later version. If you want to customize the focus ring, use `boxShadowInner` and `boxShadowOuter` to update the inner and outer colors of the focus ring. If you decide to use these, use with caution.
+     * @deprecated `focusRing` within focus, is deprecated and will not work with our current method of styling. This will be removed in a later version. If you want to customize the focus ring, use `boxShadowInner` and `boxShadowOuter` to update the inner and outer colors of the focus ring. Use with caution.
      */
     focusRing?: CSSObject;
     /**

--- a/modules/react/button/lib/types.ts
+++ b/modules/react/button/lib/types.ts
@@ -18,9 +18,6 @@ export interface ButtonColors {
   focus?: ButtonStateColors & {
     /**
      * @deprecated This option is no longer supported at run time and will be removed from the type interface in a v12. If you want to customize the focus ring, use `boxShadowInner` and `boxShadowOuter` to update the inner and outer colors of the focus ring. Use with caution.
-     * ```tsx
-     * colors={{focus: {boxShadowInner: COLOR_HERE}}}
-     * ```
      */
     focusRing?: CSSObject;
     /**

--- a/modules/react/button/lib/types.ts
+++ b/modules/react/button/lib/types.ts
@@ -17,12 +17,16 @@ export interface ButtonColors {
   active?: ButtonStateColors;
   focus?: ButtonStateColors & {
     /**
-     * FocusRing within focus, is deprecated in v12 and will not work with our current method of styling.
-     * This will be removed in a later version.
-     * @deprecated
+     * @deprecated `focusRing` within focus, is deprecated and will not work with our current method of styling. This will be removed in a later version. If you want to customize the focus ring, use `boxShadowInner` and `boxShadowOuter` to update the inner and outer colors of the focus ring. If you decide to use these, use with caution.
      */
     focusRing?: CSSObject;
+    /**
+     * Updates the color of the inner `box-shadow` within a focus ring.
+     */
     boxShadowInner?: string;
+    /**
+     * Updates the color of the outer `box-shadow` within a focus ring.
+     */
     boxShadowOuter?: string;
   };
   disabled?: ButtonStateColors;

--- a/modules/react/button/lib/types.ts
+++ b/modules/react/button/lib/types.ts
@@ -17,7 +17,8 @@ export interface ButtonColors {
   active?: ButtonStateColors;
   focus?: ButtonStateColors & {
     /**
-     * FocusRing within focus, is deprecated and will not work with our current method of styling
+     * FocusRing within focus, is deprecated in v12 and will not work with our current method of styling.
+     * This will be removed in a later version.
      * @deprecated
      */
     focusRing?: CSSObject;

--- a/modules/react/button/lib/types.ts
+++ b/modules/react/button/lib/types.ts
@@ -17,7 +17,10 @@ export interface ButtonColors {
   active?: ButtonStateColors;
   focus?: ButtonStateColors & {
     /**
-     * @deprecated `focusRing` within focus, is deprecated and will not work with our current method of styling. This will be removed in a later version. If you want to customize the focus ring, use `boxShadowInner` and `boxShadowOuter` to update the inner and outer colors of the focus ring. Use with caution.
+     * @deprecated This option is no longer supported at run time and will be removed from the type interface in a v12. If you want to customize the focus ring, use `boxShadowInner` and `boxShadowOuter` to update the inner and outer colors of the focus ring. Use with caution.
+     * ```tsx
+     * colors={{focus: {boxShadowInner: COLOR_HERE}}}
+     * ```
      */
     focusRing?: CSSObject;
     /**

--- a/modules/react/button/lib/types.ts
+++ b/modules/react/button/lib/types.ts
@@ -16,7 +16,13 @@ export interface ButtonColors {
   hover?: ButtonStateColors;
   active?: ButtonStateColors;
   focus?: ButtonStateColors & {
+    /**
+     * FocusRing within focus, is deprecated and will not work with our current method of styling
+     * @deprecated
+     */
     focusRing?: CSSObject;
+    boxShadowInner?: string;
+    boxShadowOuter?: string;
   };
   disabled?: ButtonStateColors;
 }

--- a/modules/react/button/stories/button/examples/CustomStyles.tsx
+++ b/modules/react/button/stories/button/examples/CustomStyles.tsx
@@ -20,7 +20,9 @@ const getDropdownColors = () => {
       label: colors.frenchVanilla100,
     },
     active: {},
-    focus: {},
+    focus: {
+      boxShadowOuter: colors.berrySmoothie400,
+    },
     disabled: {},
   };
 };

--- a/modules/react/button/stories/button/examples/CustomStyles.tsx
+++ b/modules/react/button/stories/button/examples/CustomStyles.tsx
@@ -21,6 +21,7 @@ const getDropdownColors = () => {
     },
     active: {},
     focus: {
+      boxShadowInner: colors.berrySmoothie200,
       boxShadowOuter: colors.berrySmoothie400,
     },
     disabled: {},

--- a/modules/react/button/stories/button/examples/Primary.tsx
+++ b/modules/react/button/stories/button/examples/Primary.tsx
@@ -10,7 +10,7 @@ import {
 
 export const Primary = () => (
   <Flex gap="s" padding="s">
-    <PrimaryButton>Primary</PrimaryButton>
+    <PrimaryButton colors={{focus: {boxShadowInner: 'red'}}}>Primary</PrimaryButton>
     <PrimaryButton icon={plusIcon} iconPosition="start">
       Primary
     </PrimaryButton>

--- a/modules/react/button/stories/button/examples/Primary.tsx
+++ b/modules/react/button/stories/button/examples/Primary.tsx
@@ -10,7 +10,7 @@ import {
 
 export const Primary = () => (
   <Flex gap="s" padding="s">
-    <PrimaryButton colors={{focus: {boxShadowInner: 'red'}}}>Primary</PrimaryButton>
+    <PrimaryButton>Primary</PrimaryButton>
     <PrimaryButton icon={plusIcon} iconPosition="start">
       Primary
     </PrimaryButton>


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #2905  <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

This fixes a TS error in buttons that wouldn't allow the update of the focusRing styles through the colors prop. Also, deprecated the use of focusRing within focus in the colors prop on buttons and added support for boxShadowInner and boxShadowOuter within focus in colors prop. 

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

### Release Note
Deprecated the use of focusRing within focus in the colors prop on buttons as this does not work with our current styling methods. Added support for boxShadowInner and boxShadowOuter within focus in colors prop. 

---

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
`/modules/react/button/lib/types.ts`
