### PR TITLE
Update deprecated urls to CodeshiftCommunity

### DIFF
--- a/modules/docs/mdx/11.0-UPGRADE-GUIDE.mdx
+++ b/modules/docs/mdx/11.0-UPGRADE-GUIDE.mdx
@@ -79,7 +79,7 @@ automatically update your code to work with most of the breaking changes in v11.
 handled by the codemod are marked with 🤖 in the Upgrade Guide.**
 
 A codemod is a script that makes programmatic transformations on your codebase by traversing the
-[AST](https://www.codeshiftcommunity.com/docs/understanding-asts), identifying patterns, and making
+[AST](https://www.hypermod.io/docs/guides/understanding-asts), identifying patterns, and making
 prescribed changes. This greatly decreases opportunities for error and reduces the number of manual
 updates, which allows you to focus on changes that need your attention. **We highly recommend you
 use the codemod for these reasons.**

--- a/modules/docs/mdx/9.0-UPGRADE-GUIDE.mdx
+++ b/modules/docs/mdx/9.0-UPGRADE-GUIDE.mdx
@@ -43,7 +43,7 @@ automatically update your code to work with most of the breaking changes in v9. 
 handled by the codemod are marked with 🤖 in the Upgrade Guide.**
 
 A codemod is a script that makes programmatic transformations on your codebase by traversing the
-[AST](https://www.codeshiftcommunity.com/docs/understanding-asts), identifying patterns, and making
+[AST](https://www.hypermod.io/docs/guides/understanding-asts), identifying patterns, and making
 prescribed changes. This greatly decreases opportunities for error and reduces the number of manual
 updates, which allows you to focus on changes that need your attention. **We highly recommend you
 use the codemod for these reasons.**


### PR DESCRIPTION
## Summary

Updates links to CodeshiftCommunity to Hypermod. We're planning to spin down the old site soon so it would be good to direct folks to the new home of this content so they can receive updates.

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [ ] Label `ready for review` has been added to PR


## Where Should the Reviewer Start?

Please just double check the URLs are still functional (ive tested them also)

## Areas for Feedback? (optional)

- [ ] Code
- [x] Documentation
- [ ] Testing
- [x] Codemods

# Testing Manually
N/A

