### PR TITLE
docs: Use relative asset paths in Storybook head files

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -12,8 +12,8 @@
   document.title = 'Canvas Kit Storybook';
 </script>
 
-<link rel="stylesheet" href="/updated-type.css" />
-<script src="/set-data-theme.js"></script>
+<link rel="stylesheet" href="./updated-type.css" />
+<script src="./set-data-theme.js"></script>
 <style>
   body {
     font-family: var(--cnvs-sys-font-family-default);

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,12 +1,12 @@
-<link rel="icon" type="image/png" href="/canvas-kit-favicon.png" sizes="192x192" />
-<link rel="shortcut icon" href="/canvas-kit-favicon.ico" />
-<link rel="preload" href="/SanaSansLCG05-Variable.ttf" as="font" type="font/ttf" crossorigin />
-<link rel="preload" href="/Roboto-Light.ttf" as="font" type="font/ttf" crossorigin />
-<link rel="preload" href="/Roboto-Regular.ttf" as="font" type="font/ttf" crossorigin />
-<link rel="preload" href="/Roboto-Medium.ttf" as="font" type="font/ttf" crossorigin />
-<link rel="preload" href="/Roboto-Bold.ttf" as="font" type="font/ttf" crossorigin />
-<link rel="preload" href="/IBMPlexMono-Regular.woff2" as="font" type="font/woff2" crossorigin />
-<link rel="preload" href="/RobotoMono-Regular.ttf" as="font" type="font/ttf" crossorigin />
+<link rel="icon" type="image/png" href="./canvas-kit-favicon.png" sizes="192x192" />
+<link rel="shortcut icon" href="./canvas-kit-favicon.ico" />
+<link rel="preload" href="./SanaSansLCG05-Variable.ttf" as="font" type="font/ttf" crossorigin />
+<link rel="preload" href="./Roboto-Light.ttf" as="font" type="font/ttf" crossorigin />
+<link rel="preload" href="./Roboto-Regular.ttf" as="font" type="font/ttf" crossorigin />
+<link rel="preload" href="./Roboto-Medium.ttf" as="font" type="font/ttf" crossorigin />
+<link rel="preload" href="./Roboto-Bold.ttf" as="font" type="font/ttf" crossorigin />
+<link rel="preload" href="./IBMPlexMono-Regular.woff2" as="font" type="font/woff2" crossorigin />
+<link rel="preload" href="./RobotoMono-Regular.ttf" as="font" type="font/ttf" crossorigin />
 <script src="https://use.fontawesome.com/660238b999.js"></script>
 <script>
   document.title = 'Canvas Kit Storybook';

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -2,8 +2,8 @@
   document.title = 'Canvas Kit Storybook';
 </script>
 
-<link rel="stylesheet" href="/updated-type.css" />
-<script src="/set-data-theme.js"></script>
+<link rel="stylesheet" href="./updated-type.css" />
+<script src="./set-data-theme.js"></script>
 
 <style type="text/css">
   html,

--- a/.storybook/updated-type.css
+++ b/.storybook/updated-type.css
@@ -5,7 +5,7 @@
   src:
     local('Sana Sans LCG 05 VF'),
     local('SanaSansLCG05VF-Regular'),
-    url(/SanaSansLCG05-Variable.ttf) format('truetype');
+    url(./SanaSansLCG05-Variable.ttf) format('truetype');
 }
 
 @font-face {
@@ -15,35 +15,35 @@
   src:
     local('Sana Sans LCG 05 VF'),
     local('SanaSansLCG05VF-Regular'),
-    url(/SanaSansLCG05-Variable.ttf) format('truetype');
+    url(./SanaSansLCG05-Variable.ttf) format('truetype');
 }
 
 @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 300;
-  src: local('Roboto Light'), local('Roboto-Light'), url(/Roboto-Light.ttf) format('truetype');
+  src: local('Roboto Light'), local('Roboto-Light'), url(./Roboto-Light.ttf) format('truetype');
 }
 
 @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 400;
-  src: local('Roboto Regular'), local('Roboto-Regular'), url(/Roboto-Regular.ttf) format('truetype');
+  src: local('Roboto Regular'), local('Roboto-Regular'), url(./Roboto-Regular.ttf) format('truetype');
 }
 
 @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 500;
-  src: local('Roboto Medium'), local('Roboto-Medium'), url(/Roboto-Medium.ttf) format('truetype');
+  src: local('Roboto Medium'), local('Roboto-Medium'), url(./Roboto-Medium.ttf) format('truetype');
 }
 
 @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 700;
-  src: local('Roboto Bold'), local('Roboto-Bold'), url(/Roboto-Bold.ttf) format('truetype');
+  src: local('Roboto Bold'), local('Roboto-Bold'), url(./Roboto-Bold.ttf) format('truetype');
 }
 
 @font-face {
@@ -53,14 +53,14 @@
   src:
     local('IBM Plex Mono'),
     local('IBMPlexMono-Regular'),
-    url(/IBMPlexMono-Regular.woff2) format('woff2');
+    url(./IBMPlexMono-Regular.woff2) format('woff2');
 }
 
 @font-face {
   font-family: 'Roboto Mono';
   font-style: normal;
   font-weight: 400;
-  src: local('Roboto Mono'), local('RobotoMono-Regular'), url(/RobotoMono-Regular.ttf) format('truetype');
+  src: local('Roboto Mono'), local('RobotoMono-Regular'), url(./RobotoMono-Regular.ttf) format('truetype');
 }
 
 [data-theme='sana-canvas'] {


### PR DESCRIPTION
## Summary

Fixes: #4120.

Changes asset paths to relative so that our `data-theme` gets set properly (defaulting to Sana Canvas theme) in Storybook. This was working fine locally and on Chromatic built Storybooks but was not working in our GitHub Pages based Storybook since it's deployed to a sub-directory, which broke asset paths.

Note: 
There are now vite-triggered warnings relating to loading font files that now appear during Storybook builds, but these are harmless -- just happening now since the asset imports are relative & Vite's CSS pipeline tries to resolve these files:

```bash
 ./SanaSansLCG05-Variable.ttf referenced in ./SanaSansLCG05-Variable.ttf didn't resolve at build time, it will remain unchanged to be resolved at runtime
  ./Roboto-Light.ttf referenced in ./Roboto-Light.ttf didn't resolve at build time, it will remain unchanged to be resolved at runtime
  ./Roboto-Regular.ttf referenced in ./Roboto-Regular.ttf didn't resolve at build time, it will remain unchanged to be resolved at runtime
  ./Roboto-Medium.ttf referenced in ./Roboto-Medium.ttf didn't resolve at build time, it will remain unchanged to be resolved at runtime
  ./Roboto-Bold.ttf referenced in ./Roboto-Bold.ttf didn't resolve at build time, it will remain unchanged to be resolved at runtime
  ./IBMPlexMono-Regular.woff2 referenced in ./IBMPlexMono-Regular.woff2 didn't resolve at build time, it will remain unchanged to be resolved at runtime
  ./RobotoMono-Regular.ttf referenced in ./RobotoMono-Regular.ttf didn't resolve at build time, it will remain unchanged to be resolved at runtime
 ```

## Release Category
Documentation


## Question
Should this be a `docs` conventional commit prefix? It is a `fix` but for docs.


---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--docs)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Documentation
- [ ] Testing
- [ ] Codemods

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

<!-- Explain how your reviewer could verify this change  -->

## Screenshots or GIFs (if applicable)

<!-- Does your change affect the UI? If so, please include a screenshot or short gif. -->

## Thank You Gif (optional)

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer! -->
<!-- ![a smiling Shiba Inu typing on a laptop](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Fixed Storybook asset loading for favicons, fonts, stylesheets, and scripts.
* Improved Storybook compatibility when served from nested or non-root paths, ensuring visual styles and typography load correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->