### PR TITLE
chore: Fix npm publish failures

### DIFF
--- a/.github/workflows/complete-unpublished.yml
+++ b/.github/workflows/complete-unpublished.yml
@@ -1,0 +1,45 @@
+name: Complete unpublished packages
+
+# Publishes workspace versions that are not yet on npm, without bumping.
+# Used to recover from a partial `lerna publish` (e.g. Sigstore tlog 409).
+on:
+  workflow_call:
+    inputs:
+      dist_tag:
+        required: true
+        type: string
+        description: 'npm dist-tag to apply (latest or support)'
+
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
+
+jobs:
+  complete-unpublished:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: Workday/canvas-kit-actions/install@v2
+        with:
+          node_version: 24.x
+
+      - name: Clear auth token for OIDC
+        run: echo "NODE_AUTH_TOKEN=" >> $GITHUB_ENV
+
+      - name: Upgrade npm for OIDC
+        run: npm install -g npm@11.11.0
+
+      - name: Configure npm registry
+        run: npm config set registry https://registry.npmjs.org/
+
+      - name: Build
+        run: yarn build
+        env:
+          TSP_SKIP_CACHE: true
+
+      - name: Publish unpublished packages
+        run: node utils/publish-packages.mjs --dist-tag ${{ inputs.dist_tag }}

--- a/.github/workflows/complete-unpublished.yml
+++ b/.github/workflows/complete-unpublished.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   complete-unpublished:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -28,7 +29,7 @@ jobs:
           node_version: 24.x
 
       - name: Clear auth token for OIDC
-        run: echo "NODE_AUTH_TOKEN=" >> $GITHUB_ENV
+        run: echo "NODE_AUTH_TOKEN=" >> "$GITHUB_ENV"
 
       - name: Upgrade npm for OIDC
         run: npm install -g npm@11.11.0
@@ -42,4 +43,11 @@ jobs:
           TSP_SKIP_CACHE: true
 
       - name: Publish unpublished packages
-        run: node utils/publish-packages.mjs --dist-tag ${{ inputs.dist_tag }}
+        env:
+          DIST_TAG: ${{ inputs.dist_tag }}
+        run: |
+          case "$DIST_TAG" in
+            latest|support|next|prerelease-next) ;;
+            *) echo "::error::Unsupported dist_tag: $DIST_TAG"; exit 1 ;;
+          esac
+          yarn publish:from-package -- --dist-tag "$DIST_TAG"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ name: Publish to npm
 # - Patch releases (automatic on master/support branches) → release.yml
 # - Minor releases (manual workflow_dispatch) → release-minor.yml
 # - Major releases (manual workflow_dispatch) → release-major.yml
+# - Complete unpublished (manual workflow_dispatch) → complete-unpublished.yml
 #
 # Commits containing [skip release] will skip publishing but still trigger forward-merge.
 #
@@ -20,12 +21,15 @@ on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: 'Release type (minor or major)'
+        description:
+          'Release type. Use complete-unpublished to finish a partial publish without bumping
+          versions.'
         required: true
         type: choice
         options:
           - minor
           - major
+          - complete-unpublished
 
 permissions:
   id-token: write # Required for OIDC
@@ -128,4 +132,13 @@ jobs:
     needs: determine-publish-type
     if: needs.determine-publish-type.outputs.publish_type == 'major'
     uses: ./.github/workflows/release-major.yml
+    secrets: inherit
+
+  # Finish packages missing from npm after a partial publish. Does not bump versions.
+  complete-unpublished:
+    needs: determine-publish-type
+    if: needs.determine-publish-type.outputs.publish_type == 'complete-unpublished'
+    uses: ./.github/workflows/complete-unpublished.yml
+    with:
+      dist_tag: ${{ github.ref_name == 'support' && 'support' || 'latest' }}
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,14 +58,14 @@ jobs:
           # For workflow_dispatch, use the selected release type
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "publish_type=${{ inputs.release_type }}" >> $GITHUB_OUTPUT
-            echo "branch=master" >> $GITHUB_OUTPUT
+            echo "branch=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
             echo "::notice::Workflow dispatch detected - release type: ${{ inputs.release_type }}"
             exit 0
           fi
 
           # For push events, determine type based on branch
-          BRANCH="${{ github.ref_name }}"
-          echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
+          BRANCH="$GITHUB_REF_NAME"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
 
           if [[ "$BRANCH" == prerelease/* ]]; then
             echo "publish_type=canary" >> $GITHUB_OUTPUT
@@ -140,5 +140,4 @@ jobs:
     if: needs.determine-publish-type.outputs.publish_type == 'complete-unpublished'
     uses: ./.github/workflows/complete-unpublished.yml
     with:
-      dist_tag: ${{ github.ref_name == 'support' && 'support' || 'latest' }}
-    secrets: inherit
+      dist_tag: ${{ needs.determine-publish-type.outputs.branch == 'support' && 'support' || 'latest' }}

--- a/.github/workflows/release-major.yml
+++ b/.github/workflows/release-major.yml
@@ -51,6 +51,8 @@ jobs:
 
       # Run the release job to publish the next major version to npm
       - uses: Workday/canvas-kit-actions/release@v2
+        id: release
+        continue-on-error: true
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           gh_rw_token: ${{ secrets.GH_RW_TOKEN }}
@@ -60,8 +62,13 @@ jobs:
 
       ## See release.yml: finish any packages a failed lerna publish left unpublished.
       - name: Publish remaining packages
-        if: failure()
-        run: node utils/publish-packages.mjs --dist-tag latest
+        id: publish-remaining
+        if: steps.release.outcome == 'failure'
+        run: yarn publish:from-package -- --dist-tag latest --require-unpublished
+
+      - name: Verify npm publish completed
+        if: steps.release.outcome == 'failure' && steps.publish-remaining.outcome != 'success'
+        run: exit 1
 
       # Update prerelease/minor to point to the next major release.
       - name: Push to prerelease/minor
@@ -89,4 +96,6 @@ jobs:
         with:
           slackWebhook: ${{ secrets.SLACK_WEBHOOK }}
           slackMessage: |
-            Major Release job failed. Please check error logs.
+            Major release job failed. If npm publish was recovered but branch updates did not
+            run, manually push master to prerelease/minor and prerelease/major and update the
+            support dist-tag. See error logs for details.

--- a/.github/workflows/release-major.yml
+++ b/.github/workflows/release-major.yml
@@ -58,6 +58,11 @@ jobs:
           version: 'major'
           toRef: 'prerelease/major'
 
+      ## See release.yml: finish any packages a failed lerna publish left unpublished.
+      - name: Publish remaining packages
+        if: failure()
+        run: node utils/publish-packages.mjs --dist-tag latest
+
       # Update prerelease/minor to point to the next major release.
       - name: Push to prerelease/minor
         uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # v1.3.0

--- a/.github/workflows/release-minor.yml
+++ b/.github/workflows/release-minor.yml
@@ -42,6 +42,11 @@ jobs:
           chromatic_project_token: ${{ secrets.CHROMATIC_APP_CODE }}
           version: 'minor'
 
+      ## See release.yml: finish any packages a failed lerna publish left unpublished.
+      - name: Publish remaining packages
+        if: failure()
+        run: node utils/publish-packages.mjs --dist-tag latest
+
       - uses: Workday/canvas-kit-actions/report-failure@v2
         if: failure()
         with:

--- a/.github/workflows/release-minor.yml
+++ b/.github/workflows/release-minor.yml
@@ -36,6 +36,8 @@ jobs:
         run: npm config set registry https://registry.npmjs.org/
 
       - uses: Workday/canvas-kit-actions/release@v2
+        id: release
+        continue-on-error: true
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           gh_rw_token: ${{ secrets.GH_RW_TOKEN }}
@@ -44,8 +46,13 @@ jobs:
 
       ## See release.yml: finish any packages a failed lerna publish left unpublished.
       - name: Publish remaining packages
-        if: failure()
-        run: node utils/publish-packages.mjs --dist-tag latest
+        id: publish-remaining
+        if: steps.release.outcome == 'failure'
+        run: yarn publish:from-package -- --dist-tag latest --require-unpublished
+
+      - name: Verify npm publish completed
+        if: steps.release.outcome == 'failure' && steps.publish-remaining.outcome != 'success'
+        run: exit 1
 
       - uses: Workday/canvas-kit-actions/report-failure@v2
         if: failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,15 @@ jobs:
           version: ${{ inputs.version }}
           toRef: ${{ inputs.to_ref }}
 
+      ## Safety net: `lerna publish from-package` is idempotent (skips versions already on
+      ## npm). If the release action aborts mid-set — typically a Sigstore transparency-log
+      ## 409 during trusted publishing — this finishes the remainder without bumping again.
+      - name: Publish remaining packages
+        if: failure()
+        run:
+          node utils/publish-packages.mjs --dist-tag ${{ inputs.branch == 'master' && 'latest' ||
+          'support' }}
+
       - uses: Workday/canvas-kit-actions/report-failure@v2
         if: failure()
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,8 @@ jobs:
         run: npm config set registry https://registry.npmjs.org/
 
       - uses: Workday/canvas-kit-actions/release@v2
+        id: release
+        continue-on-error: true
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           gh_rw_token: ${{ secrets.GH_RW_TOKEN }}
@@ -64,10 +66,15 @@ jobs:
       ## npm). If the release action aborts mid-set — typically a Sigstore transparency-log
       ## 409 during trusted publishing — this finishes the remainder without bumping again.
       - name: Publish remaining packages
-        if: failure()
+        id: publish-remaining
+        if: steps.release.outcome == 'failure'
         run:
-          node utils/publish-packages.mjs --dist-tag ${{ inputs.branch == 'master' && 'latest' ||
-          'support' }}
+          yarn publish:from-package -- --dist-tag ${{ inputs.branch == 'master' && 'latest' ||
+          'support' }} --require-unpublished
+
+      - name: Verify npm publish completed
+        if: steps.release.outcome == 'failure' && steps.publish-remaining.outcome != 'success'
+        run: exit 1
 
       - uses: Workday/canvas-kit-actions/report-failure@v2
         if: failure()

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,5 @@
 {
-  "packages": [
-    "modules/**"
-  ],
+  "packages": ["modules/**"],
   "version": "16.0.7",
   "npmClient": "yarn",
   "command": {
@@ -12,7 +10,8 @@
       "forcePublish": "*"
     },
     "publish": {
-      "forcePublish": "*"
+      "forcePublish": "*",
+      "concurrency": 1
     }
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -10,7 +10,6 @@
       "forcePublish": "*"
     },
     "publish": {
-      "forcePublish": "*",
       "concurrency": 1
     }
   }

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "format:prettier": "prettier --config=./.prettierrc.mjs --ignore-path=./.prettierignore \"**/*.{js,jsx,json,ts,tsx,md}\" --write",
     "format": "yarn eslint --fix",
     "test": "vitest run",
+    "publish:from-package": "node utils/publish-packages.mjs",
     "bump": "lerna version",
     "bump:prerelease": "lerna version prerelease --exact --preid",
     "cypress:open": "cypress open",

--- a/utils/publish-canary.mjs
+++ b/utils/publish-canary.mjs
@@ -7,7 +7,11 @@ import fetch from 'node-fetch';
 import fs from 'node:fs';
 import {promisify} from 'util';
 
-import {isRetryablePublishFailure, publishFromPackage} from './publish-packages.mjs';
+import {
+  getUnpublishedPackages,
+  isRetryablePublishFailure,
+  parsePublishedPackageLines,
+} from './publish-packages.mjs';
 
 const exec = promisify(childProcess.exec);
 
@@ -18,16 +22,26 @@ const {
   BUILD_URL = 'https://github.com/Workday/canvas-kit/actions',
 } = process.env;
 
+if (!GITHUB_REF) {
+  console.error('GITHUB_REF is required');
+  process.exit(1);
+}
+
 console.log('GITHUB_REF', GITHUB_REF);
 const branch = GITHUB_REF.replace('refs/heads/', '');
 const prefixedBuildNumber = GITHUB_RUN_NUMBER.padStart(4, '0');
 
 const isPreMajor = branch.match(/^prerelease\/major$/g);
 const isPreMinor = branch.match(/^prerelease\/minor$/g);
+
+/** @type {{sha?: string, version?: string, packages?: string[] | null}} */
 const data = {};
 
+/** @type {string} */
 let distTag;
+/** @type {string} */
 let preid;
+/** @type {string} */
 let bump;
 
 if (isPreMajor) {
@@ -39,7 +53,12 @@ if (isPreMajor) {
   process.exit(1);
 }
 
+/** @param {Record<string, string>} attachment */
 const slackAnnouncement = attachment => {
+  if (!SLACK_WEBHOOK) {
+    return;
+  }
+
   fetch(SLACK_WEBHOOK, {
     method: 'post',
     headers: {'Content-Type': 'application/json'},
@@ -121,23 +140,66 @@ exec('git diff --name-only HEAD HEAD^')
       bump,
     ];
 
-    return exec(`yarn lerna publish ${lernaFlags.join(' ')}`).catch(async err => {
-      const output = `${err.stdout || ''}\n${err.stderr || ''}\n${err.message || ''}`;
+    const lernaCommand = `yarn lerna publish ${lernaFlags.join(' ')}`;
+
+    return exec(lernaCommand)
+      .then(({stdout}) => ({stdout, packages: undefined}))
+      .catch(async err => {
+      const execErr = /** @type {Error & {stdout?: string, stderr?: string}} */ (err);
+      const output = `${execErr.stdout ?? ''}\n${execErr.stderr ?? ''}\n${execErr.message}`;
       if (!isRetryablePublishFailure(output)) {
         throw err;
       }
-      console.warn(
-        'Canary publish hit a retryable registry/provenance error. Completing unpublished packages...'
+
+      const attempted = parsePublishedPackageLines(output).filter(pkg =>
+        pkg.version.includes(`-${preid}.`)
       );
-      await publishFromPackage({distTag});
-      return {stdout: output};
+      if (attempted.length === 0) {
+        throw err;
+      }
+
+      let missing = await getUnpublishedPackages(attempted);
+      if (missing.length === 0) {
+        console.warn('All attempted canary versions are already on npm.');
+        return {
+          stdout: output,
+          packages: attempted.map(pkg => `${pkg.name}@${pkg.version}`),
+        };
+      }
+
+      console.warn(
+        `Canary publish hit a retryable registry/provenance error. Retrying missing versions:\n${missing
+          .map(pkg => `${pkg.name}@${pkg.version}`)
+          .join('\n')}`
+      );
+
+      const retryResult = await exec(lernaCommand);
+      const retryOutput = `${output}\n${retryResult.stdout ?? ''}\n${retryResult.stderr ?? ''}`;
+      const published = parsePublishedPackageLines(retryOutput).filter(pkg =>
+        pkg.version.includes(`-${preid}.`)
+      );
+      missing = await getUnpublishedPackages(published.length > 0 ? published : attempted);
+      if (missing.length > 0) {
+        throw new Error(
+          `Canary recovery failed. Still missing:\n${missing
+            .map(pkg => `${pkg.name}@${pkg.version}`)
+            .join('\n')}`
+        );
+      }
+
+      return {
+        stdout: retryOutput,
+        packages: (published.length > 0 ? published : attempted).map(
+          pkg => `${pkg.name}@${pkg.version}`
+        ),
+      };
     });
   })
-  .then(({stdout}) => {
+  .then(({stdout, packages}) => {
     console.log(stdout);
 
     const regex = new RegExp(`@workday\\/[a-z-]*@(\\d*.\\d*.\\d*-${preid}.\\d*)`, 'g');
-    data.packages = stdout.match(regex);
+    data.packages = packages ?? stdout.match(regex);
     const versionMatch = data.packages ? regex.exec(data.packages[0]) : null;
     data.version = versionMatch
       ? versionMatch[1]

--- a/utils/publish-canary.mjs
+++ b/utils/publish-canary.mjs
@@ -2,9 +2,13 @@
 // @ts-check
 'use strict';
 
-import fetch from 'node-fetch';
-import {promisify} from 'util';
 import * as childProcess from 'child_process';
+import fetch from 'node-fetch';
+import fs from 'node:fs';
+import {promisify} from 'util';
+
+import {isRetryablePublishFailure, publishFromPackage} from './publish-packages.mjs';
+
 const exec = promisify(childProcess.exec);
 
 const {
@@ -113,17 +117,31 @@ exec('git diff --name-only HEAD HEAD^')
       `--force-publish="*"`,
       `--preid ${preid}`,
       `--dist-tag ${distTag}`,
+      `--concurrency 1`,
       bump,
     ];
 
-    return exec(`yarn lerna publish ${lernaFlags.join(' ')}`);
+    return exec(`yarn lerna publish ${lernaFlags.join(' ')}`).catch(async err => {
+      const output = `${err.stdout || ''}\n${err.stderr || ''}\n${err.message || ''}`;
+      if (!isRetryablePublishFailure(output)) {
+        throw err;
+      }
+      console.warn(
+        'Canary publish hit a retryable registry/provenance error. Completing unpublished packages...'
+      );
+      await publishFromPackage({distTag});
+      return {stdout: output};
+    });
   })
   .then(({stdout}) => {
     console.log(stdout);
 
     const regex = new RegExp(`@workday\\/[a-z-]*@(\\d*.\\d*.\\d*-${preid}.\\d*)`, 'g');
     data.packages = stdout.match(regex);
-    data.version = regex.exec(data.packages[0])[1];
+    const versionMatch = data.packages ? regex.exec(data.packages[0]) : null;
+    data.version = versionMatch
+      ? versionMatch[1]
+      : JSON.parse(fs.readFileSync('lerna.json', 'utf8')).version;
 
     slackAnnouncement({
       fallback: `New canary build published (v${data.version})`,

--- a/utils/publish-packages.mjs
+++ b/utils/publish-packages.mjs
@@ -2,6 +2,14 @@
 // @ts-check
 'use strict';
 
+/**
+ * Finishes a partial npm release without bumping versions again.
+ *
+ * Compares each public workspace package's current version against the registry,
+ * then runs `lerna publish from-package` for anything still missing. Safe to call
+ * after a failed release job because already-published versions are skipped.
+ */
+
 import {execFile, spawn} from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -10,11 +18,141 @@ import {promisify} from 'node:util';
 
 const execFileAsync = promisify(execFile);
 
-const BUILD_MARKER = path.join('modules', 'react', 'dist', 'es6', 'index.js');
+// Resolve paths from this file's location so checks work regardless of cwd.
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const BUILD_MARKER = path.join(REPO_ROOT, 'modules', 'react', 'dist', 'es6', 'index.js');
 const DEFAULT_RETRIES = 5;
 const RETRY_BASE_MS = 8000;
+const REGISTRY_CHECK_CONCURRENCY = 4;
+const ALLOWED_DIST_TAGS = new Set(['latest', 'support', 'next', 'prerelease-next']);
+
+/** @typedef {{distTag: string, retries: number, verifyOnly: boolean, requireUnpublished: boolean}} PublishArgs */
 
 /**
+ * Starting point before CLI flags are applied.
+ *
+ * @returns {PublishArgs}
+ */
+function createDefaultPublishArgs() {
+  return {
+    distTag: '',
+    retries: DEFAULT_RETRIES,
+    verifyOnly: false,
+    requireUnpublished: false,
+  };
+}
+
+/**
+ * Reads a single CLI option in either `--flag value` or `--flag=value` form.
+ *
+ * @param {string[]} argv
+ * @param {number} index
+ * @param {string} flag
+ * @returns {{value: string, nextIndex: number} | null}
+ */
+function readOptionValue(argv, index, flag) {
+  const arg = argv[index];
+  const equalsPrefix = `${flag}=`;
+
+  // `--dist-tag=latest`
+  if (arg.startsWith(equalsPrefix)) {
+    return {value: arg.slice(equalsPrefix.length), nextIndex: index};
+  }
+
+  // Not the flag we're looking for; let the caller try another parser.
+  if (arg !== flag) {
+    return null;
+  }
+
+  const value = argv[index + 1];
+  // `--dist-tag` with no value, or followed by another flag.
+  if (value === undefined || value.startsWith('--')) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+
+  return {value, nextIndex: index + 1};
+}
+
+/**
+ * Walks process.argv and fills in dist-tag, retries, and verify-only flags.
+ *
+ * @param {string[]} argv
+ * @returns {PublishArgs}
+ */
+function parsePublishArgsFromArgv(argv) {
+  const args = createDefaultPublishArgs();
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+
+    if (arg === '--verify-only') {
+      args.verifyOnly = true;
+      continue;
+    }
+
+    if (arg === '--require-unpublished') {
+      args.requireUnpublished = true;
+      continue;
+    }
+
+    const distTag = readOptionValue(argv, i, '--dist-tag');
+    if (distTag) {
+      args.distTag = distTag.value;
+      i = distTag.nextIndex;
+      continue;
+    }
+
+    const retries = readOptionValue(argv, i, '--retries');
+    if (retries) {
+      args.retries = Number(retries.value);
+      i = retries.nextIndex;
+    }
+  }
+
+  return args;
+}
+
+/**
+ * Ensures parsed CLI input is complete and safe to act on.
+ *
+ * @param {PublishArgs} args
+ */
+function validatePublishArgs(args) {
+  // Publishing requires a dist-tag; verify-only mode checks npm without publishing.
+  if (!args.verifyOnly && !args.distTag) {
+    throw new Error('Missing required --dist-tag (latest, support, next, or prerelease-next)');
+  }
+
+  // Reject mistyped or unsupported tags before we touch the registry.
+  if (args.distTag && !ALLOWED_DIST_TAGS.has(args.distTag)) {
+    throw new Error(
+      `Unsupported dist-tag "${args.distTag}". Expected one of: ${[...ALLOWED_DIST_TAGS].join(', ')}`
+    );
+  }
+
+  // Retries must be a positive integer so the publish loop has a well-defined limit.
+  if (!Number.isInteger(args.retries) || args.retries < 1) {
+    throw new Error(`Invalid --retries value: ${args.retries}`);
+  }
+}
+
+/**
+ * Parses and validates CLI flags for direct script invocation or tests.
+ *
+ * @param {string[]} argv
+ * @returns {PublishArgs}
+ */
+export function parsePublishArgs(argv) {
+  const args = parsePublishArgsFromArgv(argv);
+  validatePublishArgs(args);
+  return args;
+}
+
+/**
+ * Returns true when npm/Lerna output looks like a transient failure worth retrying
+ * (Sigstore transparency-log conflicts, network blips, or registry 5xx), as opposed to
+ * a permanent error such as auth or permission denial.
+ *
  * @param {string} output
  */
 export function isRetryablePublishFailure(output) {
@@ -24,42 +162,14 @@ export function isRetryablePublishFailure(output) {
 }
 
 /**
- * @param {string[]} argv
- */
-export function parsePublishArgs(argv) {
-  /** @type {{distTag: string, retries: number, verifyOnly: boolean}} */
-  const args = {distTag: '', retries: DEFAULT_RETRIES, verifyOnly: false};
-
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
-    if (arg === '--verify-only') {
-      args.verifyOnly = true;
-    } else if (arg === '--dist-tag') {
-      args.distTag = argv[++i] ?? '';
-    } else if (arg.startsWith('--dist-tag=')) {
-      args.distTag = arg.slice('--dist-tag='.length);
-    } else if (arg === '--retries') {
-      args.retries = Number(argv[++i]);
-    } else if (arg.startsWith('--retries=')) {
-      args.retries = Number(arg.slice('--retries='.length));
-    }
-  }
-
-  if (!args.verifyOnly && !args.distTag) {
-    throw new Error('Missing required --dist-tag (latest, support, next, or prerelease-next)');
-  }
-  if (!Number.isFinite(args.retries) || args.retries < 1) {
-    throw new Error(`Invalid --retries value: ${args.retries}`);
-  }
-
-  return args;
-}
-
-/**
+ * Lists every public package in the monorepo with the version from the current checkout.
+ *
  * @returns {Promise<{name: string, version: string}[]>}
  */
 export async function getPublicPackages() {
   const {stdout} = await execFileAsync('yarn', ['-s', 'lerna', 'ls', '--json']);
+
+  // yarn may print warnings before the JSON array; find the array bounds explicitly.
   const start = stdout.indexOf('[');
   const end = stdout.lastIndexOf(']');
   if (start === -1 || end === -1) {
@@ -69,6 +179,8 @@ export async function getPublicPackages() {
 }
 
 /**
+ * Checks whether an exact package version already exists on the public npm registry.
+ *
  * @param {string} name
  * @param {string} version
  */
@@ -78,24 +190,54 @@ export async function isPackageVersionOnNpm(name, version) {
       timeout: 30000,
     });
     return stdout.trim() === version;
-  } catch {
-    return false;
+  } catch (err) {
+    const execErr = /** @type {Error & {stdout?: string, stderr?: string}} */ (err);
+    const output = `${execErr.stdout ?? ''}\n${execErr.stderr ?? ''}\n${execErr.message}`;
+
+    // Version is actually missing from npm — treat as unpublished, not an operational error.
+    if (/E404|is not in this registry|No match found for version/.test(output)) {
+      return false;
+    }
+
+    // Timeout, auth, or registry outage — do not misreport as "missing from npm".
+    throw new Error(`Could not check ${name}@${version} on npm:\n${output}`, {cause: err});
   }
 }
 
 /**
+ * Runs async work in fixed-size batches to avoid hammering npm with parallel `view` calls.
+ *
+ * @template T, R
+ * @param {T[]} items
+ * @param {number} limit
+ * @param {(item: T) => Promise<R>} fn
+ * @returns {Promise<R[]>}
+ */
+async function mapWithConcurrency(items, limit, fn) {
+  const results = [];
+  for (let i = 0; i < items.length; i += limit) {
+    const batch = items.slice(i, i + limit);
+    results.push(...(await Promise.all(batch.map(fn))));
+  }
+  return results;
+}
+
+/**
+ * Returns workspace packages whose current version is not yet on npm.
+ *
  * @param {{name: string, version: string}[]} packages
  */
 export async function getUnpublishedPackages(packages) {
-  const results = await Promise.all(
-    packages.map(async pkg => ({
-      pkg,
-      published: await isPackageVersionOnNpm(pkg.name, pkg.version),
-    }))
-  );
+  const results = await mapWithConcurrency(packages, REGISTRY_CHECK_CONCURRENCY, async pkg => ({
+    pkg,
+    published: await isPackageVersionOnNpm(pkg.name, pkg.version),
+  }));
   return results.filter(result => !result.published).map(result => result.pkg);
 }
 
+/**
+ * Refuses to publish when CI forgot to build — Lerna would ship stale or empty tarballs.
+ */
 function assertPackagesBuilt() {
   if (!fs.existsSync(BUILD_MARKER)) {
     throw new Error(
@@ -105,6 +247,9 @@ function assertPackagesBuilt() {
 }
 
 /**
+ * Runs a child process and streams stdout/stderr to the console while capturing output
+ * for retry/error classification.
+ *
  * @param {string} command
  * @param {string[]} args
  * @returns {Promise<{code: number | null, output: string}>}
@@ -134,6 +279,8 @@ function runStreaming(command, args) {
 }
 
 /**
+ * Waits longer on each subsequent attempt to give Sigstore/npm time to settle.
+ *
  * @param {number} attempt
  */
 function waitForRetry(attempt) {
@@ -143,10 +290,30 @@ function waitForRetry(attempt) {
 }
 
 /**
+ * Formats package names for log and error messages.
+ *
  * @param {{name: string, version: string}[]} packages
  */
 function formatPackageList(packages) {
   return packages.map(pkg => `${pkg.name}@${pkg.version}`).join('\n');
+}
+
+/**
+ * Parses `@scope/name@version` strings from Lerna publish output.
+ *
+ * @param {string} output
+ * @returns {{name: string, version: string}[]}
+ */
+export function parsePublishedPackageLines(output) {
+  /** @type {Map<string, {name: string, version: string}>} */
+  const packages = new Map();
+
+  for (const match of output.matchAll(/@workday\/([a-z-]+)@(\d+\.\d+\.\d+(?:-[^\s'"]+)?)/g)) {
+    const name = `@workday/${match[1]}`;
+    packages.set(name, {name, version: match[2]});
+  }
+
+  return [...packages.values()];
 }
 
 /**
@@ -155,20 +322,34 @@ function formatPackageList(packages) {
  * safe to retry after a partial release. Serial publishes plus retries recover
  * from Sigstore transparency-log 409s during npm trusted publishing.
  *
- * @param {{distTag: string, retries?: number, verifyOnly?: boolean}} options
+ * @param {{distTag: string, retries?: number, verifyOnly?: boolean, requireUnpublished?: boolean}} options
  */
-export async function publishFromPackage({distTag, retries = DEFAULT_RETRIES, verifyOnly = false}) {
+export async function publishFromPackage({
+  distTag,
+  retries = DEFAULT_RETRIES,
+  verifyOnly = false,
+  requireUnpublished = false,
+}) {
   const packages = await getPublicPackages();
   console.log(`Checking ${packages.length} public packages against the npm registry...`);
 
   let unpublished = await getUnpublishedPackages(packages);
+
+  // Nothing to do — the release is already complete on npm for this checkout.
   if (unpublished.length === 0) {
+    if (requireUnpublished) {
+      throw new Error(
+        'Release recovery found no unpublished packages. The release step likely failed for a reason other than a partial npm publish.'
+      );
+    }
+
     console.log('All workspace package versions are already on npm.');
     return packages;
   }
 
   console.log(`Missing from npm:\n${formatPackageList(unpublished)}`);
 
+  // Dry run for CI checks: report gaps without publishing.
   if (verifyOnly) {
     throw new Error(
       `Verify failed. The following versions are not on npm:\n${formatPackageList(unpublished)}`
@@ -192,11 +373,14 @@ export async function publishFromPackage({distTag, retries = DEFAULT_RETRIES, ve
     ]);
 
     unpublished = await getUnpublishedPackages(packages);
+
+    // Re-check the registry; Lerna may exit non-zero even after some packages landed.
     if (unpublished.length === 0) {
       console.log('All workspace package versions are on npm.');
       return packages;
     }
 
+    // Lerna can exit 0 while packages are still missing, or non-zero for retryable tlog errors.
     const retryable = result.code === 0 || isRetryablePublishFailure(result.output);
     if (!retryable) {
       throw new Error(
@@ -207,6 +391,8 @@ export async function publishFromPackage({distTag, retries = DEFAULT_RETRIES, ve
     }
 
     console.warn(`Retryable publish failure. Still missing:\n${formatPackageList(unpublished)}`);
+
+    // Back off before the next from-package pass (which skips versions already on npm).
     if (attempt < retries) {
       await waitForRetry(attempt);
     }
@@ -218,6 +404,7 @@ export async function publishFromPackage({distTag, retries = DEFAULT_RETRIES, ve
   );
 }
 
+// Allow `node utils/publish-packages.mjs --dist-tag latest` from release workflows.
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   Promise.resolve()
     .then(() => publishFromPackage(parsePublishArgs(process.argv.slice(2))))

--- a/utils/publish-packages.mjs
+++ b/utils/publish-packages.mjs
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+// @ts-check
+'use strict';
+
+import {execFile, spawn} from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {promisify} from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const BUILD_MARKER = path.join('modules', 'react', 'dist', 'es6', 'index.js');
+const DEFAULT_RETRIES = 5;
+const RETRY_BASE_MS = 8000;
+
+/**
+ * @param {string} output
+ */
+export function isRetryablePublishFailure(output) {
+  return /TLOG_CREATE_ENTRY_ERROR|error creating tlog entry|an equivalent entry already exists|ECONNRESET|ETIMEDOUT|EAI_AGAIN|502 Bad Gateway|503 Service Unavailable/.test(
+    output
+  );
+}
+
+/**
+ * @param {string[]} argv
+ */
+export function parsePublishArgs(argv) {
+  /** @type {{distTag: string, retries: number, verifyOnly: boolean}} */
+  const args = {distTag: '', retries: DEFAULT_RETRIES, verifyOnly: false};
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--verify-only') {
+      args.verifyOnly = true;
+    } else if (arg === '--dist-tag') {
+      args.distTag = argv[++i] ?? '';
+    } else if (arg.startsWith('--dist-tag=')) {
+      args.distTag = arg.slice('--dist-tag='.length);
+    } else if (arg === '--retries') {
+      args.retries = Number(argv[++i]);
+    } else if (arg.startsWith('--retries=')) {
+      args.retries = Number(arg.slice('--retries='.length));
+    }
+  }
+
+  if (!args.verifyOnly && !args.distTag) {
+    throw new Error('Missing required --dist-tag (latest, support, next, or prerelease-next)');
+  }
+  if (!Number.isFinite(args.retries) || args.retries < 1) {
+    throw new Error(`Invalid --retries value: ${args.retries}`);
+  }
+
+  return args;
+}
+
+/**
+ * @returns {Promise<{name: string, version: string}[]>}
+ */
+export async function getPublicPackages() {
+  const {stdout} = await execFileAsync('yarn', ['-s', 'lerna', 'ls', '--json']);
+  const start = stdout.indexOf('[');
+  const end = stdout.lastIndexOf(']');
+  if (start === -1 || end === -1) {
+    throw new Error(`Could not parse package list from lerna ls output:\n${stdout}`);
+  }
+  return JSON.parse(stdout.slice(start, end + 1));
+}
+
+/**
+ * @param {string} name
+ * @param {string} version
+ */
+export async function isPackageVersionOnNpm(name, version) {
+  try {
+    const {stdout} = await execFileAsync('npm', ['view', `${name}@${version}`, 'version'], {
+      timeout: 30000,
+    });
+    return stdout.trim() === version;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * @param {{name: string, version: string}[]} packages
+ */
+export async function getUnpublishedPackages(packages) {
+  const results = await Promise.all(
+    packages.map(async pkg => ({
+      pkg,
+      published: await isPackageVersionOnNpm(pkg.name, pkg.version),
+    }))
+  );
+  return results.filter(result => !result.published).map(result => result.pkg);
+}
+
+function assertPackagesBuilt() {
+  if (!fs.existsSync(BUILD_MARKER)) {
+    throw new Error(
+      `Refusing to publish: ${BUILD_MARKER} is missing. Packages do not appear to be built.`
+    );
+  }
+}
+
+/**
+ * @param {string} command
+ * @param {string[]} args
+ * @returns {Promise<{code: number | null, output: string}>}
+ */
+function runStreaming(command, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      env: process.env,
+    });
+    let output = '';
+
+    child.stdout.on('data', chunk => {
+      const text = String(chunk);
+      output += text;
+      process.stdout.write(text);
+    });
+    child.stderr.on('data', chunk => {
+      const text = String(chunk);
+      output += text;
+      process.stderr.write(text);
+    });
+    child.on('error', reject);
+    child.on('close', code => {
+      resolve({code, output});
+    });
+  });
+}
+
+/**
+ * @param {number} attempt
+ */
+function waitForRetry(attempt) {
+  const delay = RETRY_BASE_MS * attempt;
+  console.log(`Waiting ${delay}ms before retry ${attempt}...`);
+  return new Promise(resolve => setTimeout(resolve, delay));
+}
+
+/**
+ * @param {{name: string, version: string}[]} packages
+ */
+function formatPackageList(packages) {
+  return packages.map(pkg => `${pkg.name}@${pkg.version}`).join('\n');
+}
+
+/**
+ * Publish any workspace versions that are not yet on the registry.
+ * `lerna publish from-package` skips versions that already exist, so this is
+ * safe to retry after a partial release. Serial publishes plus retries recover
+ * from Sigstore transparency-log 409s during npm trusted publishing.
+ *
+ * @param {{distTag: string, retries?: number, verifyOnly?: boolean}} options
+ */
+export async function publishFromPackage({distTag, retries = DEFAULT_RETRIES, verifyOnly = false}) {
+  const packages = await getPublicPackages();
+  console.log(`Checking ${packages.length} public packages against the npm registry...`);
+
+  let unpublished = await getUnpublishedPackages(packages);
+  if (unpublished.length === 0) {
+    console.log('All workspace package versions are already on npm.');
+    return packages;
+  }
+
+  console.log(`Missing from npm:\n${formatPackageList(unpublished)}`);
+
+  if (verifyOnly) {
+    throw new Error(
+      `Verify failed. The following versions are not on npm:\n${formatPackageList(unpublished)}`
+    );
+  }
+
+  assertPackagesBuilt();
+
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    console.log(
+      `Publishing unpublished packages (attempt ${attempt}/${retries}) with dist-tag "${distTag}" and concurrency 1...`
+    );
+
+    const result = await runStreaming('yarn', [
+      'lerna',
+      'publish',
+      'from-package',
+      '--yes',
+      `--dist-tag=${distTag}`,
+      '--concurrency=1',
+    ]);
+
+    unpublished = await getUnpublishedPackages(packages);
+    if (unpublished.length === 0) {
+      console.log('All workspace package versions are on npm.');
+      return packages;
+    }
+
+    const retryable = result.code === 0 || isRetryablePublishFailure(result.output);
+    if (!retryable) {
+      throw new Error(
+        `Publish failed with a non-retryable error. Still missing:\n${formatPackageList(
+          unpublished
+        )}`
+      );
+    }
+
+    console.warn(`Retryable publish failure. Still missing:\n${formatPackageList(unpublished)}`);
+    if (attempt < retries) {
+      await waitForRetry(attempt);
+    }
+  }
+
+  unpublished = await getUnpublishedPackages(packages);
+  throw new Error(
+    `Exhausted ${retries} publish attempts. Still missing:\n${formatPackageList(unpublished)}`
+  );
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  Promise.resolve()
+    .then(() => publishFromPackage(parsePublishArgs(process.argv.slice(2))))
+    .catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary

Fixes: #4149

Release publishes have been failing intermittently when `canvas-kit-actions/release@v2` runs `lerna publish from-package`. Most packages land on npm, but the job exits non-zero and leaves a partial version set behind.

In [the failing run](https://github.com/Workday/canvas-kit/actions/runs/32310458799/job/96252223881), `@workday/canvas-kit-codemod` and `@workday/canvas-kit-preview-react` failed with `TLOG_CREATE_ENTRY_ERROR` (Sigstore transparency-log 409) while other `16.0.7` packages published successfully. npm trusted publishing signs each package with provenance; concurrent Lerna publishes can race on Sigstore writes, npm treats the 409 as fatal, and Lerna does not roll back packages that already landed.

This PR makes publishing more reliable and recoverable:

- **Serialize publishes** — set `command.publish.concurrency: 1` in `lerna.json` to reduce Sigstore races.
- **Retry + verify** — add `utils/publish-packages.mjs`, which checks the registry for missing workspace versions, runs `lerna publish from-package` serially, retries transient tlog/network errors, and fails only if versions are still missing.
- **Automatic catch-up** — patch/minor/major release workflows run the script on failure (`if: failure()`). `from-package` is idempotent, so this finishes the set without bumping again.
- **Manual recovery** — add a `complete-unpublished` workflow dispatch option on **Publish to npm** for finishing a partial publish without a new version bump.
- **Canary parity** — canary publishes use `--concurrency 1` and the same retry path.

**Follow-up after merge:** merge with `[skip release]` so master does not cut `16.0.8`, then run **Publish to npm → complete-unpublished** on `master` to finish the incomplete `16.0.7` set. Do not re-run the failed release job — that would bump versions.

## Release Category

Infrastructure

### Release Note

Release and canary CI now recover from partial npm publishes caused by Sigstore transparency-log 409s during trusted publishing. A new **complete-unpublished** workflow dispatch option can finish missing packages without bumping versions.

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--docs)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

This is CI/publishing infrastructure only — no component API or styling changes. The main design choice is using registry verification plus idempotent `from-package` retries rather than changing `canvas-kit-actions/release` (which still pushes git tags before publishing).

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

`utils/publish-packages.mjs` — core retry/verify logic. Then `.github/workflows/release.yml` for the automatic catch-up step, and `.github/workflows/publish.yml` for the manual `complete-unpublished` dispatch.

## Areas for Feedback?

- [x] Code
- [ ] Documentation
- [ ] Testing
- [ ] Codemods

Does the `if: failure()` catch-up step belong in these workflows, or should this move into `canvas-kit-actions/release@v2` long term (e.g. publish before pushing tags)?

## Testing Manually

1. After merge, confirm **Publish to npm** shows a `complete-unpublished` option in the workflow dispatch dropdown.
2. Run **complete-unpublished** on `master` and confirm missing `16.0.7` packages (`canvas-kit-codemod`, `canvas-kit-preview-react`, `canvas-kit-docs`) appear on npm.
3. Optionally simulate a retry locally after a build:
   ```bash
   node utils/publish-packages.mjs --dist-tag latest --verify-only
   node utils/publish-packages.mjs --dist-tag latest
   ```

## Screenshots or GIFs (if applicable)

N/A — CI/publishing changes only.

## Thank You Gif (optional)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a recovery workflow to publish workspace packages that are missing from the registry without requiring version changes.
  * Added support for selecting distribution tags during manual releases.
  * Added partial-release handling that identifies unpublished packages, verifies builds, retries recoverable failures, and publishes packages safely.

* **Bug Fixes**
  * Improved release recovery and verification when publishing fails.
  * Added clearer failure guidance for completing interrupted releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->