### PR TITLE
chore: Test v5 tokens in v15 with sana font

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -5,7 +5,7 @@
 <style type="text/css">
   body {
     padding: 0 !important;
-    font-family: sans-serif;
+    font-family: 'Sana Sans LCG 05 VF', sans-serif;
   }
 
   .story > * {
@@ -39,6 +39,7 @@
 <link rel="preload" href="Roboto-Medium.ttf" as="font" type="font/ttf" crossorigin />
 <link rel="preload" href="Roboto-Bold.ttf" as="font" type="font/ttf" crossorigin />
 <link rel="preload" href="RobotoMono-Regular.ttf" as="font" type="font/ttf" crossorigin />
+<link rel="preload" href="SanaSans-Variable.woff2" as="font" type="font/woff2" crossorigin />
 
 <!-- Font faces -->
 <style>
@@ -77,5 +78,18 @@
     font-weight: 400;
     src: local('Roboto Mono'), local('RobotoMono-Regular'),
       url(RobotoMono-Regular.ttf) format('truetype');
+  }
+
+  /*
+   * Testing only: register SanaSans under the family name the Canvas default
+   * font-family token (--cnvs-base-font-family-50) already points at, so every
+   * component that resolves --cnvs-sys-font-family-default renders with it.
+   */
+  @font-face {
+    font-family: 'Sana Sans LCG 05 VF';
+    font-style: normal;
+    font-weight: 1 1000;
+    font-display: swap;
+    src: url(SanaSans-Variable.woff2) format('woff2-variations');
   }
 </style>

--- a/modules/docs/mdx/welcomePage.tsx
+++ b/modules/docs/mdx/welcomePage.tsx
@@ -3,7 +3,7 @@ import {ExternalHyperlink, Hyperlink} from '@workday/canvas-kit-react/button';
 import {Card} from '@workday/canvas-kit-react/card';
 import {Graphic} from '@workday/canvas-kit-react/icon';
 import {Box, Flex, Grid} from '@workday/canvas-kit-react/layout';
-import {Heading, Text} from '@workday/canvas-kit-react/text';
+import {Heading, Text, Title} from '@workday/canvas-kit-react/text';
 import {createStyles, px2rem} from '@workday/canvas-kit-styling';
 import {system} from '@workday/canvas-tokens-web';
 
@@ -63,9 +63,9 @@ export const WelcomePage = () => {
             className={imageStyles}
           />
           <Flex cs={{flexDirection: 'row', position: 'absolute', top: '45%', right: '5%'}}>
-            <Text typeLevel="title.medium" cs={[bannerTextStyles, versionStyles]}>
+            <Title size="medium" cs={[bannerTextStyles, versionStyles]}>
               v{version}
-            </Text>
+            </Title>
           </Flex>
         </Box>
         <Text typeLevel="body.medium">

--- a/modules/docs/package.json
+++ b/modules/docs/package.json
@@ -52,7 +52,7 @@
     "@workday/canvas-kit-react": "^15.0.14",
     "@workday/canvas-kit-styling": "^15.0.14",
     "@workday/canvas-system-icons-web": "4.0.4",
-    "@workday/canvas-tokens-web": "4.3.0",
+    "@workday/canvas-tokens-web": "5.0.0-alpha.2",
     "markdown-to-jsx": "^7.2.0",
     "react-syntax-highlighter": "^15.5.0",
     "ts-node": "^10.9.1"

--- a/modules/labs-react/package.json
+++ b/modules/labs-react/package.json
@@ -51,7 +51,7 @@
     "@workday/canvas-kit-react": "^15.0.14",
     "@workday/canvas-kit-styling": "^15.0.14",
     "@workday/canvas-system-icons-web": "4.0.4",
-    "@workday/canvas-tokens-web": "4.3.0",
+    "@workday/canvas-tokens-web": "5.0.0-alpha.2",
     "@workday/design-assets-types": "^0.3.0",
     "chroma-js": "^2.2.0",
     "lodash.flatten": "^4.4.0",

--- a/modules/preview-react/package.json
+++ b/modules/preview-react/package.json
@@ -51,7 +51,7 @@
     "@workday/canvas-kit-react": "^15.0.14",
     "@workday/canvas-kit-styling": "^15.0.14",
     "@workday/canvas-system-icons-web": "4.0.4",
-    "@workday/canvas-tokens-web": "4.3.0",
+    "@workday/canvas-tokens-web": "5.0.0-alpha.2",
     "@workday/design-assets-types": "^0.3.0"
   },
   "devDependencies": {

--- a/modules/react/package.json
+++ b/modules/react/package.json
@@ -57,7 +57,7 @@
     "@workday/canvas-kit-preview-react": "^15.0.14",
     "@workday/canvas-kit-styling": "^15.0.14",
     "@workday/canvas-system-icons-web": "4.0.4",
-    "@workday/canvas-tokens-web": "4.3.0",
+    "@workday/canvas-tokens-web": "5.0.0-alpha.2",
     "@workday/design-assets-types": "^0.3.0",
     "chroma-js": "^2.2.0",
     "csstype": "^3.0.2",

--- a/modules/styling-transform/package.json
+++ b/modules/styling-transform/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@emotion/serialize": "^1.0.2",
     "@workday/canvas-kit-styling": "^15.0.14",
-    "@workday/canvas-tokens-web": "4.3.0",
+    "@workday/canvas-tokens-web": "5.0.0-alpha.2",
     "stylis": "4.3.6",
     "ts-node": "^10.9.1",
     "typescript": "5.0"

--- a/modules/styling/package.json
+++ b/modules/styling/package.json
@@ -55,7 +55,7 @@
     "@emotion/styled": "^11.6.0",
     "@workday/canvas-kit-react": "^15.0.14",
     "@workday/canvas-system-icons-web": "4.0.4",
-    "@workday/canvas-tokens-web": "4.3.0",
+    "@workday/canvas-tokens-web": "5.0.0-alpha.2",
     "typescript": "5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
   "@workday/canvas-applet-icons-web": "^2.0.15",
   "@workday/canvas-expressive-icons-web": "1.0.2",
   "@workday/canvas-system-icons-web": "4.0.4",
-  "@workday/canvas-tokens-web": "4.3.0",
+  "@workday/canvas-tokens-web": "5.0.0-alpha.2",
   "resolutions": {
     "ansi-regex": "3.0.1",
     "braces": "3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4834,10 +4834,10 @@
   resolved "https://registry.yarnpkg.com/@workday/canvas-system-icons-web/-/canvas-system-icons-web-4.0.4.tgz#8ddaa5a465059227d79b808c263f167f7d3b6915"
   integrity sha512-+CO8OTemP947vf/nQeVu3IxHrq9Q2sHra3/FAImkQ0w4/f3tlOgQn7YTWt7rKL2fvTYghjNN0HoHQSR0T64uWg==
 
-"@workday/canvas-tokens-web@4.3.0":
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/@workday/canvas-tokens-web/-/canvas-tokens-web-4.3.0.tgz#808a07153b574feb826226f02f0dcf412d0c3424"
-  integrity sha512-hyUwVdwSf3Vpqfh0YV+0ctZJVTFD3O8nDwKaiUJsVBsXTlze9vvLbrhFDHUh+b5PjpZSqlBKX4pmcklu9t6BAA==
+"@workday/canvas-tokens-web@5.0.0-alpha.2":
+  version "5.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@workday/canvas-tokens-web/-/canvas-tokens-web-5.0.0-alpha.2.tgz#ae972ff219668a44de86e19550a1761b8fd55e96"
+  integrity sha512-I6Eh9SR1u051aDhz+RNOXaqLrnltRn4vHwPmiTtWpNOgGu6qMsaCZWu/2Oq2ygLBzNeqlKnSoTpVYMLrdizY1w==
 
 "@workday/design-assets-types@0.2.8":
   version "0.2.8"


### PR DESCRIPTION
For testing only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Storybook now uses the Sana Sans variable font in the preview area for more consistent typography.
  * Updated the docs welcome banner version text to use the newer title styling.

* **Bug Fixes**
  * Improved font loading behavior so text displays smoothly while the custom font loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->