### PR TITLE
fix: Add flex gap to overflow list calculations

### DIFF
--- a/modules/react/collection/lib/useOverflowListModel.tsx
+++ b/modules/react/collection/lib/useOverflowListModel.tsx
@@ -6,10 +6,11 @@ import {Item} from './useBaseListModel';
 
 export function getHiddenIds(
   containerWidth: number,
+  containerGap: number,
   overflowTargetWidth: number,
   itemWidthCache: Record<string, number>,
   selectedIds: string[] | 'all',
-  items?: Item<any>[]
+  items: Item<any>[]
 ): string[] {
   /** Allows us to prioritize showing the selected item */
   let selectedKey: undefined | string;
@@ -18,17 +19,22 @@ export function getHiddenIds(
   /** Tally ids that won't fit inside the container. These will be used by components to hide
    * elements that won't fit in the container */
   const hiddenIds: string[] = [];
+  /** Track if gap should be calculated since gap doesn't apply to the width of the first item, only
+   * consecutive items */
+  let shouldAddGap = false;
+
   if (selectedIds !== 'all' && selectedIds.length) {
-    if (items?.length) {
+    if (items.length) {
       // If selectedIds[0] is not in items, use the first id from items
       selectedKey = items.find(item => item.id === selectedIds[0]) ? selectedIds[0] : items[0].id;
-    } else {
-      selectedKey = selectedIds[0];
     }
   }
 
   if (
-    Object.keys(itemWidthCache).reduce((sum, key) => sum + itemWidthCache[key], 0) <= containerWidth
+    Object.keys(itemWidthCache).reduce(
+      (sum, key, index) => sum + itemWidthCache[key] + (index > 0 ? containerGap : 0),
+      0
+    ) <= containerWidth
   ) {
     // All items fit, return empty array
     return [];
@@ -39,6 +45,7 @@ export function getHiddenIds(
     } else {
       // at least the selected item and overflow target fit. Update our itemWidth with the sum
       itemWidth += itemWidthCache[selectedKey] + overflowTargetWidth;
+      shouldAddGap = true;
     }
   } else {
     itemWidth += overflowTargetWidth;
@@ -46,7 +53,8 @@ export function getHiddenIds(
 
   for (const key in itemWidthCache) {
     if (key !== selectedKey) {
-      itemWidth += itemWidthCache[key];
+      itemWidth += itemWidthCache[key] + (shouldAddGap ? containerGap : 0);
+      shouldAddGap = true;
       if (itemWidth > containerWidth) {
         hiddenIds.push(key);
       }
@@ -75,6 +83,7 @@ export const useOverflowListModel = createModelHook({
   const [hiddenIds, setHiddenIds] = React.useState(config.initialHiddenIds);
   const [itemWidthCache, setItemWidthCache] = React.useState<Record<string, number>>({});
   const [containerWidth, setContainerWidth] = React.useState(0);
+  const [containerGap, setContainerGap] = React.useState(0);
   const containerWidthRef = React.useRef(0);
   const itemWidthCacheRef = React.useRef(itemWidthCache);
   const [overflowTargetWidth, setOverflowTargetWidth] = React.useState(0);
@@ -96,6 +105,7 @@ export const useOverflowListModel = createModelHook({
     hiddenIds: internalHiddenIds,
     itemWidthCache,
     containerWidth,
+    containerGap,
     overflowTargetWidth,
   };
 
@@ -105,6 +115,7 @@ export const useOverflowListModel = createModelHook({
       const {selectedIds} = model.selection.select(data.id, state);
       const ids = getHiddenIds(
         containerWidthRef.current,
+        containerGap,
         overflowTargetWidthRef.current,
         itemWidthCacheRef.current,
         selectedIds,
@@ -120,6 +131,21 @@ export const useOverflowListModel = createModelHook({
 
       const ids = getHiddenIds(
         containerWidthRef.current,
+        containerGap,
+        overflowTargetWidthRef.current,
+        itemWidthCacheRef.current,
+        state.selectedIds,
+        config.items
+      );
+
+      setHiddenIds(ids);
+    },
+    setContainerGap(data: {size: number}) {
+      setContainerGap(data.size);
+
+      const ids = getHiddenIds(
+        containerWidthRef.current,
+        data.size,
         overflowTargetWidthRef.current,
         itemWidthCacheRef.current,
         state.selectedIds,
@@ -142,6 +168,7 @@ export const useOverflowListModel = createModelHook({
 
       const ids = getHiddenIds(
         containerWidthRef.current,
+        containerGap,
         overflowTargetWidthRef.current,
         itemWidthCacheRef.current,
         state.selectedIds,
@@ -158,6 +185,7 @@ export const useOverflowListModel = createModelHook({
 
       const ids = getHiddenIds(
         containerWidthRef.current,
+        containerGap,
         overflowTargetWidthRef.current,
         itemWidthCacheRef.current,
         state.selectedIds !== 'all'

--- a/modules/react/collection/spec/useOverflowModel.spec.tsx
+++ b/modules/react/collection/spec/useOverflowModel.spec.tsx
@@ -4,41 +4,89 @@ describe('useOverflowModel', () => {
   describe('getHiddenIds', () => {
     const itemWidthCache = {
       first: 100,
-      second: 100,
-      third: 100,
-      fourth: 100,
+      second: 150,
+      third: 200,
+      fourth: 250,
     };
     const overflowTargetWidth = 100;
 
-    const io = [
+    [
       {
         containerWidth: 100,
+        gap: 0,
         selected: 'first',
         hiddenIds: ['first', 'second', 'third', 'fourth'],
       },
       {
         containerWidth: 199,
+        gap: 0,
         selected: 'first',
         hiddenIds: ['first', 'second', 'third', 'fourth'],
       },
       {
         containerWidth: 200,
+        gap: 0,
         selected: 'first',
         hiddenIds: ['second', 'third', 'fourth'],
       },
-      {containerWidth: 400, selected: 'first', hiddenIds: []},
-      {containerWidth: 399, selected: 'first', hiddenIds: ['third', 'fourth']},
+      {containerWidth: 700, gap: 0, selected: 'first', hiddenIds: []},
+      {containerWidth: 350, gap: 0, selected: 'first', hiddenIds: ['third', 'fourth']},
+      {containerWidth: 549, gap: 0, selected: 'first', hiddenIds: ['third', 'fourth']},
+      {containerWidth: 550, gap: 0, selected: 'first', hiddenIds: ['fourth']},
       {
-        containerWidth: 200,
+        containerWidth: 250,
+        gap: 0,
         selected: 'second',
         hiddenIds: ['first', 'third', 'fourth'],
       },
-    ].forEach(({containerWidth, hiddenIds, selected}) => {
+      // gap
+      {
+        containerWidth: 100,
+        gap: 10,
+        selected: 'first',
+        hiddenIds: ['first', 'second', 'third', 'fourth'],
+      },
+      {
+        containerWidth: 199,
+        gap: 10,
+        selected: 'first',
+        hiddenIds: ['first', 'second', 'third', 'fourth'],
+      },
+      {
+        containerWidth: 200,
+        gap: 10,
+        selected: 'first',
+        hiddenIds: ['second', 'third', 'fourth'],
+      },
+      {containerWidth: 729, gap: 10, selected: 'first', hiddenIds: ['fourth']},
+      {containerWidth: 730, gap: 10, selected: 'first', hiddenIds: []},
+      {containerWidth: 360, gap: 10, selected: 'first', hiddenIds: ['third', 'fourth']},
+      {containerWidth: 559, gap: 10, selected: 'first', hiddenIds: ['third', 'fourth']},
+      {containerWidth: 570, gap: 10, selected: 'first', hiddenIds: ['fourth']},
+      {
+        containerWidth: 250,
+        gap: 10,
+        selected: 'second',
+        hiddenIds: ['first', 'third', 'fourth'],
+      },
+    ].forEach(({containerWidth, hiddenIds, gap, selected}) => {
       it(`when containerWidth is ${containerWidth} and selected is '${selected}' should contain hiddenIds [${hiddenIds.join(
         ', '
       )}] `, () => {
         expect(
-          getHiddenIds(containerWidth, overflowTargetWidth, itemWidthCache, [selected])
+          getHiddenIds(
+            containerWidth,
+            gap,
+            overflowTargetWidth,
+            itemWidthCache,
+            [selected],
+            [
+              {id: 'first', value: 'first', index: 0, textValue: 'first'},
+              {id: 'second', value: 'second', index: 1, textValue: 'second'},
+              {id: 'third', value: 'third', index: 2, textValue: 'third'},
+              {id: 'fourth', value: 'fourth', index: 3, textValue: 'fourth'},
+            ]
+          )
         ).toEqual(hiddenIds);
       });
     });


### PR DESCRIPTION
## Summary

Adds Flexbox `gap` to overflow list calculations so that a the overflow list doesn't render outside the container. This is more noticeable with higher gap values.

Fixes #3020

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

Spec file. Also look at the overflow tabs example and choose 500px

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Testing

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

<!-- Explain how your reviewer could verify this change  -->

## Screenshots or GIFs (if applicable)

<!-- Does your change affect the UI? If so, please include a screenshot or short gif. -->

## Thank You Gif (optional)

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer! -->
<!-- ![a smiling Shiba Inu typing on a laptop](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif) -->
