### PR TITLE
fix: Use getBoundingClientRect for popup width measurement

### DIFF
--- a/modules/preview-react/select/lib/SelectMenu.tsx
+++ b/modules/preview-react/select/lib/SelectMenu.tsx
@@ -253,7 +253,7 @@ export const SelectMenu = ({
 
   const handleWidthChange = useCallback(() => {
     if (buttonRef && buttonRef.current && visibility !== 'closed') {
-      const newMenuWidth = buttonRef.current.clientWidth + 2;
+      const newMenuWidth = buttonRef.current.getBoundingClientRect().width;
       setWidth(newMenuWidth);
     }
   }, [buttonRef, visibility]);

--- a/modules/react/combobox/lib/hooks/useComboboxInput.ts
+++ b/modules/react/combobox/lib/hooks/useComboboxInput.ts
@@ -61,7 +61,7 @@ export const useComboboxInput = composeHooks(
       },
       onClick(event: React.MouseEvent) {
         if (model.state.visibility === 'hidden') {
-          model.events.setWidth(event.currentTarget.clientWidth);
+          model.events.setWidth(event.currentTarget.getBoundingClientRect().width);
         }
       },
       value: model.state.value,

--- a/modules/react/combobox/lib/hooks/useComboboxInputOpenWithArrowKeys.ts
+++ b/modules/react/combobox/lib/hooks/useComboboxInputOpenWithArrowKeys.ts
@@ -14,7 +14,7 @@ export const useComboboxInputOpenWithArrowKeys = createElemPropsHook(useCombobox
         (event.key === 'ArrowUp' && model.state.visibility !== 'visible')
       ) {
         model.events.show(event);
-        model.events.setWidth(event.currentTarget.clientWidth);
+        model.events.setWidth(event.currentTarget.getBoundingClientRect().width);
       }
     },
   };

--- a/modules/react/combobox/lib/hooks/useSetPopupWidth.ts
+++ b/modules/react/combobox/lib/hooks/useSetPopupWidth.ts
@@ -9,7 +9,7 @@ export const useSetPopupWidth = createElemPropsHook(useComboboxModel)(model => {
   const visible = model.state.visibility !== 'hidden';
   React.useLayoutEffect(() => {
     if (visible) {
-      model.events.setWidth(model.state.targetRef.current?.clientWidth || 0);
+      model.events.setWidth(model.state.targetRef.current?.getBoundingClientRect().width || 0);
     }
   }, [visible, model.events, model.state.targetRef]);
   return {};

--- a/modules/react/combobox/stories/visual-testing/testing.stories.tsx
+++ b/modules/react/combobox/stories/visual-testing/testing.stories.tsx
@@ -40,7 +40,7 @@ export const ComboboxStates = {
             // eslint-disable-next-line react-hooks/rules-of-hooks
             React.useLayoutEffect(() => {
               if (visibility === 'visible') {
-                model.events.setWidth(model.state.inputRef.current.clientWidth);
+                model.events.setWidth(model.state.inputRef.current.getBoundingClientRect().width);
               }
             }, [visibility, model.events, model.state.inputRef]);
             return (


### PR DESCRIPTION
Update SelectMenu, combobox hooks, and visual test stories to derive popup widths from getBoundingClientRect instead of clientWidth. This aligns width calculations across dropdown components and ensures consistent sizing when borders or transforms are present.

<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Resolve issue with incorrect calculations in non-chrome browsers. 
getBoundingClientRect  take into account: width + padding + border + scroll
clientWidth:
- In firefox does not take padding into account
- Does not take border into account (that why there was +2 hack previously I assume)

It should not lead to any notable visual by most of users in Chrome. Popup will match size of the input (+2px for the border). In other browsers behavior will match.

Since border-box used for all sizing using getBoundingClientRect looks like a correct approach for coherent sizing across browsers and devices.

Samples:

Before:

Firefox:
<img width="531" height="640" alt="image" src="https://github.com/user-attachments/assets/d606358e-acf5-43b2-88f3-f49e9a7b02a4" />

Edge:
<img width="499" height="573" alt="image" src="https://github.com/user-attachments/assets/52df9a71-3169-4f90-bbbb-ee5cd203876a" />

After:

Firefox:
<img width="559" height="602" alt="image" src="https://github.com/user-attachments/assets/69c06115-cc69-4e0f-9749-971ad04278a4" />


Edge:
<img width="529" height="719" alt="image" src="https://github.com/user-attachments/assets/cc05b233-7bec-41e2-bb6a-b2c443698336" />




<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
SelectMenu
ComboBox (and derived ones)


---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--docs)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Testing Manually
Try any Select menus popups - their size should match the input.
