### PR TITLE
fix: Measure offsetHeight vertical overflow

### DIFF
--- a/modules/react/collection/lib/useOverflowListTarget.tsx
+++ b/modules/react/collection/lib/useOverflowListTarget.tsx
@@ -30,7 +30,7 @@ export const useOverflowListTarget = createElemPropsHook(useOverflowListModel)((
           parseFloat(styles.marginLeft) +
           parseFloat(styles.marginRight),
         height:
-          localRef.current.offsetWidth +
+          localRef.current.offsetHeight +
           parseFloat(styles.marginTop) +
           parseFloat(styles.marginBottom),
       });


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Make sure to measure `offsetHeight`. This was missed during this [PR](https://github.com/Workday/canvas-kit/pull/3035/files#) that added the vertical overflow behavior.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

---

