### PR TITLE
chore: Update Chromatic tests to only run when ready for review

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,9 +1,21 @@
 name: Pull Request
 
-on: pull_request
+on:
+  pull_request:
+    # labeled: so Chromatic can run when "ready for review" is applied
+    types: [opened, synchronize, reopened, labeled]
+
+# Cancel in-progress runs for the same PR when a new commit is pushed.
+# Avoids burning Chromatic snapshots (and CI minutes) on superseded commits.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
+  # On labeled events, only continue when the Chromatic gate label was added —
+  # other labels should not re-run the suite.
   install:
+    if: github.event.action != 'labeled' || github.event.label.name == 'ready for review'
     runs-on: ubuntu-latest
     outputs:
       cypress-version: ${{ steps.cypress-version.outputs.version }}
@@ -16,6 +28,7 @@ jobs:
           node_version: 24.x
 
   check:
+    if: github.event.action != 'labeled'
     runs-on: ubuntu-latest
     needs: 'install'
 
@@ -40,6 +53,7 @@ jobs:
         run: yarn test
 
   build:
+    if: github.event.action != 'labeled' || github.event.label.name == 'ready for review'
     runs-on: ubuntu-latest
     needs: 'install'
 
@@ -60,7 +74,10 @@ jobs:
           path: docs
           key: ${{ runner.os }}-build-${{ github.sha }}
 
+  # Chromatic only when the PR is marked ready for review (and on later pushes
+  # while that label remains). Skipped for draft/in-progress commits.
   visual-test:
+    if: contains(github.event.pull_request.labels.*.name, 'ready for review')
     runs-on: ubuntu-latest
     needs: 'build'
 
@@ -88,6 +105,7 @@ jobs:
           exitZeroOnChanges: true
 
   integration-test:
+    if: github.event.action != 'labeled'
     runs-on: ubuntu-latest
     needs: ['install', 'build']
     strategy:


### PR DESCRIPTION
## Summary

Resolves: #4059

This PR does two things:

1. Cancel any in-progress actions for a pull request when another commit is pushed – more efficient CI and fewer tests running
2. Only run `visual-tests` when the `ready for review` label is added. This should significantly cut down on our snapshot usage.

## Release Category

Infrastructure

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--docs)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Documentation
- [ ] Testing
- [ ] Codemods

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

<!-- Explain how your reviewer could verify this change  -->

## Screenshots or GIFs (if applicable)

<!-- Does your change affect the UI? If so, please include a screenshot or short gif. -->

## Thank You Gif (optional)

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer! -->
<!-- ![a smiling Shiba Inu typing on a laptop](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pull request validation workflow reliability by limiting runs to relevant pull request events.
  * Added automatic cancellation of outdated, in-progress workflow runs.
  * Updated validation and visual testing to run based on the pull request’s review readiness label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->