### PR TITLE
fix(combobox): Use focus/blur reconfig vs rewrite for testing library

### DIFF
--- a/modules/react/combobox/lib/hooks/useComboboxInputConstrained.ts
+++ b/modules/react/combobox/lib/hooks/useComboboxInputConstrained.ts
@@ -96,17 +96,13 @@ export const useComboboxInputConstrained = createElemPropsHook(useComboboxModel)
           Object.defineProperty(formElement, 'focus', {
             configurable: true,
             writable: true,
-            get() {
-              return (options: FocusOptions) => userElement!.focus(options);
-            },
+            value: (options: FocusOptions) => userElement!.focus(options),
           });
 
           Object.defineProperty(formElement, 'blur', {
             configurable: true,
             writable: true,
-            get() {
-              return () => userElement!.blur();
-            },
+            value: () => userElement!.blur(),
           });
           return formElement;
         }

--- a/modules/react/combobox/lib/hooks/useComboboxInputConstrained.ts
+++ b/modules/react/combobox/lib/hooks/useComboboxInputConstrained.ts
@@ -95,6 +95,7 @@ export const useComboboxInputConstrained = createElemPropsHook(useComboboxModel)
           // allows reconfiguration, so we use `Object.defineProperty`.
           Object.defineProperty(formElement, 'focus', {
             configurable: true,
+            writable: true,
             get() {
               return (options: FocusOptions) => userElement!.focus(options);
             },
@@ -102,6 +103,7 @@ export const useComboboxInputConstrained = createElemPropsHook(useComboboxModel)
 
           Object.defineProperty(formElement, 'blur', {
             configurable: true,
+            writable: true,
             get() {
               return () => userElement!.blur();
             },


### PR DESCRIPTION
## Summary

Update `useComboboxInputConstrained` to use reconfiguration vs rewrite for `focus`/`blur` method redirection. This fixes an issue with `user-event` that overwrites these methods to not be rewritable: https://github.com/testing-library/user-event/pull/1252

The extra syntax makes things feel a little more enterprise Java.

## Release Category
Components

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--docs)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)