### PR TITLE
ci: Fix watch message to not clear terminal

### DIFF
--- a/modules/styling-transform/lib/createTypeScriptWatchProgram.ts
+++ b/modules/styling-transform/lib/createTypeScriptWatchProgram.ts
@@ -41,7 +41,9 @@ export const startWatch = (
     tsconfigPath,
     compilerOptions,
     ts.sys,
-    ts.createSemanticDiagnosticsBuilderProgram
+    ts.createSemanticDiagnosticsBuilderProgram,
+    reportDiagnostic,
+    reportWatchStatusChanged
   );
   host.afterProgramCreate = builderProgram => {
     onProgramCreatedOrUpdated(builderProgram);
@@ -50,3 +52,26 @@ export const startWatch = (
   const watch = ts.createWatchProgram(host);
   return [watch.getProgram(), watch.close];
 };
+
+const formatHost: ts.FormatDiagnosticsHost = {
+  getCanonicalFileName: path => path,
+  getCurrentDirectory: ts.sys.getCurrentDirectory,
+  getNewLine: () => ts.sys.newLine,
+};
+
+function reportDiagnostic(diagnostic: ts.Diagnostic) {
+  console.error(
+    'Error',
+    diagnostic.code,
+    ':',
+    ts.flattenDiagnosticMessageText(diagnostic.messageText, formatHost.getNewLine())
+  );
+}
+
+/**
+ * Prints a diagnostic every time the watch status changes.
+ * This is mainly for messages like "Starting compilation" or "Compilation completed".
+ */
+function reportWatchStatusChanged(diagnostic: ts.Diagnostic) {
+  console.log(ts.formatDiagnostic(diagnostic, formatHost));
+}


### PR DESCRIPTION
## Summary

Fix an issue where the TypeScript watch program clears the terminal. This can make development more difficult because messages outside TypeScript will disappear on file changes.

## Release Category
Infrastructure

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--docs)
- [ ] Label `ready for review` has been added to PR

