### PR TITLE
fix(collection): Fix `inert` prop in React 19

### DIFF
--- a/modules/react/collection/lib/useOverflowListItemMeasure.tsx
+++ b/modules/react/collection/lib/useOverflowListItemMeasure.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import {createElemPropsHook, useLocalRef, useMountLayout} from '@workday/canvas-kit-react/common';
 
 import {useOverflowListModel} from './useOverflowListModel';

--- a/modules/react/collection/lib/useOverflowListItemMeasure.tsx
+++ b/modules/react/collection/lib/useOverflowListItemMeasure.tsx
@@ -55,19 +55,22 @@ export const useOverflowListItemMeasure = createElemPropsHook(useOverflowListMod
       // `inert` is not directly supported in React < 19 which means the prop is forwarded directly
       // as an HTML attribute. React 19 adds support for this prop officially as a `boolean |
       // undefined`. React <19 will ignore `true`, so we need to make it the string `'true'`. We
-      // cannot change this until we drop support for React <19.
+      // cannot change this until we drop support for React <19. The old workaround was `inert: ''`
+      // which works in React <19, but in React 19, the empty string is considered `false` and the
+      // attribute is not added to the DOM. If we try to coerce a `'true'`, the attribute will be
+      // added in both React 18 and 19, but dev mode will throw a warning.
       //
       // - React 18: `inert: true` => no `inert` attribute
       // - React 18: `inert: 'true'` => `inert="true"` in the DOM
       // - React 19: `inert: true` => `inert` in the DOM
       // - React 19: `inert: 'true'` => `inert` in the DOM
       //
-      // There is a difference between `inert` in both versions, where React 18 will add the
-      // `'true'` and React 19 will not. This shouldn't cause issues unless someone has a
-      // `[inert=true]` CSS selector which will not match the React 19 behavior. For this reason, we
-      // cannot use `'false'` and must use `undefined` as the falsey case. This should ensure
-      // correct behavior in all versions of React.
-      inert: hidden ? 'true' : undefined,
+      // The only way to remove the dev warning in React 19, but have the same functionality in all
+      // versions of React, we must detect React 19 and set the attribute accordingly in either
+      // case. Do not remove this wonky code until we drop support for React <19.
+      //
+      // @ts-ignore
+      inert: React.use ? hidden : hidden ? '' : undefined,
     };
   }
 );

--- a/modules/react/collection/lib/useOverflowListItemMeasure.tsx
+++ b/modules/react/collection/lib/useOverflowListItemMeasure.tsx
@@ -51,7 +51,23 @@ export const useOverflowListItemMeasure = createElemPropsHook(useOverflowListMod
       'aria-hidden': hidden || undefined,
 
       style: hidden ? hiddenStyles : {},
-      inert: hidden ? '' : undefined,
+
+      // `inert` is not directly supported in React < 19 which means the prop is forwarded directly
+      // as an HTML attribute. React 19 adds support for this prop officially as a `boolean |
+      // undefined`. React <19 will ignore `true`, so we need to make it the string `'true'`. We
+      // cannot change this until we drop support for React <19.
+      //
+      // - React 18: `inert: true` => no `inert` attribute
+      // - React 18: `inert: 'true'` => `inert="true"` in the DOM
+      // - React 19: `inert: true` => `inert` in the DOM
+      // - React 19: `inert: 'true'` => `inert` in the DOM
+      //
+      // There is a difference between `inert` in both versions, where React 18 will add the
+      // `'true'` and React 19 will not. This shouldn't cause issues unless someone has a
+      // `[inert=true]` CSS selector which will not match the React 19 behavior. For this reason, we
+      // cannot use `'false'` and must use `undefined` as the falsey case. This should ensure
+      // correct behavior in all versions of React.
+      inert: hidden ? 'true' : undefined,
     };
   }
 );

--- a/modules/react/collection/lib/useOverflowListItemMeasure.tsx
+++ b/modules/react/collection/lib/useOverflowListItemMeasure.tsx
@@ -69,6 +69,7 @@ export const useOverflowListItemMeasure = createElemPropsHook(useOverflowListMod
       // The only way to remove the dev warning in React 19, but have the same functionality in all
       // versions of React, we must detect React 19 and set the attribute accordingly in either
       // case. Do not remove this wonky code until we drop support for React <19.
+      // https://github.com/facebook/react/issues/17157
       //
       // @ts-ignore
       inert: React.use ? hidden : hidden ? '' : undefined,


### PR DESCRIPTION
## Summary

Fix dev warning for React 19 and fix `inert` in React 19. In React <19, adding `inert=''` added the attribute and the correct behavior. In React 19, `inert=''` does not add the attribute. `'true'` works in all versions of React, but triggers a warning in React 19, so we detect React version and set the value differently to ensure correct runtime behavior and avoid any React warnings.

## Release Category
Components

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--docs)
- [x] Label `ready for review` has been added to PR
