### PR TITLE
fix(side-panel): Filter out invalid DOM prop

### DIFF
--- a/modules/react/side-panel/lib/SidePanel.tsx
+++ b/modules/react/side-panel/lib/SidePanel.tsx
@@ -136,7 +136,7 @@ const ChildrenContainer = styled('div')<Pick<SidePanelProps, 'openWidth' | 'open
   })
 );
 
-const ToggleButton = styled(TertiaryButton)<
+const ToggleButton = styled(TertiaryButton, {shouldForwardProp: prop => prop !== 'openDirection'})<
   TertiaryButtonProps & Pick<SidePanelProps, 'openDirection'>
 >(
   {


### PR DESCRIPTION
## Summary

Filter out the `openDirection` prop so it doesn't get forwarded to the `<button>` element.

## Release Category
Components

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--docs)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)
