### PR TITLE
fix: Remove default altText for Avatar

### DIFF
--- a/modules/labs-react/expandable/stories/examples/Avatar.tsx
+++ b/modules/labs-react/expandable/stories/examples/Avatar.tsx
@@ -9,7 +9,7 @@ export const Avatar = () => (
     <Expandable>
       <Expandable.Target headingLevel="h4">
         <Expandable.Icon iconPosition="start" />
-        <Expandable.Avatar url={testAvatar} />
+        <Expandable.Avatar altText="Avatar" url={testAvatar} />
         <Expandable.Title>Title</Expandable.Title>
       </Expandable.Target>
 
@@ -17,7 +17,7 @@ export const Avatar = () => (
     </Expandable>
     <Expandable>
       <Expandable.Target headingLevel="h4">
-        <Expandable.Avatar url={testAvatar} />
+        <Expandable.Avatar altText="Avatar" url={testAvatar} />
         <Expandable.Title>Title</Expandable.Title>
         <Expandable.Icon iconPosition="end" />
       </Expandable.Target>

--- a/modules/labs-react/expandable/stories/examples/LongTitle.tsx
+++ b/modules/labs-react/expandable/stories/examples/LongTitle.tsx
@@ -8,7 +8,7 @@ export const LongTitle = () => (
   <Expandable>
     <Expandable.Target headingLevel="h4">
       <Expandable.Icon iconPosition="start" />
-      <Expandable.Avatar url={testAvatar} />
+      <Expandable.Avatar altText="Avatar" url={testAvatar} />
       <Expandable.Title>
         Our house special supreme pizza includes pepperoni, sausage, bell peppers, mushrooms,
         onions, and oregano.

--- a/modules/preview-react/pill/lib/PillAvatar.tsx
+++ b/modules/preview-react/pill/lib/PillAvatar.tsx
@@ -18,7 +18,7 @@ export const PillAvatar = createSubcomponent('div')({
       style={{opacity: model.state.disabled ? '.7' : '1'}}
       size={px2rem(18)}
       as={Element}
-      altText={undefined}
+      altText="Avatar"
       {...elemProps}
     ></Avatar>
   );

--- a/modules/preview-react/pill/stories/examples/WithAvatar.tsx
+++ b/modules/preview-react/pill/stories/examples/WithAvatar.tsx
@@ -12,11 +12,11 @@ export const WithAvatar = () => {
     <Box>
       <Flex gap="xxs">
         <Pill onClick={() => setText('The first pill is clicked!')}>
-          <Pill.Avatar url={testAvatar} />
+          <Pill.Avatar altText="Avatar" url={testAvatar} />
           Regina Skeltor
         </Pill>
         <Pill onClick={() => setText('The second pill is clicked!')} disabled maxWidth={50}>
-          <Pill.Avatar url={testAvatar} />
+          <Pill.Avatar altText="Avatar" url={testAvatar} />
           Regina Skeltor
         </Pill>
       </Flex>

--- a/modules/preview-react/pill/stories/examples/WithRemovable.tsx
+++ b/modules/preview-react/pill/stories/examples/WithRemovable.tsx
@@ -16,7 +16,7 @@ export const WithRemovable = () => {
           <Pill.IconButton onClick={() => setText('The first pill is clicked!')} />
         </Pill>
         <Pill variant="removable">
-          <Pill.Avatar url={testAvatar} />
+          <Pill.Avatar altText="Avatar" url={testAvatar} />
           Carolyn Grimaldi
           <Pill.IconButton onClick={() => setText('The second pill is clicked!')} />
         </Pill>

--- a/modules/preview-react/pill/stories/testing.stories.tsx
+++ b/modules/preview-react/pill/stories/testing.stories.tsx
@@ -85,7 +85,7 @@ export const PillStatesAvatar = () => {
         {({...props}) => {
           return (
             <Pill onClick={() => console.warn('clicked')} {...props}>
-              <Pill.Avatar url={testAvatar} />
+              <Pill.Avatar altText="Avatar" url={testAvatar} />
               Regina Skeltor
             </Pill>
           );
@@ -143,7 +143,7 @@ export const RemovablePillStates = () => {
         {({avatar, maxWidth, ...props}) => {
           return (
             <Pill variant="removable" {...props}>
-              {avatar && <Pill.Avatar url={testAvatar} />}
+              {avatar && <Pill.Avatar altText="Avatar" url={testAvatar} />}
               {maxWidth ? 'This is a super long text that should overflow' : 'PillLabel'}
               <Pill.IconButton {...props} />
             </Pill>

--- a/modules/preview-react/side-panel/stories/testingCypress.stories.tsx
+++ b/modules/preview-react/side-panel/stories/testingCypress.stories.tsx
@@ -87,7 +87,7 @@ export const FirstFocusable = () => {
   return (
     <React.Fragment>
       <Header>
-        <Avatar onClick={noop} />
+        <Avatar altText="Avatar" onClick={noop} />
       </Header>
       <Container>
         <SidePanel {...panelProps}>

--- a/modules/react/_examples/stories/mdx/examples/GlobalHeader.tsx
+++ b/modules/react/_examples/stories/mdx/examples/GlobalHeader.tsx
@@ -149,7 +149,7 @@ export const Basic = () => {
             <TertiaryButton icon={inboxIcon} />
           </Tooltip>
           <Tooltip title="Profile">
-            <Avatar />
+            <Avatar altText="Avatar" />
           </Tooltip>
         </GlobalHeader.Item>
       </GlobalHeader>

--- a/modules/react/avatar/lib/Avatar.tsx
+++ b/modules/react/avatar/lib/Avatar.tsx
@@ -45,7 +45,6 @@ export interface AvatarProps extends CSProps {
     | number;
   /**
    * The alt text of the Avatar image. This prop is also used for the aria-label.
-   * @default Avatar
    */
   altText?: string;
   /**
@@ -243,7 +242,7 @@ export const avatarStencil = createStencil({
 export const Avatar = createComponent('button')({
   displayName: 'Avatar',
   Component: (
-    {variant, size, altText = 'Avatar', url, objectFit, ...elemProps}: AvatarProps,
+    {variant, size, altText, url, objectFit, ...elemProps}: AvatarProps,
     ref,
     Element
   ) => {

--- a/modules/react/avatar/stories/avatar/examples/Basic.tsx
+++ b/modules/react/avatar/stories/avatar/examples/Basic.tsx
@@ -12,7 +12,7 @@ const containerStyles = createStyles({
 
 export const Basic = () => (
   <div className={containerStyles}>
-    <Avatar onClick={handleAvatarButtonClick} />
-    <Avatar as="div" />
+    <Avatar altText="Avatar" onClick={handleAvatarButtonClick} />
+    <Avatar altText="Avatar" as="div" />
   </div>
 );

--- a/modules/react/avatar/stories/avatar/examples/Button.tsx
+++ b/modules/react/avatar/stories/avatar/examples/Button.tsx
@@ -14,8 +14,8 @@ const containerStyles = createStyles({
 
 export const Button = () => (
   <div className={containerStyles}>
-    <Avatar variant="dark" onClick={handleAvatarButtonClick} />
-    <Avatar onClick={handleAvatarButtonClick} />
-    <Avatar url={testAvatar} onClick={handleAvatarButtonClick} />
+    <Avatar altText="Avatar" variant="dark" onClick={handleAvatarButtonClick} />
+    <Avatar altText="Avatar" onClick={handleAvatarButtonClick} />
+    <Avatar altText="Avatar" url={testAvatar} onClick={handleAvatarButtonClick} />
   </div>
 );

--- a/modules/react/avatar/stories/avatar/examples/CustomStyles.tsx
+++ b/modules/react/avatar/stories/avatar/examples/CustomStyles.tsx
@@ -29,7 +29,7 @@ const containerStyles = createStyles({
 
 export const CustomStyles = () => (
   <div className={containerStyles}>
-    <Avatar as="div" {...customBlueAvatarStencil()} />
-    <Avatar as="div" {...customGreenAvatarStencil()} />
+    <Avatar altText="Avatar" as="div" {...customBlueAvatarStencil()} />
+    <Avatar altText="Avatar" as="div" {...customGreenAvatarStencil()} />
   </div>
 );

--- a/modules/react/avatar/stories/avatar/examples/Image.tsx
+++ b/modules/react/avatar/stories/avatar/examples/Image.tsx
@@ -14,13 +14,13 @@ const containerStyles = createStyles({
 export const Image = () => (
   <div className={containerStyles}>
     <h3>Working Images</h3>
-    <Avatar size="extraExtraLarge" as="div" url={testAvatar} />
-    <Avatar size="extraLarge" as="div" url={testAvatar} />
-    <Avatar size="large" as="div" url={testAvatar} />
-    <Avatar size="medium" as="div" url={testAvatar} />
-    <Avatar size="small" as="div" url={testAvatar} />
-    <Avatar size="extraSmall" as="div" url={testAvatar} />
+    <Avatar size="extraExtraLarge" altText="Avatar" as="div" url={testAvatar} />
+    <Avatar size="extraLarge" altText="Avatar" as="div" url={testAvatar} />
+    <Avatar size="large" altText="Avatar" as="div" url={testAvatar} />
+    <Avatar size="medium" altText="Avatar" as="div" url={testAvatar} />
+    <Avatar size="small" altText="Avatar" as="div" url={testAvatar} />
+    <Avatar size="extraSmall" altText="Avatar" as="div" url={testAvatar} />
     <h3>Broken Image</h3>
-    <Avatar url="/fake/path/to/image.png" as="div" />
+    <Avatar url="/fake/path/to/image.png" altText="Avatar" as="div" />
   </div>
 );

--- a/modules/react/avatar/stories/avatar/examples/LazyLoad.tsx
+++ b/modules/react/avatar/stories/avatar/examples/LazyLoad.tsx
@@ -7,7 +7,13 @@ export const LazyLoad = () => (
   <div className="story">
     {Array.from({length: 5}, (v, index) => (
       <>
-        <Avatar key={index} as="div" size="medium" url={testAvatar + '?v=' + index} />
+        <Avatar
+          key={index}
+          altText="Avatar"
+          as="div"
+          size="medium"
+          url={testAvatar + '?v=' + index}
+        />
         <br />
       </>
     ))}

--- a/modules/react/avatar/stories/avatar/examples/ObjectFit.tsx
+++ b/modules/react/avatar/stories/avatar/examples/ObjectFit.tsx
@@ -7,9 +7,10 @@ export const ObjectFit = () => (
     <h3>Original Rectangle Image</h3>
     <img alt="" src="https://picsum.photos/id/237/300/200" />
     <h3>Object fit on a Rectangle Image</h3>
-    <Avatar as="div" url="https://picsum.photos/id/237/300/200" />
+    <Avatar altText="Avatar" as="div" url="https://picsum.photos/id/237/300/200" />
     <h3>Object fit on a Rectangle Image using Dynamic Size</h3>
     <Avatar
+      altText="Avatar"
       as="div"
       size={px2rem(200)}
       url="https://picsum.photos/id/237/300/200"
@@ -18,8 +19,13 @@ export const ObjectFit = () => (
     <h3>Original Square Image</h3>
     <img alt="" src="https://picsum.photos/id/237/300/300" />
     <h3>Object fit on a Square Image</h3>
-    <Avatar as="div" url="https://picsum.photos/id/237/300/300" />
+    <Avatar altText="Avatar" as="div" url="https://picsum.photos/id/237/300/300" />
     <h3>Object fit on a Square Image using Dynamic Size</h3>
-    <Avatar as="div" size={px2rem(200)} url="https://picsum.photos/id/237/300/300" />
+    <Avatar
+      altText="Avatar"
+      as="div"
+      size={px2rem(200)}
+      url="https://picsum.photos/id/237/300/300"
+    />
   </div>
 );

--- a/modules/react/avatar/stories/avatar/examples/Size.tsx
+++ b/modules/react/avatar/stories/avatar/examples/Size.tsx
@@ -5,24 +5,24 @@ import {px2rem} from '@workday/canvas-kit-styling';
 export const Size = () => (
   <div className="story">
     <h3>Extra-Extra Large</h3>
-    <Avatar as="div" size="extraExtraLarge" />
+    <Avatar altText="Avatar" as="div" size="extraExtraLarge" />
     <h3>Extra Large</h3>
-    <Avatar as="div" size="extraLarge" />
+    <Avatar altText="Avatar" as="div" size="extraLarge" />
     <h3>Large</h3>
-    <Avatar as="div" size="large" />
+    <Avatar altText="Avatar" as="div" size="large" />
     <h3>Medium</h3>
-    <Avatar as="div" size="medium" />
+    <Avatar altText="Avatar" as="div" size="medium" />
     <h3>Small</h3>
-    <Avatar as="div" size="small" />
+    <Avatar altText="Avatar" as="div" size="small" />
     <h3>Extra Small</h3>
-    <Avatar as="div" size="extraSmall" />
+    <Avatar altText="Avatar" as="div" size="extraSmall" />
     <h3>30px</h3>
-    <Avatar as="div" size={px2rem(30)} />
+    <Avatar altText="Avatar" as="div" size={px2rem(30)} />
     <h3>40px</h3>
-    <Avatar as="div" size={px2rem(40)} />
+    <Avatar altText="Avatar" as="div" size={px2rem(40)} />
     <h3>3rem</h3>
-    <Avatar as="div" size="3rem" />
+    <Avatar altText="Avatar" as="div" size="3rem" />
     <h3>4rem</h3>
-    <Avatar as="div" size="4rem" />
+    <Avatar altText="Avatar" as="div" size="4rem" />
   </div>
 );

--- a/modules/react/avatar/stories/avatar/examples/Variant.tsx
+++ b/modules/react/avatar/stories/avatar/examples/Variant.tsx
@@ -4,8 +4,8 @@ import {Avatar} from '@workday/canvas-kit-react/avatar';
 export const Variant = () => (
   <div className="story">
     <h3>Light</h3>
-    <Avatar as="div" size="medium" />
+    <Avatar altText="Avatar" as="div" size="medium" />
     <h3>Dark</h3>
-    <Avatar as="div" size="medium" variant="dark" />
+    <Avatar altText="Avatar" as="div" size="medium" variant="dark" />
   </div>
 );


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #3116

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

This removes the default text for the `altText` prop on `Avatar`.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

### Release Note
Removed the default text for the `altText` prop on `Avatar`.

---

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
`/modules/react/avatar/lib/Avatar.tsx`

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer! -->
![Avatar](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcTJ5dWFmaWthMnk0N2lpdXBzbW1iejlsMTB6dG9mMjJsbTY4YmZkYSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/10fS0TJxfFRDLW/giphy.gif)