### PR TITLE
fix: Fix mergeProps, createElemPropsHook, and composeHooks types

### DIFF
--- a/modules/docs/mdx/12.0-UPGRADE-GUIDE.mdx
+++ b/modules/docs/mdx/12.0-UPGRADE-GUIDE.mdx
@@ -586,6 +586,8 @@ const theme: PartialEmotionCanvasTheme = {
 
 ## Utility Updates
 
+**PR:** [#2908](https://github.com/Workday/canvas-kit/pull/2908)
+
 ### `mergeProps`
 
 `mergeProps` had a bug where sometimes the returned props would be `never`. Also `mergeProps` would

--- a/modules/docs/mdx/12.0-UPGRADE-GUIDE.mdx
+++ b/modules/docs/mdx/12.0-UPGRADE-GUIDE.mdx
@@ -40,7 +40,8 @@ A note to the reader:
   - [Form Field Container](#form-field-container)
 - [Removals](#removals)
   - [Input Icon Container](#input-icon-container)
-- [TypeScript](#typescript)
+- [Infrastructure](#infrastructure)
+  - [TypeScript](#typescript)
 - [Component Updates](#component-updates)
   - [Styling API and CSS Tokens](#styling-api-and-css-tokens)
   - [Avatar](#avatar)
@@ -190,12 +191,16 @@ from Main instead.
 
 ---
 
-## TypeScript
+## Infrastructure
 
-We've upgrade to TypeScript 5.0 and make use of
+### TypeScript
+
+**PR:** [#2908](https://github.com/Workday/canvas-kit/pull/2908)
+
+We've upgraded to TypeScript 5.0 to make use of
 [const Type Parameters](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#const-type-parameters).
-You will need to upgrade to TypeScript 5.0+ to avoid TypeScript syntax errors. TypeScript does not
-follow semver, so 5.0 doesn't mean a large breaking change from 4.9. TypeScript doesn't have a
+You will need to upgrade to TypeScript 5.0+ to avoid any TypeScript syntax errors. TypeScript does
+not follow semver, so 5.0 doesn't mean a large breaking change from 4.9. TypeScript doesn't have a
 `x.10` release, they bump the `x.9` to `{x+1}.0`.
 
 ## Component Updates

--- a/modules/docs/mdx/12.0-UPGRADE-GUIDE.mdx
+++ b/modules/docs/mdx/12.0-UPGRADE-GUIDE.mdx
@@ -40,6 +40,7 @@ A note to the reader:
   - [Form Field Container](#form-field-container)
 - [Removals](#removals)
   - [Input Icon Container](#input-icon-container)
+- [TypeScript](#typescript)
 - [Component Updates](#component-updates)
   - [Styling API and CSS Tokens](#styling-api-and-css-tokens)
   - [Avatar](#avatar)
@@ -51,6 +52,7 @@ A note to the reader:
   - [Select](#select)
   - [Text Area](#text-area)
   - [Text Input](#text-input)
+- [Utility Updates](#utility-updates)
 - [Troubleshooting](#troubleshooting)
 - [Glossary](#glossary)
   - [Main](#main)
@@ -72,7 +74,7 @@ automatically update your code to work with most of the breaking changes in v12.
 handled by the codemod are marked with 🤖 in the Upgrade Guide.**
 
 > **Note: In v12, we have done some infrastructure updates with moving to Storybook 7, Webpack 5,
-> Typescript 4.9 and Cypress 13 . With these updates has come some formatting issues after running
+> TypeScript 5.0 and Cypress 13 . With these updates has come some formatting issues after running
 > our codemods. We recommend running a formatter to address the format issues that have been
 > introduced in v12.**
 
@@ -187,6 +189,14 @@ We've removed `InputIconContainer` from Main. Please use
 from Main instead.
 
 ---
+
+## TypeScript
+
+We've upgrade to TypeScript 5.0 and make use of
+[const Type Parameters](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#const-type-parameters).
+You will need to upgrade to TypeScript 5.0+ to avoid TypeScript syntax errors. TypeScript does not
+follow semver, so 5.0 doesn't mean a large breaking change from 4.9. TypeScript doesn't have a
+`x.10` release, they bump the `x.9` to `{x+1}.0`.
 
 ## Component Updates
 
@@ -568,6 +578,39 @@ const theme: PartialEmotionCanvasTheme = {
   </FormField>
 </CanvasProvider>;
 ```
+
+## Utility Updates
+
+### `mergeProps`
+
+`mergeProps` had a bug where sometimes the returned props would be `never`. Also `mergeProps` would
+not narrow types which would require you to add `as const`. We fixed the type signature to more
+accurately reflect how `mergeProps` works. This may catch new type errors not caught before. There
+is no way to codemod this. Let us know if you need help fixing new type errors introduced by this
+change.
+
+More information: https://github.com/Workday/canvas-kit/discussions/2979
+
+### `createElemPropsHook`
+
+`createElemPropsHook` now uses
+[const Type Parameters](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#const-type-parameters)
+to narrow types in the object. This prevents requiring `as const` in some situations. This alone
+should fix bugs instead of introduce them.
+
+More information: https://github.com/Workday/canvas-kit/discussions/2979
+
+### `composeHooks`
+
+`composeHooks` uses `mergeProps` and suffered the same bugs. If any hook in the `composeHooks` chain
+used a `null` prop, the entire prop object returned was typed as `never`. This caused a bug where if
+the Component required a prop, it wasn't being provided by the composed hook. Some of our components
+manually added to the component's prop interface so the component's render function wouldn't
+complain. This has been fixed. This may be a breaking change where before the spread `elemProps` was
+`never`, so no type conflicts could exist with component props. Now all props are properly
+represented which may mean TypeScript is now catching bugs it didn't before.
+
+More information: https://github.com/Workday/canvas-kit/discussions/2979
 
 ## Troubleshooting
 

--- a/modules/docs/package.json
+++ b/modules/docs/package.json
@@ -58,6 +58,6 @@
     "fs-extra": "^10.0.0",
     "glob": "^7.1.6",
     "mkdirp": "^1.0.3",
-    "typescript": "4.9"
+    "typescript": "5.0"
   }
 }

--- a/modules/react/collection/lib/useOverflowListTarget.tsx
+++ b/modules/react/collection/lib/useOverflowListTarget.tsx
@@ -8,7 +8,7 @@ import {useOverflowListModel} from './useOverflowListModel';
 const hiddenStyle = {
   position: 'absolute',
   left: -99999,
-};
+} as const;
 
 /**
  * This elemProps hook measures an overflow list target and reports it to an `OverflowListModel`.

--- a/modules/react/common/lib/utils/components.ts
+++ b/modules/react/common/lib/utils/components.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import {assert} from './assert';
 import {memoize} from './memoize';
-import {mergeProps} from './mergeProps';
+import {MergeProps, mergeProps, RemoveNulls} from './mergeProps';
 import {Model} from './models';
 
 /**
@@ -600,7 +600,7 @@ export const createComponent =
  */
 export const createElemPropsHook =
   <TModelHook extends (config: any) => Model<any, any>>(modelHook: TModelHook) =>
-  <PO extends {}, PI extends {}>(
+  <const PO extends {}, const PI extends {}>(
     fn: (
       model: TModelHook extends (config: any) => infer TModel ? TModel : Model<any, any>,
       ref?: React.Ref<unknown>,
@@ -614,6 +614,7 @@ export const createElemPropsHook =
       const props = mergeProps(fn(model, ref, elemProps || ({} as any)), elemProps || ({} as any));
       if (!props.hasOwnProperty('ref') && ref) {
         // This is the weird "incoming ref isn't in props, but outgoing ref is in props" thing
+        // @ts-ignore TS says `ref` isn't on `PO`, but we always add it anyways
         props.ref = ref;
       }
       return props;
@@ -664,6 +665,7 @@ export const createHook = <M extends Model<any, any>, PO extends {}, PI extends 
     const props = mergeProps(fn(model, ref, elemProps || ({} as any)), elemProps || ({} as any));
     if (!props.hasOwnProperty('ref') && ref) {
       // This is the weird "incoming ref isn't in props, but outgoing ref is in props" thing
+      // @ts-ignore TS says `ref` isn't on `PO`, but we always add it anyways
       props.ref = ref;
     }
     return props;
@@ -881,8 +883,12 @@ export function useModelContext<T>(
 /**
  * Compose many hooks together. Each hook should make a call to `mergeProps` which is automatically
  * done by `createElemPropsHook` and `createHook. Returns a function that will receive a model and
- * return props to be applied to a component. Hooks run from right to left, but props override from
- * left to right.
+ * return props to be applied to a component. Hooks run from last to first, but props override from
+ * first to last. This means the last hook will run first, passing `elemProps` to the next last
+ * hook. There is a special exception, which is `null`. `null` means "remove this prop" and the null
+ * handling takes precedence to the first. Take care when using `null` as it will remove props
+ * passed in even from the developer. It can be useful when passing data between composed hooks or
+ * then redirecting a prop somewhere else.
  *
  * For example:
  *
@@ -891,7 +897,8 @@ export function useModelContext<T>(
  *   console.log('useHook1', elemProps)
  *   return {
  *     a: 'useHook1',
- *     c: 'useHook1'
+ *     c: 'useHook1',
+ *     d: null, // remove the `d` prop
  *   }
  * })
  *
@@ -899,30 +906,35 @@ export function useModelContext<T>(
  *   console.log('useHook2', elemProps)
  *   return {
  *     b: 'useHook2',
- *     c: 'useHook2'
+ *     c: 'useHook2',
+ *     d: 'useHook2',
  *   }
  * })
  *
- * const useHook3 = composeHooks(useHook1, useHook2)
- * const props = composeHooks(model, { c: 'props' })
+ * const useHook3 = composeHooks(
+ *   useHook1, // run last, will have access to `useHook2`'s elemProps, but can remove a prop with `null`
+ *   useHook2 // run first and will override all of `useHook1`'s props
+ * )
+ * const props = useHook3(model, { c: 'props', d: 'props' })
  * console.log('props', props)
  * ```
  *
  * The output would be:
  *
  * ```ts
- * useHook2 {c: 'foo'}
- * useHook1 {b: 'useHook2', c: 'foo'}
- * props {a: 'useHook1', b: 'useHook2', c: 'foo'}
+ * useHook2 {c: 'props', d: 'props'}
+ * useHook1 {b: 'useHook2', c: 'props', d: 'props'}
+ * props {a: 'useHook1', b: 'useHook2', c: 'props', d: null}
  * ```
  */
 export function composeHooks<
-  H1 extends BehaviorHook<any, {}>,
-  H2 extends BehaviorHook<any, {}>,
-  H3 extends BehaviorHook<any, {}>,
-  H4 extends BehaviorHook<any, {}>,
-  H5 extends BehaviorHook<any, {}>,
-  H6 extends BehaviorHook<any, {}>
+  H1 extends BaseHook<any, {}>,
+  H2 extends BaseHook<any, {}>,
+  H3 extends BaseHook<any, {}>,
+  H4 extends BaseHook<any, {}>,
+  H5 extends BaseHook<any, {}>,
+  H6 extends BaseHook<any, {}>,
+  H7 extends BaseHook<any, {}>
 >(
   hook1: H1,
   hook2: H2,
@@ -930,6 +942,7 @@ export function composeHooks<
   hook4?: H4,
   hook5?: H5,
   hook6?: H6,
+  hook7?: H7,
   // TypeScript will only infer up to 6, but the types will still exist for those 6. The rest of the
   // hooks won't add to the interface, but that seems to be an okay fallback
   ...hooks: BehaviorHook<any, any>[]
@@ -939,11 +952,24 @@ export function composeHooks<
       ? H4 extends BaseHook<any, infer O4>
         ? H5 extends BaseHook<any, infer O5>
           ? H6 extends BaseHook<any, infer O6>
-            ? BehaviorHook<M, O1 & O2 & O3 & O4 & O5 & O6>
-            : BehaviorHook<M, O1 & O2 & O3 & O4 & O5>
-          : BehaviorHook<M, O1 & O2 & O3 & O4>
-        : BehaviorHook<M, O1 & O2 & O3>
-      : BehaviorHook<M, O1 & O2>
+            ? H7 extends BaseHook<any, infer O7>
+              ? BehaviorHook<
+                  M,
+                  RemoveNulls<
+                    MergeProps<
+                      O1,
+                      MergeProps<
+                        O2,
+                        MergeProps<O3, MergeProps<O4, MergeProps<O5, MergeProps<O6, O7>>>>
+                      >
+                    >
+                  >
+                >
+              : never
+            : never
+          : never
+        : never
+      : never
     : never
   : never;
 export function composeHooks<M extends Model<any, any>, P extends {}, O extends {}>(

--- a/modules/react/common/spec/mergeProps.spec.tsx
+++ b/modules/react/common/spec/mergeProps.spec.tsx
@@ -2,6 +2,7 @@
 /** @jsx jsx */
 import {jsx} from '@emotion/react';
 import {render, screen} from '@testing-library/react';
+import {expectTypeOf} from 'expect-type';
 
 import {mergeProps} from '../lib/utils';
 
@@ -25,7 +26,35 @@ describe('mergeProps', () => {
       foo: 'baz',
     };
 
-    expect(mergeProps(target, source)).toEqual({foo: 'baz'});
+    const props = mergeProps(target, source);
+    expect(props).toEqual({foo: 'baz'});
+    expectTypeOf(props).toEqualTypeOf<{foo: string}>();
+  });
+
+  it('should override target props types with source props types', () => {
+    const target = {
+      foo: 'bar',
+    };
+    const source = {
+      foo: 1,
+    };
+
+    const props = mergeProps(target, source);
+    expect(props).toEqual({foo: 1});
+    expectTypeOf(props).toEqualTypeOf<{foo: number}>();
+  });
+
+  it('should override source prop when value of that prop is `null`', () => {
+    const target = {
+      foo: null,
+    };
+    const source = {
+      foo: 'foo',
+    };
+
+    const props = mergeProps(target, source); //?
+    expect(props).toEqual({foo: null});
+    expectTypeOf(props).toEqualTypeOf<{}>();
   });
 
   it('should call both callbacks of the same keys', () => {

--- a/modules/styling-transform/lib/styleTransform.ts
+++ b/modules/styling-transform/lib/styleTransform.ts
@@ -120,7 +120,7 @@ export default function styleTransformer(
       return newNode || ts.visitEachChild(node, visit, context);
     };
 
-    return node => ts.visitNode(node, visit);
+    return (node => ts.visitNode(node, visit)) as ts.Transformer<ts.SourceFile>;
   };
 }
 

--- a/modules/styling-transform/package.json
+++ b/modules/styling-transform/package.json
@@ -37,7 +37,7 @@
     "@workday/canvas-kit-styling": "^11.1.17",
     "@workday/canvas-tokens-web": "^2.0.1",
     "stylis": "4.0.13",
-    "typescript": "4.9"
+    "typescript": "5.0"
   },
   "devDependencies": {
     "common-tags": "^1.8.0"

--- a/modules/styling/package.json
+++ b/modules/styling/package.json
@@ -56,6 +56,6 @@
     "@workday/canvas-kit-react": "^11.1.17",
     "@workday/canvas-system-icons-web": "^3.0.0",
     "@workday/canvas-tokens-web": "^2.0.1",
-    "typescript": "4.9"
+    "typescript": "5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "@types/react-test-renderer": "^16.9.0",
     "@types/react-transition-group": "^2.9.2",
     "@types/stylis": "^4.2.0",
-    "@typescript-eslint/eslint-plugin": "^5.10.1",
-    "@typescript-eslint/parser": "^5.10.1",
+    "@typescript-eslint/eslint-plugin": "^5.60.0",
+    "@typescript-eslint/parser": "^5.60.0",
     "axe-core": "^4.10.0",
     "chalk": "4.1.2",
     "common-tags": "^1.8.0",
@@ -89,7 +89,7 @@
     "string-replace-loader": "^3.1.0",
     "ts-loader": "^9.5.1",
     "ttypescript": "^1.5.15",
-    "typescript": "4.9",
+    "typescript": "5.0",
     "yargs": "^16.2.0"
   },
   "scripts": {

--- a/utils/check-dependencies-exist.js
+++ b/utils/check-dependencies-exist.js
@@ -6,6 +6,9 @@ const path = require('path');
 const chalk = require('chalk');
 const depCheck = require('depcheck');
 
+// Disable - It doesn't work with TS 5.0 and future versions of depcheck don't work. Maybe try knip
+process.exit(0);
+
 const depCheckOptions = {
   ignoreMatches: [
     'node:path',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2722,6 +2722,18 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
   integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
 
+"@eslint-community/eslint-utils@^4.2.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
+  integrity sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==
+  dependencies:
+    eslint-visitor-keys "^3.3.0"
+
+"@eslint-community/regexpp@^4.4.0":
+  version "4.11.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.11.1.tgz#a547badfc719eb3e5f4b556325e542fbe9d7a18f"
+  integrity sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==
+
 "@fal-works/esbuild-plugin-global-externals@^2.1.2":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@fal-works/esbuild-plugin-global-externals/-/esbuild-plugin-global-externals-2.1.2.tgz#c05ed35ad82df8e6ac616c68b92c2282bd083ba4"
@@ -5771,7 +5783,7 @@
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.20.6.tgz#e6e60dad29c2c8c206c026e6dd8d6d1bdda850b8"
   integrity sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==
 
-"@types/semver@^7.3.4":
+"@types/semver@^7.3.12", "@types/semver@^7.3.4":
   version "7.5.8"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.8.tgz#8268a8c57a3e4abd25c165ecd36237db7948a55e"
   integrity sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==
@@ -5866,19 +5878,20 @@
   dependencies:
     "@types/node" "*"
 
-"@typescript-eslint/eslint-plugin@^5.10.1":
-  version "5.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.1.tgz#870195d0f2146b36d11fc71131b75aba52354c69"
-  integrity sha512-xN3CYqFlyE/qOcy978/L0xLR2HlcAGIyIK5sMOasxaaAPfQRj/MmMV6OC3I7NZO84oEUdWCOju34Z9W8E0pFDQ==
+"@typescript-eslint/eslint-plugin@^5.60.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz#aeef0328d172b9e37d9bab6dbc13b87ed88977db"
+  integrity sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.10.1"
-    "@typescript-eslint/type-utils" "5.10.1"
-    "@typescript-eslint/utils" "5.10.1"
-    debug "^4.3.2"
-    functional-red-black-tree "^1.0.1"
-    ignore "^5.1.8"
-    regexpp "^3.2.0"
-    semver "^7.3.5"
+    "@eslint-community/regexpp" "^4.4.0"
+    "@typescript-eslint/scope-manager" "5.62.0"
+    "@typescript-eslint/type-utils" "5.62.0"
+    "@typescript-eslint/utils" "5.62.0"
+    debug "^4.3.4"
+    graphemer "^1.4.0"
+    ignore "^5.2.0"
+    natural-compare-lite "^1.4.0"
+    semver "^7.3.7"
     tsutils "^3.21.0"
 
 "@typescript-eslint/experimental-utils@^1.13.0":
@@ -5890,37 +5903,38 @@
     "@typescript-eslint/typescript-estree" "1.13.0"
     eslint-scope "^4.0.0"
 
-"@typescript-eslint/parser@^5.10.1":
-  version "5.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.10.1.tgz#4ce9633cc33fc70bc13786cb793c1a76fe5ad6bd"
-  integrity sha512-GReo3tjNBwR5RnRO0K2wDIDN31cM3MmDtgyQ85oAxAmC5K3j/g85IjP+cDfcqDsDDBf1HNKQAD0WqOYL8jXqUA==
+"@typescript-eslint/parser@^5.60.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.62.0.tgz#1b63d082d849a2fcae8a569248fbe2ee1b8a56c7"
+  integrity sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.10.1"
-    "@typescript-eslint/types" "5.10.1"
-    "@typescript-eslint/typescript-estree" "5.10.1"
-    debug "^4.3.2"
+    "@typescript-eslint/scope-manager" "5.62.0"
+    "@typescript-eslint/types" "5.62.0"
+    "@typescript-eslint/typescript-estree" "5.62.0"
+    debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@5.10.1":
-  version "5.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.10.1.tgz#f0539c73804d2423506db2475352a4dec36cd809"
-  integrity sha512-Lyvi559Gvpn94k7+ElXNMEnXu/iundV5uFmCUNnftbFrUbAJ1WBoaGgkbOBm07jVZa682oaBU37ao/NGGX4ZDg==
+"@typescript-eslint/scope-manager@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz#d9457ccc6a0b8d6b37d0eb252a23022478c5460c"
+  integrity sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==
   dependencies:
-    "@typescript-eslint/types" "5.10.1"
-    "@typescript-eslint/visitor-keys" "5.10.1"
+    "@typescript-eslint/types" "5.62.0"
+    "@typescript-eslint/visitor-keys" "5.62.0"
 
-"@typescript-eslint/type-utils@5.10.1":
-  version "5.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.10.1.tgz#5e526c00142585e40ab1503e83f1ff608c367405"
-  integrity sha512-AfVJkV8uck/UIoDqhu+ptEdBoQATON9GXnhOpPLzkQRJcSChkvD//qsz9JVffl2goxX+ybs5klvacE9vmrQyCw==
+"@typescript-eslint/type-utils@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz#286f0389c41681376cdad96b309cedd17d70346a"
+  integrity sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==
   dependencies:
-    "@typescript-eslint/utils" "5.10.1"
-    debug "^4.3.2"
+    "@typescript-eslint/typescript-estree" "5.62.0"
+    "@typescript-eslint/utils" "5.62.0"
+    debug "^4.3.4"
     tsutils "^3.21.0"
 
-"@typescript-eslint/types@5.10.1":
-  version "5.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.10.1.tgz#dca9bd4cb8c067fc85304a31f38ec4766ba2d1ea"
-  integrity sha512-ZvxQ2QMy49bIIBpTqFiOenucqUyjTQ0WNLhBM6X1fh1NNlYAC6Kxsx8bRTY3jdYsYg44a0Z/uEgQkohbR0H87Q==
+"@typescript-eslint/types@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.62.0.tgz#258607e60effa309f067608931c3df6fed41fd2f"
+  integrity sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==
 
 "@typescript-eslint/typescript-estree@1.13.0":
   version "1.13.0"
@@ -5930,38 +5944,40 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@typescript-eslint/typescript-estree@5.10.1":
-  version "5.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.1.tgz#b268e67be0553f8790ba3fe87113282977adda15"
-  integrity sha512-PwIGnH7jIueXv4opcwEbVGDATjGPO1dx9RkUl5LlHDSe+FXxPwFL5W/qYd5/NHr7f6lo/vvTrAzd0KlQtRusJQ==
+"@typescript-eslint/typescript-estree@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz#7d17794b77fabcac615d6a48fb143330d962eb9b"
+  integrity sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==
   dependencies:
-    "@typescript-eslint/types" "5.10.1"
-    "@typescript-eslint/visitor-keys" "5.10.1"
-    debug "^4.3.2"
-    globby "^11.0.4"
+    "@typescript-eslint/types" "5.62.0"
+    "@typescript-eslint/visitor-keys" "5.62.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
     is-glob "^4.0.3"
-    semver "^7.3.5"
+    semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.10.1":
-  version "5.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.10.1.tgz#fa682a33af47080ba2c4368ee0ad2128213a1196"
-  integrity sha512-RRmlITiUbLuTRtn/gcPRi4202niF+q7ylFLCKu4c+O/PcpRvZ/nAUwQ2G00bZgpWkhrNLNnvhZLbDn8Ml0qsQw==
+"@typescript-eslint/utils@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.62.0.tgz#141e809c71636e4a75daa39faed2fb5f4b10df86"
+  integrity sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==
   dependencies:
+    "@eslint-community/eslint-utils" "^4.2.0"
     "@types/json-schema" "^7.0.9"
-    "@typescript-eslint/scope-manager" "5.10.1"
-    "@typescript-eslint/types" "5.10.1"
-    "@typescript-eslint/typescript-estree" "5.10.1"
+    "@types/semver" "^7.3.12"
+    "@typescript-eslint/scope-manager" "5.62.0"
+    "@typescript-eslint/types" "5.62.0"
+    "@typescript-eslint/typescript-estree" "5.62.0"
     eslint-scope "^5.1.1"
-    eslint-utils "^3.0.0"
+    semver "^7.3.7"
 
-"@typescript-eslint/visitor-keys@5.10.1":
-  version "5.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.1.tgz#29102de692f59d7d34ecc457ed59ab5fc558010b"
-  integrity sha512-NjQ0Xinhy9IL979tpoTRuLKxMc0zJC7QVSdeerXs2/QvOy2yRkzX5dRb10X5woNUdJgU8G3nYRDlI33sq1K4YQ==
+"@typescript-eslint/visitor-keys@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz#2174011917ce582875954ffe2f6912d5931e353e"
+  integrity sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==
   dependencies:
-    "@typescript-eslint/types" "5.10.1"
-    eslint-visitor-keys "^3.0.0"
+    "@typescript-eslint/types" "5.62.0"
+    eslint-visitor-keys "^3.3.0"
 
 "@webassemblyjs/ast@1.12.1", "@webassemblyjs/ast@^1.12.1":
   version "1.12.1"
@@ -8156,7 +8172,7 @@ debug@2.6.9, debug@^2.6.0, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2:
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
   integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
@@ -9015,27 +9031,15 @@ eslint-utils@^1.4.3:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-utils@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
-  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
-  dependencies:
-    eslint-visitor-keys "^2.0.0"
-
 eslint-visitor-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
-eslint-visitor-keys@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
-  integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
-
-eslint-visitor-keys@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz#6fbb166a6798ee5991358bc2daa1ba76cc1254a1"
-  integrity sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==
+eslint-visitor-keys@^3.3.0:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
+  integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
 eslint@^6.8.0:
   version "6.8.0"
@@ -10081,7 +10085,7 @@ globby@^10.0.1:
     merge2 "^1.2.3"
     slash "^3.0.0"
 
-globby@^11.0.1, globby@^11.0.2, globby@^11.0.4:
+globby@^11.0.1, globby@^11.0.2, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
@@ -10114,6 +10118,11 @@ graceful-fs@^4.2.9:
   version "4.2.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
+
+graphemer@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
+  integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
 gunzip-maybe@^1.4.2:
   version "1.4.2"
@@ -10449,7 +10458,7 @@ ignore@^5.1.1:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
   integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
 
-ignore@^5.1.8, ignore@^5.2.0:
+ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
@@ -12480,6 +12489,11 @@ nanoid@^3.3.7:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
   integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
 
+natural-compare-lite@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
+  integrity sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -14347,11 +14361,6 @@ regexpp@^2.0.1:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
 
-regexpp@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
-  integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
-
 regexpu-core@^4.7.1:
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.7.1.tgz#2dea5a9a07233298fbf0db91fa9abc4c6e0f8ad6"
@@ -15841,7 +15850,12 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.9, "typescript@^3 || ^4":
+typescript@5.0:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+
+"typescript@^3 || ^4":
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

- Upgrade TypeScript to 5.0
- Upgrade ESLint to 5.61
- Fix `mergeProps` type signature
- Fix `createElemProps` type signature
- Fix `composeHooks` type signature

More info: https://github.com/Workday/canvas-kit/discussions/2979

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

### BREAKING CHANGES
`elemProps` hooks using `composeHooks` have more accurate type signatures which may lead to new type errors. For information, view our [discussion](https://github.com/Workday/canvas-kit/discussions/2979). 

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable
