### PR TITLE
fix: Define stable ref reference in Select input

### DIFF
--- a/modules/react/combobox/lib/hooks/useComboboxInputConstrained.ts
+++ b/modules/react/combobox/lib/hooks/useComboboxInputConstrained.ts
@@ -63,19 +63,20 @@ export const useComboboxInputConstrained = createElemPropsHook(useComboboxModel)
       formElementRef,
       () => {
         if (formLocalRef.current) {
+          const formElementRefStable = formLocalRef.current;
           // Hook into the DOM `value` property of the form input element and update the model
           // accordingly
-          Object.defineProperty(formLocalRef.current, 'value', {
+          Object.defineProperty(formElementRefStable, 'value', {
             get() {
               const value = Object.getOwnPropertyDescriptor(
-                Object.getPrototypeOf(formLocalRef.current),
+                Object.getPrototypeOf(formElementRefStable),
                 'value'
-              )?.get?.call(formLocalRef.current);
+              )?.get?.call(formElementRefStable);
               return value;
             },
             set(value: string) {
               if (
-                formLocalRef.current &&
+                formElementRefStable &&
                 value !==
                   (modelStateRef.current.selectedIds === 'all'
                     ? []
@@ -88,10 +89,10 @@ export const useComboboxInputConstrained = createElemPropsHook(useComboboxModel)
           });
 
           // forward calls to `.focus()` and `.blur()` to the user input
-          formLocalRef.current.focus = (options?: FocusOptions) => {
+          formElementRefStable.focus = (options?: FocusOptions) => {
             userLocalRef.current!.focus(options);
           };
-          formLocalRef.current.blur = () => {
+          formElementRefStable.blur = () => {
             userLocalRef.current!.blur();
           };
         }


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Create a stable reference to the form element ref in `useComboboxInputConstrained`.

React during the lifecycle will sometimes set the ref to `null`.  By setting it to a variable we create a stable reference.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

---

