### PR TITLE
fix(search-form): Show ellipsis when placeholder overflows

### DIFF
--- a/modules/labs-react/search-form/lib/SearchForm.tsx
+++ b/modules/labs-react/search-form/lib/SearchForm.tsx
@@ -263,6 +263,9 @@ const SearchInput = styled(TextInput)<
     '&::placeholder': {
       color: inputColors.placeholderColor,
     },
+    '&:placeholder-shown': {
+      textOverflow: 'ellipsis',
+    },
     '&:not([disabled])': {
       '&:focus, &:active': {
         outline: 'none',


### PR DESCRIPTION
## Summary

Add ellipsis to placeholder text in the search form.

## Release Category
Components

---

## Screenshots or GIFs (if applicable)

![Input placeholder with ellipsis](https://github.com/user-attachments/assets/d49471bc-28f2-4e3e-9255-f7ee466c3d45)