### PR TITLE
chore(text-input): Convert `InputGroup` to use Stencils

### DIFF
--- a/modules/react/text-input/lib/TextInput.tsx
+++ b/modules/react/text-input/lib/TextInput.tsx
@@ -48,7 +48,7 @@ export const textInputStencil = createStencil({
       boxShadow: `inset 0 0 0 1px ${cssVar(brand.common.focusOutline)}`,
       outline: 'none',
     },
-    '&is(:disabled, .disabled)': {
+    '&:is(:disabled, .disabled)': {
       backgroundColor: system.color.bg.alt.softer,
       borderColor: system.color.border.input.disabled,
       color: system.color.text.disabled,

--- a/modules/react/text-input/lib/TextInput.tsx
+++ b/modules/react/text-input/lib/TextInput.tsx
@@ -33,21 +33,22 @@ export const textInputStencil = createStencil({
     width: cssVar(width),
     minWidth: cssVar(width, calc.add(calc.multiply(system.space.x20, 3), system.space.x10)),
     color: system.color.text.default,
+    textOverflow: 'ellipsis',
     '::-ms-clear': {
       display: 'none',
     },
     '&::placeholder': {
       color: system.color.text.hint,
     },
-    '&:hover, &.hover': {
+    '&:is(:hover, .hover)': {
       borderColor: system.color.border.input.strong,
     },
-    '&:focus-visible:not([disabled]), &.focus:not([disabled])': {
+    '&:is(:focus-visible, .focus):where(:not([disabled]))': {
       borderColor: brand.common.focusOutline,
       boxShadow: `inset 0 0 0 1px ${cssVar(brand.common.focusOutline)}`,
       outline: 'none',
     },
-    '&:disabled, .disabled': {
+    '&is(:disabled, .disabled)': {
       backgroundColor: system.color.bg.alt.softer,
       borderColor: system.color.border.input.disabled,
       color: system.color.text.disabled,
@@ -71,11 +72,11 @@ export const textInputStencil = createStencil({
       error: {
         borderColor: brand.error.base,
         boxShadow: `inset 0 0 0 ${px2rem(1)} ${brand.error.base}`,
-        '&:hover, &.hover, &:disabled, &.disabled, &:focus-visible:not([disabled]), &.focus:not([disabled])':
+        '&:is(:hover, .hover, :disabled, .disabled, :focus-visible:not([disabled]), .focus:not([disabled]))':
           {
             borderColor: brand.error.base,
           },
-        '&:focus-visible:not([disabled]), &.focus:not([disabled])': {
+        '&:is(:focus-visible, .focus):not([disabled])': {
           boxShadow: `inset 0 0 0 ${px2rem(1)} ${brand.error.base}, 0 0 0 2px ${
             system.color.border.inverse
           }, 0 0 0 4px ${brand.common.focusOutline}`,
@@ -84,12 +85,12 @@ export const textInputStencil = createStencil({
       alert: {
         borderColor: brand.alert.darkest,
         boxShadow: `inset 0 0 0 ${px2rem(2)} ${brand.alert.base}`,
-        '&:hover, &.hover, &:disabled, &.disabled, &:focus-visible:not([disabled]), &.focus:not([disabled])':
+        '&:is(:hover, .hover, :disabled, .disabled, :focus-visible:not([disabled]), .focus:not([disabled]))':
           {
             borderColor: brand.alert.darkest,
           },
 
-        '&:focus-visible:not([disabled]), &.focus:not([disabled])': {
+        '&:is(:focus-visible, .focus):not([disabled])': {
           boxShadow: `inset 0 0 0 ${px2rem(2)} ${brand.alert.base},
         0 0 0 2px ${system.color.border.inverse},
         0 0 0 4px ${brand.common.focusOutline}`,
@@ -104,16 +105,18 @@ export const textInputStencil = createStencil({
 
 export const TextInput = createComponent('input')({
   displayName: 'TextInput',
-  Component: ({grow, error, width, ...elemProps}: TextInputProps, ref, Element) => (
-    <Element
-      type="text"
-      ref={ref}
-      {...mergeStyles(
-        elemProps,
-        textInputStencil({width: typeof width === 'number' ? px2rem(width) : width, grow, error})
-      )}
-    />
-  ),
+  Component: ({grow, error, width, ...elemProps}: TextInputProps, ref, Element) => {
+    return (
+      <Element
+        type="text"
+        ref={ref}
+        {...mergeStyles(
+          elemProps,
+          textInputStencil({width: typeof width === 'number' ? px2rem(width) : width, grow, error})
+        )}
+      />
+    );
+  },
   subComponents: {
     ErrorType,
   },

--- a/modules/react/text-input/stories/visualTesting.stories.tsx
+++ b/modules/react/text-input/stories/visualTesting.stories.tsx
@@ -115,20 +115,43 @@ export const InputGroupStates = () => (
             end: [<span>4</span>, <span>5</span>, <span>6</span>],
           },
         },
+        {
+          label: 'ClearButton w/ value',
+          props: {
+            placeholder: 'Placeholder',
+            value: 'Some Value',
+            start: [],
+            end: [<InputGroup.ClearButton />],
+          },
+        },
+        {
+          label: 'ClearButton w/o value',
+          props: {
+            placeholder: '',
+            value: '',
+            start: [],
+            end: [<InputGroup.ClearButton />],
+          },
+        },
       ]}
       columnProps={[
         {label: 'LTR', props: {dir: 'ltr'}},
         {label: 'RTL', props: {dir: 'rtl'}},
       ]}
     >
-      {props => (
+      {({value, placeholder, ...props}) => (
         <CanvasProvider theme={{canvas: {direction: props.dir}}}>
           <InputGroup width={300}>
             {props.start &&
               props.start.map((start, index) => (
-                <InputGroup.InnerStart key={index}>{start}</InputGroup.InnerStart>
+                <InputGroup.InnerStart key={index} pointerEvents="none">
+                  {start}
+                </InputGroup.InnerStart>
               ))}
-            <InputGroup.Input value="Very Long Text. Very Long Text. Very Long Text." />
+            <InputGroup.Input
+              placeholder={placeholder}
+              value={value ?? 'Very Long Text. Very Long Text. Very Long Text.'}
+            />
             {props.end &&
               props.end.map((end, index) => (
                 <InputGroup.InnerEnd key={index}>{end}</InputGroup.InnerEnd>

--- a/modules/styling-transform/lib/utils/handleCreateStencil.ts
+++ b/modules/styling-transform/lib/utils/handleCreateStencil.ts
@@ -3,7 +3,7 @@ import ts from 'typescript';
 import {slugify} from '@workday/canvas-kit-styling';
 
 import {getVarName} from './getVarName';
-import {parseObjectToStaticValue} from './parseObjectToStaticValue';
+import {maybeWrapCSSVariables, parseObjectToStaticValue} from './parseObjectToStaticValue';
 import {createStyleObjectNode, serializeStyles} from './createStyleObjectNode';
 import {getValueFromAliasedSymbol, parseNodeToStaticValue} from './parseNodeToStaticValue';
 import {NestedStyleObject, NodeTransformer, TransformerContext} from './types';
@@ -97,7 +97,7 @@ export const handleCreateStencil: NodeTransformer = (node, context) => {
           const value = parseNodeToStaticValue(node.initializer, context).toString();
           if (value) {
             // Only add the stencil variable if there's a value. An empty string means no default.
-            stencilVariables[names[varName]] = value;
+            stencilVariables[names[varName]] = String(maybeWrapCSSVariables(value, names));
           }
         }
       }

--- a/modules/styling-transform/spec/utils/handleCreateStencil.spec.ts
+++ b/modules/styling-transform/spec/utils/handleCreateStencil.spec.ts
@@ -393,6 +393,46 @@ describe('handleCreateStencil', () => {
       );
     });
 
+    it('should wrap variable values with var() if necessary', () => {
+      const program = createProgramFromSource(`
+        import {createStencil} from '@workday/canvas-kit-styling';
+
+        const buttonStencil = createStencil({
+          vars: {
+            color: '--foo'
+          },
+          base({color}) {
+            return {
+              color,
+              padding: 12
+            }
+          }
+        })
+      `);
+
+      const names = {};
+      const styles = {};
+
+      const result = transform(
+        program,
+        'test.ts',
+        withDefaultContext(program.getTypeChecker(), {styles, names})
+      );
+
+      expect(result).toContain(
+        `${names['buttonStencil.vars.color']}:var(--foo);box-sizing:border-box;color:var(${names['buttonStencil.vars.color']});padding:12px;`
+      );
+
+      expect(styles['test.css']).toContainEqual(
+        compileCSS(`.css-button {
+          --css-button-color: var(--foo);
+          box-sizing: border-box;
+          color: var(--css-button-color);
+          padding: 12px;
+        }`)
+      );
+    });
+
     it('should handle parsing modifiers with ObjectLiteralExpressions', () => {
       const program = createProgramFromSource(`
         import {createStencil, parentModifier} from '@workday/canvas-kit-styling';


### PR DESCRIPTION
## Summary

Convert `InputGroup` to use Stencils. This allows anything using the `InputGroup` to not force compatibility mode.

## Release Category
Components

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)

