### PR TITLE
fix(TabsItem): Added styles for Windows high contrast

### DIFF
--- a/modules/react/tabs/lib/TabsItem.tsx
+++ b/modules/react/tabs/lib/TabsItem.tsx
@@ -116,7 +116,8 @@ const tabItemStencil = createStencil({
     },
 
     '&:focus-visible, &.focus': {
-      outline: `none`,
+      // focus outline for Windows high contrast theme
+      outline: `${px2rem(2)} solid transparent`,
       ...focusRing({inset: 'outer', width: 0, separation: 2}),
       [buttonStencil.vars.boxShadowInner]: system.color.border.inverse,
       [buttonStencil.vars.boxShadowOuter]: brand.common.focusOutline,
@@ -139,7 +140,8 @@ const tabItemStencil = createStencil({
       [systemIconStencil.vars.color]: brand.primary.base,
       '&:after': {
         position: 'absolute',
-        height: system.space.x1,
+        // selected state for Windows high contrast theme
+        borderBottom: `${system.space.x1} solid transparent`,
         borderRadius: `${system.shape.x1} ${system.shape.x1} ${system.shape.zero} ${system.shape.zero}`,
         backgroundColor: brand.primary.base,
         bottom: system.space.zero,


### PR DESCRIPTION
Added transparent CSS outline for keyboard focus and transparent borderBottom for the selected state.

<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

My team mates brought this issue to my attention; possible regression after Page Tabs component style refactor was merged.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--docs)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->
`modules/react/tabs/lib/TabsItem.tsx`

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Documentation
- [ ] Testing
- [ ] Codemods

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

<!-- Explain how your reviewer could verify this change  -->

1. On Windows 11, go to Settings
2. Search "high contrast"
3. Select any theme, I use the first option "Aquatic"
4. On storybook, use the keyboard to focus the TabList
5. Verify focus outline is now visible
6. Use the arrow keys to select a different tab
7. Verify visual indication of the 1 selected tab

## Screenshots or GIFs (if applicable)

<!-- Does your change affect the UI? If so, please include a screenshot or short gif. -->
It should only affect the UI in a Windows high contrast theme, otherwise there should not be any changes to the UI

BEFORE: 
<img width="6183" height="3780" alt="canvas-tabs-before" src="https://github.com/user-attachments/assets/ccc047c3-7967-4e25-8c3f-6f7ce1d59e96" />

AFTER:
<img width="8136" height="5184" alt="canvas-tabs-after" src="https://github.com/user-attachments/assets/b3618621-9268-46b3-ad87-334e5e32add4" />

## Thank You Gif (optional)

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer! -->
<!-- ![a smiling Shiba Inu typing on a laptop](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif) -->
