### PR TITLE
fix: Spec tables extend through container size

### DIFF
--- a/modules/docs/lib/Value.tsx
+++ b/modules/docs/lib/Value.tsx
@@ -9,6 +9,7 @@ import {Table} from './Table';
 import {capitalize, IndentLevelContext, RenderContext, indent} from './widgetUtils';
 import {DescriptionTooltip} from './DescriptionTooltip';
 import {colors} from '@workday/canvas-kit-react/tokens';
+import {createStyles} from '@workday/canvas-kit-styling';
 
 const widgets: Record<string, React.FC<ValueProps>> = {};
 
@@ -151,6 +152,10 @@ function getTableRows(
   });
 }
 
+const tableStyles = createStyles({
+  tableLayout: 'fixed',
+});
+
 export const PropertiesTable = ({
   properties,
   showDefault = true,
@@ -168,7 +173,7 @@ export const PropertiesTable = ({
 
   return (
     <IndentLevelContext.Provider value={0}>
-      <Table>
+      <Table cs={tableStyles}>
         <Table.Head>
           <Table.Row>
             <Table.Header>Name</Table.Header>


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Spec tables in Storybook extend past the container size and start a horizontal scroll in docs. This addresses the styling of those tables.

Fixes: #3404  <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Documentation

---

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
`/modules/docs/lib/Value.tsx`
