### PR TITLE
docs: Fix v14 Upgrade Guide links

### DIFF
--- a/.storybook/routes.js
+++ b/.storybook/routes.js
@@ -56,8 +56,8 @@ const routes = {
   '/getting-started/for-developers/resources/style-props/': 'features-style-props--docs',
   '/getting-started/for-developers/resources/testing/': 'guides-testing--docs',
   '/getting-started/introduction/': 'guides-getting-started--docs',
-  '/help/upgrade-guides/canvas-v14-upgrade-guide': 'guides-upgrade-guides-v14-0-overview--docs',
-  '/help/upgrade-guides/canvas-v14-upgrade-guide#tab=visual-changes':
+  '/help/upgrade-guides/canvas-v14-upgrade-guide/': 'guides-upgrade-guides-v14-0-overview--docs',
+  '/help/upgrade-guides/canvas-v14-upgrade-guide/#tab=visual-changes':
     'guides-upgrade-guides-v14-0-visual-changes--docs',
   '/tokens/color/': 'tokens-tokens--docs#colors',
   '/tokens/depth/': 'tokens-tokens--docs#depth',

--- a/.storybook/routes.js
+++ b/.storybook/routes.js
@@ -42,6 +42,7 @@ const routes = {
   '/components/text/text/': 'components-text-text--docs',
   '/components/text/title/': 'components-text-title--docs',
   '/examples/layout/': 'examples-layouts--docs',
+  '/get-started/for-developers/theming/overview/': 'features-theming-overview--docs',
   '/getting-started/for-developers/contributing/': 'guides-contributing--docs',
   '/getting-started/for-developers/resources/api-pattern-guidelines/':
     'guides-api-pattern-guidelines--docs',
@@ -55,6 +56,9 @@ const routes = {
   '/getting-started/for-developers/resources/style-props/': 'features-style-props--docs',
   '/getting-started/for-developers/resources/testing/': 'guides-testing--docs',
   '/getting-started/introduction/': 'guides-getting-started--docs',
+  '/help/upgrade-guides/canvas-v14-upgrade-guide': 'guides-upgrade-guides-v14-0-overview--docs',
+  '/help/upgrade-guides/canvas-v14-upgrade-guide#tab=visual-changes':
+    'guides-upgrade-guides-v14-0-visual-changes--docs',
   '/tokens/color/': 'tokens-tokens--docs#colors',
   '/tokens/depth/': 'tokens-tokens--docs#depth',
   '/tokens/space/': 'tokens-tokens--docs#space',

--- a/.storybook/webpack-loader-redirect-mdx-to-github.js
+++ b/.storybook/webpack-loader-redirect-mdx-to-github.js
@@ -12,9 +12,8 @@ function webpackLoaderRedirectMDXToGithub(source) {
   // find absolute paths that match something in routes
   return source
     .replace(/\[([^\]]+)\]\((\/[^\)]+)\)/g, function replacer(_match, p1, p2) {
-      const [url, hash] = p2.split('#');
-      if (routeKeys.includes(url)) {
-        return `[${p1}](?path=/docs/${routes[url]}${hash ? '#' + hash : ''})`;
+      if (routeKeys.includes(p2)) {
+        return `[${p1}](?path=/docs/${routes[p2]})`;
       }
       // no match, return original
       return `[${p1}](${p2})`;

--- a/.storybook/webpack-loader-redirect-mdx-to-github.js
+++ b/.storybook/webpack-loader-redirect-mdx-to-github.js
@@ -12,9 +12,23 @@ function webpackLoaderRedirectMDXToGithub(source) {
   // find absolute paths that match something in routes
   return source
     .replace(/\[([^\]]+)\]\((\/[^\)]+)\)/g, function replacer(_match, p1, p2) {
-      if (routeKeys.includes(p2)) {
+      const [url, hash] = p2.split('#');
+
+      // Normally, we want to carry the hash over when we rewrite the path (for
+      // example, so `/components/buttons/button/#foo` is rewritten to
+      // `?path=/docs/components-buttons--docs#foo`). However, if the hash
+      // references the tab feature of the Canvas site (i.e., it includes
+      // `tab=`), we don't want to carry the hash over since the concept of
+      // tabbed content doesn't exist in Storybook -- in this case, we
+      // rewrite the path strictly based on the mapping in the routes file.
+      if (hash && hash.includes('tab=') && routeKeys.includes(p2)) {
         return `[${p1}](?path=/docs/${routes[p2]})`;
       }
+
+      if (routeKeys.includes(url)) {
+        return `[${p1}](?path=/docs/${routes[url]}${hash ? '#' + hash : ''})`;
+      }
+
       // no match, return original
       return `[${p1}](${p2})`;
     })

--- a/modules/docs/mdx/14.0-UPGRADE-GUIDE.mdx
+++ b/modules/docs/mdx/14.0-UPGRADE-GUIDE.mdx
@@ -13,7 +13,7 @@ any questions.
 v14.0 Introduces Workday's new brand direction which includes a new color palette and with it, some
 styling updates to our components.
 
-**Please consult our [v14 Visual Changes](/help/upgrade-guides/canvas-v14-upgrade-guide#tab=visual-changes) page for a visual reference of what's changed.**
+**Please consult our [v14 Visual Changes](/help/upgrade-guides/canvas-v14-upgrade-guide/#tab=visual-changes) page for a visual reference of what's changed.**
 
 > **Note:** While v14 does not require an upgrade to our v3 tokens, we strongly advise to upgrade to the latest to ensure proper branding.
 
@@ -214,7 +214,7 @@ someFunction(ErrorType.Caution);
 
 ### New Documentation
 
-We've **significantly** improved our theming documentation. Please consult our new [Canvas Kit Theming Guide](/get-started/for-developers/theming/overview).
+We've **significantly** improved our theming documentation. Please consult our new [Canvas Kit Theming Guide](/get-started/for-developers/theming/overview/).
 
 ### Canvas Provider 🚨
 
@@ -351,7 +351,7 @@ revolve around the use of our new brand colors. For a better guide on what has c
 tokens, please view the Tokens v3.0.0
 [Upgrade Guide](https://workday.github.io/canvas-tokens/?path=/docs/guides-upgrade-guides-v3-overview--docs).
 
-The following components have been updated (**see [v14 Visual Changes](/help/upgrade-guides/canvas-v14-upgrade-guide#tab=visual-changes) for a visual reference of the updates**):
+The following components have been updated (**see [v14 Visual Changes](/help/upgrade-guides/canvas-v14-upgrade-guide/#tab=visual-changes) for a visual reference of the updates**):
 
 - `Breadcrumbs` [#3270](https://github.com/Workday/canvas-kit/pull/3270),[#3447](https://github.com/Workday/canvas-kit/pull/3447)
 - `Buttons` [#3394](https://github.com/Workday/canvas-kit/pull/3394)

--- a/modules/docs/mdx/14.0-UPGRADE-GUIDE.mdx
+++ b/modules/docs/mdx/14.0-UPGRADE-GUIDE.mdx
@@ -13,7 +13,7 @@ any questions.
 v14.0 Introduces Workday's new brand direction which includes a new color palette and with it, some
 styling updates to our components.
 
-- For a list of visual changes, please view our v14 visual changes doc [here](https://workday.github.io/canvas-kit/?path=/docs/guides-upgrade-guides-v14-0-visual-changes--docs).
+**Please consult our [v14 Visual Changes](/help/upgrade-guides/canvas-v14-upgrade-guide#tab=visual-changes) page for a visual reference of what's changed.**
 
 > **Note:** While v14 does not require an upgrade to our v3 tokens, we strongly advise to upgrade to the latest to ensure proper branding.
 
@@ -24,6 +24,7 @@ styling updates to our components.
 - [Tokens](#tokens)
 - [Caution Naming](#caution-naming)
 - [Theming](#theming)
+  - [New Documentation](#new-documentation)
   - [Canvas Provider](#canvas-provider-)
 - [Component Updates](#component-updates)
   - [Avatar (Preview)](#avatar-preview)
@@ -211,6 +212,10 @@ someFunction(ErrorType.Caution);
 
 ## Theming
 
+### New Documentation
+
+We've **significantly** improved our theming documentation. Please consult our new [Canvas Kit Theming Guide](/get-started/for-developers/theming/overview).
+
 ### Canvas Provider 🚨
 
 **PRs:** [#3407](https://github.com/Workday/canvas-kit/pull/3407),
@@ -225,8 +230,7 @@ Canvas Provider has been updated to **remove** default branding colors to ensure
 our CSS variables. Instead of generating a palette and shifting the brightness and darkness with
 `chroma.js`, we use `oklch` to generate the palette colors.
 
-Prior to v14, the `CanvasProvider` created a cascade barrier, re definding brand CSS variables under a class, creating a higher specificity. This made it difficult to override brand tokens in certain scenarios. v14 Removes that barrier.
-For more information on what is a cascade barrier, please [view our theming docs here](https://github.com/Workday/canvas-kit/issues). For a mode detailed overview of the changes in v14, please view our [v14 Upgrade Guide](https://workday.github.io/canvas-kit/?path=/docs/features-theming-overview--docs#what-is-a-cascade-barrier).
+Prior to v14, `CanvasProvider` created a [cascade barrier](/get-started/for-developers/theming/overview/#what-is-a-cascade-barrier), which redefined brand CSS variables under a class and created a higher specificity. This made it difficult to override brand tokens in certain scenarios. v14 removes that barrier.
 
 **Before in v13**
 In v13, the `useTheme` hook would call `createCanvasTheme` which generated a
@@ -286,8 +290,6 @@ different. If you want more control over the colors, we suggest providing the fu
 The reason for this change is to ensure that the CSS variables properly cascade to all components.
 Before in v13, the `CanvasProvider` would add the brand tokens under a class name, creating a higher
 specificity.
-
-For a thorough guide on theming, please view our theming docs [here](https://workday.github.io/canvas-kit/?path=/docs/features-theming-overview--docs).
 
 ## Component Updates
 
@@ -349,9 +351,7 @@ revolve around the use of our new brand colors. For a better guide on what has c
 tokens, please view the Tokens v3.0.0
 [Upgrade Guide](https://workday.github.io/canvas-tokens/?path=/docs/guides-upgrade-guides-v3-overview--docs).
 
-> **Note:** If you want a visual diff of the changes, please view the [Visual Changes](https://workday.github.io/canvas-kit/?path=/docs/guides-upgrade-guides-v14-0-visual-changes--docs) guide.
-
-The following components have been updated:
+The following components have been updated (**see [v14 Visual Changes](/help/upgrade-guides/canvas-v14-upgrade-guide#tab=visual-changes) for a visual reference of the updates**):
 
 - `Breadcrumbs` [#3270](https://github.com/Workday/canvas-kit/pull/3270),[#3447](https://github.com/Workday/canvas-kit/pull/3447)
 - `Buttons` [#3394](https://github.com/Workday/canvas-kit/pull/3394)

--- a/modules/docs/mdx/14.0-VISUAL-CHANGES.mdx
+++ b/modules/docs/mdx/14.0-VISUAL-CHANGES.mdx
@@ -24,7 +24,7 @@ import textInputImage from './images/v14-text-input.png';
 
 # Canvas Kit 14.0 Visual Changes
 
-This guide contains an overview of the changes in Canvas Kit v14. If you have any issues, feel free to report them [here](https://github.com/Workday/canvas-kit/issues). For a mode detailed overview of the changes in v14, please view our [v14 Upgrade Guide](/help/upgrade-guides/canvas-v14-upgrade-guide).
+This guide contains an overview of the changes in Canvas Kit v14. If you have any issues, feel free to report them [here](https://github.com/Workday/canvas-kit/issues). For a mode detailed overview of the changes in v14, please view our [v14 Upgrade Guide](/help/upgrade-guides/canvas-v14-upgrade-guide/).
 
 <Graphic src={{url: avatarImage}} />
 <Graphic src={{url: breadcrumbsImage}} />

--- a/modules/docs/mdx/14.0-VISUAL-CHANGES.mdx
+++ b/modules/docs/mdx/14.0-VISUAL-CHANGES.mdx
@@ -24,7 +24,7 @@ import textInputImage from './images/v14-text-input.png';
 
 # Canvas Kit 14.0 Visual Changes
 
-This guide contains an overview of the changes in Canvas Kit v14. If you have any issues, feel free to report them [here](https://github.com/Workday/canvas-kit/issues). For a mode detailed overview of the changes in v14, please view our [v14 Upgrade Guide](https://workday.github.io/canvas-kit/?path=/docs/guides-upgrade-guides-v14-0-overview--docs).
+This guide contains an overview of the changes in Canvas Kit v14. If you have any issues, feel free to report them [here](https://github.com/Workday/canvas-kit/issues). For a mode detailed overview of the changes in v14, please view our [v14 Upgrade Guide](/help/upgrade-guides/canvas-v14-upgrade-guide).
 
 <Graphic src={{url: avatarImage}} />
 <Graphic src={{url: breadcrumbsImage}} />


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Updates our links in the v14 Upgrade Guide to our Visual Changes and Theming docs to work with the Canvas site.

Includes wordsmithing and typo fixes.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Documentation

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--docs)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable