### PR TITLE
chore: Fix circular deps and broken ts-patch build

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -13,7 +13,7 @@ import stylingConfig from '../styling.config';
 import { vitePluginInlineSpecifications } from './vite-plugin-inline-specifications';
 import { vitePluginRedirectMDXToGithub } from './vite-plugin-redirect-mdx-to-github';
 import { vitePluginWholeSource } from './vite-plugin-whole-source';
-import { vitePluginTypescriptWithTransformers } from '@workday/canvas-kit-styling-transform';
+import { vitePluginTypescriptWithTransformers } from '@workday/canvas-kit-styling-transform/vite';
 import { getDocParser } from '@workday/canvas-kit-docs/docgen/createDocProgram';
 
 // const modulesPath = path.resolve(__dirname, '../modules');

--- a/modules/docs/llm/llm-style-props-migration.txt
+++ b/modules/docs/llm/llm-style-props-migration.txt
@@ -685,11 +685,11 @@ const myStyles = createStyles({
 
 ### Webpack
 
-The `@webpack/canvas-kit-styling-transform` package comes with a webpack loader that can be added to development and/or production.
+The `@workday/canvas-kit-styling-transform` package comes with a webpack loader that can be added to development and/or production. Import the plugin from the `/webpack` subpath:
 
 ```js
 // import the transform - CJS and ESM are supported
-import {StylingWebpackPlugin} from '@workday/canvas-kit-styling-transform';
+import {StylingWebpackPlugin} from '@workday/canvas-kit-styling-transform/webpack';
 
 // somewhere only once. For static webpack config files, this can be near the top.
 // If inside Storybook, Gatsby, Next.js, etc configs, put inside the function that is called that

--- a/modules/react/package.json
+++ b/modules/react/package.json
@@ -54,7 +54,6 @@
     "@workday/canvas-colors-web": "^2.0.0",
     "@workday/canvas-expressive-icons-web": "1.0.2",
     "@workday/canvas-kit-popup-stack": "^15.0.14",
-    "@workday/canvas-kit-preview-react": "^15.0.14",
     "@workday/canvas-kit-styling": "^15.0.14",
     "@workday/canvas-system-icons-web": "4.0.4",
     "@workday/canvas-tokens-web": "4.3.0",

--- a/modules/styling-transform/index.ts
+++ b/modules/styling-transform/index.ts
@@ -9,8 +9,6 @@ export {createPropertyTransform} from './lib/createPropertyTransform';
 export {styleTransformer};
 export {withDefaultContext} from './lib/styleTransform';
 export {getClassName} from './lib/utils/handleCreateStencil';
-export {StylingWebpackPlugin} from './lib/webpackPlugin';
-export {vitePluginTypescriptWithTransformers} from './lib/vitePlugin';
 
 // be compatible with ts-patch which expects a default export
 export default styleTransformer;

--- a/modules/styling-transform/package.json
+++ b/modules/styling-transform/package.json
@@ -11,6 +11,7 @@
     ".": "./index.ts",
     "./vite": "./vite.ts",
     "./webpack": "./webpack.ts",
+    "./webpack-loader": "./lib/webpack-loader.ts",
     "./testing": "./testing.ts"
   },
   "repository": {

--- a/modules/styling-transform/package.json
+++ b/modules/styling-transform/package.json
@@ -7,6 +7,12 @@
   "sideEffects": false,
   "main": "index.ts",
   "module": "index.ts",
+  "exports": {
+    ".": "./index.ts",
+    "./vite": "./vite.ts",
+    "./webpack": "./webpack.ts",
+    "./testing": "./testing.ts"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Workday/canvas-kit.git",
@@ -17,6 +23,8 @@
     "lib/*",
     "dist/*",
     "index.ts",
+    "vite.ts",
+    "webpack.ts",
     "testing.ts"
   ],
   "scripts": {

--- a/modules/styling-transform/vite.ts
+++ b/modules/styling-transform/vite.ts
@@ -1,0 +1,2 @@
+export {vitePluginTypescriptWithTransformers} from './lib/vitePlugin';
+export type {Options as VitePluginOptions} from './lib/vitePlugin';

--- a/modules/styling-transform/vite.ts
+++ b/modules/styling-transform/vite.ts
@@ -1,2 +1,1 @@
 export {vitePluginTypescriptWithTransformers} from './lib/vitePlugin';
-export type {Options as VitePluginOptions} from './lib/vitePlugin';

--- a/modules/styling-transform/webpack.ts
+++ b/modules/styling-transform/webpack.ts
@@ -1,0 +1,1 @@
+export {StylingWebpackPlugin} from './lib/webpackPlugin';

--- a/modules/styling/package.json
+++ b/modules/styling/package.json
@@ -53,7 +53,6 @@
     "@emotion/react": "^11.7.1",
     "@emotion/serialize": "^1.0.2",
     "@emotion/styled": "^11.6.0",
-    "@workday/canvas-kit-react": "^15.0.14",
     "@workday/canvas-system-icons-web": "4.0.4",
     "@workday/canvas-tokens-web": "4.3.0",
     "typescript": "5.0"

--- a/modules/styling/stories/mdx/Overview.mdx
+++ b/modules/styling/stories/mdx/Overview.mdx
@@ -225,17 +225,17 @@ const myStyles = createStyles({
 
 ### Webpack
 
-The `@webpack/canvas-kit-styling-transform` package comes with a webpack loader that can be added to
-development and/or production.
+The `@workday/canvas-kit-styling-transform` package comes with a webpack loader that can be added to
+development and/or production. Import the plugin from the `/webpack` subpath:
 
 ```js
 // import the transform - CJS and ESM are supported
-import {StylingWebpackPlugin} from '@workday/canvas-kit-styling-transform';
+import {StylingWebpackPlugin} from '@workday/canvas-kit-styling-transform/webpack';
 
 // somewhere only once. For static webpack config files, this can be near the top.
 // If inside Storybook, Gatsby, Next.js, etc configs, put inside the function that is called that
 // returns a webpack config
-const tsPlugin = const tsPlugin = new StylingWebpackPlugin({
+const tsPlugin = new StylingWebpackPlugin({
   tsconfigPath: path.resolve(__dirname, '../tsconfig.json'), // allows your TS config to be used
   // A different tsconfig could be used if you want to use TS to transpile to something like ES2019 and
   // also have Babel process the file.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "name": "canvas-kit",
   "author": "Workday, Inc. (https://www.workday.com)",
   "license": "Apache-2.0",
-  "type": "module",
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.26.3",
     "@babel/plugin-transform-runtime": "^7.26.3",


### PR DESCRIPTION
## Summary

Fixes: #4038

There are two problems we're fixing in this PR:

1. We had circular dependencies in a couple of our packages
2. Our styling transform package was exporting a Vite plugin (for Storybook) a Webpack (for external consumers). Vite is ESM only and it was breaking the `build:cjs` script.

To fix the cjs build we separated out the builds into separate files / exports, and this seems to help ts-patch sort through the build properly.

There is a minor breaking change to the import path for anyone importing `StylingWebpackPlugin`. Given that this is breaking our infrastructure, I think it's worth the impact. Docs have been updated.

```ts
// before
import {StylingWebpackPlugin} from '@workday/canvas-kit-styling-transform';
import {vitePluginTypescriptWithTransformers} from '@workday/canvas-kit-styling-transform';

// after
import {StylingWebpackPlugin} from '@workday/canvas-kit-styling-transform/webpack';
import {vitePluginTypescriptWithTransformers} from '@workday/canvas-kit-styling-transform/vite';
```

## Release Category

Infrastructure

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--docs)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Documentation
- [ ] Testing
- [ ] Codemods

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

<!-- Explain how your reviewer could verify this change  -->

## Screenshots or GIFs (if applicable)

<!-- Does your change affect the UI? If so, please include a screenshot or short gif. -->

## Thank You Gif (optional)

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer! -->
<!-- ![a smiling Shiba Inu typing on a laptop](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/clarified direct package entry points for the styling transform tooling (Vite, Webpack, loader, and testing) to support simpler imports.
  * Exposed the relevant Vite and Webpack plugin exports via the new entry points.

* **Documentation**
  * Updated Webpack integration guides and examples to use the correct `/webpack` import path and fixed a snippet typo.

* **Chores**
  * Updated Storybook’s Vite TypeScript transformer import path.
  * Adjusted package module/type and removed pinned preview/development dependency entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->