### PR TITLE
docs: Fix Firefox hard-fail on markdown-to-jsx bug

### DIFF
--- a/modules/docs/lib/MDXElements.tsx
+++ b/modules/docs/lib/MDXElements.tsx
@@ -25,7 +25,7 @@ export const MDX = createComponent('div')({
  */
 const Button = (props: any) => {
   const components = useMDXComponents();
-  if (props['data-symbol'] !== undefined) {
+  if (props['data-symbol'] !== undefined && props.children) {
     return (
       <code>
         <SymbolDialog
@@ -49,8 +49,8 @@ const Button = (props: any) => {
 function convertLinkToSymbolLinks(input: string): string {
   return input.replace(
     /{@link ([a-z0-9.]+)( [a-z0-9.]+)?}/gi,
-    (substr, symbol, text = '') =>
-      `<button href="#" data-symbol="${text.trim()}" class="token symbol">${symbol}</button>`
+    (_substr, symbol, text = '') =>
+      `<button data-symbol="${text.trim()}" className="token symbol">${symbol}</button>`
   );
 }
 


### PR DESCRIPTION
## Summary

The `markdown-to-jsx` seems to have a bug in Firefox that causes improperly formatted HTML. This was causing an edge case that isn't supposed to be possible in our documentation system. Instead of Firefox erroring on proper parsing, we instead guard an access. Firefox will now show improperly formatted content rather than erroring out with no content. We will address the Firefox bug with our Vite upgrade where we drop `markdown-to-jsx` which should fix the issue.

## Release Category
Documentation

---
