### PR TITLE
docs: Fix broken site-to-storybook route mappings

### DIFF
--- a/.storybook/routes.js
+++ b/.storybook/routes.js
@@ -43,20 +43,20 @@ const routes = {
   '/components/text/title/': 'components-text-title--docs',
   '/examples/layout/': 'examples-layouts--docs',
   '/get-started/for-developers/theming/overview/': 'features-theming-overview--docs',
-  '/getting-started/for-developers/contributing/': 'guides-contributing--docs',
+  '/get-started/for-contributors/code/': 'guides-contributing--docs',
   '/get-started/for-developers/guides/combobox/': 'features-combobox--docs',
-  '/getting-started/for-developers/resources/api-pattern-guidelines/':
+  '/get-started/for-developers/documentation/api-pattern-guidelines/':
     'guides-api-pattern-guidelines--docs',
-  '/getting-started/for-developers/resources/collection-api/': 'features-collections--docs',
-  '/getting-started/for-developers/resources/compound-components/':
+  '/get-started/for-developers/guides/collection-api/': 'features-collections--docs',
+  '/get-started/for-developers/documentation/compound-components/':
     'guides-compound-components--docs',
-  '/getting-started/for-developers/resources/creating-compound-components/':
+  '/get-started/for-developers/documentation/creating-compound-components/':
     'guides-creating-compound-components--docs',
-  '/getting-started/for-developers/resources/responsive-styling/':
+  '/get-started/for-developers/guides/responsive-styling/':
     'features-responsive-styling--responsive-container',
-  '/getting-started/for-developers/resources/style-props/': 'features-style-props--docs',
-  '/getting-started/for-developers/resources/testing/': 'guides-testing--docs',
-  '/getting-started/introduction/': 'guides-getting-started--docs',
+  '/get-started/for-developers/documentation/style-props/': 'features-style-props--docs',
+  '/get-started/for-developers/documentation/testing/': 'guides-testing--docs',
+  '/get-started/introduction/': 'guides-getting-started--docs',
   '/help/upgrade-guides/canvas-v14-upgrade-guide/': 'guides-upgrade-guides-v14-0-overview--docs',
   '/help/upgrade-guides/canvas-v14-upgrade-guide/#tab=visual-changes':
     'guides-upgrade-guides-v14-0-visual-changes--docs',

--- a/modules/docs/llm/upgrade-guides/10.0-UPGRADE-GUIDE.md
+++ b/modules/docs/llm/upgrade-guides/10.0-UPGRADE-GUIDE.md
@@ -261,7 +261,7 @@ the target and popup to `4px`.
 **PR:** [#2309](https://github.com/Workday/canvas-kit/pull/2309)
 
 We've converted `Select` into a
-[compound component](/getting-started/for-developers/resources/compound-components/) which provides
+[compound component](/get-started/for-developers/documentation/compound-components/) which provides
 a flexible API and access to its internals via its subcomponents.
 
 ```tsx

--- a/modules/docs/llm/upgrade-guides/9.0-UPGRADE-GUIDE.md
+++ b/modules/docs/llm/upgrade-guides/9.0-UPGRADE-GUIDE.md
@@ -105,7 +105,7 @@ finished.
 ### Table
 
 We've introduced a new `Table`
-[compound component](/getting-started/for-developers/resources/compound-components/) to the Preview
+[compound component](/get-started/for-developers/documentation/compound-components/) to the Preview
 package. `Table` is a compound component that is used to present information in a two-dimensional
 [table](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table) comprised of rows and
 columns of cells containing data.
@@ -379,7 +379,7 @@ previously in [Main](#main) (for reference, see
 [`Toast`](https://d2krrudi3mmzzw.cloudfront.net/v8/?path=/docs/components-popups-toast--error) in
 [Main](#main) from v8).
 
-`Toast` is a [compound component](/getting-started/for-developers/resources/compound-components/)
+`Toast` is a [compound component](/get-started/for-developers/documentation/compound-components/)
 which provides a flexible API and access to its internals via its subcomponents. It supports a new
 `mode` prop which applies the proper accessibility features to the component based on the desired
 mode: `status`, `alert`, or `dialog`.

--- a/modules/docs/mdx/10.0-UPGRADE-GUIDE.mdx
+++ b/modules/docs/mdx/10.0-UPGRADE-GUIDE.mdx
@@ -257,7 +257,7 @@ the target and popup to `4px`.
 **PR:** [#2309](https://github.com/Workday/canvas-kit/pull/2309)
 
 We've converted `Select` into a
-[compound component](/getting-started/for-developers/resources/compound-components/) which provides
+[compound component](/get-started/for-developers/documentation/compound-components/) which provides
 a flexible API and access to its internals via its subcomponents.
 
 ```tsx

--- a/modules/docs/mdx/5.0-UPGRADE-GUIDE.mdx
+++ b/modules/docs/mdx/5.0-UPGRADE-GUIDE.mdx
@@ -869,7 +869,7 @@ interface MyButtonProps extends ExtractProps<> {
 
 ### Card
 
-Card is now a [compound component](/getting-started/for-developers/resources/compound-components/)
+Card is now a [compound component](/get-started/for-developers/documentation/compound-components/)
 composed of a `Card.Body` and an optional `Card.Heading`. This allows direct access to the heading
 and body elements.
 
@@ -1060,7 +1060,7 @@ There is no codemod for this change.
 ### Popups
 
 Popup has transitioned to a
-[compound component](/getting-started/for-developers/resources/compound-components/), along with all
+[compound component](/get-started/for-developers/documentation/compound-components/), along with all
 Popup-based behavior hooks. What was a `Popup` in v4 is now a `Popup.Card` in v5. The target button
 and `Popper` components have also been converted to subcomponents of `Popup`.
 
@@ -1396,7 +1396,7 @@ const MyPopup = () => {
 ### Modal
 
 Modal has transitioned to a
-[compound component](/getting-started/for-developers/resources/compound-components/). What was
+[compound component](/get-started/for-developers/documentation/compound-components/). What was
 `Modal` in v4 is now `Modal.Card` in v5.
 
 #### v4

--- a/modules/docs/mdx/7.0-UPGRADE-GUIDE.mdx
+++ b/modules/docs/mdx/7.0-UPGRADE-GUIDE.mdx
@@ -515,7 +515,7 @@ creating `ActionBar.List` subcomponent and replacing all `ActionBar` children to
 
 ### Banner
 
-Banner is now a [compound component](/getting-started/for-developers/resources/compound-components/)
+Banner is now a [compound component](/get-started/for-developers/documentation/compound-components/)
 composed of `Banner.Icon`, `Banner.Label`, and `Banner.ActionText`. This allows direct access to the
 icon, label, and text elements.
 
@@ -534,7 +534,7 @@ icon, label, and text elements.
 🤖 The codemod will rewrite your JSX to match the new API.
 
 Like all compound components, `Banner` is written using the
-[createComponent](/getting-started/for-developers/resources/creating-compound-components/#disclosurecontent-component)
+[createComponent](/get-started/for-developers/documentation/creating-compound-components/#disclosurecontent-component)
 utility from our
 [common](https://github.com/Workday/canvas-kit/blob/ff77c5bd83e41c3ab2b9c55e41a8b7c1fde33a1b/modules/react/common/lib/utils/components.ts#L167)
 module; it supports [ref forwarding](https://reactjs.org/docs/forwarding-refs.html) and using the
@@ -743,7 +743,7 @@ buttons or other buttons that aren't supported by our standard button components
 
 We've updated `AccentIcon`, `AppletIcon`, `Graphic`, `Icon`, `Svg`, `SystemIcon`, and
 `SystemIconCircle` to use the
-[createComponent](/getting-started/for-developers/resources/creating-compound-components/#disclosurecontent-component)
+[createComponent](/get-started/for-developers/documentation/creating-compound-components/#disclosurecontent-component)
 utility from our
 [common](https://github.com/Workday/canvas-kit/blob/ff77c5bd83e41c3ab2b9c55e41a8b7c1fde33a1b/modules/react/common/lib/utils/components.ts#L167)
 module; they now support [ref forwarding](https://reactjs.org/docs/forwarding-refs.html) and using
@@ -917,7 +917,7 @@ codemod.
 ### Segmented Control
 
 `SegmentedControl` is now a
-[compound component](/getting-started/for-developers/resources/compound-components/).
+[compound component](/get-started/for-developers/documentation/compound-components/).
 
 Given the [removal of `IconButton`](#removal-of-icon-button) in v7, you'll now need to use
 `SegmentedControl.Button` instead.

--- a/modules/docs/mdx/8.0-UPGRADE-GUIDE.mdx
+++ b/modules/docs/mdx/8.0-UPGRADE-GUIDE.mdx
@@ -193,7 +193,7 @@ const Example = styled('div')(
 ### Responsive Styles
 
 We've added a set of
-[responsive utilities](/getting-started/for-developers/resources/responsive-styling/) to facilitate
+[responsive utilities](/get-started/for-developers/guides/responsive-styling/) to facilitate
 container-based and viewport-based responsive styling:
 
 - **useResponsiveContainerStyles**: A hook that allows developers to create container-based
@@ -367,7 +367,7 @@ text with built-in support for our Canvas type tokens.
 We've added a new version of
 [`SegmentedControl`](https://workday.github.io/canvas-kit/?path=/docs/preview-segmented-control-react--basic)
 which has been redesigned as a
-[compound component](/getting-started/for-developers/resources/compound-components/) to the Preview
+[compound component](/get-started/for-developers/documentation/compound-components/) to the Preview
 package. `SegmentedControl` represents a linear group of multiple buttons allowing the selection of
 a specific value and is best used for switching between different views of the same content.
 
@@ -419,7 +419,7 @@ You may still use `SegmentedControl` in the Main package, but note that it will 
 We've added a new version of
 [`StatusIndicator`](https://workday.github.io/canvas-kit/?path=/docs/preview-status-indicator-react--basic)
 which has been redesigned as a
-[compound component](/getting-started/for-developers/resources/compound-components/) to the Preview
+[compound component](/get-started/for-developers/documentation/compound-components/) to the Preview
 package. `StatusIndicator` is best used for helping the user quickly identify the status of a task,
 action, or page element.
 
@@ -673,7 +673,7 @@ const StyledBox = styled(Box)({
 ### Breadcrumbs
 
 `Breadcrumbs` has been promoted to the Main package. It now uses the list system from our
-[Collection API](/getting-started/for-developers/resources/collection-api/) which provides new
+[Collection API](/get-started/for-developers/guides/collection-api/) which provides new
 overflow behavior based on container width.
 
 The following code-moddable changes have been made to the `Breadcrumbs` API (see below for

--- a/modules/docs/mdx/9.0-UPGRADE-GUIDE.mdx
+++ b/modules/docs/mdx/9.0-UPGRADE-GUIDE.mdx
@@ -100,7 +100,7 @@ finished.
 ### Table
 
 We've introduced a new `Table`
-[compound component](/getting-started/for-developers/resources/compound-components/) to the Preview
+[compound component](/get-started/for-developers/documentation/compound-components/) to the Preview
 package. `Table` is a compound component that is used to present information in a two-dimensional
 [table](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table) comprised of rows and
 columns of cells containing data.
@@ -376,7 +376,7 @@ previously in [Main](#main) (for reference, see
 [`Toast`](https://d2krrudi3mmzzw.cloudfront.net/v8/?path=/docs/components-popups-toast--error) in
 [Main](#main) from v8).
 
-`Toast` is a [compound component](/getting-started/for-developers/resources/compound-components/)
+`Toast` is a [compound component](/get-started/for-developers/documentation/compound-components/)
 which provides a flexible API and access to its internals via its subcomponents. It supports a new
 `mode` prop which applies the proper accessibility features to the component based on the desired
 mode: `status`, `alert`, or `dialog`.

--- a/modules/docs/mdx/CONTRIBUTING.mdx
+++ b/modules/docs/mdx/CONTRIBUTING.mdx
@@ -150,7 +150,7 @@ dependencies, then it's required.
 Canvas Kit uses [Jest](https://jestjs.io/) and
 [React Testing Library](https://testing-library.com/docs/react-testing-library/intro) to unit test
 our React components. For more information about our testing strategy and how we write unit tests,
-visit our [Testing Readme](/getting-started/for-developers/resources/testing/).
+visit our [Testing Readme](/get-started/for-developers/documentation/testing/).
 
 Canvas Kit uses [Cypress](https://cypress.io) for UI tests. For info on why we chose Cypress, visit
 [Why Cypress?](https://github.com/Workday/canvas-kit/tree/master/cypress/WHY_CYPRESS.md) For more
@@ -190,9 +190,9 @@ Upon commit, [lint-staged](https://github.com/okonet/lint-staged) will run your 
 
 If creating a React module, a new compound component will be created. To find out more about
 Compound Components, refer to
-[Compound Components](/getting-started/for-developers/resources/compound-components/). To find out
+[Compound Components](/get-started/for-developers/documentation/compound-components/). To find out
 more about creating Compound Components, refer to
-[Creating Compound Components](/getting-started/for-developers/resources/creating-compound-components/).
+[Creating Compound Components](/get-started/for-developers/documentation/creating-compound-components/).
 
 ### Exporting a Module
 
@@ -216,7 +216,7 @@ This will start the unit tests.
 ### Code Style Guide
 
 Refer to the
-[API & Pattern Guidelines](/getting-started/for-developers/resources/api-pattern-guidelines/).
+[API & Pattern Guidelines](/get-started/for-developers/documentation/api-pattern-guidelines/).
 
 Rules are enforced using [ESLint](https://eslint.org) and code formatting is provided through
 [Prettier](https://prettier.io).

--- a/modules/docs/mdx/CREATING_COMPOUND_COMPONENTS.mdx
+++ b/modules/docs/mdx/CREATING_COMPOUND_COMPONENTS.mdx
@@ -3,7 +3,7 @@
 # Building a Compound Component
 
 Refer to the
-[Compound Component documentation](/getting-started/for-developers/resources/compound-components/)
+[Compound Component documentation](/get-started/for-developers/documentation/compound-components/)
 document to learn about what a compound component is.
 
 This document will go through building a simplified Disclosure component to help solidify the

--- a/modules/preview-react/multi-select/stories/MultiSelect.mdx
+++ b/modules/preview-react/multi-select/stories/MultiSelect.mdx
@@ -33,11 +33,11 @@ yarn add @workday/canvas-kit-preview-react
 ### Basic Example
 
 `MultiSelect` supports a
-[dynamic API](/getting-started/for-developers/resources/collection-api/#dynamic-items) where you
+[dynamic API](/get-started/for-developers/guides/collection-api/#dynamic-items) where you
 pass an array of items via the `items` prop and provide a render function to display the items. The
 items may be provided as an
-[array of strings](/getting-started/for-developers/resources/collection-api/#array-of-strings) or an
-[array of objects](/getting-started/for-developers/resources/collection-api/#array-of-objects).
+[array of strings](/get-started/for-developers/guides/collection-api/#array-of-strings) or an
+[array of objects](/get-started/for-developers/guides/collection-api/#array-of-objects).
 
 `MultiSelect` should be used in tandem with [Form Field](/components/inputs/form-field/) where the
 `MultiSelect` wraps the `FormField` element and the `FormField` element wraps the children of

--- a/modules/preview-react/segmented-control/lib/SegmentedControl.tsx
+++ b/modules/preview-react/segmented-control/lib/SegmentedControl.tsx
@@ -19,7 +19,7 @@ export interface SegmentedControlProps {
  * ```
  *
  * Alternatively, you may pass in a model using the [hoisted model
- * pattern](/getting-started/for-developers/resources/compound-components/#configuring-a-model).
+ * pattern](/get-started/for-developers/documentation/compound-components/#configuring-a-model).
  *
  * ```tsx
  * const model = useSegmentedControlModel({

--- a/modules/preview-react/segmented-control/stories/SegmentedControl.mdx
+++ b/modules/preview-react/segmented-control/stories/SegmentedControl.mdx
@@ -15,7 +15,7 @@ import {Dynamic} from './examples/Dynamic';
 # Canvas Kit Segmented Control
 
 Segmented Control is a
-[compound component](/getting-started/for-developers/resources/compound-components/) that represents
+[compound component](/get-started/for-developers/documentation/compound-components/) that represents
 a linear group of multiple buttons allowing the selection of a specific value.
 
 [> Workday Design Reference](https://design.workday.com/components/buttons/segmented-control)
@@ -127,7 +127,7 @@ Set the `disabled` prop of `SegmentedControl` to disable the entire component in
 ### Dynamic Items
 
 `SegmentedControl` supports a
-[dynamic API](/getting-started/for-developers/resources/collection-api/#dynamic-items) where instead
+[dynamic API](/get-started/for-developers/guides/collection-api/#dynamic-items) where instead
 of statically providing the JSX for each `SegmentedControl.Item`, you pass an array of `items` in
 the `model` state and provide a render function to display the items.
 

--- a/modules/preview-react/status-indicator/stories/StatusIndicator.mdx
+++ b/modules/preview-react/status-indicator/stories/StatusIndicator.mdx
@@ -54,7 +54,7 @@ We **strongly** discourage using text in a `StatusIndicator` which will cause it
 maximum width of `200px`. In situations where this cannot be avoided and text must be overflowed, we
 suggest wrapping `StatusIndicator` in an `OverflowTooltip` and applying `tabIndex={0}` to it so the
 overflowed text is accessible via keyboard and mouse. You may also override the default `maxWidth`
-of `StatusIndicator` via [style props](/getting-started/for-developers/resources/style-props/).
+of `StatusIndicator` via [style props](/get-started/for-developers/documentation/style-props/).
 
 <ExampleCodeBlock code={Overflow} />
 

--- a/modules/react/action-bar/stories/ActionBar.mdx
+++ b/modules/react/action-bar/stories/ActionBar.mdx
@@ -10,7 +10,7 @@ import * as ActionBarStories from './ActionBar.stories';
 
 # Canvas Kit Action Bar
 
-Action Bar is a [compound component](/getting-started/for-developers/resources/compound-components/)
+Action Bar is a [compound component](/get-started/for-developers/documentation/compound-components/)
 that contains primary and secondary actions related to a page or task.
 
 [> Workday Design Reference](https://design.workday.com/components/buttons/action-bar)

--- a/modules/react/banner/stories/Banner.mdx
+++ b/modules/react/banner/stories/Banner.mdx
@@ -16,7 +16,7 @@ import * as BannerStories from './Banner.stories';
 
 # Canvas Kit Banner
 
-`Banner` is a [compound component](/getting-started/for-developers/resources/compound-components/)
+`Banner` is a [compound component](/get-started/for-developers/documentation/compound-components/)
 used surface important information and feedback to the user about a task, action, or state.
 
 [> Workday Design Reference](https://design.workday.com/components/indicators/banners)

--- a/modules/react/breadcrumbs/README.md
+++ b/modules/react/breadcrumbs/README.md
@@ -1,7 +1,7 @@
 # Canvas Kit React Breadcrumbs
 
 Breadcrumbs is a
-[compound component](/getting-started/for-developers/resources/compound-components/) that allows
+[compound component](/get-started/for-developers/documentation/compound-components/) that allows
 users to keep track and maintain awareness of their location as they navigate through pages,
 folders, files, etc.
 

--- a/modules/react/breadcrumbs/stories/Breadcrumbs.mdx
+++ b/modules/react/breadcrumbs/stories/Breadcrumbs.mdx
@@ -11,7 +11,7 @@ import * as BreadcrumbsStories from './Breadcrumbs.stories';
 # Canvas Kit Breadcrumbs
 
 Breadcrumbs is a
-[compound component](/getting-started/for-developers/resources/compound-components/) that allows
+[compound component](/get-started/for-developers/documentation/compound-components/) that allows
 users to keep track and maintain awareness of their location as they navigate through pages,
 folders, files, etc.
 

--- a/modules/react/card/stories/card.mdx
+++ b/modules/react/card/stories/card.mdx
@@ -12,7 +12,7 @@ import {WithStencils} from './examples/Stencils';
 # Canvas Kit Card
 
 A Card is a preview that serves as an entry point to more detailed information. Card is a
-presentational [compound component](/getting-started/for-developers/resources/compound-components/)
+presentational [compound component](/get-started/for-developers/documentation/compound-components/)
 used as a building block for other components such as [Popup](/components/popups/popup/) and
 [Modal](/components/popups/modal/).
 

--- a/modules/react/common/stories/mdx/CompoundComponentUtilities.mdx
+++ b/modules/react/common/stories/mdx/CompoundComponentUtilities.mdx
@@ -11,7 +11,7 @@ import {CreateComponent} from './examples/CreateComponent';
 # Compound Component Utilities
 
 The following utilities are used to create and compose
-[compound components](/getting-started/for-developers/resources/compound-components/).
+[compound components](/get-started/for-developers/documentation/compound-components/).
 
 ## Installation
 

--- a/modules/react/layout/stories/Box.mdx
+++ b/modules/react/layout/stories/Box.mdx
@@ -34,18 +34,18 @@ supports all `BoxProps` such as `padding`, it also supports semantic anchor elem
 
 ### Style Props
 
-`Box` exposes [style props](/getting-started/for-developers/resources/style-props/) that allow you
+`Box` exposes [style props](/get-started/for-developers/documentation/style-props/) that allow you
 to modify styles in an ergonomic way across components. To learn more about individual sets of `Box`
 style props, consult the lists below.
 
-- [Background Style Props](/getting-started/for-developers/resources/style-props/#background)
-- [Border Style Props](/getting-started/for-developers/resources/style-props/#border)
-- [Color Style Props](/getting-started/for-developers/resources/style-props/#color)
-- [Depth Style Props](/getting-started/for-developers/resources/style-props/#depth)
-- [Flex Item Style Props](/getting-started/for-developers/resources/style-props/#flex-item)
-- [Grid Item Style Props](/getting-started/for-developers/resources/style-props/#grid-item)
-- [Layout Style Props](/getting-started/for-developers/resources/style-props/#layout)
-- [Other Style Props](/getting-started/for-developers/resources/style-props/#other)
-- [Position Style Props](/getting-started/for-developers/resources/style-props/#position)
-- [Space Style Props](/getting-started/for-developers/resources/style-props/#space)
-- [Text Style Props](/getting-started/for-developers/resources/style-props/#text)
+- [Background Style Props](/get-started/for-developers/documentation/style-props/#background)
+- [Border Style Props](/get-started/for-developers/documentation/style-props/#border)
+- [Color Style Props](/get-started/for-developers/documentation/style-props/#color)
+- [Depth Style Props](/get-started/for-developers/documentation/style-props/#depth)
+- [Flex Item Style Props](/get-started/for-developers/documentation/style-props/#flex-item)
+- [Grid Item Style Props](/get-started/for-developers/documentation/style-props/#grid-item)
+- [Layout Style Props](/get-started/for-developers/documentation/style-props/#layout)
+- [Other Style Props](/get-started/for-developers/documentation/style-props/#other)
+- [Position Style Props](/get-started/for-developers/documentation/style-props/#position)
+- [Space Style Props](/get-started/for-developers/documentation/style-props/#space)
+- [Text Style Props](/get-started/for-developers/documentation/style-props/#text)

--- a/modules/react/layout/stories/Flex.mdx
+++ b/modules/react/layout/stories/Flex.mdx
@@ -55,13 +55,13 @@ building layouts.
 #### Props
 
 `Flex` exposes
-[flex container style props](/getting-started/for-developers/resources/style-props/#flex) and `Box`
+[flex container style props](/get-started/for-developers/documentation/style-props/#flex) and `Box`
 style props.
 
 ### Flex.Item
 
 `Flex.Item` is a subcomponent of `Flex`. It is a `Box` component under the hood and exposes
-[flex item style props](/getting-started/for-developers/resources/style-props/#flex-item) that map
+[flex item style props](/get-started/for-developers/documentation/style-props/#flex-item) that map
 to CSS Flexbox Item properties. This provides greater control over how child components render in
 your layout.
 
@@ -76,5 +76,5 @@ your layout.
 #### Props
 
 `Flex.Item` exposes
-[flex item style props](/getting-started/for-developers/resources/style-props/#flex-item) and `Box`
+[flex item style props](/get-started/for-developers/documentation/style-props/#flex-item) and `Box`
 style props.

--- a/modules/react/layout/stories/Grid.mdx
+++ b/modules/react/layout/stories/Grid.mdx
@@ -99,13 +99,13 @@ layouts.
 #### Props
 
 `Grid` exposes
-[grid container style props](/getting-started/for-developers/resources/style-props/#grid) and `Box`
+[grid container style props](/get-started/for-developers/documentation/style-props/#grid) and `Box`
 style props.
 
 ### Grid.Item
 
 `Grid.Item` is a subcomponent of `Grid`. It is a `Box` component under the hood and exposes
-[grid item style props](/getting-started/for-developers/resources/style-props/#grid) that map to CSS
+[grid item style props](/get-started/for-developers/documentation/style-props/#grid) that map to CSS
 Grid Item properties. This provides greater control over how child components render in your layout.
 
 ```tsx

--- a/modules/react/pagination/stories/pagination.mdx
+++ b/modules/react/pagination/stories/pagination.mdx
@@ -13,7 +13,7 @@ import * as PaginationStories from './pagination.stories';
 # Canvas Kit Pagination
 
 `Pagination` is a
-[compound component](/getting-started/for-developers/resources/compound-components/) that allows
+[compound component](/get-started/for-developers/documentation/compound-components/) that allows
 users to navigate between pages in a range.
 
 [> Workday Design Reference](https://design.workday.com/components/navigation/pagination)
@@ -49,7 +49,7 @@ readers.
 By default, `Pagination` will create and use its own [model](#model) internally. Alternatively, you
 may configure your own model with `usePaginationModel` and pass it to `Pagination` via the `model`
 prop. This pattern is referred to as
-[hoisting the model](/getting-started/for-developers/resources/compound-components/#configuring-a-model)
+[hoisting the model](/get-started/for-developers/documentation/compound-components/#configuring-a-model)
 and provides direct access to its `state` and `events` outside of the `Pagination` component.
 
 In this example, we set up external observation of the model state and create an external button to
@@ -97,7 +97,7 @@ You can use `useResizeObserver` to accomplish this as in the example below.
 ## Model
 
 If `Pagination` was stripped of all its markup, attributes, and styling, what would remain is the
-[model](/getting-started/for-developers/resources/compound-components/#models). The model is an
+[model](/get-started/for-developers/documentation/compound-components/#models). The model is an
 object composed of two parts: `state` which describes the current snapshot in time of the component
 and `events` which describes events that can be sent to the model.
 
@@ -138,7 +138,7 @@ export const CustomPagination = () => {
 Alternatively, if you need direct access to the model's `state` and `events` outside of the
 `Pagination` component, you may configure your own model with `usePaginationModel` and pass it to
 `Pagination` via a pattern called
-[hoisting the model](/getting-started/for-developers/resources/compound-components/#configuring-a-model).
+[hoisting the model](/get-started/for-developers/documentation/compound-components/#configuring-a-model).
 
 ```tsx
 const model = usePaginationModel({

--- a/modules/react/popup/stories/Popup.mdx
+++ b/modules/react/popup/stories/Popup.mdx
@@ -47,7 +47,7 @@ yarn add @workday/canvas-kit-react
 ## Usage
 
 The `Popup` component is a generic
-[Compound Component](/getting-started/for-developers/resources/compound-components/) that is used to
+[Compound Component](/get-started/for-developers/documentation/compound-components/) that is used to
 build popup UIs that are not already covered by Canvas Kit.
 
 ### Basic Example

--- a/modules/react/select/stories/Select.mdx
+++ b/modules/react/select/stories/Select.mdx
@@ -43,11 +43,11 @@ yarn add @workday/canvas-kit-react
 ### Basic Example
 
 `Select` supports a
-[dynamic API](/getting-started/for-developers/resources/collection-api/#dynamic-items) where you
+[dynamic API](/get-started/for-developers/guides/collection-api/#dynamic-items) where you
 pass an array of items via the `items` prop and provide a render function to display the items. The
 items may be provided as an
-[array of strings](/getting-started/for-developers/resources/collection-api/#array-of-strings) or an
-[array of objects](/getting-started/for-developers/resources/collection-api/#array-of-objects).
+[array of strings](/get-started/for-developers/guides/collection-api/#array-of-strings) or an
+[array of objects](/get-started/for-developers/guides/collection-api/#array-of-objects).
 
 `Select` should be used in tandem with [Form Field](/components/inputs/form-field/) where the
 `Select` wraps the `FormField` element and the `FormField` element wraps the children of `Select` to
@@ -77,7 +77,7 @@ value of the `Select`.
 By default, `Select` will create and use its own model internally. Alternatively, you may configure
 your own model with `useSelectModel` and pass it to `Select` via the `model` prop. This pattern is
 referred to as
-[hoisting the model](/getting-started/for-developers/resources/compound-components/#configuring-a-model)
+[hoisting the model](/get-started/for-developers/documentation/compound-components/#configuring-a-model)
 and provides direct access to its `state` and `events` outside of the `Select` component.
 
 In this example, we set up external observation of the model state and create an external button to

--- a/modules/react/tabs/lib/Tabs.tsx
+++ b/modules/react/tabs/lib/Tabs.tsx
@@ -42,7 +42,7 @@ export interface TabsProps {
  * ```
  *
  * See [Configuring a
- * Model](/getting-started/for-developers/resources/compound-components/#configuring-a-model) for
+ * Model](/get-started/for-developers/documentation/compound-components/#configuring-a-model) for
  * more information on model configuration.
  */
 export const Tabs = createContainer()({

--- a/modules/react/tabs/lib/useTabsModel.tsx
+++ b/modules/react/tabs/lib/useTabsModel.tsx
@@ -10,7 +10,7 @@ import {useMenuModel} from '@workday/canvas-kit-react/menu';
 
 /**
  * The TabsModel extends the [Collection
- * System](/getting-started/for-developers/resources/collection-api/). Tabs have tab items and
+ * System](/get-started/for-developers/guides/collection-api/). Tabs have tab items and
  * panels. Tabs can be overflowed if there isn't enough room to render and will overflow to a
  * {@link MenuModel} sub-model.
  *

--- a/modules/react/tabs/stories/Tabs.mdx
+++ b/modules/react/tabs/stories/Tabs.mdx
@@ -15,7 +15,7 @@ import * as TabsStories from './Tabs.stories';
 
 # Canvas Kit Tabs
 
-`Tabs` is a [compound component](/getting-started/for-developers/resources/compound-components/)
+`Tabs` is a [compound component](/get-started/for-developers/documentation/compound-components/)
 that allows users to navigate between related views of content while remaining in context of the
 page.
 
@@ -60,7 +60,7 @@ should render.
 By default, `Tabs` will create and use its own [model](#model) internally. Alternatively, you may
 configure your own model with `useTabsModel` and pass it to `Tabs` via the `model` prop. This
 pattern is referred to as
-[hoisting the model](/getting-started/for-developers/resources/compound-components/#configuring-a-model)
+[hoisting the model](/get-started/for-developers/documentation/compound-components/#configuring-a-model)
 and provides direct access to its `state` and `events` outside of the `Tabs` component.
 
 In this example, we set up external observation of the model state and create an external button to

--- a/modules/react/text/stories/Text.mdx
+++ b/modules/react/text/stories/Text.mdx
@@ -22,7 +22,7 @@ yarn add @workday/canvas-kit-react
 ### Basic Example
 
 `Text` is built on top of [`Box`](/components/layout/box/) and supports a multitude of
-[style props](/getting-started/for-developers/resources/style-props/) including spacing props such
+[style props](/get-started/for-developers/documentation/style-props/) including spacing props such
 as `margin` and `padding`, as well as text styling props such as `fontSize` and `fontWeight`.
 
 `Text` renders a `<span>` element by default. You may override the rendered element using the `as`

--- a/modules/react/toast/stories/toast.mdx
+++ b/modules/react/toast/stories/toast.mdx
@@ -12,7 +12,7 @@ import * as ToastStories from './toast.stories';
 
 # Canvas Kit Toast
 
-`Toast` is a [compound component](/getting-started/for-developers/resources/compound-components/)
+`Toast` is a [compound component](/get-started/for-developers/documentation/compound-components/)
 that contains updates or messages about the status of an application's process.
 
 ## Installation


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes a number of site-to-storybook route mappings which were broken when content originally under...

`https://canvas.workdaydesign.com/getting-started/for-developers/resources/`

...was moved to new sub-folders under...

`https://canvas.workdaydesign.com/get-started/for-developers/`

...on the new site.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Documentation

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--docs)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable