### PR TITLE
chore: Fix stalled CI storybook builds

### DIFF
--- a/modules/styling-transform/lib/createTypeScriptWatchProgram.ts
+++ b/modules/styling-transform/lib/createTypeScriptWatchProgram.ts
@@ -10,9 +10,12 @@ export function getTSConfigFile(tsconfigPath: string) {
 }
 
 /** Create a one-shot TypeScript program suitable for production builds. */
-export const createProgram = (tsconfigPath: string): ts.Program => {
-  const {options, fileNames} = getTSConfigFile(tsconfigPath);
-  return ts.createProgram(fileNames, options);
+export const createProgram = (
+  tsconfigPath: string,
+  compilerOptions: ts.CompilerOptions
+): ts.Program => {
+  const {fileNames} = getTSConfigFile(tsconfigPath);
+  return ts.createProgram(fileNames, compilerOptions);
 };
 
 export const getCompilerOptions = (tsconfigPath: string) => {

--- a/modules/styling-transform/lib/createTypeScriptWatchProgram.ts
+++ b/modules/styling-transform/lib/createTypeScriptWatchProgram.ts
@@ -9,6 +9,12 @@ export function getTSConfigFile(tsconfigPath: string) {
   return ts.parseJsonConfigFileContent(configFile.config, ts.sys, basePath, {}, tsconfigPath);
 }
 
+/** Create a one-shot TypeScript program suitable for production builds. */
+export const createProgram = (tsconfigPath: string): ts.Program => {
+  const {options, fileNames} = getTSConfigFile(tsconfigPath);
+  return ts.createProgram(fileNames, options);
+};
+
 export const getCompilerOptions = (tsconfigPath: string) => {
   let compilerOptions: ts.CompilerOptions = {
     jsx: ts.JsxEmit.React,

--- a/modules/styling-transform/lib/vitePlugin.ts
+++ b/modules/styling-transform/lib/vitePlugin.ts
@@ -1,7 +1,7 @@
 import ts, {type CompilerOptions, type Program} from 'typescript';
 import {type Plugin, createFilter} from 'vite';
 
-import {getCompilerOptions, startWatch} from './createTypeScriptWatchProgram';
+import {createProgram, getCompilerOptions, startWatch} from './createTypeScriptWatchProgram';
 
 type Filepath = string;
 type InvalidateModule = () => void;
@@ -28,17 +28,22 @@ export interface Options {
 }
 
 export function vitePluginTypescriptWithTransformers(config: Options = {}): Plugin {
-  let tsProgram: ts.BuilderProgram;
+  let tsProgram: ts.Program | ts.BuilderProgram;
   let compilerOptions: CompilerOptions;
   let filter: ReturnType<(typeof import('vite'))['createFilter']>;
   const moduleInvalidationQueue: Map<Filepath, InvalidateModule> = new Map();
-  let closeWatch: CloseWatch;
+  // When the production (static) build runs, closeWatch is a no-op because there's no watch to close.
+  let closeWatch: CloseWatch | undefined;
+  // When the program is running in development with watch mode, tsProgram is a BuilderProgram.
+  // When the program is running in production, tsProgram is a Program.
+  // We need to get the Program from the BuilderProgram to get the correct source files.
+  const getProgram = () => ('getProgram' in tsProgram ? tsProgram.getProgram() : tsProgram);
 
   return {
     name: 'vite-plugin-typescript',
     enforce: 'pre',
 
-    async configResolved() {
+    async configResolved(resolvedConfig) {
       const tsconfigPath = config.tsconfigPath ?? './tsconfig.json';
       compilerOptions = config.compilerOptions ?? (await getCompilerOptions(tsconfigPath));
 
@@ -46,6 +51,14 @@ export function vitePluginTypescriptWithTransformers(config: Options = {}): Plug
       const excludeArray = config.exclude ?? [];
 
       filter = createFilter(includeArray, excludeArray);
+      // If Vite is running a production (static) build, we need to create a new Program instead of running watch mode.
+      if (resolvedConfig.command === 'build') {
+        // Watch mode keeps the Node process alive after Vite finishes.
+        // Storybook's static build does not reliably call closeBundle before file writes.
+        tsProgram = createProgram(tsconfigPath);
+        return;
+      }
+      // Watch mode is now only used for development builds.
       [tsProgram, closeWatch] = await startWatch(compilerOptions, tsconfigPath, program => {
         tsProgram = program;
 
@@ -62,13 +75,13 @@ export function vitePluginTypescriptWithTransformers(config: Options = {}): Plug
       }
 
       const printer = ts.createPrinter(compilerOptions);
+      const program = getProgram();
 
       const transformers =
-        config.transformers?.filter(t => t !== undefined).map(t => t!(tsProgram.getProgram())) ||
-        [];
+        config.transformers?.filter(t => t !== undefined).map(t => t!(program)) || [];
 
       const sourceFile =
-        tsProgram.getSourceFile(id) || ts.createSourceFile(id, '', ts.ScriptTarget.ES2019);
+        program.getSourceFile(id) || ts.createSourceFile(id, '', ts.ScriptTarget.ES2019);
 
       const transformed = printer.printFile(
         ts
@@ -82,9 +95,14 @@ export function vitePluginTypescriptWithTransformers(config: Options = {}): Plug
 
       return postTransform || transformed;
     },
+    // Runs when the build finishes.
+    // This is an extra precaution in case Storybook / Vite don't call closeBundle before the process exits.
+    buildEnd() {
+      closeWatch?.();
+    },
 
     closeBundle() {
-      closeWatch();
+      closeWatch?.();
     },
   };
 }

--- a/modules/styling-transform/lib/vitePlugin.ts
+++ b/modules/styling-transform/lib/vitePlugin.ts
@@ -55,7 +55,7 @@ export function vitePluginTypescriptWithTransformers(config: Options = {}): Plug
       if (resolvedConfig.command === 'build') {
         // Watch mode keeps the Node process alive after Vite finishes.
         // Storybook's static build does not reliably call closeBundle before file writes.
-        tsProgram = createProgram(tsconfigPath);
+        tsProgram = createProgram(tsconfigPath, compilerOptions);
         return;
       }
       // Watch mode is now only used for development builds.


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

Fixes: #4043

Our `storybook-build` script in GitHub actions is regularly stalling out, presumably because the Vite plugin is always running in watch mode. That watch mode doesn't reliably get turned off, and it shuts down.

I'm not sure why we're always running watch mode for a production build. It makes more sense for a development server. This PR adds some logic to tell the Vite server to only run watch mode in development, and it adds an extra catch to make sure the watch mode always closes.

## Release Category

Infrastructure

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--docs)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Documentation
- [ ] Testing
- [ ] Codemods

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

<!-- Explain how your reviewer could verify this change  -->

## Screenshots or GIFs (if applicable)

<!-- Does your change affect the UI? If so, please include a screenshot or short gif. -->

## Thank You Gif (optional)

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer! -->
<!-- ![a smiling Shiba Inu typing on a laptop](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TypeScript transform processing now supports both one-time build runs and ongoing watch/dev runs, using the appropriate TypeScript program for each mode.
* **Bug Fixes**
  * Improved reliability when switching between build and watch, with safer program lifecycle handling and cleanup to reduce lingering watch activity.
  * Transformer processing more consistently targets the active TypeScript program and source files during compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->