### PR TITLE
fix: Support negative values

### DIFF
--- a/modules/styling-transform/lib/utils/parseNodeToStaticValue.ts
+++ b/modules/styling-transform/lib/utils/parseNodeToStaticValue.ts
@@ -37,6 +37,15 @@ export function parseNodeToStaticValue(
     return parseFloat(node.text);
   }
 
+  // -12
+  if (
+    ts.isPrefixUnaryExpression(node) &&
+    node.operator === ts.SyntaxKind.MinusToken &&
+    ts.isNumericLiteral(node.operand)
+  ) {
+    return -parseFloat(node.operand.text);
+  }
+
   // undefined
   if (ts.isIdentifier(node) && node.text === 'undefined') {
     return 'undefined';

--- a/modules/styling-transform/spec/utils/parseNodeToStaticValue.spec.ts
+++ b/modules/styling-transform/spec/utils/parseNodeToStaticValue.spec.ts
@@ -31,6 +31,17 @@ describe('parseNodeToStaticValue', () => {
     expect(parseNodeToStaticValue(node, withDefaultContext(program.getTypeChecker()))).toEqual(12);
   });
 
+  it('should return the negative number value of a PrefixUnaryExpression NumericLiteral', () => {
+    const program = createProgramFromSource(`
+      -12
+    `);
+
+    const sourceFile = program.getSourceFile('test.ts')!;
+    const node = findNodes(sourceFile, '', ts.isPrefixUnaryExpression)![0];
+
+    expect(parseNodeToStaticValue(node, withDefaultContext(program.getTypeChecker()))).toEqual(-12);
+  });
+
   it('should return the string value of a string Identifier', () => {
     const program = createProgramFromSource(`
       const foo = 'bar';


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Add support for negative numbers in `createStyles` and `createStencil`

## Release Category
Styling

---
