### PR TITLE
fix: Compound components should accept `ElementComponent`

### DIFF
--- a/modules/react/common/lib/utils/components.ts
+++ b/modules/react/common/lib/utils/components.ts
@@ -237,6 +237,7 @@ export const createContainer =
     E extends
       | keyof JSX.IntrinsicElements
       | React.ComponentType
+      | ElementComponent<any, any>
       | ElementComponentM<any, any, any>
       | undefined = undefined
   >(
@@ -379,6 +380,7 @@ export const createSubcomponent =
     E extends
       | keyof JSX.IntrinsicElements
       | React.ComponentType
+      | ElementComponent<any, any>
       | ElementComponentM<any, any, any>
       | undefined = undefined
   >(

--- a/modules/react/common/spec/components.spec.tsx
+++ b/modules/react/common/spec/components.spec.tsx
@@ -185,6 +185,17 @@ describe('createContainer', () => {
 
     render(<ComposedComponent />);
   });
+
+  it('should accept an `ElementComponent`', () => {
+    const Component = createComponent('div')({
+      Component(props: {requiredProp: number}, ref, Element) {
+        return <Element />;
+      },
+    });
+
+    // There should be no TS error
+    const Subcomponent = createContainer(Component);
+  });
 });
 
 describe('createSubcomponent', () => {
@@ -210,6 +221,17 @@ describe('createSubcomponent', () => {
     })((props, Element) => <Element data-testid="test" {...props} />);
 
     expect(Component.as('button')).toBe(Component.as('button'));
+  });
+
+  it('should accept an `ElementComponent`', () => {
+    const Component = createComponent('div')({
+      Component(props: {requiredProp: number}, ref, Element) {
+        return <Element />;
+      },
+    });
+
+    // There should be no TS error
+    const Subcomponent = createSubcomponent(Component);
   });
 });
 


### PR DESCRIPTION
## Summary

Add support for the `ElementComponent` type in `createContainer` and `createSubomponent`

Fixes: #3182 

## Release Category
Components

---

## Checklist

- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)
