### PR TITLE
docs: Set Sana theme in Storybook docs view & canvas view

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -7,9 +7,7 @@
 </script>
 
 <link rel="stylesheet" href="/updated-type.css" />
-<script>
-  document.documentElement.setAttribute('data-theme', 'sana-canvas');
-</script>
+<script src="/set-data-theme.js"></script>
 <style>
   body {
     font-family: var(--cnvs-sys-font-family-default);

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -3,9 +3,7 @@
 </script>
 
 <link rel="stylesheet" href="/updated-type.css" />
-<script>
-  document.documentElement.setAttribute('data-theme', 'sana-canvas');
-</script>
+<script src="/set-data-theme.js"></script>
 
 <style type="text/css">
   html,

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -21,14 +21,6 @@ export const globalTypes = {
     name: 'Theme',
     description: 'Token theme',
     defaultValue: 'sana',
-    toolbar: {
-      icon: 'paintbrush',
-      items: [
-        {value: 'canvas', title: 'Canvas'},
-        {value: 'sana', title: 'Sana Canvas'},
-      ],
-      showName: true,
-    },
   },
 };
 

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -4,8 +4,10 @@ import {defaultCanvasTheme} from '@workday/canvas-kit-react/common';
 import '@workday/canvas-tokens-web/css/base/_variables.css';
 import '@workday/canvas-tokens-web/css/brand/_variables.css';
 import '@workday/canvas-tokens-web/css/component/_variables.css';
-import '@workday/canvas-tokens-web/css/sana/_variables.css';
 import '@workday/canvas-tokens-web/css/system/_variables.css';
+// Imported after system so its equal-specificity `[data-theme="sana-canvas"]` rules win
+// the cascade tie over system's unscoped `:root` rules when set on <html>.
+import '@workday/canvas-tokens-web/css/sana/_variables.css';
 
 import {CanvasProviderDecorator} from '../utils/storybook';
 import routes from './routes';
@@ -15,14 +17,6 @@ import './updated-type.css';
 
 // set routes on window for testing the validity of the routes
 window.__routes = routes;
-
-export const globalTypes = {
-  theme: {
-    name: 'Theme',
-    description: 'Token theme',
-    defaultValue: 'sana',
-  },
-};
 
 export const decorators = [CanvasProviderDecorator];
 

--- a/.storybook/set-data-theme.js
+++ b/.storybook/set-data-theme.js
@@ -1,0 +1,8 @@
+// ?theme=canvas` URL param for switching off the default Sana Canvas theme, for dev and QA use only.
+// This must be set on <html> (not a nested element) since the sana token CSS only defines
+// `[data-theme="sana-canvas"]` overrides - there's no `[data-theme="canvas"]` rule to undo it.
+var themeParam = new URLSearchParams(window.location.search).get('theme');
+document.documentElement.setAttribute(
+  'data-theme',
+  themeParam === 'canvas' ? 'canvas' : 'sana-canvas'
+);

--- a/modules/docs/lib/ExampleCodeBlock.tsx
+++ b/modules/docs/lib/ExampleCodeBlock.tsx
@@ -5,7 +5,7 @@ import {vscDarkPlus} from 'react-syntax-highlighter/dist/cjs/styles/prism';
 
 import {TertiaryButton} from '@workday/canvas-kit-react/button';
 import {Card} from '@workday/canvas-kit-react/card';
-import {CanvasProvider, defaultBranding} from '@workday/canvas-kit-react/common';
+import {CanvasProvider} from '@workday/canvas-kit-react/common';
 import {Tooltip} from '@workday/canvas-kit-react/tooltip';
 import {calc, createStencil, cssVar, px2rem} from '@workday/canvas-kit-styling';
 import {checkCircleIcon, copyIcon} from '@workday/canvas-system-icons-web';
@@ -137,7 +137,7 @@ export const ExampleCodeBlock = ({code}: any) => {
       <Card data-part="example-block" className="sb-unstyled">
         {/* This allows for the div to scroll on smaller viewports while not allowing the components to overflow over the container */}
         <Card.Body data-part="example-block-container">
-          <CanvasProvider className={defaultBranding} data-theme="sana-canvas">
+          <CanvasProvider>
             {React.createElement(code)}
             {code && (
               <div data-part="code-toggle-stackblitz-btn-container">
@@ -157,7 +157,7 @@ export const ExampleCodeBlock = ({code}: any) => {
       </Card>
       <Card data-part="code-block" cs={{padding: 0}}>
         <Card.Body cs={{position: 'relative'}}>
-          <CanvasProvider className={defaultBranding}>
+          <CanvasProvider>
             {code && (
               <div ref={textInput}>
                 <SyntaxHighlighter

--- a/utils/download-fonts.js
+++ b/utils/download-fonts.js
@@ -64,6 +64,12 @@ async function main() {
     resolve(__dirname, '../public/updated-type.css')
   );
 
+  // Serve the theme-setting script from public/ so Storybook head <script> tags work without bundler resolution
+  fs.copyFileSync(
+    resolve(__dirname, '../.storybook/set-data-theme.js'),
+    resolve(__dirname, '../public/set-data-theme.js')
+  );
+
   await Promise.all(
     fontsToDownload.map(fileName => {
       return download(fontBaseUrl + fileName, resolve(__dirname, '../public', fileName));

--- a/utils/storybook/CanvasProviderDecorator.tsx
+++ b/utils/storybook/CanvasProviderDecorator.tsx
@@ -20,10 +20,8 @@ export default makeDecorator({
     const theme: PartialEmotionCanvasTheme = {
       canvas: parameters.theme || defaultCanvasTheme,
     };
-    const tokenTheme = context.globals?.theme;
-    const dataTheme = tokenTheme === 'sana' ? 'sana-canvas' : 'canvas';
     return (
-      <CanvasProvider theme={theme} className={storyStyles} data-theme={dataTheme}>
+      <CanvasProvider theme={theme} className={storyStyles}>
         {storyFn(context) as React.ReactNode}
       </CanvasProvider>
     );


### PR DESCRIPTION
## Summary

Fixes: #4032 

Updates Storybook to set the Sana theme on `<html>` itself, so that it covers both docs view and canvas view.

The `CanvasProvider` decorator only wraps individual `<Story>` blocks, not
the surrounding MDX code, so we didn't have the Sana theme in docs view before. This moves the `data-theme` attribute  to `<html>` itself (`preview-head.html` and `manager-head.html`). Also:

  - Reordered token CSS imports in preview.js so sana/_variables.css is
    imported after system/_variables.css.  We need this since we're setting the theme on the `html` element, and  `[data-theme="sana-canvas"]`and `:root` have equal specificity
    on that element the later-imported rule wins the tie.
  - Removed `defaultBranding` from ExampleCodeBlock's `CanvasProvider`, as it
    hardcoded system.color.brand.accent.primary to Workday blue directly
    on the element, which overrode Sana theme values



## Release Category
Documentation

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--docs)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?
- [ ] yarn start
- [ ] Load up a component in docs view like http://localhost:9001/?path=/docs/components-buttons--docs and make sure you see the Sana theme applied
- [ ] Change the URL to http://localhost:9001/?path=/docs/components-buttons--docs&theme=canvas and you should see the Sana theme _not_ applied
- [ ] Load up a component in canvas view like http://localhost:9001/?path=/story/components-buttons--primary and make sure you see the Sana theme applied
- [ ] Change the URL to http://localhost:9001/?path=/story/components-buttons--primary&theme=canvas and you should see the Sana theme _not_ applied


## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Documentation
- [ ] Testing
- [ ] Codemods

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

<!-- Explain how your reviewer could verify this change  -->

## Screenshots or GIFs (if applicable)

<!-- Does your change affect the UI? If so, please include a screenshot or short gif. -->

## Thank You Gif (optional)

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer! -->
<!-- ![a smiling Shiba Inu typing on a laptop](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Storybook now supports theme selection via a URL parameter, making it easier to preview the canvas and default themes.
* **Bug Fixes**
  * Improved theme loading so the correct styling is applied earlier in the page load.
  * Example and documentation views now render with more consistent theme behavior.
* **Chores**
  * Updated Storybook setup to simplify theme handling and keep styling overrides working as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->