### PR TITLE
fix: Add focusRing plugin back to style transform

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -8,6 +8,7 @@ import getSpecifications from '../modules/docs/utils/get-specifications';
 import {getDocParser} from '../modules/docs/docgen/createDocProgram';
 // Drop the `/index.ts` if using the published package
 import {styleTransformer, StylingWebpackPlugin} from '@workday/canvas-kit-styling-transform';
+import stylingConfig from '../styling.config';
 
 const modulesPath = path.resolve(__dirname, '../modules');
 const processDocs = process.env.SKIP_DOCGEN !== 'true';
@@ -70,7 +71,7 @@ const config: StorybookConfig = {
               };
             }
           : undefined,
-        styleTransformer,
+        program => styleTransformer(program, {...stylingConfig, extractCSS: false}),
       ],
       postTransform(code, id) {
         if (docsMap.get(id) && processDocs) {

--- a/.storybook/typescript-transform.ts
+++ b/.storybook/typescript-transform.ts
@@ -1,0 +1,8 @@
+import ts from 'typescript';
+
+import config from '../styling.config';
+import styleTransformer from '@workday/canvas-kit-styling-transform';
+
+export default function transform(program: ts.Program) {
+  return styleTransformer(program, config);
+}

--- a/modules/labs-react/tsconfig.json
+++ b/modules/labs-react/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "plugins": [
       {
-        "transform": "../styling-transform/index.ts"
+        "transform": "../../.storybook/typescript-transform.ts"
       }
     ]
   }

--- a/modules/preview-react/tsconfig.json
+++ b/modules/preview-react/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "plugins": [
       {
-        "transform": "../styling-transform/index.ts"
+        "transform": "../../.storybook/typescript-transform.ts"
       }
     ]
   }

--- a/modules/react/tsconfig.json
+++ b/modules/react/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "plugins": [
       {
-        "transform": "../styling-transform/index.ts"
+        "transform": "../../.storybook/typescript-transform.ts"
       }
     ]
   }

--- a/styling.config.ts
+++ b/styling.config.ts
@@ -2,7 +2,7 @@ import crypto from 'node:crypto';
 
 import {createConfig} from '@workday/canvas-kit-styling-transform';
 
-import pkg from '../package.json';
+import pkg from './lerna.json';
 import {handleFocusRing} from './utils/style-transform/handleFocusRing';
 
 const config = createConfig({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
     "skipLibCheck": true,
     "plugins": [
       {
-        "transform": "./modules/styling-transform/index.ts"
+        "transform": "./.storybook/typescript-transform.ts"
       }
     ]
   },

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -3,3 +3,7 @@ declare module '*.jpg';
 declare module '*package.json' {
   const version: string;
 }
+
+declare module '*lerna.json' {
+  const version: string;
+}


### PR DESCRIPTION
## Summary

Fixes the style transform to add back the `focusRing` plugin that was accidentally removed in #3356 

## Release Category
Infrastructure


---
