### PR TITLE
fix: Updated Radio in Main to use MaybeWrapCSSVariables

### DIFF
--- a/modules/react/radio/lib/Radio.tsx
+++ b/modules/react/radio/lib/Radio.tsx
@@ -10,7 +10,7 @@ import {
 } from '@workday/canvas-kit-react/common';
 import {borderRadius, colors, inputColors, space} from '@workday/canvas-kit-react/tokens';
 import {LabelText} from '@workday/canvas-kit-react/text';
-import {px2rem} from '@workday/canvas-kit-styling';
+import {maybeWrapCSSVariables, px2rem} from '@workday/canvas-kit-styling';
 
 /**
  * @deprecated ⚠️ `RadioProps` in Main has been deprecated and will be removed in a future major version. Please use [`Radio` in Preview](https://workday.github.io/canvas-kit/?path=/docs/preview-inputs-radio--docs) instead.
@@ -137,14 +137,14 @@ const RadioInput = styled('input')<RadioProps & StyledType>(
       backgroundColor: checked
         ? variant === 'inverse'
           ? colors.frenchVanilla100
-          : themePrimary.main
+          : maybeWrapCSSVariables(themePrimary.main)
         : disabled
         ? inputColors.disabled.background
         : 'white',
       borderColor: checked
         ? variant === 'inverse'
           ? colors.soap300
-          : themePrimary.main
+          : maybeWrapCSSVariables(themePrimary.main)
         : disabled
         ? inputColors.disabled.border
         : variant === 'inverse'
@@ -174,7 +174,8 @@ const RadioInput = styled('input')<RadioProps & StyledType>(
         innerColor: variant === 'inverse' ? colors.blackPepper400 : undefined,
         outerColor: variant === 'inverse' ? colors.frenchVanilla100 : themeFocusOutline,
       }),
-      borderColor: variant === 'inverse' ? colors.frenchVanilla100 : themePrimary.main,
+      borderColor:
+        variant === 'inverse' ? colors.frenchVanilla100 : maybeWrapCSSVariables(themePrimary.main),
       borderWidth: '2px',
     },
     ...mouseFocusBehavior({
@@ -187,14 +188,14 @@ const RadioInput = styled('input')<RadioProps & StyledType>(
         borderColor: checked
           ? variant === 'inverse'
             ? colors.soap300
-            : themePrimary.main
+            : maybeWrapCSSVariables(themePrimary.main)
           : inputColors.border,
       },
       '&:focus:hover ~ div:first-of-type, &:focus:active ~ div:first-of-type': {
         borderColor: checked
           ? variant === 'inverse'
             ? colors.soap300
-            : themePrimary.main
+            : maybeWrapCSSVariables(themePrimary.main)
           : variant === 'inverse'
           ? colors.soap300
           : inputColors.hoverBorder,
@@ -233,7 +234,7 @@ const RadioBackground = styled('div')<RadioProps>(
     borderColor: checked
       ? variant === 'inverse'
         ? colors.soap300
-        : themePrimary.main
+        : maybeWrapCSSVariables(themePrimary.main)
       : disabled
       ? colors.licorice100
       : variant === 'inverse'
@@ -242,7 +243,7 @@ const RadioBackground = styled('div')<RadioProps>(
     backgroundColor: checked
       ? variant === 'inverse'
         ? colors.frenchVanilla100
-        : themePrimary.main
+        : maybeWrapCSSVariables(themePrimary.main)
       : disabled
       ? inputColors.disabled.background
       : 'white',
@@ -263,8 +264,8 @@ const RadioCheck = styled('div')<Pick<RadioProps, 'checked' | 'variant'>>(
   ({theme, variant}) => ({
     backgroundColor:
       variant === 'inverse'
-        ? theme.canvas.palette.primary.main
-        : theme.canvas.palette.primary.contrast,
+        ? maybeWrapCSSVariables(theme.canvas.palette.primary.main)
+        : maybeWrapCSSVariables(theme.canvas.palette.primary.contrast),
   }),
   ({checked}) => ({
     opacity: checked ? 1 : 0,


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #3904  <!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

This fixes the missing wrapping `var()` issue with `Radio` in `Main`.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

### Release Note
Fixes colors on `Radio` in `main` to show colors when selected.

---

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
`/modules/react/radio/lib/Radio.tsx`
