### PR TITLE
fix: Add gap to overflow calculations

### DIFF
--- a/modules/react/collection/lib/useOverflowListMeasure.ts
+++ b/modules/react/collection/lib/useOverflowListMeasure.ts
@@ -14,7 +14,6 @@ import {useOverflowListModel} from './useOverflowListModel';
  * overflow detection.
  */
 export const useOverflowListMeasure = createElemPropsHook(useOverflowListModel)((model, ref) => {
-  // const localRef = React.useRef(null);
   const {elementRef, localRef} = useLocalRef(ref as React.Ref<HTMLElement>);
   const gapProperty = model.state.orientation === 'horizontal' ? 'columnGap' : 'rowGap';
 

--- a/modules/react/collection/lib/useOverflowListMeasure.ts
+++ b/modules/react/collection/lib/useOverflowListMeasure.ts
@@ -1,6 +1,11 @@
 import * as React from 'react';
 
-import {createElemPropsHook, useForkRef, useResizeObserver} from '@workday/canvas-kit-react/common';
+import {
+  createElemPropsHook,
+  useMountLayout,
+  useResizeObserver,
+  useLocalRef,
+} from '@workday/canvas-kit-react/common';
 
 import {useOverflowListModel} from './useOverflowListModel';
 
@@ -9,12 +14,22 @@ import {useOverflowListModel} from './useOverflowListModel';
  * overflow detection.
  */
 export const useOverflowListMeasure = createElemPropsHook(useOverflowListModel)((model, ref) => {
-  const localRef = React.useRef(null);
-  const {ref: resizeRef} = useResizeObserver({
+  // const localRef = React.useRef(null);
+  const {elementRef, localRef} = useLocalRef(ref as React.Ref<HTMLElement>);
+  const gapProperty = model.state.orientation === 'horizontal' ? 'columnGap' : 'rowGap';
+
+  useResizeObserver({
     ref: localRef,
     onResize: model.events.setContainerWidth,
   });
-  const elementRef = useForkRef(ref, resizeRef);
+  useMountLayout(() => {
+    if (localRef.current) {
+      const styles = getComputedStyle(localRef.current);
+      model.events.setContainerGap({
+        size: styles.gap === 'normal' ? 0 : Number(styles[gapProperty].replace('px', '')),
+      });
+    }
+  });
 
   return {
     ref: elementRef,


### PR DESCRIPTION
## Summary

Adds the setting of the container gap to the `useOverflowListMeasure` hook

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

---