### PR TITLE
ci: Pad canary build ids with zeros

### DIFF
--- a/utils/publish-canary.mjs
+++ b/utils/publish-canary.mjs
@@ -10,11 +10,13 @@ const exec = promisify(childProcess.exec);
 const {
   SLACK_WEBHOOK,
   GITHUB_REF,
+  GITHUB_RUN_NUMBER = '0',
   BUILD_URL = 'https://github.com/Workday/canvas-kit/actions',
 } = process.env;
 
 console.log('GITHUB_REF', GITHUB_REF);
 const branch = GITHUB_REF.replace('refs/heads/', '');
+const prefixedBuildNumber = GITHUB_RUN_NUMBER.padStart(4, '0');
 
 const isPreMajor = branch.match(/^prerelease\/major$/g);
 const isPreMinor = branch.match(/^prerelease\/minor$/g);
@@ -97,11 +99,11 @@ exec('git diff --name-only HEAD HEAD^')
       // `v5.2.3` -> `v6.0.0-beta.n`
       if (isPreMajor) {
         // for pre major releases, we'll assume we're going to start with an alpha prerelease
-        preid = `alpha.${process.env.GITHUB_RUN_NUMBER || 0}-next`;
+        preid = `alpha.${prefixedBuildNumber}-next`;
         bump = 'premajor';
       } else {
         // we'll use `next` for pre minors
-        preid = `${process.env.GITHUB_RUN_NUMBER || 0}-next`;
+        preid = `${prefixedBuildNumber}-next`;
         bump = 'preminor';
       }
     }


### PR DESCRIPTION
## Summary

We have issues with pre-ids in our canary builds where package managers sort alphabetically. This is an issue when we go from `999` to `1000`. When sorting alphabetically, "1000" is before "999" instead of after. If we prefix with a zero, we can handle up to 9999 before we have this issue. `0999` is properly sorted before `1000`

## Release Category
Infrastructure

---
