### PR TITLE
chore: Deprecated Themeable. Use CanvasProvider instead

### DIFF
--- a/modules/react/common/lib/theming/types.ts
+++ b/modules/react/common/lib/theming/types.ts
@@ -240,6 +240,7 @@ export interface CanvasTheme {
 
 /**
  * Indicates a component is themeable with a CanvasTheme
+ * @deprecated `Themeable` is deprecated. If you want to theme your application, please use `<CanvasProvider theme={{canvas: {palette: {primary: {main: 'orange'}}}}} />` at the root of your application or use our CSS tokens to change individual component styles as seen in our [Button docs](https://workday.github.io/canvas-kit/?path=/docs/components-buttons--docs#custom-styles).
  */
 export interface Themeable {
   theme?: EmotionCanvasTheme;


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: https://github.com/Workday/canvas-kit/issues/3298

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Types

### Release Note
We've deprecated `Themeable`. Use the `CanvasProvider` with the `theme` object to theme your application at the root level. If you wish to customize styles for a component you can use CSS variables and our tokens to do so. [Here's an example](https://workday.github.io/canvas-kit/?path=/docs/components-buttons--docs#custom-styles) with our Buttons.

Before we introduce our new Tokens, we had `Themeable` to indicate that our components can be themed. As we've transitioned to updating our components to use our new CSS tokens, this type is no longer needed. Our components can be themed at the root level via the `CanvasProvider`  our through our CSS tokens.

---