### PR TITLE
fix(select): Remove excess props from `SelectInputProps`

### DIFF
--- a/modules/react/common/lib/utils/components.ts
+++ b/modules/react/common/lib/utils/components.ts
@@ -77,8 +77,6 @@ type ExtractHTMLAttributes<T extends React.DetailedHTMLProps<any, any>> =
  * - `ExtractProps<typeof Card, 'aside'>`: `CardProps & React.HTMLAttributes<HTMLElement>`
  * - `ExtractProps<typeof Card, never>`: `CardProps`
  *
- * **Note:** The `never` means "don't include the default HTML attributes in the prop interface". The `as` prop is used to determine the final HTML attributes. Forgetting to use the `never` means the prop interfaces can be incompatible unintentionally, causing TypeScript issues for developers doing things we say is supported.
- *
  * @template TComponent The component you wish to extract props from. Needs 'typeof` in front:
  * `typeof Card`
  * @template TElement An optional override of the element that will be used. Define this if you use

--- a/modules/react/common/lib/utils/components.ts
+++ b/modules/react/common/lib/utils/components.ts
@@ -77,6 +77,8 @@ type ExtractHTMLAttributes<T extends React.DetailedHTMLProps<any, any>> =
  * - `ExtractProps<typeof Card, 'aside'>`: `CardProps & React.HTMLAttributes<HTMLElement>`
  * - `ExtractProps<typeof Card, never>`: `CardProps`
  *
+ * **Note:** The `never` means "don't include the default HTML attributes in the prop interface". The `as` prop is used to determine the final HTML attributes. Forgetting to use the `never` means the prop interfaces can be incompatible unintentionally, causing TypeScript issues for developers doing things we say is supported.
+ *
  * @template TComponent The component you wish to extract props from. Needs 'typeof` in front:
  * `typeof Card`
  * @template TElement An optional override of the element that will be used. Define this if you use

--- a/modules/react/select/lib/SelectInput.tsx
+++ b/modules/react/select/lib/SelectInput.tsx
@@ -52,7 +52,7 @@ const hiddenSelectInputStencil = createStencil({
   },
 });
 
-export const SelectInput = createSubcomponent(TextInput.as('input'))({
+export const SelectInput = createSubcomponent(TextInput)({
   modelHook: useSelectModel,
   elemPropsHook: useSelectInput,
 })<SelectInputProps>(({inputStartIcon, formInputProps, ...elemProps}, Element, model) => {

--- a/modules/react/select/lib/SelectInput.tsx
+++ b/modules/react/select/lib/SelectInput.tsx
@@ -52,40 +52,34 @@ const hiddenSelectInputStencil = createStencil({
   },
 });
 
-export const SelectInput = createSubcomponent(TextInput)({
+export const SelectInput = createSubcomponent(TextInput.as('input'))({
   modelHook: useSelectModel,
   elemPropsHook: useSelectInput,
-})<SelectInputProps>(
-  (
-    {placeholder = 'Choose an option', inputStartIcon, formInputProps, ...elemProps},
-    Element,
-    model
-  ) => {
-    return (
-      <InputGroup data-width="ck-formfield-width">
-        {inputStartIcon && model.state.selectedIds.length > 0 && (
-          <InputGroup.InnerStart data-part="select-start-icon-container" {...selectIconsStencil()}>
-            <SystemIcon data-part="select-start-icon" icon={inputStartIcon} />
-          </InputGroup.InnerStart>
-        )}
-        {/* Hidden input to handle ids */}
-        <InputGroup.Input
-          data-part="select-hidden-input"
-          {...formInputProps}
-          {...hiddenSelectInputStencil()}
-        />
-        {/* Visual input */}
-        <InputGroup.Input
-          as={Element}
-          placeholder={placeholder}
-          data-part="select-visual-input"
-          {...elemProps}
-          {...mergeStyles(elemProps, selectInputStencil())}
-        />
-        <InputGroup.InnerEnd data-part="select-caret-container" {...selectIconsStencil()}>
-          <SystemIcon data-part="select-caret-icon" icon={caretDownSmallIcon} />
-        </InputGroup.InnerEnd>
-      </InputGroup>
-    );
-  }
-);
+})<SelectInputProps>(({inputStartIcon, formInputProps, ...elemProps}, Element, model) => {
+  return (
+    <InputGroup data-width="ck-formfield-width">
+      {inputStartIcon && model.state.selectedIds.length > 0 && (
+        <InputGroup.InnerStart data-part="select-start-icon-container" {...selectIconsStencil()}>
+          <SystemIcon data-part="select-start-icon" icon={inputStartIcon} />
+        </InputGroup.InnerStart>
+      )}
+      {/* Hidden input to handle ids */}
+      <InputGroup.Input
+        data-part="select-hidden-input"
+        {...formInputProps}
+        {...hiddenSelectInputStencil()}
+      />
+      {/* Visual input */}
+      <InputGroup.Input
+        as={Element}
+        placeholder="Choose an option" // This will get overridden by the placeholder prop on `Select.Input`
+        data-part="select-visual-input"
+        {...elemProps}
+        {...mergeStyles(elemProps, selectInputStencil())}
+      />
+      <InputGroup.InnerEnd data-part="select-caret-container" {...selectIconsStencil()}>
+        <SystemIcon data-part="select-caret-icon" icon={caretDownSmallIcon} />
+      </InputGroup.InnerEnd>
+    </InputGroup>
+  );
+});

--- a/modules/react/select/lib/SelectInput.tsx
+++ b/modules/react/select/lib/SelectInput.tsx
@@ -55,26 +55,37 @@ const hiddenSelectInputStencil = createStencil({
 export const SelectInput = createSubcomponent(TextInput)({
   modelHook: useSelectModel,
   elemPropsHook: useSelectInput,
-})<SelectInputProps>(({inputStartIcon, formInputProps, ...elemProps}, Element, model) => {
-  return (
-    <InputGroup data-width="ck-formfield-width" {...selectInputStencil()}>
-      {inputStartIcon && model.state.selectedIds.length > 0 && (
-        <InputGroup.InnerStart {...selectInputStencil.parts.startIconContainer}>
-          <SystemIcon {...selectInputStencil.parts.startIcon} icon={inputStartIcon} />
-        </InputGroup.InnerStart>
-      )}
-      {/* Hidden input to handle ids */}
-      <InputGroup.Input {...selectInputStencil.parts.hiddenInput} {...formInputProps} />
-      {/* Visual input */}
-      <InputGroup.Input
-        as={Element}
-        placeholder="Choose an option"
-        {...selectInputStencil.parts.visualInput}
-        {...elemProps}
-      />
-      <InputGroup.InnerEnd {...selectInputStencil.parts.caretContainer}>
-        <SystemIcon {...selectInputStencil.parts.caret} icon={caretDownSmallIcon} />
-      </InputGroup.InnerEnd>
-    </InputGroup>
-  );
-});
+})<SelectInputProps>(
+  (
+    {placeholder = 'Choose an option', inputStartIcon, formInputProps, ...elemProps},
+    Element,
+    model
+  ) => {
+    return (
+      <InputGroup data-width="ck-formfield-width">
+        {inputStartIcon && model.state.selectedIds.length > 0 && (
+          <InputGroup.InnerStart data-part="select-start-icon-container" {...selectIconsStencil()}>
+            <SystemIcon data-part="select-start-icon" icon={inputStartIcon} />
+          </InputGroup.InnerStart>
+        )}
+        {/* Hidden input to handle ids */}
+        <InputGroup.Input
+          data-part="select-hidden-input"
+          {...formInputProps}
+          {...hiddenSelectInputStencil()}
+        />
+        {/* Visual input */}
+        <InputGroup.Input
+          as={Element}
+          placeholder={placeholder}
+          data-part="select-visual-input"
+          {...elemProps}
+          {...mergeStyles(elemProps, selectInputStencil())}
+        />
+        <InputGroup.InnerEnd data-part="select-caret-container" {...selectIconsStencil()}>
+          <SystemIcon data-part="select-caret-icon" icon={caretDownSmallIcon} />
+        </InputGroup.InnerEnd>
+      </InputGroup>
+    );
+  }
+);

--- a/modules/react/select/lib/SelectInput.tsx
+++ b/modules/react/select/lib/SelectInput.tsx
@@ -11,7 +11,7 @@ import {useSelectModel} from './hooks/useSelectModel';
 import {createSubcomponent, ExtractProps} from '@workday/canvas-kit-react/common';
 import {system} from '@workday/canvas-tokens-web';
 
-export interface SelectInputProps extends ExtractProps<typeof TextInput>, CSProps {
+export interface SelectInputProps extends ExtractProps<typeof TextInput, never>, CSProps {
   /**
    * The Icon to render at the start of the `input`. Use this prop if your options
    * include icons that you would like to render in the `input` when selected.

--- a/modules/react/select/lib/SelectInput.tsx
+++ b/modules/react/select/lib/SelectInput.tsx
@@ -55,37 +55,26 @@ const hiddenSelectInputStencil = createStencil({
 export const SelectInput = createSubcomponent(TextInput)({
   modelHook: useSelectModel,
   elemPropsHook: useSelectInput,
-})<SelectInputProps>(
-  (
-    {placeholder = 'Choose an option', inputStartIcon, formInputProps, ...elemProps},
-    Element,
-    model
-  ) => {
-    return (
-      <InputGroup data-width="ck-formfield-width">
-        {inputStartIcon && model.state.selectedIds.length > 0 && (
-          <InputGroup.InnerStart data-part="select-start-icon-container" {...selectIconsStencil()}>
-            <SystemIcon data-part="select-start-icon" icon={inputStartIcon} />
-          </InputGroup.InnerStart>
-        )}
-        {/* Hidden input to handle ids */}
-        <InputGroup.Input
-          data-part="select-hidden-input"
-          {...formInputProps}
-          {...hiddenSelectInputStencil()}
-        />
-        {/* Visual input */}
-        <InputGroup.Input
-          as={Element}
-          placeholder={placeholder}
-          data-part="select-visual-input"
-          {...elemProps}
-          {...mergeStyles(elemProps, selectInputStencil())}
-        />
-        <InputGroup.InnerEnd data-part="select-caret-container" {...selectIconsStencil()}>
-          <SystemIcon data-part="select-caret-icon" icon={caretDownSmallIcon} />
-        </InputGroup.InnerEnd>
-      </InputGroup>
-    );
-  }
-);
+})<SelectInputProps>(({inputStartIcon, formInputProps, ...elemProps}, Element, model) => {
+  return (
+    <InputGroup data-width="ck-formfield-width" {...selectInputStencil()}>
+      {inputStartIcon && model.state.selectedIds.length > 0 && (
+        <InputGroup.InnerStart {...selectInputStencil.parts.startIconContainer}>
+          <SystemIcon {...selectInputStencil.parts.startIcon} icon={inputStartIcon} />
+        </InputGroup.InnerStart>
+      )}
+      {/* Hidden input to handle ids */}
+      <InputGroup.Input {...selectInputStencil.parts.hiddenInput} {...formInputProps} />
+      {/* Visual input */}
+      <InputGroup.Input
+        as={Element}
+        placeholder="Choose an option"
+        {...selectInputStencil.parts.visualInput}
+        {...elemProps}
+      />
+      <InputGroup.InnerEnd {...selectInputStencil.parts.caretContainer}>
+        <SystemIcon {...selectInputStencil.parts.caret} icon={caretDownSmallIcon} />
+      </InputGroup.InnerEnd>
+    </InputGroup>
+  );
+});


### PR DESCRIPTION
## Summary

Removing unintentional props from `SelectInputProps`. Any component that uses `create*` component utility functions and uses `ExtractProps` for the prop interface should use `never` as the second parameter. The `never` means "don't include the default HTML attributes in the prop interface". The `as` prop is used to determine the final HTML attributes. Forgetting to use the `never` means the prop interfaces can be incompatible unintentionally, causing TypeScript issues for developers doing things we say is supported.

## Release Category
Components

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--docs)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)
