### PR TITLE
feat: Add option to close modal on mobile via overlay

### DIFF
--- a/cypress/component/Modal.spec.tsx
+++ b/cypress/component/Modal.spec.tsx
@@ -3,6 +3,7 @@ import {Basic} from '../../modules/react/modal/stories/examples/Basic';
 import {WithoutCloseIcon} from '../../modules/react/modal/stories/examples/WithoutCloseIcon';
 import {CustomFocus} from '../../modules/react/modal/stories/examples/CustomFocus';
 import {CustomTarget} from '../../modules/react/modal/stories/examples/CustomTarget';
+import {WithMobileOverlayCloseEnabled} from '../../modules/react/modal/stories/examples/WithMobileOverlayCloseEnabled';
 
 import {WithRadioButtons} from '../../modules/react/modal/stories/examples/WithRadioButtons';
 import {StackedModals} from '../../modules/react/modal/stories/examples/StackedModals';
@@ -169,6 +170,27 @@ describe('Modal', () => {
       });
     });
   });
+});
+
+context('given the WithMobileOverlayCloseEnabled example is rendered', () => {
+  beforeEach(() => {
+    cy.mount(<WithMobileOverlayCloseEnabled />);
+  });
+
+  context(
+    'when clicking outside the modal on mobile view with enableMobileCloseOnOverlayClick === true',
+    () => {
+      beforeEach(() => {
+        cy.mount(<WithMobileOverlayCloseEnabled />);
+        cy.viewport('iphone-x');
+        cy.get('body').realTouch();
+      });
+
+      it(`should close the modal`, () => {
+        cy.findByRole('dialog', {name: 'MIT License'}).should('not.exist');
+      });
+    }
+  );
 });
 
 context('given the FormModal example is rendered', () => {

--- a/cypress/component/Modal.spec.tsx
+++ b/cypress/component/Modal.spec.tsx
@@ -172,16 +172,16 @@ describe('Modal', () => {
   });
 });
 
-context('given the WithMobileOverlayCloseEnabled example is rendered', () => {
+context('given the WithMobileOverlayCloseEnabled example is rendered and modal is opened', () => {
   beforeEach(() => {
     cy.mount(<WithMobileOverlayCloseEnabled />);
+    cy.findByRole('button', {name: 'Open License'}).click();
   });
 
   context(
     'when clicking outside the modal on mobile view with enableMobileCloseOnOverlayClick === true',
     () => {
       beforeEach(() => {
-        cy.mount(<WithMobileOverlayCloseEnabled />);
         cy.viewport('iphone-x');
         cy.get('body').realTouch();
       });

--- a/modules/react/modal/lib/hooks/useCloseOnOverlayClick.ts
+++ b/modules/react/modal/lib/hooks/useCloseOnOverlayClick.ts
@@ -31,7 +31,7 @@ export const useCloseOnOverlayClick = createElemPropsHook(usePopupModel)(model =
 
       if (
         dialog &&
-        modality !== 'touch' &&
+        (modality !== 'touch' || model.state.enableMobileCloseOnOverlayClick) &&
         elements.length &&
         elements[elements.length - 1] === model.state.stackRef.current &&
         elementsBetweenDialogAnBody.some(element => element === event.target)
@@ -39,7 +39,7 @@ export const useCloseOnOverlayClick = createElemPropsHook(usePopupModel)(model =
         model.events.hide(event);
       }
     },
-    [model.state.stackRef, model.events, modality]
+    [model.state.stackRef, model.events, modality, model.state.enableMobileCloseOnOverlayClick]
   );
 
   const visible = model.state.visibility !== 'hidden';

--- a/modules/react/modal/stories/examples/WithMobileOverlayCloseEnabled.tsx
+++ b/modules/react/modal/stories/examples/WithMobileOverlayCloseEnabled.tsx
@@ -1,0 +1,41 @@
+import {Modal, useModalModel} from '@workday/canvas-kit-react/modal';
+import {PrimaryButton} from '@workday/canvas-kit-react/button';
+import {Flex, Box} from '@workday/canvas-kit-react/layout';
+
+export const WithMobileOverlayCloseEnabled = () => {
+  const model = useModalModel({
+    enableMobileCloseOnOverlayClick: true,
+  });
+
+  const handleAcknowledge = () => {
+    console.log('License Acknowledged');
+  };
+
+  const handleCancel = () => {
+    console.log('Cancel clicked');
+  };
+
+  return (
+    <Modal model={model}>
+      <Modal.Target as={PrimaryButton}>Open License</Modal.Target>
+      <Modal.Overlay>
+        <Modal.Card>
+          <Modal.CloseIcon aria-label="Close" />
+          <Modal.Heading>MIT License</Modal.Heading>
+          <Modal.Body>
+            <Box as="p" marginY="zero">
+              Permission is hereby granted, free of charge, to any person obtaining a copy of this
+              software and associated documentation files (the "Software").
+            </Box>
+          </Modal.Body>
+          <Flex gap="s" padding="xxs">
+            <Modal.CloseButton as={PrimaryButton} onClick={handleAcknowledge}>
+              Acknowledge
+            </Modal.CloseButton>
+            <Modal.CloseButton onClick={handleCancel}>Cancel</Modal.CloseButton>
+          </Flex>
+        </Modal.Card>
+      </Modal.Overlay>
+    </Modal>
+  );
+};

--- a/modules/react/popup/lib/hooks/usePopupModel.ts
+++ b/modules/react/popup/lib/hooks/usePopupModel.ts
@@ -22,6 +22,11 @@ export const usePopupModel = createModelHook({
      * focus will be moved to the first focusable element inside the popup.
      */
     initialFocusRef: undefined as undefined | React.RefObject<any>,
+    /**
+     * Optional flag to enable close on background overlay click for mobile devices.
+     * By default, this behaviour is disabled.
+     */
+    enableMobileCloseOnOverlayClick: false,
   },
   requiredConfig: useDisclosureModel.requiredConfig,
 })(config => {
@@ -58,6 +63,11 @@ export const usePopupModel = createModelHook({
      * @default 'bottom'
      */
     placement,
+    /**
+     * Optional flag to enable close on background overlay click for mobile devices.
+     * By default, this behaviour is disabled.
+     */
+    enableMobileCloseOnOverlayClick: config.enableMobileCloseOnOverlayClick,
   };
 
   const events = {


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

This PR introduces an optional configuration option for modal that allows users to close modal by clicking on background overlay. By default, this behaviour is disabled for `modality === 'touch'`

## Summary

Resolves issue https://github.com/Workday/canvas-kit/issues/3108

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

For Mobile Inventory Modernization project - but also seemingly other use cases - there are cases when we have informational modals that do not critically require an explicit user selection via buttons, so dismissing modal via overlay click makes sense from a UX point of view.

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--docs)
- [ ] Label `ready for review` has been added to PR

## Reviewers
@josh-bagwell
@RayRedGoose

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->
modules/react/modal/lib/hooks/useCloseOnOverlayClick.ts

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Documentation
- [ ] Testing
- [ ] Codemods

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

<!-- Explain how your reviewer could verify this change  -->

## Screenshots or GIFs (if applicable)

<!-- Does your change affect the UI? If so, please include a screenshot or short gif. -->

## Thank You Gif (optional)

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer! -->
<!-- ![a smiling Shiba Inu typing on a laptop](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in setting to allow modals to close when users tap the overlay on touch/mobile devices.
  * Included a new example demonstrating the mobile overlay-close behavior.
* **Bug Fixes**
  * Updated overlay-close behavior so touch devices follow the enabled setting.
* **Tests**
  * Added a component test covering touch interaction to verify the license dialog closes as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->