### PR TITLE
fix: Add pointerEvents style to svg in BaseButtonComponent

### DIFF
--- a/modules/react/button/lib/BaseButton.tsx
+++ b/modules/react/button/lib/BaseButton.tsx
@@ -248,6 +248,11 @@ export const buttonStencil = createStencil({
         outlineOffset: 0,
       },
     },
+    // prevent ReactDOM 19 SVG issue https://github.com/Workday/canvas-kit/issues/3357.
+    // Can be removed when the ReactDOM 19 issue is fixed.
+    svg: {
+      pointerEvents: 'none',
+    },
   }),
   modifiers: {
     /**


### PR DESCRIPTION
## Summary

Fixes: #3357

Add `pointerEvents: none` to the SVG style in `BaseButton` component. This fixes a bug in React 19 where clicking the SVG icon within a button prevents the click event and loses focus.

## Release Category
Components

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--docs)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?
[modules/react/button/lib/BaseButton.tsx]

## Testing Manually
- Build the package and check if pointer-events is available on the DOM on <svg> tag. 
- Try out this demo button with the new modules. https://stackblitz.com/edit/toolbar-button-tooltip-sswuectw?file=src%2FDemo.tsx 

## Screenshots or GIFs (if applicable)
N/A
<!-- Does your change affect the UI? If so, please include a screenshot or short gif. -->

## Thank You Gif
![thank-you-gif-1](https://github.com/user-attachments/assets/87008be4-2bf8-452e-8f34-fce4f3afb96b)
