### PR TITLE
fix: Remove extract docs in canary to prevent exceeding limit [skip release]

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -26,10 +26,10 @@ jobs:
       ## Build Storybook and extract component stories for Storybook aggregation. This will be used
       ## for Chromatic rebaselining and publishing to GH Pages. Should be before `yarn build` since
       ## built assets mess up this command
+      #  removed yarn sb extract docs docs/stories.json because we were exceeding limit in CI, add back in once we find more space
       - name: Build Storybook
         run: |
           yarn build-storybook --quiet
-          yarn sb extract docs docs/stories.json
 
       ## Build for packaging.
       - name: Build


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: https://github.com/Workday/canvas-kit/issues/2947

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Infrastructure

---

