### PR TITLE
fix: Handle empty stack ref in useAssistiveHideSiblings

### DIFF
--- a/modules/react/popup/lib/hooks/useAssistiveHideSiblings.ts
+++ b/modules/react/popup/lib/hooks/useAssistiveHideSiblings.ts
@@ -23,7 +23,7 @@ export const useAssistiveHideSiblings = createElemPropsHook(usePopupModel)(model
     }
 
     const siblings = [
-      ...((model.state.stackRef.current?.parentElement?.children as any) as HTMLElement[]),
+      ...((model.state.stackRef.current?.parentElement?.children || []) as HTMLElement[]),
     ].filter(el => el !== model.state.stackRef.current);
     const prevAriaHidden = siblings.map(el => el.getAttribute('aria-hidden'));
     siblings.forEach(el => {


### PR DESCRIPTION

## Summary

Fixes a rare issue when the popup model's stack ref is `undefined`. This will mostly happen in `StrictMode`.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

---

## Checklist
(https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [x] Label `ready for review` has been added to PR
