### PR TITLE
docs: Add AI functionality disclosure example to Tooltip docs

### DIFF
--- a/modules/react/tooltip/stories/Tooltip.mdx
+++ b/modules/react/tooltip/stories/Tooltip.mdx
@@ -5,6 +5,7 @@ import {InformationHighlight} from '@workday/canvas-kit-react/information-highli
 import {StatusIndicator} from '@workday/canvas-kit-preview-react/status-indicator';
 
 import TooltipStoriesMeta from './Tooltip.stories';
+import {AIDisclosure} from './examples/AIDisclosure';
 import {CustomContent} from './examples/CustomContent';
 import {Default} from './examples/Default';
 import {DelayedTooltip} from './examples/DelayedTooltip';
@@ -136,6 +137,14 @@ tooltip yourself, you can set the `type` to `muted`. This will not add any speci
 to the target element.
 
 <ExampleCodeBlock code={Muted} />
+
+### AI Functionality Disclosure
+
+When a control triggers AI-powered functionality, disclose that to assistive technology users with
+a `description` type tooltip. This adds an `aria-description` to the target element so screen
+reader users are informed of the AI involvement without changing the element's visible label.
+
+<ExampleCodeBlock code={AIDisclosure} />
 
 ### Custom Content
 

--- a/modules/react/tooltip/stories/examples/AIDisclosure.tsx
+++ b/modules/react/tooltip/stories/examples/AIDisclosure.tsx
@@ -1,0 +1,10 @@
+import {PrimaryButton} from '@workday/canvas-kit-react/button';
+import {Tooltip} from '@workday/canvas-kit-react/tooltip';
+
+export const AIDisclosure = () => {
+  return (
+    <Tooltip type="description" title="This functionality is powered by AI.">
+      <PrimaryButton>Summarize</PrimaryButton>
+    </Tooltip>
+  );
+};


### PR DESCRIPTION
## Summary

Resolves: #4125

Adds a new "AI Functionality Disclosure" example and docs section to the Tooltip page, showing how to use `type="description"` to disclose that a control triggers AI-powered functionality (e.g. "This functionality is powered by AI.") to assistive technology users, without changing the element's visible label.

## Release Category
Documentation

### Release Note

---

## Checklist

- [x] MDX documentation adheres to Canvas Kit's Documentation Guidelines
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

- [x] PR title is short and descriptive
- [x] PR summary describes the change (Fixes/Resolves linked correctly)

## Where Should the Reviewer Start?

`modules/react/tooltip/stories/Tooltip.mdx` and the new `modules/react/tooltip/stories/examples/AIDisclosure.tsx`

## Areas for Feedback? (optional)

- [x] Documentation

## Testing Manually

Docs-only MDX + example component change, following the existing example pattern in this file (e.g. `DescriptionType`). I could not run this repo's full yarn/lerna build and typecheck scripts in my environment, so please double-check the MDX renders as expected in Storybook.