### PR TITLE
fix: Remove default altText for Avatar

### DIFF
--- a/modules/react/avatar/lib/Avatar.tsx
+++ b/modules/react/avatar/lib/Avatar.tsx
@@ -45,7 +45,6 @@ export interface AvatarProps extends CSProps {
     | number;
   /**
    * The alt text of the Avatar image. This prop is also used for the aria-label.
-   * @default Avatar
    */
   altText?: string;
   /**
@@ -240,7 +239,7 @@ export const avatarStencil = createStencil({
 export const Avatar = createComponent('button')({
   displayName: 'Avatar',
   Component: (
-    {variant, size = 'medium', altText = 'Avatar', url, objectFit, ...elemProps}: AvatarProps,
+    {variant, size = 'medium', altText, url, objectFit, ...elemProps}: AvatarProps,
     ref,
     Element
   ) => {

--- a/modules/react/avatar/stories/avatar/examples/Basic.tsx
+++ b/modules/react/avatar/stories/avatar/examples/Basic.tsx
@@ -11,7 +11,7 @@ const containerStyles = createStyles({
 
 export const Basic = () => (
   <div className={containerStyles}>
-    <Avatar onClick={handleAvatarButtonClick} />
-    <Avatar as="div" />
+    <Avatar altText="Avatar" onClick={handleAvatarButtonClick} />
+    <Avatar altText="Avatar" as="div" />
   </div>
 );

--- a/modules/react/avatar/stories/avatar/examples/Button.tsx
+++ b/modules/react/avatar/stories/avatar/examples/Button.tsx
@@ -13,8 +13,8 @@ const containerStyles = createStyles({
 
 export const Button = () => (
   <div className={containerStyles}>
-    <Avatar variant="dark" onClick={handleAvatarButtonClick} />
-    <Avatar onClick={handleAvatarButtonClick} />
-    <Avatar url={testAvatar} onClick={handleAvatarButtonClick} />
+    <Avatar altText="Avatar" variant="dark" onClick={handleAvatarButtonClick} />
+    <Avatar altText="Avatar" onClick={handleAvatarButtonClick} />
+    <Avatar altText="Avatar" url={testAvatar} onClick={handleAvatarButtonClick} />
   </div>
 );

--- a/modules/react/avatar/stories/avatar/examples/Image.tsx
+++ b/modules/react/avatar/stories/avatar/examples/Image.tsx
@@ -13,13 +13,13 @@ const containerStyles = createStyles({
 export const Image = () => (
   <div className={containerStyles}>
     <h3>Working Images</h3>
-    <Avatar size="extraExtraLarge" as="div" url={testAvatar} />
-    <Avatar size="extraLarge" as="div" url={testAvatar} />
-    <Avatar size="large" as="div" url={testAvatar} />
-    <Avatar size="medium" as="div" url={testAvatar} />
-    <Avatar size="small" as="div" url={testAvatar} />
-    <Avatar size="extraSmall" as="div" url={testAvatar} />
+    <Avatar size="extraExtraLarge" as="div" url={testAvatar} altText="Avatar" />
+    <Avatar size="extraLarge" as="div" url={testAvatar} altText="Avatar" />
+    <Avatar size="large" as="div" url={testAvatar} altText="Avatar" />
+    <Avatar size="medium" as="div" url={testAvatar} altText="Avatar" />
+    <Avatar size="small" as="div" url={testAvatar} altText="Avatar" />
+    <Avatar size="extraSmall" as="div" url={testAvatar} altText="Avatar" />
     <h3>Broken Image</h3>
-    <Avatar url="/fake/path/to/image.png" as="div" />
+    <Avatar url="/fake/path/to/image.png" as="div" altText="Avatar" />
   </div>
 );

--- a/modules/react/avatar/stories/avatar/examples/LazyLoad.tsx
+++ b/modules/react/avatar/stories/avatar/examples/LazyLoad.tsx
@@ -6,7 +6,13 @@ export const LazyLoad = () => (
   <div className="story">
     {Array.from({length: 5}, (v, index) => (
       <>
-        <Avatar key={index} as="div" size="medium" url={testAvatar + '?v=' + index} />
+        <Avatar
+          key={index}
+          as="div"
+          size="medium"
+          url={testAvatar + '?v=' + index}
+          altText="Avatar"
+        />
         <br />
       </>
     ))}

--- a/modules/react/avatar/stories/avatar/examples/ObjectFit.tsx
+++ b/modules/react/avatar/stories/avatar/examples/ObjectFit.tsx
@@ -6,9 +6,10 @@ export const ObjectFit = () => (
     <h3>Original Rectangle Image</h3>
     <img alt="" src="https://picsum.photos/id/237/300/200" />
     <h3>Object fit on a Rectangle Image</h3>
-    <Avatar as="div" url="https://picsum.photos/id/237/300/200" />
+    <Avatar altText="Avatar" as="div" url="https://picsum.photos/id/237/300/200" />
     <h3>Object fit on a Rectangle Image using Dynamic Size</h3>
     <Avatar
+      altText="Avatar"
       as="div"
       size={px2rem(200)}
       url="https://picsum.photos/id/237/300/200"
@@ -17,8 +18,13 @@ export const ObjectFit = () => (
     <h3>Original Square Image</h3>
     <img alt="" src="https://picsum.photos/id/237/300/300" />
     <h3>Object fit on a Square Image</h3>
-    <Avatar as="div" url="https://picsum.photos/id/237/300/300" />
+    <Avatar altText="Avatar" as="div" url="https://picsum.photos/id/237/300/300" />
     <h3>Object fit on a Square Image using Dynamic Size</h3>
-    <Avatar as="div" size={px2rem(200)} url="https://picsum.photos/id/237/300/300" />
+    <Avatar
+      altText="Avatar"
+      as="div"
+      size={px2rem(200)}
+      url="https://picsum.photos/id/237/300/300"
+    />
   </div>
 );


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #3116

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

This removes the default text for the `altText` prop on `Avatar`.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

### Release Note
Removed the default text for the `altText` prop on `Avatar`.

---

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
`/modules/react/avatar/lib/Avatar.tsx`

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer! -->
![Avatar](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcTJ5dWFmaWthMnk0N2lpdXBzbW1iejlsMTB6dG9mMjJsbTY4YmZkYSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/10fS0TJxfFRDLW/giphy.gif)
