### PR TITLE
fix(OverflowTooltip): Add missing showDelay and hideDelay prop support for OverflowTooltip

### DIFF
--- a/modules/react/tooltip/lib/OverflowTooltip.tsx
+++ b/modules/react/tooltip/lib/OverflowTooltip.tsx
@@ -89,6 +89,14 @@ export interface OverflowTooltipProps extends Omit<React.HTMLAttributes<HTMLDivE
    * disable the fallback placements.
    */
   fallbackPlacements?: Placement[];
+  /**
+   * Amount of time (in ms) to delay before showing the Tooltip
+   */
+  showDelay?: number;
+  /**
+   * Amount of time (in ms) to delay before hiding the Tooltip
+   */
+  hideDelay?: number;
 }
 
 function mergeCallbacks<T extends {[key: string]: any}>(
@@ -113,10 +121,16 @@ export const OverflowTooltip = ({
   placement = 'top',
   fallbackPlacements = defaultFallbackPlacements,
   children,
+  showDelay,
+  hideDelay,
   ...elemProps
 }: OverflowTooltipProps) => {
   const [titleText, setTitleText] = React.useState('');
-  const {targetProps, popperProps, tooltipProps} = useTooltip({type: 'muted'});
+  const {targetProps, popperProps, tooltipProps} = useTooltip({
+    type: 'muted',
+    showDelay,
+    hideDelay,
+  });
 
   const onMouseEnter = (event: React.MouseEvent) => {
     const target = event.currentTarget;

--- a/modules/react/tooltip/spec/OverflowTooltip.spec.tsx
+++ b/modules/react/tooltip/spec/OverflowTooltip.spec.tsx
@@ -1,4 +1,15 @@
-import {findEllipsisElement, findOverflowElement} from '..';
+import {fireEvent, render, screen} from '@testing-library/react';
+import {act} from 'react-dom/test-utils';
+
+import {OverflowTooltip, findEllipsisElement, findOverflowElement} from '..';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe('findEllipsisElement', () => {
   it('returns null if element has no children attribute [SVG in IE 11]', () => {
@@ -11,5 +22,65 @@ describe('findOverflowElement', () => {
   it('returns null if element has no children attribute [SVG in IE 11]', () => {
     const el = document.createElement('svg');
     expect(findOverflowElement(el)).toBeNull();
+  });
+});
+
+describe('OverflowTooltip', () => {
+  const markAsOverflowed = (target: HTMLElement) => {
+    Object.defineProperty(target, 'scrollWidth', {configurable: true, value: 200});
+    Object.defineProperty(target, 'clientWidth', {configurable: true, value: 100});
+  };
+
+  it('should render the tooltip after the delay when "showDelay" is passed', () => {
+    render(
+      <OverflowTooltip showDelay={1000}>
+        <span style={{overflow: 'hidden'}}>Overflowed Text</span>
+      </OverflowTooltip>
+    );
+
+    const target = screen.getByText('Overflowed Text');
+    markAsOverflowed(target);
+
+    fireEvent.mouseEnter(target);
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(screen.queryByRole('tooltip')).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(700);
+    });
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+  });
+
+  it('should hide the tooltip after the delay when "hideDelay" is passed', () => {
+    render(
+      <OverflowTooltip hideDelay={300}>
+        <span style={{overflow: 'hidden'}}>Overflowed Text</span>
+      </OverflowTooltip>
+    );
+
+    const target = screen.getByText('Overflowed Text');
+    markAsOverflowed(target);
+
+    fireEvent.mouseEnter(target);
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+    fireEvent.mouseLeave(target);
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(screen.queryByRole('tooltip')).toBeNull();
   });
 });

--- a/modules/react/tooltip/stories/examples/Ellipsis.tsx
+++ b/modules/react/tooltip/stories/examples/Ellipsis.tsx
@@ -52,6 +52,11 @@ export const Ellipsis = () => {
       <OverflowTooltip>
         <CustomContent />
       </OverflowTooltip>
+      <OverflowTooltip showDelay={2000} hideDelay={2000}>
+        <SecondaryButton cs={{maxWidth: px2rem(200)}}>
+          2 second delay on show and hide content
+        </SecondaryButton>
+      </OverflowTooltip>
     </React.Fragment>
   );
 };


### PR DESCRIPTION
## Summary

Fixes: #3614 

- Adds showDelay and hideDelay values for the OverflowTooltip. This was flagged as an oversight at the time, so I've categorised this as a fix. 
- Adds tests and example in Storybook. 

## Release Category

Components

### Release Note

- Adds ability to pass showDelay and hideDelay values for OverflowTooltip

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--docs)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

- The Ellipsis story update gives an example of these additional props. 

## Areas for Feedback? (optional)

- [ ] Code
- [ ] Documentation
- [ ] Testing
- [ ] Codemods

## Testing Manually

- I've updated the Ellipsis story to add `hideDelay` and `showDelay` values, so you can see it working there. 

## Screenshots or GIFs (if applicable)

- N/A

## Thank You Gif (optional)

<!-- ![a smiling Shiba Inu typing on a laptop](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable delays for showing and hiding overflow tooltips.
  * Added an example demonstrating two-second show and hide delays.

* **Tests**
  * Added coverage for delayed tooltip display and hiding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->