### PR TITLE
fix: Remove extra backtick from Preview Switch MDX

### DIFF
--- a/modules/preview-react/switch/stories/Switch.mdx
+++ b/modules/preview-react/switch/stories/Switch.mdx
@@ -11,7 +11,7 @@ import {LabelPosition} from './examples/LabelPosition';
 import {RTL} from './examples/RTL';
 import {RefForwarding} from './examples/RefForwarding';
 
-<Meta of={SwitchStoriesMeta} />`
+<Meta of={SwitchStoriesMeta} />
 
 # Canvas Kit Switch
 


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Removes an extra backtick from the Preview `Switch.mdx`. This was preventing the Storybook `<Meta>` block from being [stripped out during the build-mdx script](https://github.com/Workday/canvas-kit/blob/master/modules/docs/utils/build-mdx.js#L29), causing the site to break when referencing the Preview `Switch.mdx` (the site has no concept of Storybook blocks).

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Documentation

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--docs)
- [x] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable