### PR TITLE
fix: Deconstruct typelevel from props and pass to stencil

### DIFF
--- a/modules/preview-react/status-indicator/lib/StatusIndicatorLabel.tsx
+++ b/modules/preview-react/status-indicator/lib/StatusIndicatorLabel.tsx
@@ -23,9 +23,9 @@ const statusIndicatorLabelStencil = createStencil({
 
 export const StatusIndicatorLabel = createComponent('span')({
   displayName: 'StatusIndicator.Label',
-  Component: ({children, ...elemProps}: StatusIndicatorLabelProps, ref, Element) => {
+  Component: ({children, typeLevel, ...elemProps}: StatusIndicatorLabelProps, ref, Element) => {
     return (
-      <Element ref={ref} {...mergeStyles(elemProps, statusIndicatorLabelStencil())}>
+      <Element ref={ref} {...mergeStyles(elemProps, statusIndicatorLabelStencil({typeLevel}))}>
         {children}
       </Element>
     );


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Deconstruct `typeLevel` from `elemProps` in `StatusIndicator.Label` to ensure type styles can be overwritten. 

## Release Category
Components


---

