### PR TITLE
fix(popup): Fix useReturnFocus to respect tabindex=-1 buttons

### DIFF
--- a/cypress/integration/Popup.spec.ts
+++ b/cypress/integration/Popup.spec.ts
@@ -462,9 +462,9 @@ describe('Popup', () => {
         });
       });
 
-      context('when the user scrolls to the right', () => {
+      context('when the user scrolls to the left', () => {
         beforeEach(() => {
-          cy.findByTestId('scroll-area').scrollTo('right');
+          cy.findByTestId('scroll-area').scrollTo('left');
         });
 
         context('when the user clicks outside', () => {

--- a/cypress/integration/Popup.spec.ts
+++ b/cypress/integration/Popup.spec.ts
@@ -420,6 +420,16 @@ describe('Popup', () => {
         });
       });
 
+      context('when the user clicks on the tabindex button', () => {
+        beforeEach(() => {
+          cy.findByRole('button', {name: 'Button with TabIndex=-1'}).should('not.have.focus');
+        });
+
+        it('should not focus the "Open Popup" button', () => {
+          cy.findByRole('button', {name: 'Open Popup'}).should('not.have.focus');
+        });
+      });
+
       context('when the user scrolls to the top', () => {
         beforeEach(() => {
           cy.findByTestId('scroll-area').scrollTo('top');

--- a/modules/react/button/lib/BaseButton.tsx
+++ b/modules/react/button/lib/BaseButton.tsx
@@ -169,7 +169,7 @@ export const buttonStencil = createStencil({
       opacity: cssVar(buttonColorPropVars.default.opacity, cssVar(opacity, system.opacity.full)),
     },
     // Focus Styles
-    '&:focus-visible, &.focus': {
+    '&:focus, &.focus': {
       backgroundColor: cssVar(
         buttonColorPropVars.focus.background,
         cssVar(background, 'transparent')

--- a/modules/react/button/lib/BaseButton.tsx
+++ b/modules/react/button/lib/BaseButton.tsx
@@ -169,7 +169,7 @@ export const buttonStencil = createStencil({
       opacity: cssVar(buttonColorPropVars.default.opacity, cssVar(opacity, system.opacity.full)),
     },
     // Focus Styles
-    '&:focus, &.focus': {
+    '&:focus-visible, &.focus': {
       backgroundColor: cssVar(
         buttonColorPropVars.focus.background,
         cssVar(background, 'transparent')

--- a/modules/react/common/lib/utils/elements.ts
+++ b/modules/react/common/lib/utils/elements.ts
@@ -1,8 +1,4 @@
-/**
- * Is an element focusable? This function performs various tests to see if the element in question
- * can receive focus. Should skip disabled elements as they are not focusable.
- */
-export const isFocusable = (element: Element): boolean => {
+const isBaseFocusable = (element: Element): boolean => {
   if (element.hasAttribute('disabled')) {
     return false;
   }
@@ -12,9 +8,15 @@ export const isFocusable = (element: Element): boolean => {
   const validAnchor = nodeName === 'a' && element.hasAttribute('href');
   const validAudioVideo = ['audio', 'video'].includes(nodeName) && element.hasAttribute('controls');
   const validImgObject = ['img', 'object'].includes(nodeName) && element.hasAttribute('usemap');
-  const validNativelyFocusable =
-    ['button', 'details', 'embed', 'iframe', 'select', 'textarea'].includes(nodeName) &&
-    element.getAttribute('tabindex') !== '-1';
+  const validNativelyFocusable = [
+    'button',
+    'details',
+    'embed',
+    'iframe',
+    'select',
+    'textarea',
+  ].includes(nodeName);
+
   const hasTabIndex = element.getAttribute('tabindex') === '0';
 
   return (
@@ -28,6 +30,26 @@ export const isFocusable = (element: Element): boolean => {
 };
 
 /**
+ * Is an element focusable? This function performs various tests to see if the element in question
+ * can receive focus via a pointer. Should skip disabled elements as they are not focusable.
+ */
+export const isMouseFocusable = isBaseFocusable;
+
+/**
+ * Is an element focusable? This function performs various tests to see if the element in question
+ * can receive focus via the keyboard. Should skip disabled elements as they are not focusable.
+ */
+export const isKeyboardFocusable = (element: Element): boolean => {
+  return isBaseFocusable(element) && element.getAttribute('tabindex') !== '-1';
+};
+
+/**
+ * @deprecated Use `isMouseFocusable` for mouse events and `isKeyboardFocusable` for keyboard
+ * events. `isFocusable` is an alias to `isKeyboardFocusable`
+ */
+export const isFocusable = isKeyboardFocusable;
+
+/**
  * Get the first focusable element in a container.
  *
  * Returns an array of elements if the first focusable element is a radio group
@@ -39,7 +61,7 @@ export const getFirstFocusableElement = (
 
   for (let i = 0; i < elements.length; i++) {
     const element = elements.item(i);
-    if (element && isFocusable(element) && element.getAttribute('tabindex') !== '-1') {
+    if (element && isKeyboardFocusable(element) && element.getAttribute('tabindex') !== '-1') {
       if (isRadioInput(element)) {
         const radioGroup = getRadioGroup(container, element);
 
@@ -73,7 +95,7 @@ export const getLastFocusableElement = (container: HTMLElement): Element[] | Ele
 
   for (let i = elements.length - 1; i >= 0; i--) {
     const element = elements.item(i);
-    if (element && isFocusable(element) && element.getAttribute('tabindex') !== '-1') {
+    if (element && isKeyboardFocusable(element) && element.getAttribute('tabindex') !== '-1') {
       if (isRadioInput(element)) {
         const radioGroup = getRadioGroup(container, element);
 

--- a/modules/react/popup/lib/hooks/useReturnFocus.tsx
+++ b/modules/react/popup/lib/hooks/useReturnFocus.tsx
@@ -24,7 +24,12 @@ function getScrollParent(element: HTMLElement): HTMLElement {
 function getFocusableElement(element: Element | null): Element | null {
   if (element === null || element === document.body || !element.parentElement) {
     return null;
-  } else if (isFocusable(element)) {
+  } else if (
+    isFocusable(element) ||
+    ['button', 'details', 'embed', 'iframe', 'select', 'textarea'].includes(
+      element.nodeName.toLowerCase()
+    )
+  ) {
     return element;
   }
 

--- a/modules/react/popup/stories/stories_testing.tsx
+++ b/modules/react/popup/stories/stories_testing.tsx
@@ -392,9 +392,12 @@ export const ReturnFocusTest = () => {
             <FormField.Label>Name</FormField.Label>
             <FormField.Input as={TextInput} />
           </FormField>
-          <Popup.Target style={{marginBottom: 400, marginLeft: 410}} data-testid="target">
-            Open Popup
-          </Popup.Target>
+          <Flex style={{marginBottom: 400, marginLeft: 410}}>
+            <SecondaryButton id="return-focus-button-tabindex" tabIndex={-1}>
+              Button with TabIndex=-1
+            </SecondaryButton>
+            <Popup.Target data-testid="target">Open Popup</Popup.Target>
+          </Flex>
           <Popup.Popper>
             <Popup.Card>
               <Popup.CloseIcon aria-label="Close" />


### PR DESCRIPTION
## Summary

Separate the concept of focusability between keyboard and mouse. Buttons with a `tabindex` of `-1` are focusable via a pointer device, but not via a keyboard. A user clicking on a button that isn't focusable by keyboard is still a valid target for avoiding focus stealing.

Fixes #3140

Fixes: #1234 <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

## Release Category
Components

---

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

Test

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Testing

## Testing Manually

Go to the `ReturnFocusTest` and open the popup and click on the tabindex button. The Cypress Test also does this.