### PR TITLE
fix: Ensure disabled is passed to MultiSelect sub components so input plus options are disabled

### DIFF
--- a/modules/preview-react/multi-select/lib/MultiSelectInput.tsx
+++ b/modules/preview-react/multi-select/lib/MultiSelectInput.tsx
@@ -58,6 +58,11 @@ export const multiSelectStencil = createStencil({
       },
     },
 
+    '&:has(:disabled, .disabled)': {
+      borderColor: system.color.border.input.disabled,
+      color: system.color.text.disabled,
+    },
+
     '& :where([data-part="form-input"])': {
       position: 'absolute',
       top: system.space.zero,
@@ -135,6 +140,7 @@ export const MultiSelectInput = createSubcomponent(TextInput)({
       style,
       'aria-labelledby': ariaLabelledBy,
       removeLabel,
+      disabled,
       formInputProps,
       ...elemProps
     },
@@ -150,13 +156,14 @@ export const MultiSelectInput = createSubcomponent(TextInput)({
             as={Element}
             aria-labelledby={ariaLabelledBy}
             readOnly
+            disabled={disabled}
             {...elemProps}
           />
           <InputGroup.InnerEnd pointerEvents="none">
             <SystemIcon icon={caretDownSmallIcon} />
           </InputGroup.InnerEnd>
         </InputGroup>
-        <MultiSelectedList removeLabel={removeLabel} />
+        <MultiSelectedList disabled={disabled} removeLabel={removeLabel} />
       </div>
     );
   }
@@ -175,6 +182,7 @@ export const MultiSelectSearchInput = createSubcomponent(TextInput)({
       removeLabel,
       formInputProps,
       ref,
+      disabled,
       ...elemProps
     },
     Element,
@@ -195,6 +203,7 @@ export const MultiSelectSearchInput = createSubcomponent(TextInput)({
             data-part="user-input"
             as={Element}
             aria-labelledby={ariaLabelledBy}
+            disabled={disabled}
             {...elemProps}
           />
           <InputGroup.InnerEnd width={system.space.x4}>
@@ -204,7 +213,7 @@ export const MultiSelectSearchInput = createSubcomponent(TextInput)({
             <SystemIcon icon={caretDownSmallIcon} />
           </InputGroup.InnerEnd>
         </InputGroup>
-        <MultiSelectedList removeLabel={removeLabel} />
+        <MultiSelectedList removeLabel={removeLabel} disabled={disabled} />
       </div>
     );
   }

--- a/modules/preview-react/multi-select/lib/MultiSelectedItem.tsx
+++ b/modules/preview-react/multi-select/lib/MultiSelectedItem.tsx
@@ -14,6 +14,10 @@ import {useMultiSelectModel} from './useMultiSelectModel';
 
 export interface MultiSelectedItemProps {
   /**
+   * Disabled on the `Pill` component.
+   */
+  disabled?: boolean;
+  /**
    * Remove label on a MultiSelectedItem. In English, the label may be "Remove" and the screen
    * reader will read out "Remove {option}".
    *
@@ -36,9 +40,9 @@ export const useMultiSelectedItem = composeHooks(
 export const MultiSelectedItem = createSubcomponent('span')({
   modelHook: useMultiSelectModel,
   elemPropsHook: useMultiSelectedItem,
-})<MultiSelectedItemProps>(({children, removeLabel, ref, ...elemProps}, Element) => {
+})<MultiSelectedItemProps>(({children, removeLabel, disabled, ref, ...elemProps}, Element) => {
   return (
-    <Pill as={Element} variant="removable">
+    <Pill as={Element} disabled={disabled} variant="removable">
       {children}
       <Pill.IconButton aria-label={removeLabel} ref={ref} {...(elemProps as any)} />
     </Pill>

--- a/modules/preview-react/multi-select/lib/MultiSelectedList.tsx
+++ b/modules/preview-react/multi-select/lib/MultiSelectedList.tsx
@@ -8,23 +8,35 @@ import {MultiSelectedItem, MultiSelectedItemProps} from './MultiSelectedItem';
 
 export interface MultiSelectedListProps
   extends MultiSelectedItemProps,
-    React.HTMLAttributes<HTMLDivElement> {}
+    React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Disabled is forwarded to the MultiSelectedItem component to make sure each item is also
+   * disabled.
+   */
+  disabled?: boolean;
+}
 
 export const MultiSelectedList = createSubcomponent('div')({
   modelHook: useMultiSelectModel,
-})<MultiSelectedListProps>(({'aria-labelledby': ariaLabelledBy, removeLabel}, Element, model) => {
-  return model.selected.state.items.length ? (
-    <>
-      <div data-part="separator" />
-      <ListBox
-        model={model.selected}
-        as={Element}
-        role="listbox"
-        aria-orientation="horizontal"
-        aria-labelledby={ariaLabelledBy}
-      >
-        {item => <MultiSelectedItem removeLabel={removeLabel}>{item.textValue}</MultiSelectedItem>}
-      </ListBox>
-    </>
-  ) : null;
-});
+})<MultiSelectedListProps>(
+  ({'aria-labelledby': ariaLabelledBy, disabled, removeLabel}, Element, model) => {
+    return model.selected.state.items.length ? (
+      <>
+        <div data-part="separator" />
+        <ListBox
+          model={model.selected}
+          as={Element}
+          role="listbox"
+          aria-orientation="horizontal"
+          aria-labelledby={ariaLabelledBy}
+        >
+          {item => (
+            <MultiSelectedItem disabled={disabled} removeLabel={removeLabel}>
+              {item.textValue}
+            </MultiSelectedItem>
+          )}
+        </ListBox>
+      </>
+    ) : null;
+  }
+);

--- a/modules/preview-react/multi-select/stories/MultiSelect.mdx
+++ b/modules/preview-react/multi-select/stories/MultiSelect.mdx
@@ -6,6 +6,7 @@ import {
 } from '@workday/canvas-kit-docs';
 
 import {Basic} from './examples/Basic';
+import {Disabled} from './examples/Disabled';
 import {Complex} from './examples/Complex';
 import {Icons} from './examples/Icons';
 import {Controlled} from './examples/Controlled';
@@ -56,7 +57,11 @@ attached to the `MultiSelect.Input` and read out as a group for voiceover.
 </MultiSelect>
 ```
 
-<ExampleCodeBlock code={Basic} />
+### Disabled Example
+
+Disabling `MultiSelect` involves passing the `disabled` prop to the `MultiSelect.Input` component.
+
+<ExampleCodeBlock code={Disabled} />
 
 ### Complex
 

--- a/modules/preview-react/multi-select/stories/MultiSelect.stories.ts
+++ b/modules/preview-react/multi-select/stories/MultiSelect.stories.ts
@@ -4,6 +4,7 @@ import mdxDoc from './MultiSelect.mdx';
 
 import {MultiSelect} from '@workday/canvas-kit-preview-react/multi-select';
 import {Basic as BasicExample} from './examples/Basic';
+import {Disabled as DisabledExample} from './examples/Disabled';
 import {Icons as IconsExample} from './examples/Icons';
 import {Complex as ComplexExample} from './examples/Complex';
 import {Controlled as ControlledExample} from './examples/Controlled';
@@ -24,6 +25,10 @@ type Story = StoryObj<typeof MultiSelect>;
 
 export const Basic: Story = {
   render: BasicExample,
+};
+
+export const Disabled: Story = {
+  render: DisabledExample,
 };
 
 export const Icons: Story = {

--- a/modules/preview-react/multi-select/stories/examples/Disabled.tsx
+++ b/modules/preview-react/multi-select/stories/examples/Disabled.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import {FormField} from '@workday/canvas-kit-react/form-field';
+import {MultiSelect} from '@workday/canvas-kit-preview-react/multi-select';
+
+const items = ['Cheese', 'Olives', 'Onions', 'Pepperoni', 'Peppers'];
+
+export const Disabled = () => {
+  return (
+    <>
+      <MultiSelect items={items} initialSelectedIds={['Olives', 'Onions', 'Pepperoni']}>
+        <FormField orientation="horizontal">
+          <FormField.Label>Toppings</FormField.Label>
+          <FormField.Input
+            as={MultiSelect.Input}
+            placeholder="Select Multiple"
+            removeLabel="Remove"
+            disabled
+          />
+          <MultiSelect.Popper>
+            <MultiSelect.Card>
+              <MultiSelect.List>
+                {item => (
+                  <MultiSelect.Item data-id={item}>
+                    <MultiSelect.Item.Text>{item}</MultiSelect.Item.Text>
+                  </MultiSelect.Item>
+                )}
+              </MultiSelect.List>
+            </MultiSelect.Card>
+          </MultiSelect.Popper>
+        </FormField>
+      </MultiSelect>
+    </>
+  );
+};


### PR DESCRIPTION
## Summary

Forward disabled prop to the whole component. The `MultiSelect.Input` will now forward the `disabled` prop down to the `Pill` component and will apply disabled styling to the container element.

Fixes: #3294

## Release Category
Components

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--docs)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

