### PR TITLE
ci: Fix forward merge workflow

### DIFF
--- a/.github/workflows/forward-merge.yml
+++ b/.github/workflows/forward-merge.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Cache Build
         id: build-cache
-        uses: actions/cache/@v2
+        uses: actions/cache/@v3
         with:
           path: docs
           key: ${{ runner.os }}-build-${{ github.sha }}


### PR DESCRIPTION
## Summary

Fixes the forward-merge job. GitHub removed the `actions/cache@v2` branch. It has be updated to `actions/cache@v3`

## Release Category
Infrastructure

---

