### PR TITLE
chore(ci): Fix commit message parsing in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Determine publish type
         id: determine
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           # Debug: Show incoming event information
           echo "::group::Debug Information"
@@ -48,7 +50,7 @@ jobs:
           echo "Ref: ${{ github.ref }}"
           echo "Ref name: ${{ github.ref_name }}"
           echo "SHA: ${{ github.sha }}"
-          echo "Commit message: ${{ github.event.head_commit.message }}"
+          echo "Commit message: $COMMIT_MESSAGE"
           echo "::endgroup::"
 
           # For workflow_dispatch, use the selected release type
@@ -68,7 +70,7 @@ jobs:
             echo "::notice::Branch '${BRANCH}' matched prerelease/* - publish type: canary"
           elif [[ "$BRANCH" == "master" ]] || [[ "$BRANCH" == "support" ]]; then
             # Check if commit message contains [skip release]
-            if [[ "${{ github.event.head_commit.message }}" == *"[skip release]"* ]]; then
+            if [[ "$COMMIT_MESSAGE" == *"[skip release]"* ]]; then
               echo "publish_type=skip" >> $GITHUB_OUTPUT
               echo "::notice::Commit contains [skip release] - skipping publish"
             else

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,14 +43,20 @@ jobs:
         id: determine
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          REF: ${{ github.ref }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           # Debug: Show incoming event information
           echo "::group::Debug Information"
           echo "Event name: ${{ github.event_name }}"
-          echo "Ref: ${{ github.ref }}"
-          echo "Ref name: ${{ github.ref_name }}"
+          echo "Ref: $REF"
+          echo "Ref name: $REF_NAME"
           echo "SHA: ${{ github.sha }}"
-          echo "Commit message: $COMMIT_MESSAGE"
+          STOP_TOKEN="commit-message-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "Commit message:"
+          echo "::stop-commands::${STOP_TOKEN}"
+          printf '%s\n' "$COMMIT_MESSAGE"
+          echo "::${STOP_TOKEN}::"
           echo "::endgroup::"
 
           # For workflow_dispatch, use the selected release type
@@ -62,7 +68,7 @@ jobs:
           fi
 
           # For push events, determine type based on branch
-          BRANCH="${{ github.ref_name }}"
+          BRANCH="$REF_NAME"
           echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
 
           if [[ "$BRANCH" == prerelease/* ]]; then
@@ -83,13 +89,15 @@ jobs:
           fi
 
       - name: Summary
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           echo "## Publish Decision" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Parameter | Value |" >> $GITHUB_STEP_SUMMARY
           echo "|-----------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| Event | \`${{ github.event_name }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| Branch | \`${{ github.ref_name }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Branch | \`${REF_NAME}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| Publish Type | \`${{ steps.determine.outputs.publish_type }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           if [[ "${{ steps.determine.outputs.publish_type }}" == "skip" ]]; then


### PR DESCRIPTION
## Summary

Fixes: #4161

The **Publish to npm** workflow failed on a `master` push ([run #578](https://github.com/Workday/canvas-kit/actions/runs/33646213784)) when `determine-publish-type` exited with a bash syntax error before any publish decision could be made.

### What failed

The `determine-publish-type` job failed with:

```
syntax error near unexpected token `then'
```

### Root cause

Commit `79d455e` had a subject line with a stray backtick and a long multiline squash-merge body. In `publish.yml`, the workflow inlined `${{ github.event.head_commit.message }}` directly into the generated bash script for the `[skip release]` check. GitHub Actions substitutes that expression literally into the shell, so backticks triggered command substitution, newlines broke the `if [[ ... ]]` statement, and bash could not parse the script.

### Why it happened now

The workflow has always been fragile for commit messages containing shell-special characters (backticks, `$`, quotes, newlines). This commit happened to trigger it because of the backtick in the squash-merge subject plus markdown backticks in the body.

### Fix

Pass the commit message through a `COMMIT_MESSAGE` environment variable on the `determine` step so GitHub Actions escapes the value correctly, then reference `$COMMIT_MESSAGE` in the debug echo and `[skip release]` check instead of inlining the expression in the `run` block.

The same vulnerability exists on both `master` and `support` (same workflow, same branch check). This PR targets `support` first; the fix should be forward-merged or cherry-picked to `master` as well.

## Release Category
Infrastructure

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--docs)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

`.github/workflows/publish.yml` — the `determine-publish-type` job (`COMMIT_MESSAGE` env var and its two usages).

## Testing Manually

Merge is sufficient; the next push to `support` or `master` with a multiline squash-merge commit (especially one containing backticks) should pass `determine-publish-type` instead of failing with a bash syntax error. Optionally re-run the failed publish workflow on `master` after this fix is on that branch.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved release publishing workflow diagnostics by consistently displaying the relevant branch and commit information.
  - Safeguarded commit message output during publishing so its contents cannot be interpreted as workflow commands.
  - Updated release checks to use consistent branch references when determining publishing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->