### PR TITLE
chore: Upgrade to tokens alpha.10

### DIFF
--- a/modules/docs/package.json
+++ b/modules/docs/package.json
@@ -50,7 +50,7 @@
     "@workday/canvas-kit-react": "^13.2.7",
     "@workday/canvas-kit-styling": "^13.2.7",
     "@workday/canvas-system-icons-web": "^3.0.35",
-    "@workday/canvas-tokens-web": "3.0.0-alpha.9",
+    "@workday/canvas-tokens-web": "3.0.0-alpha.10",
     "markdown-to-jsx": "^7.2.0",
     "react-syntax-highlighter": "^15.5.0",
     "ts-node": "^10.9.1"

--- a/modules/labs-react/package.json
+++ b/modules/labs-react/package.json
@@ -49,7 +49,7 @@
     "@workday/canvas-kit-react": "^13.2.7",
     "@workday/canvas-kit-styling": "^13.2.7",
     "@workday/canvas-system-icons-web": "^3.0.35",
-    "@workday/canvas-tokens-web": "3.0.0-alpha.9",
+    "@workday/canvas-tokens-web": "3.0.0-alpha.10",
     "@workday/design-assets-types": "^0.2.10",
     "chroma-js": "^2.2.0",
     "lodash.flatten": "^4.4.0",

--- a/modules/preview-react/package.json
+++ b/modules/preview-react/package.json
@@ -49,7 +49,7 @@
     "@workday/canvas-kit-react": "^13.2.7",
     "@workday/canvas-kit-styling": "^13.2.7",
     "@workday/canvas-system-icons-web": "^3.0.35",
-    "@workday/canvas-tokens-web": "3.0.0-alpha.9",
+    "@workday/canvas-tokens-web": "3.0.0-alpha.10",
     "@workday/design-assets-types": "^0.2.10"
   },
   "devDependencies": {

--- a/modules/react/package.json
+++ b/modules/react/package.json
@@ -53,7 +53,7 @@
     "@workday/canvas-kit-popup-stack": "^13.2.7",
     "@workday/canvas-kit-styling": "^13.2.7",
     "@workday/canvas-system-icons-web": "^3.0.35",
-    "@workday/canvas-tokens-web": "3.0.0-alpha.9",
+    "@workday/canvas-tokens-web": "3.0.0-alpha.10",
     "@workday/design-assets-types": "^0.2.10",
     "chroma-js": "^2.2.0",
     "csstype": "^3.0.2",

--- a/modules/styling-transform/package.json
+++ b/modules/styling-transform/package.json
@@ -40,7 +40,7 @@
     "@emotion/serialize": "^1.0.2",
     "@workday/canvas-kit-styling": "^13.2.7",
     "stylis": "4.0.13",
-    "@workday/canvas-tokens-web": "3.0.0-alpha.9",
+    "@workday/canvas-tokens-web": "3.0.0-alpha.10",
     "ts-node": "^10.9.1",
     "typescript": "5.0"
   },

--- a/modules/styling/package.json
+++ b/modules/styling/package.json
@@ -55,7 +55,7 @@
     "@emotion/styled": "^11.6.0",
     "@workday/canvas-kit-react": "^13.2.7",
     "@workday/canvas-system-icons-web": "^3.0.35",
-    "@workday/canvas-tokens-web": "3.0.0-alpha.9",
+    "@workday/canvas-tokens-web": "3.0.0-alpha.10",
     "typescript": "5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "@workday/canvas-accent-icons-web": "^3.0.9",
     "@workday/canvas-applet-icons-web": "^2.0.9",
     "@workday/canvas-system-icons-web": "^3.0.35",
-    "@workday/canvas-tokens-web": "3.0.0-alpha.9",
+    "@workday/canvas-tokens-web": "3.0.0-alpha.10",
     "jest-environment-jsdom": "^29.7.0",
     "ts-jest": "^29.2.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6290,10 +6290,10 @@
   dependencies:
     "@workday/design-assets-types" "0.2.10"
 
-"@workday/canvas-tokens-web@3.0.0-alpha.9":
-  version "3.0.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/@workday/canvas-tokens-web/-/canvas-tokens-web-3.0.0-alpha.9.tgz#56fa84f1166e66ee45858274113733ad453fa663"
-  integrity sha512-yQ4IjcPgPYjgrV1XdxQRKuIIAz7tQQSHUbmhGdm2q3XyFrXpjDuRYCvc4CjV3tP9xA4/hJQae8qhw54gt0KMtw==
+"@workday/canvas-tokens-web@3.0.0-alpha.10":
+  version "3.0.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/@workday/canvas-tokens-web/-/canvas-tokens-web-3.0.0-alpha.10.tgz#38a765109485c31640662e853eaff004a7417e1f"
+  integrity sha512-UkR43imHzyTb47I+lrRuxe1No95+IdM4N4mKNpF/IcVzg/OLAjosmqOkYzztMSacKO9+lRjrVtNkrKnubWvkBg==
 
 "@workday/design-assets-types@0.2.10", "@workday/design-assets-types@^0.2.10":
   version "0.2.10"
@@ -15788,7 +15788,16 @@ string-replace-loader@^3.1.0:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -15875,7 +15884,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15895,6 +15904,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -17068,7 +17084,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -17081,6 +17097,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Upgrades to `alpha.10` that will update `overlay-inverse` and `translucent-inverse` to use `neutral.1000` as main color.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Infrastructure
