### PR TITLE
fix: Add support for vars and parts to compound modifiers

### DIFF
--- a/modules/styling-transform/spec/utils/handleCreateStencil.spec.ts
+++ b/modules/styling-transform/spec/utils/handleCreateStencil.spec.ts
@@ -603,6 +603,10 @@ describe('handleCreateStencil', () => {
             {
               modifiers: { size: 'large', inverse: true},
               styles: { padding: 40 }
+            },
+            {
+              modifiers: { size: 'small', inverse: true},
+              styles: ({color}) => ({ padding: 20, color })
             }
           ]
         })
@@ -633,6 +637,10 @@ describe('handleCreateStencil', () => {
       // compound
       expect(styles['test.css']).toContainEqual(
         compileCSS('.css-button.size-large.inverse{padding:40px;}')
+      );
+      // compound function wrapper
+      expect(styles['test.css']).toContainEqual(
+        compileCSS('.css-button.size-small.inverse{padding:20px;color:var(--css-button-color);}')
       );
     });
 

--- a/modules/styling/lib/cs.ts
+++ b/modules/styling/lib/cs.ts
@@ -1320,7 +1320,11 @@ export function createStencil<
         compound.map(compoundModifier => {
           return {
             modifiers: compoundModifier.modifiers,
-            styles: createStyles(compoundModifier.styles),
+            styles: createStyles(
+              typeof compoundModifier.styles === 'function'
+                ? compoundModifier.styles({..._vars, ..._partsVars})
+                : compoundModifier.styles
+            ),
           };
         })
       )

--- a/modules/styling/spec/cs.spec.tsx
+++ b/modules/styling/spec/cs.spec.tsx
@@ -874,10 +874,17 @@ describe('cs', () => {
         base: {},
         modifiers: {
           variant: {
-            regular: {},
+            regular: {
+              '--variant': 'regular',
+            },
           },
           size: {
-            large: {},
+            large: {
+              '--size': 'large',
+            },
+            small: {
+              '--size': 'small',
+            },
           },
         },
         compound: [
@@ -895,8 +902,18 @@ describe('cs', () => {
               ).toEqualTypeOf<'[data-part="my-separator"]'>();
 
               return {
+                '--modifiers': 'var(--regular-large)',
                 color: varsAndParts.color,
               };
+            },
+          },
+          {
+            modifiers: {
+              variant: 'regular',
+              size: 'small',
+            },
+            styles: {
+              color: 'blue',
             },
           },
         ],
@@ -908,7 +925,7 @@ describe('cs', () => {
       let found = false;
       for (const sheet of document.styleSheets as any as Iterable<CSSStyleSheet>) {
         for (const rule of sheet.cssRules as any as Iterable<CSSRule>) {
-          if (rule.cssText.includes(myStencil.modifiers.variant.regular)) {
+          if (rule.cssText.includes('var(--regular-large)')) {
             expect(rule.cssText).toContain(`color: var(${myStencil.vars.color})`);
             found = true;
           }


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Add support for vars and parts to compound modifiers in the type definitions and runtime.

## Release Category
Styling

---

## Checklist

- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Testing

## Example

```tsx
const myStencil = createStencil({
  vars: {
    color: 'red',
  },
  base: {},
  modifiers: {
    variant: {
      regular: {},
    },
    size: {
      large: {},
    },
  },
  compound: [
    {
      modifiers: {
        variant: 'regular',
        size: 'large',
      },
      // function wrapper wasn't supported before
      styles: ({ color }) => {
        return {
          color: color,
        };
      },
    },
})
```