### PR TITLE
feat(styling): Add support for fallthrough modifiers

### DIFF
--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -415,8 +415,10 @@ export function createModifiers<M extends ModifierConfig>(input: M): ModifierRet
   const modifierFn = (modifiers: Partial<ModifierValues<M>>) => {
     return combineClassNames(
       Object.keys(input)
-        .filter(key => (input as any)[key][modifiers[key]])
-        .map(key => (input as any)[key][modifiers[key]])
+        .map(
+          key => (input as any)[key][modifiers[key]] || (modifiers[key] && (input as any)[key]._)
+        )
+        .filter(input => input) // only return defined class names
     );
   };
 

--- a/modules/styling/spec/cs.spec.tsx
+++ b/modules/styling/spec/cs.spec.tsx
@@ -348,6 +348,29 @@ describe('cs', () => {
       const myModifiers = myModifiersFactory();
       expectTypeOf(myModifiers.size).toMatchTypeOf<{large: CS; small: CS}>();
     });
+
+    describe('with a "_" modifier key', () => {
+      const myModifiersFactory = () =>
+        createModifiers({
+          size: {
+            large: createStyles({fontSize: '1.5rem'}),
+            small: createStyles({fontSize: '0.8rem'}),
+            _: createStyles({fontSize: 'var(--size)'}),
+          },
+        });
+
+      it('should not return any classes when "size" is not provided', () => {
+        const myModifiers = myModifiersFactory();
+
+        expect(myModifiers({})).toEqual('');
+      });
+
+      it('should return the CSS class of the "_" key when no other modifier matches and a matching modifier key is provided', () => {
+        const myModifiers = myModifiersFactory();
+
+        expect(myModifiers({size: 'foo' as any})).toEqual(myModifiers.size._);
+      });
+    });
   });
 
   describe('createCompoundModifiers', () => {


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

A modifier key of `_` can be used to indicate a fallthrough modifier. This is useful if we want to conditionally add a CSS property only when a CSS variable is provided.

https://github.com/Workday/canvas-kit/discussions/2941

## Release Category
Styling

---

## Checklist

- [x] Label `ready for review` has been added to PR
