### PR TITLE
fix: Prevent build step in modules from running in parallel

### DIFF
--- a/modules/docs/package.json
+++ b/modules/docs/package.json
@@ -27,7 +27,7 @@
     "build:docs": "node ./utils/build-docs.js",
     "build:rebuild": "npm-run-all clean build",
     "build:specs": "node ./utils/build-specifications.js",
-    "build": "npm-run-all --parallel build:es6 build:mdx --parallel build:specs build:docs",
+    "build": "npm-run-all build:es6 build:mdx build:specs build:docs",
     "depcheck": "node ../../utils/check-dependencies-exist.js",
     "typecheck:src": "tsc -p . --noEmit --incremental false"
   },

--- a/modules/labs-react/package.json
+++ b/modules/labs-react/package.json
@@ -27,7 +27,7 @@
     "build:cjs": "tspc -p tsconfig.cjs.json",
     "build:es6": "tspc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6",
+    "build": "npm-run-all build:cjs build:es6",
     "prepack": "node ../../utils/publish.js pre labs-react",
     "postpack": "node ../../utils/publish.js post labs-react",
     "depcheck": "node ../../utils/check-dependencies-exist.js",

--- a/modules/popup-stack/package.json
+++ b/modules/popup-stack/package.json
@@ -24,7 +24,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6",
+    "build": "npm-run-all build:cjs build:es6",
     "depcheck": "node ../../utils/check-dependencies-exist.js",
     "typecheck:src": "tsc -p . --noEmit --incremental false"
   },

--- a/modules/preview-react/package.json
+++ b/modules/preview-react/package.json
@@ -27,7 +27,7 @@
     "build:cjs": "tspc -p tsconfig.cjs.json",
     "build:es6": "tspc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6",
+    "build": "npm-run-all build:cjs build:es6",
     "prepack": "node ../../utils/publish.js pre preview-react",
     "postpack": "node ../../utils/publish.js post preview-react",
     "depcheck": "node ../../utils/check-dependencies-exist.js",

--- a/modules/react-fonts/package.json
+++ b/modules/react-fonts/package.json
@@ -25,7 +25,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6",
+    "build": "npm-run-all build:cjs build:es6",
     "depcheck": "node ../../utils/check-dependencies-exist.js",
     "typecheck:src": "tsc -p . --noEmit --incremental false"
   },

--- a/modules/react/package.json
+++ b/modules/react/package.json
@@ -27,7 +27,7 @@
     "build:cjs": "tspc -p tsconfig.cjs.json",
     "build:es6": "tspc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6",
+    "build": "npm-run-all build:cjs build:es6",
     "prepack": "node ../../utils/publish.js pre react",
     "postpack": "node ../../utils/publish.js post react",
     "depcheck": "node ../../utils/check-dependencies-exist.js",

--- a/modules/styling/package.json
+++ b/modules/styling/package.json
@@ -27,7 +27,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es6": "tsc -p tsconfig.es6.json",
     "build:rebuild": "npm-run-all clean build",
-    "build": "npm-run-all --parallel build:cjs build:es6",
+    "build": "npm-run-all build:cjs build:es6",
     "depcheck": "node ../../utils/check-dependencies-exist.js",
     "typecheck:src": "tsc -p . --noEmit --incremental false"
   },

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "clean": "lerna run clean",
     "depcheck": "lerna run depcheck",
     "prebuild": "yarn depcheck",
-    "build": "lerna run build",
+    "build": "lerna run build --maxWorkers 1",
     "build:rebuild": "lerna run build:rebuild",
     "create-module": "./utils/create-component/createComponent.js",
     "create-component": "./utils/create-component/createComponent.js",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "clean": "lerna run clean",
     "depcheck": "lerna run depcheck",
     "prebuild": "yarn depcheck",
-    "build": "lerna run build --maxWorkers 1",
+    "build": "lerna run build",
     "build:rebuild": "lerna run build:rebuild",
     "create-module": "./utils/create-component/createComponent.js",
     "create-component": "./utils/create-component/createComponent.js",


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

`ts-patch` was running our typescript builds in parallel, causing cache issues between modules. Removing `--parallel` from the `build` step within each package so that it is sequential.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Infrastructure

---

