### PR TITLE
fix: Update styling transform to use deterministic hashes

### DIFF
--- a/modules/styling-transform/lib/styleTransform.ts
+++ b/modules/styling-transform/lib/styleTransform.ts
@@ -1,18 +1,18 @@
 /// <reference types="node" />
-import ts from 'typescript';
 import path from 'node:path';
+import ts from 'typescript';
 
 import {getVariablesFromFiles} from './utils/getCssVariables';
-import {handleCreateVars} from './utils/handleCreateVars';
-import {handleCreateStyles} from './utils/handleCreateStyles';
-import {handleCreateStencil} from './utils/handleCreateStencil';
 import {handleCalc} from './utils/handleCalc';
-import {handlePx2Rem} from './utils/handlePx2Rem';
+import {handleCreateStencil} from './utils/handleCreateStencil';
+import {handleCreateStyles} from './utils/handleCreateStyles';
+import {handleCreateVars} from './utils/handleCreateVars';
 import {handleCssVar} from './utils/handleCssVar';
-import {Config, NodeTransformer, ObjectTransform, TransformerContext} from './utils/types';
-import {handleKeyframes} from './utils/handleKeyframes';
 import {handleInjectGlobal} from './utils/handleInjectGlobal';
+import {handleKeyframes} from './utils/handleKeyframes';
 import {handleParentModifier} from './utils/handleParentModifier';
+import {handlePx2Rem} from './utils/handlePx2Rem';
+import {NodeTransformer, ObjectTransform, TransformerContext} from './utils/types';
 
 export type NestedStyleObject = {[key: string]: string | NestedStyleObject};
 
@@ -26,8 +26,6 @@ let extractedNames: TransformerContext['extractedNames'] = {};
 let styles: TransformerContext['styles'] = {};
 let cache: TransformerContext['cache'] = {};
 let loadedFallbacks = false;
-let configLoaded = false;
-let config: Config = {};
 
 /**
  * The reset is used in tests and should not be called normally.
@@ -50,29 +48,15 @@ const defaultTransformers = [
   handleCreateStencil,
   handleInjectGlobal,
 ];
-
-export default function styleTransformer(
+export default styleTransformer;
+export function styleTransformer(
   program: ts.Program,
   {fallbackFiles = [], ...options}: Partial<StyleTransformerOptions> = {}
 ): ts.TransformerFactory<ts.SourceFile> {
-  if (!configLoaded) {
-    const configPath = getConfig(program.getCurrentDirectory());
-
-    if (configPath) {
-      console.log('Config file found:', configPath);
-      config = require(configPath).default;
-    }
-
-    configLoaded = true;
-  }
-
-  const {names, ...transformContext} = withDefaultContext(program.getTypeChecker(), {
-    ...config,
-    ...options,
-  });
+  const {names, ...transformContext} = withDefaultContext(program.getTypeChecker(), options);
 
   if (!loadedFallbacks) {
-    const files = fallbackFiles
+    const files: string[] = fallbackFiles
       .filter(file => file) // don't process empty files
       .map(file => {
         // Find the fully-qualified path name. This could error which should give "module not found" errors
@@ -136,6 +120,7 @@ export function withDefaultContext(
     styles,
     cache,
     checker,
+    seed: '',
     extractCSS: false,
     getFileName: path => path.replace(/\.tsx?/, '.css'),
     objectTransforms: [] as ObjectTransform[],
@@ -161,22 +146,26 @@ export function transform(
 
   const printer = ts.createPrinter();
 
+  const transformers = [styleTransformer(program, options)];
+
   return printer.printFile(
-    ts
-      .transform(source, [styleTransformer(program, options)])
-      .transformed.find(s => s.fileName === source.fileName) || source
+    ts.transform(source, transformers).transformed.find(s => s.fileName === source.fileName) ||
+      source
   );
 }
 
 const handleTransformers =
   (transformers: ((node: ts.Node, context: TransformerContext) => ts.Node | void)[]) =>
   (node: ts.Node, context: TransformerContext) => {
-    return transformers.reduce((result, transformer) => {
-      if (result) {
-        return result;
-      }
-      return transformer(node, context);
-    }, undefined as ts.Node | void);
+    return transformers.reduce(
+      (result, transformer) => {
+        if (result) {
+          return result;
+        }
+        return transformer(node, context);
+      },
+      undefined as ts.Node | void
+    );
   };
 
 export function getConfig(basePath = '.') {

--- a/modules/styling-transform/lib/utils/types.ts
+++ b/modules/styling-transform/lib/utils/types.ts
@@ -74,6 +74,7 @@ export type TransformerContext = {
   fileName: string;
   transform: NodeTransformer;
   extractCSS: boolean;
+  seed: string;
 };
 
 export type NestedStyleObject = {[key: string]: number | string | NestedStyleObject};
@@ -206,6 +207,12 @@ export interface Config {
    * different prefix for each module in a monorepo.
    */
   getPrefix?: (path: string) => string;
+
+  /**
+   * Optional seed for the hash. This can be useful if you want each build to have a different hash.
+   * If you provide the same seed, the same hash will be generated for every style.
+   */
+  seed?: string;
 }
 
 export type ObjectTransform = (

--- a/modules/styling-transform/package.json
+++ b/modules/styling-transform/package.json
@@ -1,27 +1,30 @@
 {
   "name": "@workday/canvas-kit-styling-transform",
-  "version": "13.1.4",
+  "version": "13.1.2",
   "description": "The custom CSS in JS solution that takes JS styles and turns them into static CSS",
   "author": "Workday, Inc. (https://www.workday.com)",
   "license": "Apache-2.0",
-  "main": "index.js",
-  "module": "index.js",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/es6/index.js",
   "sideEffects": false,
-  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/workday/canvas-kit.git",
     "directory": "modules/styling/parser"
   },
   "files": [
-    "*/package.json",
-    "*/lib/*",
-    "*/index.ts",
-    "dist/",
+    "package.json",
+    "lib/*",
+    "index.js",
+    "dist/*",
     "index.ts",
     "testing.ts"
   ],
   "scripts": {
+    "clean": "rimraf dist && rimraf .build-info && mkdirp dist",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:es6": "tsc -p tsconfig.es6.json",
+    "build": "npm-run-all build:cjs build:es6",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [
@@ -34,13 +37,15 @@
   ],
   "dependencies": {
     "@emotion/serialize": "^1.0.2",
-    "@workday/canvas-kit-styling": "^13.1.4",
-    "@workday/canvas-tokens-web": "^2.1.1",
+    "@workday/canvas-kit-styling": "^13.1.2",
     "stylis": "4.0.13",
-    "ts-node": "^10.9.1",
-    "typescript": "5.0"
+    "ts-node": "^10.9.1"
   },
   "devDependencies": {
-    "common-tags": "^1.8.0"
+    "common-tags": "^1.8.0",
+    "@types/common-tags": "^1.8.0"
+  },
+  "peerDependencies": {
+    "typescript": ">=5.0"
   }
 }

--- a/styling.config.ts
+++ b/styling.config.ts
@@ -1,5 +1,8 @@
+import crypto from 'node:crypto';
+
 import {createConfig} from '@workday/canvas-kit-styling-transform';
 
+import pkg from '../package.json';
 import {handleFocusRing} from './utils/style-transform/handleFocusRing';
 
 const config = createConfig({
@@ -21,11 +24,8 @@ const config = createConfig({
       })
       .toLowerCase();
   },
-  fallbackFiles: [
-    '@workday/canvas-tokens-web/css/base/_variables.css',
-    '@workday/canvas-tokens-web/css/brand/_variables.css',
-    '@workday/canvas-tokens-web/css/system/_variables.css',
-  ],
+  seed: crypto.createHash('sha256').update(pkg.version).digest('hex').slice(0, 6),
+  fallbackFiles: [],
   objectTransforms: [handleFocusRing],
 });
 

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,1 +1,5 @@
 declare module '*.jpg';
+
+declare module '*package.json' {
+  const version: string;
+}


### PR DESCRIPTION
## Summary

The `styling-transform` module did not package properly and couldn't be used outside of CK source code.

- Updated `package.json` `files` to ensure all files are in the node package
- Updated build process to create commonjs and es6 builds so users don't need to do any special TypeScript processing
- Updated styling config to use a version-based seed so each version of Canvas Kit has a unique set of styles so they don't have style merge collisions

## Release Category
Infrastructure

---
