### PR TITLE
feat(text-input): Support CSS Variables in InputGroup

### DIFF
--- a/modules/react/text-input/lib/InputGroup.tsx
+++ b/modules/react/text-input/lib/InputGroup.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import {space} from '@workday/canvas-kit-react/tokens';
+import {maybeWrapCSSVariables} from '@workday/canvas-kit-styling';
+import {system} from '@workday/canvas-tokens-web';
 import {
   createContainer,
   createElemPropsHook,
@@ -198,11 +199,11 @@ export const InputGroup = createContainer('div')({
   // `offsetEnd` arrays
   React.Children.forEach(children, child => {
     if (React.isValidElement<any>(child) && child.type === InputGroupInnerStart) {
-      const width = child.props.width || space.xl;
+      const width = maybeWrapCSSVariables(child.props.width || system.space.x10);
       offsetsStart.push(width);
     }
     if (React.isValidElement<any>(child) && child.type === InputGroupInnerEnd) {
-      const width = child.props.width || space.xl;
+      const width = maybeWrapCSSVariables(child.props.width || system.space.x10);
       offsetsEnd.push(width);
     }
   });

--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -36,9 +36,17 @@ type DefaultedVarsShape = Record<string, string> | Record<string, Record<string,
 
 /**
  * Wrap all unwrapped CSS Variables. For example, `{padding: '--foo'}` will be replaced with
- * `{padding: 'var(--foo)'}`. It also works on variables in the middle of the property.
+ * `{padding: 'var(--foo)'}`. It also works on variables in the middle of the property. Takes any
+ * string and returns a string with CSS variables wrapped if necesary.
+ * 
+ * ```ts
+ * maybeWrapCSSVariables('1rem'); // 1rem
+ * maybeWrapCSSVariables('--foo'); // var(--foo)
+ * maybeWrapCSSVariables('var(--foo); // var(--foo)
+ * maybeWrapCSSVariables('calc(--foo)'); // calc(var(--foo))
+ * ```
  */
-function maybeWrapCSSVariables(input: string): string {
+export function maybeWrapCSSVariables(input: string): string {
   // matches an string starting with `--` that isn't already wrapped in a `var()`. It tries to match
   // any character that isn't a valid separator in CSS
   return input.replace(

--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -42,7 +42,7 @@ type DefaultedVarsShape = Record<string, string> | Record<string, Record<string,
  * ```ts
  * maybeWrapCSSVariables('1rem'); // 1rem
  * maybeWrapCSSVariables('--foo'); // var(--foo)
- * maybeWrapCSSVariables('var(--foo); // var(--foo)
+ * maybeWrapCSSVariables('var(--foo)'); // var(--foo)
  * maybeWrapCSSVariables('calc(--foo)'); // calc(var(--foo))
  * ```
  */


### PR DESCRIPTION
## Summary

Add support for the new Canvas tokens that utilize CSS Variables in `InputGroup` and export the `maybeWrapCssVars` function from the styling package.

## Release Category
Components

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)