### PR TITLE
docs: Add Snapshot serializers to ignore hashes

### DIFF
--- a/modules/docs/mdx/TESTING.mdx
+++ b/modules/docs/mdx/TESTING.mdx
@@ -162,6 +162,31 @@ This will ensure snapshot tests have stable ids for each snapshot. It is still p
 changing if you add an additional component that uses id generation - subsequent ids will be
 different, but this will prevent snapshot tests that don't have any changes from showing diffs.
 
+The Canvas Kit Styling package uses CSS Variables and multiple class names with unique hashes.
+The following snapshot serializers handle styling. Setting unique seeds will not effect static style
+hashes because the styles are created before any test code is run. These serializers ignore the
+hashes instead.
+
+```ts
+// Handle `css-{hash}` class names
+const emotionClassnameRegex = /(css-[a-zA-Z0-9]{1,7})/g;
+expect.addSnapshotSerializer({
+  test: (val) => typeof val === "string" && emotionClassnameRegex.test(val),
+  print: (val) => {
+    return `"${val.replaceAll(emotionClassnameRegex, "css-xxxxx")}"`;
+  },
+});
+
+// Handle `--myVariableName-{hash}` CSS variables used by Stencils
+const cssVariableRegex = /(--([a-zA-Z-]+)-[a-zA-Z0-9]{1,7})/g;
+expect.addSnapshotSerializer({
+  test: (val) => typeof val === "string" && cssVariableRegex.test(val),
+  print: (val) => {
+    return `"${val.replaceAll(cssVariableRegex, "--$2-xxxxx")}"`;
+  },
+});
+```
+
 ## Functional tests
 
 Canvas Kit uses [Cypress](https://cypress.io) for browser-based behavior testing (additional info:


### PR DESCRIPTION
## Summary

Adds Snapshot serializers to the testing documentation with ways to ignore hashes injected by our Static Styling package.

## Release Category
Documentation

---
