### PR TITLE
fix: Support false modifier values

### DIFF
--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -1074,7 +1074,7 @@ export function parentModifier(value: string) {
  * compound modifiers.
  */
 export function createStencil<
-  M extends StencilModifierConfig<V> = {},
+  M extends StencilModifierConfig<V>, // TODO: default to `{}` and fix inference in `StyleReturn` types so that modifier style return functions give correct inference to variables
   V extends DefaultedVarsShape = {},
   E extends BaseStencil<any, any, any, any> = never, // use BaseStencil to avoid infinite loops
   ID extends string = never

--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -653,11 +653,6 @@ export function createStyles(
       // https://codesandbox.io/s/stupefied-bartik-9c2jtd?file=/src/App.tsx
       const {styles} = serializeStyles([convertedStyles as CastStyleProps]);
 
-      // use `css.call()` instead of `css()` to trick Emotion's babel plugin to not rewrite our code
-      // to remove our generated Id for the name:
-      // https://github.com/emotion-js/emotion/blob/f3b268f7c52103979402da919c9c0dd3f9e0e189/packages/babel-plugin/src/utils/transform-expression-with-styles.js#L81-L82
-      // Without this "fix", anyone using the Emotion babel plugin would get different results than
-      // intended when styles are merged.
       const name = generateUniqueId();
       createStylesCache[`${instance.cache.key}-${name}`] = true;
       return instance.css({name, styles});
@@ -814,7 +809,7 @@ export type StencilCompoundConfig<M> = {
 };
 
 type ModifierValuesStencil<
-  M extends StencilModifierConfig<any, any>,
+  M extends StencilModifierConfig<any, any> = {},
   V extends DefaultedVarsShape = {}
 > = {
   [P in keyof M]?: P extends keyof V
@@ -992,8 +987,8 @@ type StencilDefaultModifierReturn<M> = {
 };
 
 export interface BaseStencil<
-  M extends StencilModifierConfig<V>,
-  V extends DefaultedVarsShape,
+  M extends StencilModifierConfig<V> = {},
+  V extends DefaultedVarsShape = {},
   E extends BaseStencil<any, any, any, any> = never,
   ID extends string = never
 > {
@@ -1004,8 +999,8 @@ export interface BaseStencil<
 }
 
 export interface Stencil<
-  M extends StencilModifierConfig<V, E>,
-  V extends DefaultedVarsShape,
+  M extends StencilModifierConfig<V, E> = {},
+  V extends DefaultedVarsShape = {},
   E extends BaseStencil<any, any, any, any> = never,
   ID extends string = never
 > extends BaseStencil<M, V, E, ID> {
@@ -1079,7 +1074,7 @@ export function parentModifier(value: string) {
  * compound modifiers.
  */
 export function createStencil<
-  M extends StencilModifierConfig<V>,
+  M extends StencilModifierConfig<V> = {},
   V extends DefaultedVarsShape = {},
   E extends BaseStencil<any, any, any, any> = never, // use BaseStencil to avoid infinite loops
   ID extends string = never
@@ -1157,7 +1152,7 @@ export function createStencil<
     const inputModifiers = {...composes?.defaultModifiers, ...defaultModifiers};
     // Only override defaults if a value is defined
     for (const key in input) {
-      if (input[key]) {
+      if (input[key] !== undefined) {
         // @ts-ignore
         inputModifiers[key] = input[key];
       }

--- a/modules/styling/spec/cs.spec.tsx
+++ b/modules/styling/spec/cs.spec.tsx
@@ -857,10 +857,14 @@ describe('cs', () => {
           },
           grow: {
             true: {},
+            false: {},
           },
         },
         // make sure boolean modifiers are valid in compound config
-        compound: [{modifiers: {size: 'large', grow: true}, styles: {}}],
+        compound: [
+          {modifiers: {size: 'large', grow: true}, styles: {}},
+          {modifiers: {size: 'large', grow: false}, styles: {}},
+        ],
       });
 
       type Args = Exclude<Parameters<typeof myStencil>[0], undefined>;
@@ -874,6 +878,36 @@ describe('cs', () => {
       myStencil({
         grow: true,
       });
+    });
+
+    it('should apply true styles', () => {
+      const myStencil = createStencil({
+        base: {},
+        modifiers: {
+          grow: {
+            true: {width: '100%'},
+            false: {width: '100px'},
+          },
+        },
+      });
+
+      const {className} = myStencil({grow: true});
+      expect(className).toContain(myStencil.modifiers.grow.true);
+    });
+
+    it('should apply false styles', () => {
+      const myStencil = createStencil({
+        base: {},
+        modifiers: {
+          grow: {
+            true: {width: '100%'},
+            false: {width: '100px'},
+          },
+        },
+      });
+
+      const {className} = myStencil({grow: false});
+      expect(className).toContain(myStencil.modifiers.grow.false);
     });
 
     describe('when extending', () => {
@@ -909,6 +943,7 @@ describe('cs', () => {
           modifiers: {
             extra: {
               true: {},
+              false: {},
             },
           },
         });
@@ -933,6 +968,8 @@ describe('cs', () => {
         expectTypeOf(extendedStencil.modifiers).toHaveProperty('extra');
         expectTypeOf(extendedStencil.modifiers.extra).toHaveProperty('true');
         expectTypeOf(extendedStencil.modifiers.extra.true).toEqualTypeOf<string>();
+        expectTypeOf(extendedStencil.modifiers.extra).toHaveProperty('false');
+        expectTypeOf(extendedStencil.modifiers.extra.false).toEqualTypeOf<string>();
 
         // calling the stencil
         type Args = Exclude<Parameters<typeof extendedStencil>[0], undefined>;
@@ -945,6 +982,9 @@ describe('cs', () => {
         // while the actual function call fails
         extendedStencil({
           extra: true,
+        });
+        extendedStencil({
+          extra: false,
         });
       });
 
@@ -971,11 +1011,13 @@ describe('cs', () => {
           modifiers: {
             extra: {
               true: {},
+              false: {},
             },
           },
           compound: [
             {modifiers: {size: 'large'}, styles: {}},
             {modifiers: {size: 'large', extra: true}, styles: {}},
+            {modifiers: {size: 'large', extra: false}, styles: {}},
           ],
         });
 
@@ -1004,6 +1046,49 @@ describe('cs', () => {
         extendedStencil({
           extra: true,
         });
+        extendedStencil({
+          extra: false,
+        });
+      });
+
+      it('should apply true modifier styles', () => {
+        const baseStencil = createStencil({
+          base: {},
+        });
+
+        const extendedStencil = createStencil({
+          extends: baseStencil,
+          base: {},
+          modifiers: {
+            grow: {
+              true: {width: '100%'},
+              false: {width: '100px'},
+            },
+          },
+        });
+
+        const {className} = extendedStencil({grow: true});
+        expect(className).toContain(extendedStencil.modifiers.grow.true);
+      });
+
+      it('should apply false modifier styles', () => {
+        const baseStencil = createStencil({
+          base: {},
+        });
+
+        const extendedStencil = createStencil({
+          extends: baseStencil,
+          base: {},
+          modifiers: {
+            grow: {
+              true: {width: '100%'},
+              false: {width: '100px'},
+            },
+          },
+        });
+
+        const {className} = extendedStencil({grow: false});
+        expect(className).toContain(extendedStencil.modifiers.grow.false);
       });
 
       it('should set default modifiers using base modifiers', () => {

--- a/modules/styling/spec/cs.spec.tsx
+++ b/modules/styling/spec/cs.spec.tsx
@@ -845,6 +845,27 @@ describe('cs', () => {
       expect(result2.className).toContain(`${myStencil.base} ${myStencil.modifiers.width.zero}`);
     });
 
+    it('should infer variables within a modifier style return function', () => {
+      const myStencil = createStencil({
+        vars: {
+          width: '10px',
+          height: '10px',
+        },
+        base: {},
+        modifiers: {
+          width: {
+            zero: ({width}) => {
+              expectTypeOf(width).toEqualTypeOf<string>();
+
+              return {
+                width: width,
+              };
+            },
+          },
+        },
+      });
+    });
+
     it('should convert "true" modifiers into boolean', () => {
       const myStencil = createStencil({
         vars: {
@@ -1054,6 +1075,7 @@ describe('cs', () => {
       it('should apply true modifier styles', () => {
         const baseStencil = createStencil({
           base: {},
+          modifiers: {}, // TODO: Remove this requirement
         });
 
         const extendedStencil = createStencil({
@@ -1074,6 +1096,7 @@ describe('cs', () => {
       it('should apply false modifier styles', () => {
         const baseStencil = createStencil({
           base: {},
+          modifiers: {}, // TODO: Remove this requirement
         });
 
         const extendedStencil = createStencil({


### PR DESCRIPTION
## Summary

- Support modifiers with a `false` value

## Release Category
Styling

---

## Checklist

- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

Tests
